### PR TITLE
MODE-1105 Corrected logic to import graph from classpath resource

### DIFF
--- a/modeshape-graph/src/main/java/org/modeshape/graph/Graph.java
+++ b/modeshape-graph/src/main/java/org/modeshape/graph/Graph.java
@@ -2797,7 +2797,11 @@ public class Graph {
                         return typeAttribute;
                     }
                 };
-                importer.importXml(stream, at, skipRootElement).execute(); // 'importXml' creates and uses a new batch
+                try {
+                    importer.importXml(stream, at, skipRootElement).execute(); // 'importXml' creates and uses a new batch
+                } finally {
+                    stream.close();
+                }
                 return Graph.this.nextGraph;
             }
         };
@@ -2906,12 +2910,7 @@ public class Graph {
         ClassLoader classLoader = getClass().getClassLoader();
         InputStream stream = classLoader.getResourceAsStream(pathToFile);
         if (stream != null) {
-            try {
-                stream.close();
-                return importXmlFrom(pathToFile, classLoader);
-            } catch (IOException e) {
-                // shouldn't happen, but continue anyway ...
-            }
+            return importXmlFrom(stream);
         }
         // Try a URL ...
         try {
@@ -2941,7 +2940,7 @@ public class Graph {
         InputStream stream = null;
         RuntimeException error = null;
         try {
-            stream = getClass().getResourceAsStream(resourceName);
+            stream = classLoader.getResourceAsStream(resourceName);
             return importXmlFrom(stream);
         } catch (RuntimeException e) {
             error = e;

--- a/modeshape-jcr/src/test/java/org/modeshape/jcr/JcrEngineTest.java
+++ b/modeshape-jcr/src/test/java/org/modeshape/jcr/JcrEngineTest.java
@@ -128,8 +128,24 @@ public class JcrEngineTest {
     }
 
     @Test
-    public void shouldCreateRepositoryEngineFromConfigurationFileWithInitialContentInRepository() throws Exception {
+    public void shouldCreateRepositoryEngineFromConfigurationFileWithInitialContentInFileWithRelativePath() throws Exception {
         configuration = new JcrConfiguration().loadFrom("src/test/resources/config/configRepositoryWithInitialContent.xml");
+        engine = configuration.build();
+        engine.start();
+        repository = engine.getRepository("My Repository");
+        session = repository.login();
+
+        javax.jcr.Node cars = session.getRootNode().getNode("Cars");
+        javax.jcr.Node prius = session.getRootNode().getNode("Cars/Hybrid/Toyota Prius");
+        javax.jcr.Node g37 = session.getRootNode().getNode("Cars/Sports/Infiniti G37");
+        assertThat(cars, is(notNullValue()));
+        assertThat(prius, is(notNullValue()));
+        assertThat(g37, is(notNullValue()));
+    }
+
+    @Test
+    public void shouldCreateRepositoryEngineFromConfigurationFileWithInitialContentInFileOnClasspath() throws Exception {
+        configuration = new JcrConfiguration().loadFrom("src/test/resources/config/configRepositoryWithInitialContentOnClasspath.xml");
         engine = configuration.build();
         engine.start();
         repository = engine.getRepository("My Repository");

--- a/modeshape-jcr/src/test/resources/config/configRepositoryWithInitialContentOnClasspath.xml
+++ b/modeshape-jcr/src/test/resources/config/configRepositoryWithInitialContentOnClasspath.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- 
+  ~ ModeShape (http://www.modeshape.org)
+  ~
+  ~ See the COPYRIGHT.txt file distributed with this work for information
+  ~ regarding copyright ownership.  Some portions may be licensed
+  ~ to Red Hat, Inc. under one or more contributor license agreements.
+  ~ See the AUTHORS.txt file in the distribution for a full listing of 
+  ~ individual contributors.
+  ~
+  ~ ModeShape is free software. Unless otherwise indicated, all code in ModeShape
+  ~ is licensed to you under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ ModeShape is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+  ~ or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+  ~ for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public License
+  ~ along with this distribution; if not, write to:
+  ~ Free Software Foundation, Inc.
+  ~ 51 Franklin Street, Fifth Floor
+  ~ Boston, MA  02110-1301  USA
+  -->
+<configuration xmlns:mode="http://www.modeshape.org/1.0"
+               xmlns:jcr="http://www.jcp.org/jcr/1.0"
+               xmlns:nt="http://www.jcp.org/jcr/nt/1.0">
+    <!-- Define the sources from which content is made available.  -->
+    <mode:sources jcr:primaryType="nt:unstructured">
+        <mode:source jcr:name="Stuff" mode:classname="org.modeshape.graph.connector.inmemory.InMemoryRepositorySource" mode:retryLimit="3" defaultWorkspaceName="default"/>
+    </mode:sources>
+    <!-- JCR Repositories.  This is required, with a separate repository for each JCR repository instance. -->
+    <mode:repositories>
+        <mode:repository jcr:name="My Repository" mode:source="Stuff">
+            <mode:options>
+                <mode:option jcr:name="jaasLoginConfigName" mode:value="modeshape-jcr"/>
+            </mode:options>
+            <jcr:nodeTypes>
+                <mode:resource>src/test/resources/cars.cnd</mode:resource>
+            </jcr:nodeTypes>
+            <mode:initialContent mode:workspaces="default" mode:applyToNewWorkspaces="true" mode:content="initialWorkspaceContent.xml"/>
+        </mode:repository>
+    </mode:repositories>
+</configuration>


### PR DESCRIPTION
The logic of importing Graph content from an XML file on the classpath was not correct, and was always closing the stream before anything could be read from the stream. Added a test case to verify the reported behavior, and then verified that moving the 'stream.close()' call to the correct location works as expected.

All unit and integration tests pass with these changes.
