### PR TITLE
MODE-1114 Corrected import (and replace) behavior when imported content includes versionable nodes 

### DIFF
--- a/modeshape-integration-tests/src/test/java/org/modeshape/test/integration/AbstractModeShapeTest.java
+++ b/modeshape-integration-tests/src/test/java/org/modeshape/test/integration/AbstractModeShapeTest.java
@@ -137,7 +137,20 @@ public abstract class AbstractModeShapeTest {
 
     protected static void importContent( Class<?> testClass,
                                          String pathToResourceFile,
+                                         int importBehavior ) throws Exception {
+        importContent(testClass, pathToResourceFile, null, importBehavior);
+    }
+
+    protected static void importContent( Class<?> testClass,
+                                         String pathToResourceFile,
                                          String jcrPathToImportUnder ) throws Exception {
+        importContent(testClass, pathToResourceFile, jcrPathToImportUnder, ImportUUIDBehavior.IMPORT_UUID_CREATE_NEW);
+    }
+
+    protected static void importContent( Class<?> testClass,
+                                         String pathToResourceFile,
+                                         String jcrPathToImportUnder,
+                                         int importBehavior ) throws Exception {
         // Use a session to load the contents ...
         Session session = repository.login();
         try {
@@ -151,7 +164,7 @@ public abstract class AbstractModeShapeTest {
             if (jcrPathToImportUnder == null || jcrPathToImportUnder.trim().length() == 0) jcrPathToImportUnder = "/";
 
             try {
-                session.getWorkspace().importXML(jcrPathToImportUnder, stream, ImportUUIDBehavior.IMPORT_UUID_CREATE_NEW);
+                session.getWorkspace().importXML(jcrPathToImportUnder, stream, importBehavior);
             } finally {
                 stream.close();
             }

--- a/modeshape-integration-tests/src/test/java/org/modeshape/test/integration/performance/JcrRepositoryPerformanceTest.java
+++ b/modeshape-integration-tests/src/test/java/org/modeshape/test/integration/performance/JcrRepositoryPerformanceTest.java
@@ -35,6 +35,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
+import javax.jcr.ImportUUIDBehavior;
 import javax.jcr.Node;
 import javax.jcr.NodeIterator;
 import javax.jcr.Property;
@@ -67,7 +68,7 @@ public class JcrRepositoryPerformanceTest extends AbstractAdHocModeShapeTest {
         printDetail = false;
     }
 
-    @Ignore( "Removed from automatic builds. Can be run manually." )
+    @Ignore( "Removed from automatic builds due to time of test. Can be run manually." )
     @Test
     public void shouldSimulateGuvnorUsageAgainstRepositoryWithInMemoryStore() throws Exception {
         print = true;
@@ -80,14 +81,14 @@ public class JcrRepositoryPerformanceTest extends AbstractAdHocModeShapeTest {
         // Verify the file was imported ...
         withSession(new VerifyContent());
 
-        simulateGuvnorUsage();
+        simulateGuvnorUsage(5);
     }
 
-    @Ignore( "Removed from automatic builds. Can be run manually." )
+    @Ignore( "Removed from automatic builds due to time of test. Can be run manually." )
     @Test
     public void shouldSimulateGuvnorUsageAgainstRepositoryWithJpaStore() throws Exception {
         print = true;
-        startEngine("config/configRepositoryForDroolsJpaPerformance.xml", "Repo");
+        startEngine("config/configRepositoryForDroolsJpaCreate.xml", "Repo");
         assertNode("/", "mode:root");
         // import the file ...
         importContent(getClass(), "io/drools/mortgage-sample-repository.xml");
@@ -96,14 +97,15 @@ public class JcrRepositoryPerformanceTest extends AbstractAdHocModeShapeTest {
         // Verify the file was imported ...
         withSession(new VerifyContent());
 
-        simulateGuvnorUsage();
+        simulateGuvnorUsage(4);
     }
 
+    @Ignore( "Removed from automatic builds due to time of test. Can be run manually." )
     @FixFor( "MODE-1113" )
     @Test
     public void shouldHaveImportContentAvailableAfterRestart() throws Exception {
         // print = true;
-        startEngine("config/configRepositoryForDroolsJpaPerformance.xml", "Repo");
+        startEngine("config/configRepositoryForDroolsJpaCreate.xml", "Repo");
         assertNode("/", "mode:root");
         // import the file ...
         importContent(getClass(), "io/drools/mortgage-sample-repository.xml");
@@ -125,7 +127,208 @@ public class JcrRepositoryPerformanceTest extends AbstractAdHocModeShapeTest {
         withSession(new VerifyContent());
     }
 
-    protected void simulateGuvnorUsage() throws Exception {
+    @FixFor( "MODE-1114" )
+    @Test
+    public void shouldImportMultipleTimesAsNewContent() throws Exception {
+        // print = true;
+        // printDetail = false;
+        startEngine("config/configRepositoryForDroolsInMemoryPerformance.xml", "Repo");
+        assertNode("/", "mode:root");
+
+        // import the file multiple times ...
+        int importBehavior = ImportUUIDBehavior.IMPORT_UUID_CREATE_NEW;
+        for (int i = 0; i != 3; ++i) {
+            importContent(getClass(), "io/drools/mortgage-sample-repository.xml", importBehavior);
+            session().refresh(false);
+            assertNode("/drools:repository");
+
+            // Verify the file was imported ...
+            withSession(new VerifyContent());
+        }
+
+        simulateGuvnorUsage(1);
+    }
+
+    @Ignore( "Removed from automatic builds due to time of test. Can be run manually." )
+    @FixFor( "MODE-1114" )
+    @Test
+    public void shouldImportMultipleTimesAsNewContentUsingJpa() throws Exception {
+        // print = true;
+        // printDetail = false;
+        startEngine("config/configRepositoryForDroolsJpaCreate.xml", "Repo");
+        assertNode("/", "mode:root");
+
+        // import the file multiple times ...
+        int importBehavior = ImportUUIDBehavior.IMPORT_UUID_CREATE_NEW;
+        for (int i = 0; i != 3; ++i) {
+            importContent(getClass(), "io/drools/mortgage-sample-repository.xml", importBehavior);
+            session().refresh(false);
+            assertNode("/drools:repository");
+
+            // Verify the file was imported ...
+            withSession(new VerifyContent());
+        }
+
+        simulateGuvnorUsage(1);
+    }
+
+    @FixFor( "MODE-1114" )
+    @Test
+    public void shouldImportMultipleTimesAsReplacedContent() throws Exception {
+        print = true;
+        printDetail = false;
+        startEngine("config/configRepositoryForDroolsInMemoryPerformance.xml", "Repo");
+        assertNode("/", "mode:root");
+
+        // import the file multiple times ...
+        int importBehavior = ImportUUIDBehavior.IMPORT_UUID_COLLISION_REPLACE_EXISTING;
+        for (int i = 0; i != 2; ++i) {
+            importContent(getClass(), "io/drools/mortgage-sample-repository.xml", importBehavior);
+            session().refresh(false);
+            assertNode("/drools:repository");
+
+            // Verify the file was imported ...
+            withSession(new VerifyContent());
+        }
+
+        simulateGuvnorUsage(1);
+    }
+
+    @Ignore( "Removed from automatic builds due to time of test. Can be run manually." )
+    @FixFor( "MODE-1114" )
+    @Test
+    public void shouldImportMultipleTimesAsReplacedContentUsingJpa() throws Exception {
+        print = true;
+        printDetail = false;
+        startEngine("config/configRepositoryForDroolsJpaCreate.xml", "Repo");
+        assertNode("/", "mode:root");
+
+        // import the file multiple times ...
+        int importBehavior = ImportUUIDBehavior.IMPORT_UUID_COLLISION_REPLACE_EXISTING;
+        for (int i = 0; i != 2; ++i) {
+            importContent(getClass(), "io/drools/mortgage-sample-repository.xml", importBehavior);
+            session().refresh(false);
+            assertNode("/drools:repository");
+
+            // Verify the file was imported ...
+            withSession(new VerifyContent());
+        }
+
+        simulateGuvnorUsage(1);
+    }
+
+    @FixFor( "MODE-1114" )
+    @Test
+    public void shouldImportOnceAndSimulateGuvnorUsage() throws Exception {
+        // print = true;
+        // printDetail = false;
+        startEngine("config/configRepositoryForDroolsInMemoryPerformance.xml", "Repo");
+        assertNode("/", "mode:root");
+
+        // import the file multiple times ...
+        int importBehavior = ImportUUIDBehavior.IMPORT_UUID_COLLISION_REPLACE_EXISTING;
+        importContent(getClass(), "io/drools/mortgage-sample-repository.xml", importBehavior);
+        session().refresh(false);
+        assertNode("/drools:repository");
+
+        // Verify the file was imported ...
+        withSession(new VerifyContent());
+
+        simulateGuvnorUsage(1);
+    }
+
+    @FixFor( "MODE-1114" )
+    @Test
+    public void shouldImportOnceAndSimulateGuvnorUsageUsingJpa() throws Exception {
+        // print = true;
+        // printDetail = false;
+        startEngine("config/configRepositoryForDroolsJpaCreate.xml", "Repo");
+        assertNode("/", "mode:root");
+
+        // import the file multiple times ...
+        int importBehavior = ImportUUIDBehavior.IMPORT_UUID_COLLISION_REPLACE_EXISTING;
+        importContent(getClass(), "io/drools/mortgage-sample-repository.xml", importBehavior);
+        session().refresh(false);
+        assertNode("/drools:repository");
+
+        // Verify the file was imported ...
+        withSession(new VerifyContent());
+
+        simulateGuvnorUsage(1);
+    }
+
+    @FixFor( "MODE-1114" )
+    @Test
+    public void shouldImportAndSimulateGuvnorUsageTwice() throws Exception {
+        // print = true;
+        // printDetail = false;
+        startEngine("config/configRepositoryForDroolsInMemoryPerformance.xml", "Repo");
+        assertNode("/", "mode:root");
+
+        // import the file multiple times ...
+        int importBehavior = ImportUUIDBehavior.IMPORT_UUID_COLLISION_REPLACE_EXISTING;
+        importContent(getClass(), "io/drools/mortgage-sample-repository.xml", importBehavior);
+        session().refresh(false);
+        assertNode("/drools:repository");
+
+        // Verify the file was imported ...
+        withSession(new VerifyContent());
+
+        simulateGuvnorUsage(2);
+        withSession(new PrintVersionHistory("/drools:repository/drools:package_area/mortgages/assets/ApplicantDsl"));
+
+        // Import over the top ...
+        session().refresh(false);
+        importContent(getClass(), "io/drools/mortgage-sample-repository.xml", importBehavior);
+        session().refresh(false);
+        assertNode("/drools:repository");
+
+        // Verify the file was imported ...
+        withSession(new VerifyContent());
+        withSession(new PrintVersionHistory("/drools:repository/drools:package_area/mortgages/assets/ApplicantDsl"));
+
+        simulateGuvnorUsage(1);
+
+        withSession(new PrintVersionHistory("/drools:repository/drools:package_area/mortgages/assets/ApplicantDsl"));
+    }
+
+    @Ignore( "Removed from automatic builds due to time of test. Can be run manually." )
+    @FixFor( "MODE-1114" )
+    @Test
+    public void shouldImportAndSimulateGuvnorUsageTwiceUsingJpa() throws Exception {
+        // print = true;
+        // printDetail = false;
+        startEngine("config/configRepositoryForDroolsJpaCreate.xml", "Repo");
+        assertNode("/", "mode:root");
+
+        // import the file multiple times ...
+        int importBehavior = ImportUUIDBehavior.IMPORT_UUID_COLLISION_REPLACE_EXISTING;
+        importContent(getClass(), "io/drools/mortgage-sample-repository.xml", importBehavior);
+        session().refresh(false);
+        assertNode("/drools:repository");
+
+        // Verify the file was imported ...
+        withSession(new VerifyContent());
+        withSession(new PrintVersionHistory("/drools:repository/drools:package_area/mortgages/assets/ApplicantDsl"));
+
+        // simulateGuvnorUsage(1);
+
+        // Import over the top ...
+        session().refresh(false);
+        importContent(getClass(), "io/drools/mortgage-sample-repository.xml", importBehavior);
+        session().refresh(false);
+        assertNode("/drools:repository");
+
+        // Verify the file was imported ...
+        withSession(new VerifyContent());
+        withSession(new PrintVersionHistory("/drools:repository/drools:package_area/mortgages/assets/ApplicantDsl"));
+
+        simulateGuvnorUsage(1);
+
+    }
+
+    protected void simulateGuvnorUsage( int count ) throws Exception {
+        assertThat(count >= 0, is(true));
 
         // for (int i = 0; i != 30; ++i) {
         // // Create a snapshot ...
@@ -137,7 +340,7 @@ public class JcrRepositoryPerformanceTest extends AbstractAdHocModeShapeTest {
         Stopwatch total = new Stopwatch(true, "Total usage");
         Stopwatch sw15 = new Stopwatch(true, "First " + NUMBER_OF_COPIES);
         Stopwatch swRest = new Stopwatch(true, "Remaining");
-        for (int i = 0; i != 30; ++i) {
+        for (int i = 0; i != count; ++i) {
             sw.start();
             total.start();
             if (i <= NUMBER_OF_COPIES) sw15.start();
@@ -338,6 +541,40 @@ public class JcrRepositoryPerformanceTest extends AbstractAdHocModeShapeTest {
             checkout(assetNode);
             updateDescription(assetNode, "This is the new description");
             checkin(assetNode, "First change");
+        }
+    }
+
+    protected class PrintVersionHistory extends DroolsOperation {
+        private String path;
+
+        public PrintVersionHistory( String path ) {
+            this.path = path;
+        }
+
+        @SuppressWarnings( "synthetic-access" )
+        public void run( Session s ) throws RepositoryException {
+            Node assetNode = s.getNode(path);
+            VersionManager vmgr = s.getWorkspace().getVersionManager();
+            Node versionHistory = vmgr.getVersionHistory(path);
+            if (print) {
+                print("");
+                print("Node with history:");
+                printNode(assetNode);
+                printSubgraph(versionHistory);
+                // print(" Base version:");
+                // Node baseVersion = vmgr.getBaseVersion(path);
+                // print(baseVersion.getPath());
+                // printSubgraph(baseVersion);
+                // print(" Predecessors:");
+                // Property predecessors = assetNode.getProperty("jcr:predecessors");
+                // if (predecessors != null) {
+                // for (Value value : predecessors.getValues()) {
+                // Node predecessor = s.getNodeByIdentifier(value.getString());
+                // print(predecessor.getPath());
+                // printSubgraph(predecessor);
+                // }
+                // }
+            }
         }
     }
 

--- a/modeshape-integration-tests/src/test/resources/config/configRepositoryForDroolsJpaCreate.xml
+++ b/modeshape-integration-tests/src/test/resources/config/configRepositoryForDroolsJpaCreate.xml
@@ -43,7 +43,7 @@
             mode:compressData="${jpaSource.compressData}"
             mode:predefinedWorkspaceNames="default, otherWorkspace, system"
             mode:showSql="${jpaSource.showSql}"
-            mode:autoGenerateSchema="update"
+            mode:autoGenerateSchema="create"
             mode:creatingWorkspacesAllowed="true"
             mode:defaultWorkspaceName="default"/>    
     </mode:sources>

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrContentHandler.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrContentHandler.java
@@ -223,9 +223,9 @@ class JcrContentHandler extends DefaultHandler {
                     // properties are valid. If they are, then the history must have been imported (or the import
                     // replaced a versionable node that already had history).
                     boolean validHistory = isValidReference(node, JcrLexicon.VERSION_HISTORY, false);
-                    boolean validBaseVersion = isValidReference(node, JcrLexicon.BASE_VERSION, false);
-                    boolean validPredecessors = isValidReference(node, JcrLexicon.PREDECESSORS, false);
                     if (validHistory) {
+                        boolean validBaseVersion = isValidReference(node, JcrLexicon.BASE_VERSION, false);
+                        boolean validPredecessors = isValidReference(node, JcrLexicon.PREDECESSORS, false);
                         // There is a valid version history already ...
                         if (!validBaseVersion || !validPredecessors) {
                             // The imported base version is not valid anymore, so set it to the base version from the history ...
@@ -672,7 +672,10 @@ class JcrContentHandler extends DefaultHandler {
                         switch (uuidBehavior) {
                             case ImportUUIDBehavior.IMPORT_UUID_COLLISION_REPLACE_EXISTING:
                                 parent = existingNodeWithUuid.getParent();
-                                existingNodeWithUuid.remove();
+                                // Destroy the existing node, but do so via the cache so that we don't record
+                                // the removal by UUID, since the new node has the same UUID and the import
+                                // may create references to the new node)
+                                existingNodeWithUuid.editor().destroy();
                                 break;
                             case ImportUUIDBehavior.IMPORT_UUID_CREATE_NEW:
                                 uuid = UUID.randomUUID();
@@ -684,7 +687,10 @@ class JcrContentHandler extends DefaultHandler {
                                                                                                                        uuid,
                                                                                                                        parent.getPath()));
                                 }
-                                existingNodeWithUuid.remove();
+                                // Destroy the existing node, but do so via the cache so that we don't record
+                                // the removal by UUID, since the new node has the same UUID and the import
+                                // may create references to the new node)
+                                existingNodeWithUuid.editor().destroy();
                                 break;
                             case ImportUUIDBehavior.IMPORT_UUID_COLLISION_THROW:
                                 throw new ItemExistsException(

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrTools.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrTools.java
@@ -512,7 +512,7 @@ public class JcrTools {
             }
         }
         sb.append(" jcr:primaryType=" + node.getPrimaryNodeType().getName());
-        boolean referenceable = false;
+        boolean referenceable = node.isNodeType("mix:referenceable");
         if (node.getMixinNodeTypes().length != 0) {
             sb.append(" jcr:mixinTypes=[");
             boolean first = true;
@@ -520,7 +520,6 @@ public class JcrTools {
                 if (first) first = false;
                 else sb.append(',');
                 sb.append(mixin.getName());
-                if (mixin.getName().equals("mix:referenceable")) referenceable = true;
             }
             sb.append(']');
         }

--- a/modeshape-jcr/src/main/resources/org/modeshape/jcr/JcrI18n.properties
+++ b/modeshape-jcr/src/main/resources/org/modeshape/jcr/JcrI18n.properties
@@ -210,7 +210,7 @@ errorSynchronizingNodeTypes = Node types changed due to remote update.  Could no
 
 errorRefreshingNodeTypesFromSystem = Encountered the following error(s) while reading the node types from the system content: {0}
 problemRefreshingNodeTypesFromSystem = Encountered following problems reading node types from system content: {0}
-errorRefreshingNodeTypes = Node types were read from the system content, and appear to be inconsistent or invalid.
+errorRefreshingNodeTypes = Node types were read from the system content, and appear to be inconsistent or invalid: {0}
 
 # Lock messages
 nodeNotLockable = The node at '{0}' is not lockable.  Add the 'mix:lockable' mixin type to make it lockable.


### PR DESCRIPTION
Added several new integration tests to try and replicate the problem. One of these tests did replicate it: the trick was to import an XML file (with referenceable nodes and versionable nodes), to re-import the same XML file while replacing content with duplicate UUIDs, and then checking out, changing, and checking in one of the versionable nodes (that is a descendant of another versionable node that was imported). The checkin causes the problem because it attempted to resolve the 'jcr:predecessors' REFERENCE property, which contains a UUID that does not correspond to a node in the repository.

After quite a bit of debugging (almost two days), I was able to figure out what was actually going on. Basically, when the second import is happening and is importing a node with the same UUID as an existing node, the existing node must be replaced (e.g., removed). If that existing node is also versionable, then there is a version history and this was not being removed. Removing these version histories did not work and resulting in what appeared to be invalid, since it prevents recovering of previously-versioning information.

A second approach was more successful: leave the version history and remove the "mix:versionable" properties from the newly-imported nodes (as was being done already). The JcrVersionManager code that initializes the version history was always generating a new UUID for the base version, even though this new UUID is not written to the version history if the version history already exists. (The JcrVersionManager code creates a node with the UUID only if the node is absent.) This is the fundamental source of the problem. Simply re-reading the root version's UUID and using it for the "jcr:baseVersion" property and in the "jcr:predecessors" property appears to work.

The new integration tests test a number of permutations of operations on both in-memory and JDBC connectors, and these tests pass - as do all other unit and integration tests. Therefore, this appears to fix the issue, and results in identical behavior and version history content whether or not the content is imported multiple times. In other words, the behavior when importing multiple times and modifying the versioned content (using checkout, modify, checkin) is the same as importing once and doing the same modifications.

However, during verification of the results, [MODE-1117](https://issues.jboss.org/browse/MODE-1117) was discovered. Although not technically related to this issue, it does cause the "jcr:predecessors" and "jcr:successors" properties to be incorrect.

These changes need to be merged into the '2.2.x' branch.
