### PR TITLE
MODE-1106 Tweak to reduce the JavaDoc build times during assembly.

### DIFF
--- a/modeshape-distribution/pom.xml
+++ b/modeshape-distribution/pom.xml
@@ -1117,6 +1117,9 @@
 		        <artifactId>maven-javadoc-plugin</artifactId>
 						<version>${maven.javadoc.plugin.version}</version>
 						<configuration>
+		          <!-- Workaround for http://jira.codehaus.org/browse/MJAVADOC-268 and http://jira.codehaus.org/browse/MJAVADOC-286 -->
+		          <detectOfflineLinks>false</detectOfflineLinks>
+		          <!-- end of workaround -->
 		          <includeDependencySources>true</includeDependencySources>
 		          <dependencySourceExcludes>
 		            <!-- place here any patterns for dependencies not to be included in the JavaDoc -->


### PR DESCRIPTION
Building the 'modeshape-distribution' module and including JavaDoc (the default) succeeded with no problems. But when building the whole shebang, producing the JavaDoc during the run of 'modeshape-distribution' resulted in many slow checks (and generation?) of existing JavaDoc. Indeed, simply producing the JavaDoc could take in excess of 10 or 20 minutes. See http://jira.codehaus.org/browse/MJAVADOC-268 for a description of the problem and http://jira.codehaus.org/browse/MJAVADOC-286 for a workaround.

Changed JavaDoc plugin configuration in the 'modeshape-distribution/pom.xml' file to set the "detectOfflineLinks" parameter to false (the default is 'true'). This seems to fix the issue, as demonstrated by a reduction in total build time by about 10 minutes.
