### PR TITLE
MODE-1131 Corrected REST query handling of null values in query results

### DIFF
--- a/web/modeshape-web-jcr-rest-client/src/main/java/org/modeshape/web/jcr/rest/client/domain/QueryRow.java
+++ b/web/modeshape-web-jcr-rest-client/src/main/java/org/modeshape/web/jcr/rest/client/domain/QueryRow.java
@@ -20,7 +20,7 @@ public class QueryRow {
     }
 
     public Collection<String> getColumnNames() {
-        return values.keySet();
+        return queryTypes != null ? queryTypes.keySet() : values.keySet();
     }
 
     public Object getValue( String columnName ) {
@@ -29,5 +29,15 @@ public class QueryRow {
 
     public String getColumnType( String columnName ) {
         return queryTypes.get(columnName);
+    }
+
+    /**
+     * {@inheritDoc}
+     * 
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+        return values.toString();
     }
 }

--- a/web/modeshape-web-jcr-rest-client/src/main/java/org/modeshape/web/jcr/rest/client/json/JsonRestClient.java
+++ b/web/modeshape-web-jcr-rest-client/src/main/java/org/modeshape/web/jcr/rest/client/json/JsonRestClient.java
@@ -634,6 +634,8 @@ public final class JsonRestClient implements IRestClient {
             String response = connection.read();
             JSONObject result = new JSONObject(response);
             Map<String, String> columnTypes = new HashMap<String, String>();
+
+            // Get the result types ...
             if (result.has("types")) {
                 JSONObject types = (JSONObject)result.get("types");
 
@@ -645,6 +647,7 @@ public final class JsonRestClient implements IRestClient {
 
             Map<String, String> types = Collections.unmodifiableMap(columnTypes);
 
+            // Get the rows ...
             JSONArray rows = (JSONArray)result.get("rows");
             List<QueryRow> queryRows = new LinkedList<QueryRow>();
             for (int i = 0; i < rows.length(); i++) {

--- a/web/modeshape-web-jcr-rest-war/src/main/resources/configRepository.xml
+++ b/web/modeshape-web-jcr-rest-war/src/main/resources/configRepository.xml
@@ -42,6 +42,8 @@
             <nodeTypes jcr:primaryType="nodeTypes"/>
             <!-- Define any namespaces for this repository, other than those already defined by JCR or ModeShape-->
             <namespaces jcr:primaryType="namespaces" />
+            <!-- Define what the initial content looks like for each workspace -->
+            <initialContent workspaces="default" applyToNewWorkspaces="true" content="modeshape-initial-content.xml"/>
         </repository>
     </repositories>
 </configuration>

--- a/web/modeshape-web-jcr-rest-war/src/main/resources/modeshape-initial-content.xml
+++ b/web/modeshape-web-jcr-rest-war/src/main/resources/modeshape-initial-content.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- 
+  ~ ModeShape (http://www.modeshape.org)
+  ~
+  ~ See the COPYRIGHT.txt file distributed with this work for information
+  ~ regarding copyright ownership.  Some portions may be licensed
+  ~ to Red Hat, Inc. under one or more contributor license agreements.
+  ~ See the AUTHORS.txt file in the distribution for a full listing of 
+  ~ individual contributors.
+  ~
+  ~ ModeShape is free software. Unless otherwise indicated, all code in ModeShape
+  ~ is licensed to you under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ ModeShape is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+  ~ or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+  ~ for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public License
+  ~ along with this distribution; if not, write to:
+  ~ Free Software Foundation, Inc.
+  ~ 51 Franklin Street, Fifth Floor
+  ~ Boston, MA  02110-1301  USA
+  -->
+<files xmlns:jcr="http://www.jcp.org/jcr/1.0" jcr:primaryType="nt:folder" jcr:mixinTypes="mode:publishArea">
+</files>

--- a/web/modeshape-web-jcr-rest-war/src/test/java/org/modeshape/web/jcr/rest/JcrResourcesTest.java
+++ b/web/modeshape-web-jcr-rest-war/src/test/java/org/modeshape/web/jcr/rest/JcrResourcesTest.java
@@ -206,8 +206,8 @@ public class JcrResourcesTest {
         assertThat(properties.get("jcr:uuid"), is(notNullValue()));
 
         JSONArray children = body.getJSONArray("children");
-        assertThat(children.length(), is(1));
-        assertThat(children.getString(0), is("jcr:system"));
+        assertThat(children.length(), is(2));
+        assertThat(children.getString(1), is("jcr:system"));
 
         assertThat(connection.getResponseCode(), is(HttpURLConnection.HTTP_OK));
         connection.disconnect();
@@ -231,7 +231,7 @@ public class JcrResourcesTest {
         assertThat(properties.get("jcr:uuid"), is(notNullValue()));
 
         JSONObject children = body.getJSONObject("children");
-        assertThat(children.length(), is(1));
+        assertThat(children.length(), is(2));
 
         JSONObject system = children.getJSONObject("jcr:system");
         assertThat(system.length(), is(2));

--- a/web/modeshape-web-jcr-rest/src/main/java/org/modeshape/web/jcr/rest/QueryHandler.java
+++ b/web/modeshape-web-jcr-rest/src/main/java/org/modeshape/web/jcr/rest/QueryHandler.java
@@ -16,10 +16,10 @@ import javax.jcr.query.Row;
 import javax.jcr.query.RowIterator;
 import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.core.UriInfo;
-import org.modeshape.common.annotation.Immutable;
 import org.codehaus.jettison.json.JSONArray;
 import org.codehaus.jettison.json.JSONException;
 import org.codehaus.jettison.json.JSONObject;
+import org.modeshape.common.annotation.Immutable;
 
 /**
  * Resource handler that implements REST methods for items.
@@ -86,7 +86,9 @@ public class QueryHandler extends AbstractHandler {
             for (String columnName : columnNames) {
                 Value value = resultRow.getValue(columnName);
 
-                if (value.getType() == PropertyType.BINARY) {
+                if (value == null) {
+                    // do nothing ...
+                } else if (value.getType() == PropertyType.BINARY) {
                     jsonRow.put(columnName + BASE64_ENCODING_SUFFIX, jsonEncodedStringFor(value));
                 } else {
                     jsonRow.put(columnName, value.getString());


### PR DESCRIPTION
The QueryHandler logic was always presuming there would be a non-null Value object in all query results. Obviously, this is wrong.

Added unit and integration tests to verify that using the REST API to issue queries where the results do contain null values does indeed result in the same exceptions. This required changing the 'modeshape-web-jcr-rest-war' module's JCR configuration to add initial content (with one node that had no value for an optional property).

Then, corrected the logic to look for null values and not record a value for the column name in the JSON response. Also verified that the JsonRestClient class is properly handling such missing name/value pairs, while still properly containing the name of the columns.

Verified that the new unit and integration tests pass with the fixes. Indeed, all unit and integration tests pass.
