### PR TITLE
MODE-1112 Changes to support building in MEAD 

### DIFF
--- a/deploy/jbossas/modeshape-jbossas-web-rest-war/pom.xml
+++ b/deploy/jbossas/modeshape-jbossas-web-rest-war/pom.xml
@@ -160,7 +160,7 @@
          <artifactId>maven-deploy-plugin</artifactId>
           <version>${maven.deploy.plugin.version}</version>
          <configuration>
-           <skip>true</skip>
+           <skip>false</skip>
         </configuration>
       </plugin>
             

--- a/deploy/jbossas/modeshape-jbossas-web-webdav-war/pom.xml
+++ b/deploy/jbossas/modeshape-jbossas-web-webdav-war/pom.xml
@@ -154,7 +154,7 @@
               <artifactId>maven-deploy-plugin</artifactId>
               <version>${maven.deploy.plugin.version}</version>
               <configuration>
-                 <skip>true</skip>
+                 <skip>false</skip>
               </configuration>
             </plugin>
 

--- a/modeshape-distribution/pom.xml
+++ b/modeshape-distribution/pom.xml
@@ -1230,6 +1230,7 @@
 
 										-nopackagediagram
 					          </additionalparam>
+                      <detectOfflineLinks>false</detectOfflineLinks>
 		            </configuration>
 		          </execution>
 		          <execution>
@@ -1276,6 +1277,7 @@
 
 										-nopackagediagram
 					          </additionalparam>
+                      <detectOfflineLinks>false</detectOfflineLinks>
 		            </configuration>
 		          </execution>
 		        </executions>

--- a/utils/modeshape-jdbc/pom.xml
+++ b/utils/modeshape-jdbc/pom.xml
@@ -275,7 +275,7 @@
                     <phase>package</phase>
                     <configuration>
                         <tasks>
-                            <unzip src="target/modeshape-jdbc-${project.version}-http-jar-with-dependencies.zip" dest="target/tempjars" />
+                            <unzip src="target/modeshape-jdbc-${project.version}-http-jar-with-dependencies.jar" dest="target/tempjars" />
                             
                             <unzip src="target/tempjars/jaxrs-api-1.2.1.GA.jar" dest="target/temploc" />                                   
                             <unzip src="target/tempjars/jcr-2.0.jar" dest="target/temploc" />                                   

--- a/utils/modeshape-jdbc/src/assembly/kit.xml
+++ b/utils/modeshape-jdbc/src/assembly/kit.xml
@@ -6,7 +6,7 @@
   <id>http-jar-with-dependencies</id>
       
   <formats>
-    <format>zip</format>
+    <format>jar</format>
   </formats>
   <includeBaseDirectory>false</includeBaseDirectory>
 


### PR DESCRIPTION
A few changes to a few POMs are required to better support building ModeShape within MEAD. The changes were pretty minor, but full assembly builds do succeed with these changes.
