### PR TITLE
Mode 1092

### DIFF
--- a/modeshape-graph/src/main/java/org/modeshape/graph/property/basic/StringReference.java
+++ b/modeshape-graph/src/main/java/org/modeshape/graph/property/basic/StringReference.java
@@ -78,6 +78,16 @@ public class StringReference implements Reference {
 
     /**
      * {@inheritDoc}
+     * 
+     * @see java.lang.Object#hashCode()
+     */
+    @Override
+    public int hashCode() {
+        return id.hashCode();
+    }
+
+    /**
+     * {@inheritDoc}
      */
     public int compareTo( Reference that ) {
         if (this == that) return 0;

--- a/modeshape-graph/src/main/java/org/modeshape/graph/property/basic/UuidReference.java
+++ b/modeshape-graph/src/main/java/org/modeshape/graph/property/basic/UuidReference.java
@@ -85,6 +85,16 @@ public class UuidReference implements Reference {
 
     /**
      * {@inheritDoc}
+     * 
+     * @see java.lang.Object#hashCode()
+     */
+    @Override
+    public int hashCode() {
+        return uuid.hashCode();
+    }
+
+    /**
+     * {@inheritDoc}
      */
     public int compareTo( Reference that ) {
         if (this == that) return 0;

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrValue.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrValue.java
@@ -423,7 +423,8 @@ final class JcrValue implements org.modeshape.jcr.api.Value {
                 }
 
             case PropertyType.REFERENCE:
-                if (this.type != PropertyType.STRING && this.type != PropertyType.BINARY) {
+                if (this.type != PropertyType.STRING && this.type != PropertyType.BINARY
+                    && this.type != PropertyType.WEAKREFERENCE) {
                     throw createValueFormatException(Node.class);
                 }
                 try {
@@ -432,7 +433,7 @@ final class JcrValue implements org.modeshape.jcr.api.Value {
                     throw createValueFormatException(vfe);
                 }
             case PropertyType.WEAKREFERENCE:
-                if (this.type != PropertyType.STRING && this.type != PropertyType.BINARY) {
+                if (this.type != PropertyType.STRING && this.type != PropertyType.BINARY && this.type != PropertyType.REFERENCE) {
                     throw createValueFormatException(Node.class);
                 }
                 try {

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/SessionCache.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/SessionCache.java
@@ -1069,8 +1069,9 @@ class SessionCache {
                  * findPropertyDefinition checks constraints for all property types except REFERENCE.  To avoid unnecessary loading of nodes,
                  * REFERENCE constraints are only checked when the property is first set.
                  */
-                boolean referencePropMissedConstraints = skipReferenceValidation && definition != null
-                                                         && definition.getRequiredType() == PropertyType.REFERENCE
+                boolean referencePropMissedConstraints = skipReferenceValidation
+                                                         && definition != null
+                                                         && (definition.getRequiredType() == PropertyType.REFERENCE || definition.getRequiredType() == PropertyType.WEAKREFERENCE)
                                                          && !definition.canCastToTypeAndSatisfyConstraints(value);
                 if (definition == null || referencePropMissedConstraints) {
                     throw new ConstraintViolationException(JcrI18n.noDefinition.text("property",
@@ -1272,7 +1273,7 @@ class SessionCache {
                  * REFERENCE constraints are only checked when the property is first set.
                  */
                 boolean referencePropMissedConstraints = definition != null
-                                                         && definition.getRequiredType() == PropertyType.REFERENCE
+                                                         && (definition.getRequiredType() == PropertyType.REFERENCE || definition.getRequiredType() == PropertyType.WEAKREFERENCE)
                                                          && !definition.canCastToTypeAndSatisfyConstraints(newValues);
                 if (definition == null || referencePropMissedConstraints) {
                     throw new ConstraintViolationException(JcrI18n.noDefinition.text("property",


### PR DESCRIPTION
Several minor problems were corrected so that it is possible to set a WEAKREFERENCE property on a node
and have that property remain a WEAKREFERENCE. Evidently there are no explicit checks for this in
the JCR 2.0 TCK, so this change adds a new unit test. Several of the errors were likely leftover
from when WEAKREFERENCE was added in JCR 2.0, but all corrections are relatively minor and reinforce
the similarity and conversion between REFERENCE and WEAKREFERENCE.

All unit and integration tests complete successfully with these changes.
