### PR TITLE
MODE-1112 Explicitly set maven-assembly-plugin version to 2.2 to fix missing dependencies when modeshape chooses 2.2-beta-5

### DIFF
--- a/modeshape-assembly-descriptors/src/main/resources/assemblies/text-extractor-with-dependencies.xml
+++ b/modeshape-assembly-descriptors/src/main/resources/assemblies/text-extractor-with-dependencies.xml
@@ -24,7 +24,6 @@
   <fileSets>
     <fileSet>
       <directory>../../src/main/resources</directory>
-			<useStrictFiltering>true</useStrictFiltering>
 			<outputDirectory>META-INF</outputDirectory>
       <includes>
 				<include>AUTHORS.txt</include>

--- a/modeshape-parent/pom.xml
+++ b/modeshape-parent/pom.xml
@@ -689,6 +689,11 @@
 					<version>${maven.jar.plugin.version}</version>
 				</plugin>
 				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-assembly-plugin</artifactId>
+					<version>${maven.assembly.plugin.version}</version>
+				</plugin>
+				<plugin>
 					<groupId>org.apache.felix</groupId>
 					<artifactId>maven-bundle-plugin</artifactId>
 					<version>${maven.bundle.plugin.version}</version>


### PR DESCRIPTION
Added maven-assembly-plugin to the plugin management section of the parent pom.
Removed <useStrictFiltering> tag from a fileset as this is not valid in 2.2.
