### PR TITLE
MODE-1109 Corrected the RemoteInfinispanSource tests to work on IPv6.

### DIFF
--- a/extensions/modeshape-connector-infinispan/src/main/java/org/modeshape/connector/infinispan/InfinispanRepository.java
+++ b/extensions/modeshape-connector-infinispan/src/main/java/org/modeshape/connector/infinispan/InfinispanRepository.java
@@ -82,7 +82,7 @@ public class InfinispanRepository extends Repository<InfinispanNode, InfinispanW
      * This method shuts down the workspace and makes it no longer usable. This method should also only be called once.
      */
     public void shutdown() {
-        //this.cacheContainer.stop();
+        this.cacheContainer.stop();
     }
 
     /**

--- a/extensions/modeshape-connector-infinispan/src/test/java/org/modeshape/connector/infinispan/RemoteInfinispanConnectorReadWriteTest.java
+++ b/extensions/modeshape-connector-infinispan/src/test/java/org/modeshape/connector/infinispan/RemoteInfinispanConnectorReadWriteTest.java
@@ -42,7 +42,6 @@ import org.modeshape.graph.connector.RepositoryConnection;
 import org.modeshape.graph.connector.RepositoryContext;
 
 /**
- *
  * @author johnament
  */
 public class RemoteInfinispanConnectorReadWriteTest {
@@ -55,6 +54,7 @@ public class RemoteInfinispanConnectorReadWriteTest {
     public static void closeConnection() throws Exception {
         RemoteInfinispanTestHelper.releaseServer();
     }
+
     private ExecutionContext context;
     private RemoteInfinispanSource source;
     private RepositoryContext mockRepositoryContext;
@@ -72,7 +72,9 @@ public class RemoteInfinispanConnectorReadWriteTest {
         source.setDefaultWorkspaceName(predefinedWorkspaceNames[0]);
         source.setCreatingWorkspacesAllowed(true);
         source.initialize(mockRepositoryContext);
-        source.setRemoteInfinispanServerList(String.format("%s:%s",RemoteInfinispanTestHelper.HOST,RemoteInfinispanTestHelper.PORT));
+        source.setRemoteInfinispanServerList(String.format("%s:%s",
+                                                           RemoteInfinispanTestHelper.hostAddress(),
+                                                           RemoteInfinispanTestHelper.hostPort()));
     }
 
     @After

--- a/extensions/modeshape-connector-infinispan/src/test/java/org/modeshape/connector/infinispan/RemoteInfinispanConnectorReadableTest.java
+++ b/extensions/modeshape-connector-infinispan/src/test/java/org/modeshape/connector/infinispan/RemoteInfinispanConnectorReadableTest.java
@@ -58,8 +58,8 @@ public class RemoteInfinispanConnectorReadableTest extends ReadableConnectorTest
         source.setDefaultWorkspaceName(predefinedWorkspaceNames[0]);
         source.setCreatingWorkspacesAllowed(false);
         source.setRemoteInfinispanServerList(String.format("%s:%s",
-                                                           RemoteInfinispanTestHelper.HOST,
-                                                           RemoteInfinispanTestHelper.PORT));
+                                                           RemoteInfinispanTestHelper.hostAddress(),
+                                                           RemoteInfinispanTestHelper.hostPort()));
         return source;
     }
 

--- a/extensions/modeshape-connector-infinispan/src/test/java/org/modeshape/connector/infinispan/RemoteInfinispanConnectorWritableTest.java
+++ b/extensions/modeshape-connector-infinispan/src/test/java/org/modeshape/connector/infinispan/RemoteInfinispanConnectorWritableTest.java
@@ -55,11 +55,16 @@ public class RemoteInfinispanConnectorWritableTest extends WritableConnectorTest
         source.setDefaultWorkspaceName(predefinedWorkspaceNames[0]);
         source.setCreatingWorkspacesAllowed(true);
         source.setRemoteInfinispanServerList(String.format("%s:%s",
-                                                           RemoteInfinispanTestHelper.HOST,
-                                                           RemoteInfinispanTestHelper.PORT));
+                                                           RemoteInfinispanTestHelper.hostAddress(),
+                                                           RemoteInfinispanTestHelper.hostPort()));
         return source;
     }
 
+    /**
+     * {@inheritDoc}
+     * 
+     * @see org.modeshape.graph.connector.test.AbstractConnectorTest#cleanUpSourceResources()
+     */
     @Override
     protected void cleanUpSourceResources() throws Exception {
         RemoteInfinispanTestHelper.releaseServer();

--- a/extensions/modeshape-connector-infinispan/src/test/java/org/modeshape/connector/infinispan/RemoteInfinispanSourceTest.java
+++ b/extensions/modeshape-connector-infinispan/src/test/java/org/modeshape/connector/infinispan/RemoteInfinispanSourceTest.java
@@ -49,7 +49,6 @@ import org.modeshape.graph.connector.RepositoryConnection;
 import org.modeshape.graph.connector.RepositoryContext;
 
 /**
- *
  * @author johnament
  */
 public class RemoteInfinispanSourceTest {
@@ -71,6 +70,7 @@ public class RemoteInfinispanSourceTest {
     public static void closeConnection() throws Exception {
         RemoteInfinispanTestHelper.releaseServer();
     }
+
     @Before
     public void beforeEach() throws Exception {
         MockitoAnnotations.initMocks(this);
@@ -151,10 +151,7 @@ public class RemoteInfinispanSourceTest {
     public void shouldCreateJndiReferenceAndRecreatedObjectFromReference() throws Exception {
         BasicCachePolicy cachePolicy = new BasicCachePolicy();
         cachePolicy.setTimeToLive(1000L, TimeUnit.MILLISECONDS);
-        convertToAndFromJndiReference(validName,
-                                      validRootNodeUuid,
-                                      cachePolicy,
-                                      100);
+        convertToAndFromJndiReference(validName, validRootNodeUuid, cachePolicy, 100);
     }
 
     @Test
@@ -206,6 +203,10 @@ public class RemoteInfinispanSourceTest {
         throws Exception {
         source.setName(validName);
         source.initialize(repositoryContext);
+        // The HotRod server is started on the host's actual address, which is not '127.0.0.1', so we have to set the server list
+        source.setRemoteInfinispanServerList(String.format("%s:%s",
+                                                           RemoteInfinispanTestHelper.hostAddress(),
+                                                           RemoteInfinispanTestHelper.hostPort()));
         connection = source.getConnection();
         assertThat(connection, is(notNullValue()));
         // assertThat(connection.getCache(), is(notNullValue()));


### PR DESCRIPTION
When creating the HotRod server and client, the test code now dynamically looks up the address of the local host and uses that for configuration. This works whether the local host has an IPv4 or IPv6 address. Also, some of the tests were not properly shutting down the client before the server, which would occasionally fail if the server happened to shut down before the client.

All unit and integration tests pass with these changes.
