### PR TITLE
MODE-1112 Corrections to the build process

### DIFF
--- a/deploy/jbossas/assembly/kit.xml
+++ b/deploy/jbossas/assembly/kit.xml
@@ -22,17 +22,17 @@
         </fileSet>
     
         <fileSet>
-            <directory>modeshape-jbossas-service/target/distribution/modeshape-services.jar.dir</directory>
+            <directory>modeshape-jbossas-service/target/distribution/modeshape-services-jar-content</directory>
             <outputDirectory>deploy/modeshape-services.jar</outputDirectory>
         </fileSet>
         
         <fileSet>
-            <directory>modeshape-jbossas-web-rest-war/target/distribution/modeshape-rest.war.dir</directory>
+            <directory>modeshape-jbossas-web-rest-war/target/distribution/modeshape-rest-war-content</directory>
             <outputDirectory>deploy/modeshape-rest.war</outputDirectory>
         </fileSet>
 
         <fileSet>
-            <directory>modeshape-jbossas-web-webdav-war/target/distribution/modeshape-webdav.war.dir</directory>
+            <directory>modeshape-jbossas-web-webdav-war/target/distribution/modeshape-webdav-war-content</directory>
             <outputDirectory>deploy/modeshape-webdav.war</outputDirectory>
         </fileSet>
 				

--- a/deploy/jbossas/modeshape-jbossas-service/src/assembly/kit.xml
+++ b/deploy/jbossas/modeshape-jbossas-service/src/assembly/kit.xml
@@ -9,7 +9,7 @@
   in order to build a complete set of artifacts to be deployed to a JBoss AS server
  -->
   
-  <id>services.jar</id>
+  <id>services-jar-content</id>
    
   <formats>
 	<format>dir</format>

--- a/deploy/jbossas/modeshape-jbossas-web-rest-war/src/assembly/kit.xml
+++ b/deploy/jbossas/modeshape-jbossas-web-rest-war/src/assembly/kit.xml
@@ -8,7 +8,7 @@
   in order to build a complete set of artifacts to be deployed to a JBoss AS server
  -->
   
-  <id>rest.war</id>
+  <id>rest-war-content</id>
   
   <formats>
 	<format>dir</format>

--- a/deploy/jbossas/modeshape-jbossas-web-webdav-war/src/assembly/kit.xml
+++ b/deploy/jbossas/modeshape-jbossas-web-webdav-war/src/assembly/kit.xml
@@ -4,7 +4,7 @@
   xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.0 http://maven.apache.org/xsd/assembly-1.1.0.xsd">
 
   
-  <id>webdav.war</id>
+  <id>webdav-war-content</id>
   
   <formats>
 	<format>dir</format>

--- a/deploy/jbossas/pom.xml
+++ b/deploy/jbossas/pom.xml
@@ -55,6 +55,7 @@
 										<addClasspath>true</addClasspath>
 									</manifest>
 								</archive>
+								<attach>false</attach>
                                </configuration>
                                 <executions>
                                     <execution>


### PR DESCRIPTION
The build process created a `jbossas-{version}-{version}-dist.zip` file that was used as an intermediate file during assembly of the real `modeshape-jbossas-{version}-dist.zip` file. Not only was the filename incorrect (the version was in the name twice), but the file should not have been installed into the local repository. These changes correct the name and prevent the installation.

The `modeshape-jbossas-{version}-dist.zip` file was missing the exploded content from the `-service.jar`, `-web-rest.war` and `-web-webdav.war` files. This was due to a mismatched names between the modules' kit.xml files and the jbossas parent module's kit.xml. Correcting these results in correct content for the distribution ZIP file located at `deploy/jbossas/target/distribution/modeshape-jbossas-{version}-dist.zip`.
