### PR TITLE
Mode 1073 - Adjusted how several of the sequencing integration test cases wait for the sequenced information.

### DIFF
--- a/modeshape-integration-tests/src/test/java/org/modeshape/test/integration/AbstractModeShapeTest.java
+++ b/modeshape-integration-tests/src/test/java/org/modeshape/test/integration/AbstractModeShapeTest.java
@@ -247,6 +247,42 @@ public abstract class AbstractModeShapeTest {
         waitUntilSequencedNodesIs(totalNumberOfNodesSequenced, 5);
     }
 
+    protected Node waitUntilSequencedNodeIsAvailable( String path ) throws InterruptedException, RepositoryException {
+        long startTime = System.currentTimeMillis();
+        for (int i = 0; i != 10 * 5; ++i) { // 10 seconds at the most
+            try {
+                return assertNode(path);
+            } catch (PathNotFoundException t) {
+                Thread.sleep(200); // wait a bit while the new content is indexed
+            } catch (AssertionError t) {
+                Thread.sleep(200); // wait a bit while the new content is indexed
+            }
+        }
+        long endTime = System.currentTimeMillis();
+        double seconds = (endTime - startTime) / 1000.0d;
+        fail("Unable to find '" + path + "' even after waiting " + seconds + " seconds");
+        return null;
+    }
+
+    protected Node waitUntilSequencedNodeIsAvailable( String path,
+                                                      String primaryType,
+                                                      String... mixinTypes ) throws InterruptedException, RepositoryException {
+        long startTime = System.currentTimeMillis();
+        for (int i = 0; i != 10 * 5; ++i) { // 10 seconds at the most
+            try {
+                return assertNode(path, primaryType, mixinTypes);
+            } catch (PathNotFoundException t) {
+                Thread.sleep(200); // wait a bit while the new content is indexed
+            } catch (AssertionError t) {
+                Thread.sleep(200); // wait a bit while the new content is indexed
+            }
+        }
+        long endTime = System.currentTimeMillis();
+        double seconds = (endTime - startTime) / 1000.0d;
+        fail("Unable to find '" + path + "' even after waiting " + seconds + " seconds");
+        return null;
+    }
+
     /**
      * Block until the total number of sequenced nodes is at last the value specified. If not enough sequenced nodes are produced
      * within the allotted number of seconds, this method causes a unit test failure.

--- a/modeshape-integration-tests/src/test/java/org/modeshape/test/integration/sequencer/CndSequencerInJpaIntegrationTest.java
+++ b/modeshape-integration-tests/src/test/java/org/modeshape/test/integration/sequencer/CndSequencerInJpaIntegrationTest.java
@@ -71,11 +71,10 @@ public class CndSequencerInJpaIntegrationTest extends AbstractSequencerTest {
         // print = true;
         uploadFile("sequencers/cnd/jsr_283_builtins.cnd", "/files/");
         waitUntilSequencedNodesIs(1);
-        Thread.sleep(1000); // wait a bit while the new content is indexed
 
         // Find the sequenced node ...
         String path = "/sequenced/cnd/jsr_283_builtins.cnd";
-        Node cnd = assertNode(path, "nt:unstructured");
+        Node cnd = waitUntilSequencedNodeIsAvailable(path, "nt:unstructured");
         printSubgraph(cnd);
 
         Node file1 = assertNode(path + "/nt:activity", "nt:nodeType", "mode:derived");
@@ -97,12 +96,11 @@ public class CndSequencerInJpaIntegrationTest extends AbstractSequencerTest {
         // print = true;
         uploadFile("sequencers/cnd/jsr_283_builtins.cnd", "/files/a/b");
         waitUntilSequencedNodesIs(1);
-        Thread.sleep(200); // wait a bit while the new content is indexed
         // printSubgraph(assertNode("/"));
 
         // Find the sequenced node ...
         String path = "/sequenced/cnd/a/b/jsr_283_builtins.cnd";
-        Node cnd = assertNode(path, "nt:unstructured");
+        Node cnd = waitUntilSequencedNodeIsAvailable(path, "nt:unstructured");
         printSubgraph(cnd);
 
         Node file1 = assertNode(path + "/nt:activity", "nt:nodeType", "mode:derived");
@@ -130,12 +128,11 @@ public class CndSequencerInJpaIntegrationTest extends AbstractSequencerTest {
         uploadFile("sequencers/cnd/jsr_283_builtins.cnd", "/files/a/b");
         uploadFile("sequencers/cnd/images.cnd", "/files/a/b");
         waitUntilSequencedNodesIs(2, 10);
-        Thread.sleep(1000); // wait a bit while the new content is indexed
         // printSubgraph(assertNode("/"));
 
-        // Find the sequenced node ...
+        // Find the sequenced node (may have to wait a bit for the sequencing to finish) ...
         String path = "/sequenced/cnd/a/b/jsr_283_builtins.cnd";
-        Node cnd = assertNode(path, "nt:unstructured");
+        Node cnd = waitUntilSequencedNodeIsAvailable(path, "nt:unstructured");
         printSubgraph(cnd);
 
         Node file1 = assertNode(path + "/nt:activity", "nt:nodeType", "mode:derived");

--- a/modeshape-integration-tests/src/test/java/org/modeshape/test/integration/sequencer/CndSequencerIntegrationTest.java
+++ b/modeshape-integration-tests/src/test/java/org/modeshape/test/integration/sequencer/CndSequencerIntegrationTest.java
@@ -97,12 +97,10 @@ public class CndSequencerIntegrationTest extends AbstractSequencerTest {
         // print = true;
         uploadFile("sequencers/cnd/jsr_283_builtins.cnd", "/files/a/b");
         waitUntilSequencedNodesIs(1);
-        Thread.sleep(200); // wait a bit while the new content is indexed
-        // printSubgraph(assertNode("/"));
 
         // Find the sequenced node ...
         String path = "/sequenced/cnd/a/b/jsr_283_builtins.cnd";
-        Node cnd = assertNode(path, "nt:unstructured");
+        Node cnd = waitUntilSequencedNodeIsAvailable(path, "nt:unstructured");
         printSubgraph(cnd);
 
         Node file1 = assertNode(path + "/nt:activity", "nt:nodeType", "mode:derived");
@@ -130,12 +128,10 @@ public class CndSequencerIntegrationTest extends AbstractSequencerTest {
         uploadFile("sequencers/cnd/jsr_283_builtins.cnd", "/files/a/b");
         uploadFile("sequencers/cnd/images.cnd", "/files/a/b");
         waitUntilSequencedNodesIs(2, 10);
-        Thread.sleep(1000); // wait a bit while the new content is indexed
-        // printSubgraph(assertNode("/"));
 
         // Find the sequenced node ...
         String path = "/sequenced/cnd/a/b/jsr_283_builtins.cnd";
-        Node cnd = assertNode(path, "nt:unstructured");
+        Node cnd = waitUntilSequencedNodeIsAvailable(path, "nt:unstructured");
         printSubgraph(cnd);
 
         Node file1 = assertNode(path + "/nt:activity", "nt:nodeType", "mode:derived");

--- a/modeshape-integration-tests/src/test/java/org/modeshape/test/integration/sequencer/DeleteDerivedContentIntegrationTest.java
+++ b/modeshape-integration-tests/src/test/java/org/modeshape/test/integration/sequencer/DeleteDerivedContentIntegrationTest.java
@@ -72,12 +72,10 @@ public class DeleteDerivedContentIntegrationTest extends AbstractSequencerTest {
         for (int i = 0; i != 2; ++i) {
             uploadFile("sequencers/cnd/jsr_283_builtins.cnd", "/files/");
             waitUntilSequencedNodesIs(1 * (i + 1));
-            Thread.sleep(200); // wait a bit while the new content is indexed
-            // printSubgraph(assertNode("/"));
 
             // Find the sequenced node ...
             String derivedPath = "/sequenced/cnd/jsr_283_builtins.cnd";
-            Node cnd = assertNode(derivedPath, "nt:unstructured");
+            Node cnd = waitUntilSequencedNodeIsAvailable(derivedPath, "nt:unstructured");
             printSubgraph(cnd);
 
             Node file1 = assertNode(derivedPath + "/nt:activity", "nt:nodeType", "mode:derived");

--- a/modeshape-integration-tests/src/test/java/org/modeshape/test/integration/sequencer/JavaSequencerIntegrationTest.java
+++ b/modeshape-integration-tests/src/test/java/org/modeshape/test/integration/sequencer/JavaSequencerIntegrationTest.java
@@ -58,8 +58,9 @@ public class JavaSequencerIntegrationTest extends AbstractSequencerTest {
     public void beforeEach() throws Exception {
         super.beforeEach();
         session.getWorkspace().getNamespaceRegistry().registerNamespace("java", "http://www.modeshape.org/java/1.0");
-        session.getWorkspace().getNamespaceRegistry().registerNamespace("class",
-                                                                        "http://www.modeshape.org/sequencer/javaclass/1.0");
+        session.getWorkspace()
+               .getNamespaceRegistry()
+               .registerNamespace("class", "http://www.modeshape.org/sequencer/javaclass/1.0");
     }
 
     @After
@@ -75,12 +76,10 @@ public class JavaSequencerIntegrationTest extends AbstractSequencerTest {
         assertThat(file.exists(), is(true));
         uploadFile(file.toURI().toURL(), "/files/");
         waitUntilSequencedNodesIs(1);
-        Thread.sleep(200); // wait a bit while the new content is indexed
-        // printSubgraph(assertNode("/"));
 
         // Find the sequenced node ...
         String path = "/sequenced/java/ClusteringTest.java";
-        Node java = assertNode(path, "nt:unstructured");
+        Node java = waitUntilSequencedNodeIsAvailable(path, "nt:unstructured");
         printSubgraph(java);
 
         assertNode(path + "/ClusteringTest", "class:class", "mode:derived");

--- a/modeshape-integration-tests/src/test/java/org/modeshape/test/integration/sequencer/SequencerTest.java
+++ b/modeshape-integration-tests/src/test/java/org/modeshape/test/integration/sequencer/SequencerTest.java
@@ -35,8 +35,8 @@ import org.junit.After;
 import org.junit.Test;
 import org.modeshape.graph.connector.inmemory.InMemoryRepositorySource;
 import org.modeshape.jcr.JcrConfiguration;
-import org.modeshape.jcr.ModeShapeRoles;
 import org.modeshape.jcr.JcrRepository.Option;
+import org.modeshape.jcr.ModeShapeRoles;
 import org.modeshape.sequencer.image.ImageMetadataLexicon;
 import org.modeshape.test.integration.AbstractModeShapeTest;
 
@@ -170,8 +170,9 @@ public class SequencerTest extends AbstractModeShapeTest {
                      .setProperty("defaultWorkspaceName", metaWorkSpace);
 
         // Image repository
-        configuration.repository(repoId).registerNamespace(ImageMetadataLexicon.Namespace.PREFIX,
-                                                           ImageMetadataLexicon.Namespace.URI).setSource(repoSrcId);
+        configuration.repository(repoId)
+                     .registerNamespace(ImageMetadataLexicon.Namespace.PREFIX, ImageMetadataLexicon.Namespace.URI)
+                     .setSource(repoSrcId);
 
         // Metadata repository
         configuration.repository(metaRepoId)
@@ -204,7 +205,7 @@ public class SequencerTest extends AbstractModeShapeTest {
         assertThat(file.exists(), is(true));
         uploadFile(file.toURI().toURL(), "/files/");
         waitUntilSequencedNodesIs(1);
-        Thread.sleep(200); // wait a bit while the new content is indexed
+        Thread.sleep(400); // wait a bit while the new content is indexed
 
         // Now look for the derived content ...
         Repository imageRepo = engine.getRepository(metaRepoId);

--- a/modeshape-integration-tests/src/test/java/org/modeshape/test/integration/sequencer/TeiidSequencerIntegrationTest.java
+++ b/modeshape-integration-tests/src/test/java/org/modeshape/test/integration/sequencer/TeiidSequencerIntegrationTest.java
@@ -95,10 +95,12 @@ public class TeiidSequencerIntegrationTest extends AbstractSequencerTest {
         // print = true;
         uploadFile("sequencers/teiid/vdb/qe.vdb", "/files/");
         waitUntilSequencingFinishes();
-        Thread.sleep(200); // wait a bit while the new content is indexed
 
         // Find the sequenced node ...
-        Node vdb = assertNode("/sequenced/teiid/vdbs/qe", "vdb:virtualDatabase", "mix:referenceable", "mode:derived");
+        Node vdb = waitUntilSequencedNodeIsAvailable("/sequenced/teiid/vdbs/qe",
+                                                     "vdb:virtualDatabase",
+                                                     "mix:referenceable",
+                                                     "mode:derived");
         printSubgraph(vdb);
         printQuery("SELECT * FROM [vdb:virtualDatabase]", 1);
         printQuery("SELECT * FROM [vdb:model]", 3);
@@ -116,10 +118,12 @@ public class TeiidSequencerIntegrationTest extends AbstractSequencerTest {
         // print = true;
         uploadFile("sequencers/teiid/vdb/qe.vdb", "/files/my/favorites");
         waitUntilSequencingFinishes();
-        Thread.sleep(200); // wait a bit while the new content is indexed
 
         // Find the sequenced node ...
-        Node vdb = assertNode("/sequenced/teiid/vdbs/my/favorites/qe", "vdb:virtualDatabase", "mix:referenceable", "mode:derived");
+        Node vdb = waitUntilSequencedNodeIsAvailable("/sequenced/teiid/vdbs/my/favorites/qe",
+                                                     "vdb:virtualDatabase",
+                                                     "mix:referenceable",
+                                                     "mode:derived");
         printSubgraph(vdb);
         printQuery("SELECT * FROM [vdb:virtualDatabase]", 1);
         printQuery("SELECT * FROM [vdb:model]", 3);
@@ -137,10 +141,12 @@ public class TeiidSequencerIntegrationTest extends AbstractSequencerTest {
         // print = true;
         uploadFile("sequencers/teiid/vdb/PartsFromXml.vdb", "/files/");
         waitUntilSequencingFinishes();
-        Thread.sleep(200); // wait a bit while the new content is indexed
 
         // Find the sequenced node ...
-        Node vdb = assertNode("/sequenced/teiid/vdbs/PartsFromXml", "vdb:virtualDatabase", "mix:referenceable", "mode:derived");
+        Node vdb = waitUntilSequencedNodeIsAvailable("/sequenced/teiid/vdbs/PartsFromXml",
+                                                     "vdb:virtualDatabase",
+                                                     "mix:referenceable",
+                                                     "mode:derived");
         printSubgraph(vdb);
         printQuery("SELECT * FROM [vdb:virtualDatabase]", 1);
         printQuery("SELECT * FROM [vdb:model]", 2);
@@ -160,10 +166,12 @@ public class TeiidSequencerIntegrationTest extends AbstractSequencerTest {
         // print = true;
         uploadFile("sequencers/teiid/vdb/YahooUdfTest.vdb", "/files/");
         waitUntilSequencingFinishes();
-        Thread.sleep(200); // wait a bit while the new content is indexed
 
         // Find the sequenced node ...
-        Node vdb = assertNode("/sequenced/teiid/vdbs/YahooUdfTest", "vdb:virtualDatabase", "mix:referenceable", "mode:derived");
+        Node vdb = waitUntilSequencedNodeIsAvailable("/sequenced/teiid/vdbs/YahooUdfTest",
+                                                     "vdb:virtualDatabase",
+                                                     "mix:referenceable",
+                                                     "mode:derived");
         printSubgraph(vdb);
         printQuery("SELECT * FROM [vdb:virtualDatabase]", 1);
         printQuery("SELECT * FROM [vdb:model]", 4);
@@ -181,10 +189,9 @@ public class TeiidSequencerIntegrationTest extends AbstractSequencerTest {
     public void shouldFindVdbsUsingQueryWithMultipleVariables() throws Exception {
         String[] vdbFiles = {"YahooUdfTest.vdb", "qe.vdb", "qe.2.vdb", "qe.3.vdb", "qe.4.vdb", "PartsFromXml.vdb"};
         uploadVdbs("/files/", vdbFiles);
-        Thread.sleep(1000); // wait a bit while the new content is indexed
 
         // Print out the top level of the VDBs ...
-        Node files = assertNode("/files");
+        Node files = waitUntilSequencedNodeIsAvailable("/files");
         // print = true;
         printSubgraph(files, 5);
 
@@ -194,7 +201,7 @@ public class TeiidSequencerIntegrationTest extends AbstractSequencerTest {
 
         // Print out the top level of the VDBs ...
         // print = true;
-        Node vdbs = assertNode("/sequenced");
+        Node vdbs = waitUntilSequencedNodeIsAvailable("/sequenced");
         // print = true;
         printSubgraph(vdbs, 4);
 

--- a/modeshape-integration-tests/src/test/java/org/modeshape/test/integration/sequencer/XmlSequencerIntegrationTest.java
+++ b/modeshape-integration-tests/src/test/java/org/modeshape/test/integration/sequencer/XmlSequencerIntegrationTest.java
@@ -70,11 +70,9 @@ public class XmlSequencerIntegrationTest extends AbstractSequencerTest {
         // print = true;
         uploadFile("jcr-import-test.xml", "/files/");
         waitUntilSequencedNodesIs(1);
-        Thread.sleep(1000); // wait a bit while the new content is indexed
-        // printSubgraph(assertNode("/"));
 
         // Find the sequenced node ...
-        printSubgraph(assertNode("/sequenced/xml", "nt:unstructured"));
+        printSubgraph(waitUntilSequencedNodeIsAvailable("/sequenced/xml", "nt:unstructured"));
         String path = "/sequenced/xml/jcr-import-test.xml";
         Node xml = assertNode(path, "modexml:document", "mode:derived");
         printSubgraph(xml);
@@ -96,12 +94,10 @@ public class XmlSequencerIntegrationTest extends AbstractSequencerTest {
         // print = true;
         uploadFile("jcr-import-test.xml", "/files/a/b");
         waitUntilSequencedNodesIs(1);
-        Thread.sleep(1000); // wait a bit while the new content is indexed
-        // printSubgraph(assertNode("/"));
 
         // Find the sequenced node ...
         String path = "/sequenced/xml/a/b/jcr-import-test.xml";
-        Node xml = assertNode(path, "modexml:document", "mode:derived");
+        Node xml = waitUntilSequencedNodeIsAvailable(path, "modexml:document", "mode:derived");
         printSubgraph(xml);
 
         // Node file1 = assertNode(path + "/nt:activity", "nt:nodeType");

--- a/modeshape-integration-tests/src/test/java/org/modeshape/test/integration/sequencer/ZipSequencerIntegrationTest.java
+++ b/modeshape-integration-tests/src/test/java/org/modeshape/test/integration/sequencer/ZipSequencerIntegrationTest.java
@@ -75,11 +75,10 @@ public class ZipSequencerIntegrationTest extends AbstractSequencerTest {
         // print = true;
         uploadFile("sequencers/zip/test-files.zip", "/files/");
         waitUntilSequencedNodesIs(1);
-        Thread.sleep(1000); // wait a bit while the new content is indexed
 
         // Find the sequenced node ...
         String path = "/sequenced/zip/test-files.zip";
-        Node zipped = assertNode(path, "zip:file","mode:derived");
+        Node zipped = waitUntilSequencedNodeIsAvailable(path, "zip:file", "mode:derived");
         Node file1 = assertNode(path + "/MODE-966-fix.patch", "nt:file");
         Node data1 = assertNode(path + "/MODE-966-fix.patch/jcr:content", "nt:resource");
         Node fold1 = assertNode(path + "/testFolder", "nt:folder");
@@ -112,11 +111,10 @@ public class ZipSequencerIntegrationTest extends AbstractSequencerTest {
         // print = true;
         uploadFile("sequencers/zip/test-files.zip", "/files/a/b");
         waitUntilSequencedNodesIs(1);
-        Thread.sleep(1000); // wait a bit while the new content is indexed
 
         // Find the sequenced node ...
         String path = "/sequenced/zip/a/b/test-files.zip";
-        Node zipped = assertNode(path, "zip:file","mode:derived");
+        Node zipped = waitUntilSequencedNodeIsAvailable(path, "zip:file", "mode:derived");
         Node file1 = assertNode(path + "/MODE-966-fix.patch", "nt:file");
         Node data1 = assertNode(path + "/MODE-966-fix.patch/jcr:content", "nt:resource");
         Node fold1 = assertNode(path + "/testFolder", "nt:folder");

--- a/modeshape-integration-tests/src/test/java/org/modeshape/test/integration/sequencer/ddl/DdlSequencer2IntegrationTest.java
+++ b/modeshape-integration-tests/src/test/java/org/modeshape/test/integration/sequencer/ddl/DdlSequencer2IntegrationTest.java
@@ -70,10 +70,8 @@ public class DdlSequencer2IntegrationTest extends AbstractSequencerTest {
         uploadFile("org/modeshape/test/integration/sequencer/ddl/create_schema.ddl", "/files/a/b");
         uploadFile("org/modeshape/test/integration/sequencer/ddl/grant_test_statements.ddl", "/files/a/b");
         waitUntilSequencedNodesIs(2, 10);
-        Thread.sleep(400); // wait a bit while the new content is indexed
-        // printSubgraph(assertNode("/"));
 
-        assertNode("/files", "nt:folder", "mode:publishArea");
+        waitUntilSequencedNodeIsAvailable("/files", "nt:folder", "mode:publishArea");
         assertNode("/files/a", "nt:folder");
         assertNode("/files/a/b", "nt:folder");
         assertNode("/files/a/b/create_schema.ddl", "nt:file");


### PR DESCRIPTION
This is an additional change for MODE-1073 (in addition to the previous pull-request that was already merged into 'master' and '2.2.x').

Several integration tests have recently been failing periodically, especially on Hudson (where the machines are generally slower). Many of the sequencing-related integration tests upload/publish one or more files, and then wait while ModeShape asynchronously sequences them and updates the indexes with the content derived from the uploaded artifact(s). This wait logic was relatively flawed, and resulted in periodic failures.

These test cases were changed to use a single method that looked for a particular node and, if the node was not available in the session or via query, would sleep for 200ms and then retry. This continues for approximately 10 seconds, after which the method causes an assertion failure. However, most of the time the method only has to wait a second or two (again, depending upon the speed of the machine); thus hopefully the 10 second timeout is sufficient at this time.

With these changes, none of the sequencing-related integration tests have been failing for me locally, even after repeated runs.
