### PR TITLE
MODE-1108, Making 3 module compile with JDK backwards compatibility.

### DIFF
--- a/modeshape-graph/pom.xml
+++ b/modeshape-graph/pom.xml
@@ -79,6 +79,19 @@
   </dependencies>
 	<build>
 		<plugins>
+                        <!-- Specify the compiler options and settings -->
+                        <plugin>
+                                <groupId>org.apache.maven.plugins</groupId>
+                                <artifactId>maven-compiler-plugin</artifactId>
+                                <version>${maven.compiler.plugin.version}</version>
+                                <configuration>
+                                        <source>1.5</source>
+                                        <target>1.5</target>
+                                        <showDeprecation>false</showDeprecation>
+                                        <showWarnings>false</showWarnings>
+                                </configuration>
+                        </plugin>
+
 			<!--
 				Adding OSGI metadata to the JAR without changing the packaging type.
 			-->

--- a/modeshape-jcr-api/pom.xml
+++ b/modeshape-jcr-api/pom.xml
@@ -32,6 +32,19 @@
 
   <build>
 	<plugins>
+           <!-- Specify the compiler options and settings -->
+                        <plugin>
+                                <groupId>org.apache.maven.plugins</groupId>
+                                <artifactId>maven-compiler-plugin</artifactId>
+                                <version>${maven.compiler.plugin.version}</version>
+                                <configuration>
+                                        <source>1.5</source>
+                                        <target>1.5</target>
+                                        <showDeprecation>false</showDeprecation>
+                                        <showWarnings>false</showWarnings>
+                                </configuration>
+                        </plugin>
+
 	  <!--
 	Adding OSGI metadata to the JAR without changing the packaging type.
 			-->

--- a/modeshape-jcr/pom.xml
+++ b/modeshape-jcr/pom.xml
@@ -179,6 +179,18 @@
       </resource>
     </resources>
     <plugins>
+      <!-- Specify the compiler options and settings -->
+         <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <version>${maven.compiler.plugin.version}</version>
+            <configuration>
+                <source>1.5</source>
+                <target>1.5</target>
+                <showDeprecation>false</showDeprecation>
+                <showWarnings>false</showWarnings>
+            </configuration>
+      </plugin>
       <!--
     	Adding OSGI metadata to the JAR without changing the packaging type.
       -->


### PR DESCRIPTION
Hi guys,

This patch allows the guvnor project to compile with JDK 1.5. This enables us to drastically reduce the complexity of the guvnor build. 

Cheers,

--Kurt
