### PR TITLE
MODE-1099 Added ability for clients to publish files as being versioned 

### DIFF
--- a/web/modeshape-web-jcr-rest-client/src/main/java/org/modeshape/web/jcr/rest/client/IJcrConstants.java
+++ b/web/modeshape-web-jcr-rest-client/src/main/java/org/modeshape/web/jcr/rest/client/IJcrConstants.java
@@ -52,6 +52,11 @@ public interface IJcrConstants {
     String FOLDER_NODE_TYPE = "nt:folder";
 
     /**
+     * The JCR versionable mixin node type (<code>mix:versionable</code>).
+     */
+    String VERSIONABLE_NODE_TYPE = "mix:versionable";
+
+    /**
      * The JCR data property name (<code>jcr:lastModified</code>).
      */
     String LAST_MODIFIED = "jcr:lastModified";
@@ -65,6 +70,11 @@ public interface IJcrConstants {
      * The JCR primary type property name (<code>jcr:primaryType</code>).
      */
     String PRIMARY_TYPE_PROPERTY = "jcr:primaryType";
+
+    /**
+     * The JCR mixin type property name (<code>jcr:mixinTypes</code>).
+     */
+    String MIXIN_TYPES_PROPERTY = "jcr:mixinTypes";
 
     /**
      * The JCR resource node type (<code>nt:resource</code>).

--- a/web/modeshape-web-jcr-rest-client/src/main/java/org/modeshape/web/jcr/rest/client/IRestClient.java
+++ b/web/modeshape-web-jcr-rest-client/src/main/java/org/modeshape/web/jcr/rest/client/IRestClient.java
@@ -78,7 +78,9 @@ public interface IRestClient {
     Collection<Workspace> getWorkspaces( Repository repository ) throws Exception;
 
     /**
-     * Publishes, or uploads, a local file to the workspace at the specified path.
+     * Publishes, or uploads, a local file to the workspace at the specified path. This method does not utilize any versioning,
+     * and is equivalent to calling {@link #publish(Workspace, String, File, boolean) "<code>publish(workspace,path,file,false)}
+     * </code>".
      * 
      * @param workspace the workspace where the resource will be published (never <code>null</code>)
      * @param path the unencoded path to the folder where the file will be published (never <code>null</code>)
@@ -88,6 +90,24 @@ public interface IRestClient {
     Status publish( Workspace workspace,
                     String path,
                     File file );
+
+    /**
+     * Publishes, or uploads, a local file to the workspace at the specified path. This method allows the client to specify
+     * whether the uploaded file should be versioned. If so, this method will add the "mix:versionable" mixin to the "nt:file"
+     * node, and subsequent attempts to re-publish will result in new versions in the version history of the file. If no
+     * versioning is to be done, then no version history is maintained for the file, and subsequent attemps to re-publish will
+     * simply overwrite any existing content.
+     * 
+     * @param workspace the workspace where the resource will be published (never <code>null</code>)
+     * @param path the unencoded path to the folder where the file will be published (never <code>null</code>)
+     * @param file the resource being published (never <code>null</code>)
+     * @param useVersioning true if the uploaded file should be versioned, or false if no JCR versioning be used
+     * @return a status of the publishing operation outcome (never <code>null</code>)
+     */
+    Status publish( Workspace workspace,
+                    String path,
+                    File file,
+                    boolean useVersioning );
 
     /**
      * Unpublishes, or deletes, the resource at the specified path in the workspace. If a file being unpublished is not found in

--- a/web/modeshape-web-jcr-rest-client/src/main/java/org/modeshape/web/jcr/rest/client/json/FileNode.java
+++ b/web/modeshape-web-jcr-rest-client/src/main/java/org/modeshape/web/jcr/rest/client/json/FileNode.java
@@ -75,9 +75,23 @@ public final class FileNode extends JsonNode {
     public FileNode( Workspace workspace,
                      String path,
                      File file ) throws Exception {
+        this(workspace, path, file, false);
+    }
+
+    /**
+     * @param workspace the workspace being used (never <code>null</code>)
+     * @param path the path in the workspace (never <code>null</code>)
+     * @param file the file on the local file system (never <code>null</code>)
+     * @param versionable true if the file node should be versionable
+     * @throws Exception if there is a problem constructing the file node
+     */
+    public FileNode( Workspace workspace,
+                     String path,
+                     File file,
+                     boolean versionable ) throws Exception {
         super(file.getName());
-    	assert workspace != null;
-    	assert path != null;
+        assert workspace != null;
+        assert path != null;
 
         this.file = file;
         this.path = path;
@@ -100,6 +114,9 @@ public final class FileNode extends JsonNode {
         properties = new JSONObject();
         kid.put(IJsonConstants.PROPERTIES_KEY, properties);
         properties.put(IJcrConstants.PRIMARY_TYPE_PROPERTY, IJcrConstants.RESOURCE_NODE_TYPE);
+        if (versionable) {
+            properties.put(IJcrConstants.MIXIN_TYPES_PROPERTY, IJcrConstants.VERSIONABLE_NODE_TYPE);
+        }
 
         // add required jcr:lastModified property
         Calendar lastModified = Calendar.getInstance();
@@ -141,7 +158,7 @@ public final class FileNode extends JsonNode {
      * @see #getFileContentsUrl()
      */
     String getFileContents( String jsonResponse ) throws Exception {
-    	assert jsonResponse != null;
+        assert jsonResponse != null;
         JSONObject contentNode = new JSONObject(jsonResponse);
         JSONObject props = (JSONObject)contentNode.get(IJsonConstants.PROPERTIES_KEY);
         String encodedContents = props.getString(IJcrConstants.DATA_PROPERTY);

--- a/web/modeshape-web-jcr-rest-client/src/main/java/org/modeshape/web/jcr/rest/client/json/JsonRestClient.java
+++ b/web/modeshape-web-jcr-rest-client/src/main/java/org/modeshape/web/jcr/rest/client/json/JsonRestClient.java
@@ -89,13 +89,15 @@ public final class JsonRestClient implements IRestClient {
      * @param workspace the workspace where the file node is being created
      * @param path the path in the workspace to the folder where the file node is being created
      * @param file the file whose contents will be contained in the file node being created
+     * @param useVersioning true if 'mix:versionable' should be added to the file node
      * @throws Exception if there is a problem creating the file
      */
     private void createFileNode( Workspace workspace,
                                  String path,
-                                 File file ) throws Exception {
+                                 File file,
+                                 boolean useVersioning ) throws Exception {
         LOGGER.trace("createFileNode: workspace={0}, path={1}, file={2}", workspace.getName(), path, file.getAbsolutePath());
-        FileNode fileNode = new FileNode(workspace, path, file);
+        FileNode fileNode = new FileNode(workspace, path, file, useVersioning);
         URL fileNodeUrl = fileNode.getUrl();
         URL fileNodeUrlWithTerseResponse = new URL(fileNodeUrl.toString() + "?mode:includeNode=false");
         HttpClientConnection connection = connect(workspace.getServer(), fileNodeUrlWithTerseResponse, RequestMethod.POST);
@@ -127,13 +129,15 @@ public final class JsonRestClient implements IRestClient {
      * @param workspace the workspace where the file node is being created
      * @param path the path in the workspace to the folder where the file node is being created
      * @param file the file whose contents will be contained in the file node being created
+     * @param useVersioning true if 'mix:versionable' should be added to the file node
      * @throws Exception if there is a problem creating the file
      */
     private void updateFileNode( Workspace workspace,
                                  String path,
-                                 File file ) throws Exception {
+                                 File file,
+                                 boolean useVersioning ) throws Exception {
         LOGGER.trace("updateFileNode: workspace={0}, path={1}, file={2}", workspace.getName(), path, file.getAbsolutePath());
-        FileNode fileNode = new FileNode(workspace, path, file);
+        FileNode fileNode = new FileNode(workspace, path, file, useVersioning);
         URL fileNodeUrl = fileNode.getUrl();
         URL fileNodeUrlWithTerseResponse = new URL(fileNodeUrl.toString() + "?mode:includeNode=false");
         HttpClientConnection connection = connect(workspace.getServer(), fileNodeUrlWithTerseResponse, RequestMethod.PUT);
@@ -444,6 +448,19 @@ public final class JsonRestClient implements IRestClient {
     public Status publish( Workspace workspace,
                            String path,
                            File file ) {
+        return publish(workspace, path, file, false);
+    }
+
+    /**
+     * {@inheritDoc}
+     * 
+     * @see org.modeshape.web.jcr.rest.client.IRestClient#publish(org.modeshape.web.jcr.rest.client.domain.Workspace,
+     *      java.lang.String, java.io.File, boolean)
+     */
+    public Status publish( Workspace workspace,
+                           String path,
+                           File file,
+                           boolean useVersioning ) {
         assert workspace != null;
         assert path != null;
         assert file != null;
@@ -452,12 +469,12 @@ public final class JsonRestClient implements IRestClient {
         try {
             if (pathExists(workspace, path, file)) {
                 // Update it ...
-                updateFileNode(workspace, path, file);
+                updateFileNode(workspace, path, file, useVersioning);
             } else {
                 // doesn't exist so make sure the parent path exists
                 ensureFolderExists(workspace, path);
                 // publish file
-                createFileNode(workspace, path, file);
+                createFileNode(workspace, path, file, useVersioning);
             }
 
         } catch (Exception e) {

--- a/web/modeshape-web-jcr-rest-client/src/test/java/org/modeshape/web/jcr/rest/client/MockRestClient.java
+++ b/web/modeshape-web-jcr-rest-client/src/test/java/org/modeshape/web/jcr/rest/client/MockRestClient.java
@@ -88,6 +88,20 @@ public final class MockRestClient implements IRestClient {
     /**
      * {@inheritDoc}
      * 
+     * @see org.modeshape.web.jcr.rest.client.IRestClient#publish(org.modeshape.web.jcr.rest.client.domain.Workspace,
+     *      java.lang.String, java.io.File, boolean)
+     */
+    @Override
+    public Status publish( Workspace workspace,
+                           String path,
+                           File file,
+                           boolean useVersioning ) {
+        return null;
+    }
+
+    /**
+     * {@inheritDoc}
+     * 
      * @see org.modeshape.web.jcr.rest.client.IRestClient#unpublish(org.modeshape.web.jcr.rest.client.domain.Workspace,
      *      java.lang.String, java.io.File)
      */


### PR DESCRIPTION
Previously, the REST client API would publish as file by creating an "nt:file" node with the standard properties and "jcr:content" child node, but would never create nodes that were versionable. This change adds a method to the IRestClient interface that allows a client to specify whether the published file should be versioned, in which case the "mix:versionable" mixin is added to the "nt:file" node's list of "jcr:mixinTypes".
