### PR TITLE
MODE-1135 Added function framework to the Graph API

### DIFF
--- a/modeshape-graph/src/main/java/org/modeshape/graph/request/FunctionRequest.java
+++ b/modeshape-graph/src/main/java/org/modeshape/graph/request/FunctionRequest.java
@@ -1,0 +1,428 @@
+/*
+ * ModeShape (http://www.modeshape.org)
+ * See the COPYRIGHT.txt file distributed with this work for information
+ * regarding copyright ownership.  Some portions may be licensed
+ * to Red Hat, Inc. under one or more contributor license agreements.
+ * See the AUTHORS.txt file in the distribution for a full listing of 
+ * individual contributors.
+ *
+ * ModeShape is free software. Unless otherwise indicated, all code in ModeShape
+ * is licensed to you under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ * 
+ * ModeShape is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.modeshape.graph.request;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import org.modeshape.common.util.CheckArg;
+import org.modeshape.common.util.HashCode;
+import org.modeshape.graph.ExecutionContext;
+import org.modeshape.graph.GraphI18n;
+import org.modeshape.graph.Location;
+import org.modeshape.graph.connector.base.Processor;
+import org.modeshape.graph.property.PropertyType;
+import org.modeshape.graph.property.ValueFactories;
+import org.modeshape.graph.property.ValueFactory;
+import org.modeshape.graph.property.ValueFormatException;
+import org.modeshape.graph.request.function.Function;
+
+/**
+ * 
+ */
+public final class FunctionRequest extends Request implements Cloneable {
+
+    private static final long serialVersionUID = 1L;
+
+    private final Location at;
+    private final String workspaceName;
+    private final Function function;
+    private final Map<String, Serializable> inputs;
+    private final Map<String, Serializable> outputs;
+    private List<Request> requests;
+    private Location actualLocation;
+
+    /**
+     * Create a request to execute the function the properties and number of children of a node at the supplied location.
+     * 
+     * @param function the function to be performed
+     * @param at the location of the node to be read
+     * @param workspaceName the name of the workspace containing the node
+     * @param inputs the immutable map of input names to values for the function invocation, or null if there are no inputs
+     * @throws IllegalArgumentException if the function, location or workspace name is null
+     */
+    public FunctionRequest( Function function,
+                            Location at,
+                            String workspaceName,
+                            Map<String, Serializable> inputs ) {
+        CheckArg.isNotNull(function, "function");
+        CheckArg.isNotNull(at, "at");
+        CheckArg.isNotNull(workspaceName, "workspaceName");
+        this.workspaceName = workspaceName;
+        this.at = at;
+        this.function = function;
+        this.inputs = inputs != null ? inputs : Collections.<String, Serializable>emptyMap();
+        this.outputs = new HashMap<String, Serializable>();
+    }
+
+    /**
+     * {@inheritDoc}
+     * 
+     * @see org.modeshape.graph.request.Request#isReadOnly()
+     */
+    @Override
+    public boolean isReadOnly() {
+        return function.isReadOnly();
+    }
+
+    /**
+     * Get the location defining the node that is to be read.
+     * 
+     * @return the location of the node; never null
+     */
+    public Location at() {
+        return at;
+    }
+
+    /**
+     * Get the name of the workspace in which the function is being applied.
+     * 
+     * @return the name of the workspace; never null
+     */
+    public String inWorkspace() {
+        return workspaceName;
+    }
+
+    /**
+     * The unmodifiable map of input parameter name to value.
+     * 
+     * @return the map of input names to values; never null but possibly empty
+     */
+    public Map<String, Serializable> inputs() {
+        return inputs;
+    }
+
+    /**
+     * Get the value for the named input to this function. If the actual value corresponds to a {@link PropertyType}, then the
+     * value will be converted to the specified type using the {@link ExecutionContext}'s {@link ValueFactories}. Otherwise, the
+     * value will simply be cast to the supplied type.
+     * 
+     * @param <T> the desired type of the value
+     * @param name the name of the input parameter
+     * @param type the expected type of the value
+     * @param defaultValue the default value to use, if the input doesn't have the named parameter
+     * @param context the execution context to be used for converting the value; may not be null
+     * @return the (possibly null) value for the named input, or the specified default value if there is no such named parameter
+     * @throws ValueFormatException if the conversion from to the expected value could not be performed
+     */
+    public <T> T input( String name,
+                        Class<T> type,
+                        T defaultValue,
+                        ExecutionContext context ) {
+        return convert(name, type, defaultValue, this.inputs, context);
+    }
+
+    /**
+     * Get the value for the named input to this function. The actual value will be converted to the specified type using the
+     * {@link ExecutionContext}'s {@link ValueFactories}.
+     * 
+     * @param <T> the desired type of the value
+     * @param name the name of the input parameter
+     * @param type the expected type of the value
+     * @param defaultValue the default value to use, if the input doesn't have the named parameter
+     * @param context the execution context to be used for converting the value; may not be null
+     * @return the (possibly null) value for the named input, or the specified default value if there is no such named parameter
+     * @throws ValueFormatException if the conversion from to the expected value could not be performed
+     */
+    public <T> T input( String name,
+                        PropertyType type,
+                        T defaultValue,
+                        ExecutionContext context ) {
+        return convert(name, type, defaultValue, this.inputs, context);
+    }
+
+    /**
+     * Get the function implementation
+     * 
+     * @return the function implementation; never null
+     */
+    public Function function() {
+        return function;
+    }
+
+    /**
+     * The unmodifiable map of input parameter name to value.
+     * 
+     * @return the map of input names to values; never null but possibly empty
+     */
+    public Map<String, Serializable> outputs() {
+        return outputs;
+    }
+
+    /**
+     * Get the value for the named output to this function.
+     * 
+     * @param <T> the desired type of the value
+     * @param name the name of the output parameter
+     * @param type the expected type of the value used to convert the actual value using the
+     * @param context the execution context to be used for converting the value; may not be null
+     * @return the (possibly null) value for the named output, or null if there is no such named parameter
+     * @throws ValueFormatException if the conversion from to the expected value could not be performed
+     */
+    public <T> T output( String name,
+                         Class<T> type,
+                         ExecutionContext context ) {
+        return convert(name, type, null, this.outputs, context);
+    }
+
+    /**
+     * Get the value for the named output to this function.
+     * 
+     * @param <T> the desired type of the value
+     * @param name the name of the output parameter
+     * @param type the expected type of the value used to convert the actual value using the
+     * @param defaultValue the default value for the output parameter, if there is no such named parameter
+     * @param context the execution context to be used for converting the value; may not be null
+     * @return the (possibly null) value for the named output, or the specified default if there is no such named parameter
+     * @throws ValueFormatException if the conversion from to the expected value could not be performed
+     */
+    public <T> T output( String name,
+                         Class<T> type,
+                         T defaultValue,
+                         ExecutionContext context ) {
+        return convert(name, type, defaultValue, this.outputs, context);
+    }
+
+    /**
+     * Get the value for the named output to this function. The actual value will be converted to the specified type using the
+     * {@link ExecutionContext}'s {@link ValueFactories}.
+     * <p>
+     * This is a convenience method, as the value would have already been set by the same function invocation using
+     * {@link #setOutput(String, Serializable)}.
+     * </p>
+     * 
+     * @param <T> the desired type of the value
+     * @param name the name of the output parameter
+     * @param type the expected type of the value
+     * @param defaultValue the default value for the output parameter, if there is no such named parameter
+     * @param context the execution context to be used for converting the value; may not be null
+     * @return the (possibly null) value for the named output, or null if there is no such named parameter
+     * @throws ValueFormatException if the conversion from to the expected value could not be performed
+     */
+    public <T> T output( String name,
+                         PropertyType type,
+                         T defaultValue,
+                         ExecutionContext context ) {
+        return convert(name, type, defaultValue, this.outputs, context);
+    }
+
+    /**
+     * Set the value for the named output parameter for the function. If the value is nul, the parameter will be removed.
+     * 
+     * @param name the name of the output parameter; may not be null
+     * @param value the value for the named parameter; may be null
+     * @return the prior value for this named parameter
+     * @throws IllegalArgumentException if the name is null or empty
+     * @throws IllegalStateException if the request is frozen
+     */
+    public Serializable setOutput( String name,
+                                   Serializable value ) {
+        checkNotFrozen();
+        CheckArg.isNotEmpty(name, "name");
+        return value != null ? this.outputs.put(name, value) : this.outputs.remove(name);
+    }
+
+    /**
+     * Add an actual request created and executed by the invocation of this function. This method will be called by the
+     * {@link Processor} and should not be called elsewhere.
+     * 
+     * @param request the request
+     * @throws IllegalArgumentException if the request reference is null
+     */
+    public void addActualRequest( Request request ) {
+        checkNotFrozen();
+        CheckArg.isNotNull(request, "request");
+        if (requests == null) requests = new ArrayList<Request>();
+        requests.add(request);
+    }
+
+    /**
+     * Add the actual requests created and executed by the invocation of this function. This method will be called by the
+     * {@link Processor} and should not be called elsewhere.
+     * 
+     * @param requests the requests
+     * @throws IllegalArgumentException if the requests reference is null
+     */
+    public void addActualRequests( Iterable<Request> requests ) {
+        checkNotFrozen();
+        CheckArg.isNotNull(requests, "requests");
+        if (this.requests == null) requests = new ArrayList<Request>();
+        for (Request request : requests) {
+            if (request != null) this.requests.add(request);
+        }
+    }
+
+    /**
+     * Get the number of actual requests created and executed by the invocation of this function. This will always be 0 before the
+     * request is processed.
+     * 
+     * @return the number of actual requests; never negative
+     */
+    public int getActualRequestCount() {
+        return requests != null ? requests.size() : 0;
+    }
+
+    /**
+     * Get the actual requests created and executed by the invocation of this function. These may be read requests or
+     * {@link ChangeRequest change requests}.
+     * 
+     * @return the actual requests that the function created and executed; never null
+     */
+    public Iterator<Request> getActualRequests() {
+        if (requests != null) return requests.iterator();
+        return Collections.<Request>emptyList().iterator();
+    }
+
+    /**
+     * Sets the actual and complete location of the node whose children and properties have been read. This method must be called
+     * when processing the request, and the actual location must have a {@link Location#getPath() path}.
+     * 
+     * @param actual the actual location of the node being read, or null if the {@link #at() current location} should be used
+     * @throws IllegalArgumentException if the actual location is null or does not have a path.
+     * @throws IllegalStateException if the request is frozen
+     */
+    public void setActualLocationOfNode( Location actual ) {
+        checkNotFrozen();
+        CheckArg.isNotNull(actual, "actual");
+        if (!actual.hasPath()) {
+            throw new IllegalArgumentException(GraphI18n.actualLocationMustHavePath.text(actual));
+        }
+        this.actualLocation = actual;
+    }
+
+    /**
+     * Get the actual location of the node whose children and properties were read.
+     * 
+     * @return the actual location, or null if the actual location was not set
+     */
+    public Location getActualLocationOfNode() {
+        return actualLocation;
+    }
+
+    /**
+     * {@inheritDoc}
+     * 
+     * @see org.modeshape.graph.request.Request#cancel()
+     */
+    @Override
+    public void cancel() {
+        super.cancel();
+        this.actualLocation = null;
+        this.outputs.clear();
+    }
+
+    /**
+     * {@inheritDoc}
+     * 
+     * @see java.lang.Object#hashCode()
+     */
+    @Override
+    public int hashCode() {
+        return HashCode.compute(at, workspaceName);
+    }
+
+    /**
+     * {@inheritDoc}
+     * 
+     * @see java.lang.Object#equals(java.lang.Object)
+     */
+    @Override
+    public boolean equals( Object obj ) {
+        if (obj == this) return true;
+        if (this.getClass().isInstance(obj)) {
+            FunctionRequest that = (FunctionRequest)obj;
+            if (!this.at().isSame(that.at())) return false;
+            if (!this.inWorkspace().equals(that.inWorkspace())) return false;
+            if (!this.function.getClass().equals(that.function.getClass())) return false;
+            if (!this.inputs().equals(that.inputs())) return false;
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * {@inheritDoc}
+     * 
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+        String workspaceName = this.workspaceName != null ? "'" + this.workspaceName + "'" : "default";
+        String functionName = function.getClass().getSimpleName();
+        return "applyfn at " + printable(at()) + " (in " + workspaceName + " workspace) the " + functionName;
+    }
+
+    @Override
+    public RequestType getType() {
+        return RequestType.FUNCTION;
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * This method does not clone the results.
+     * </p>
+     */
+    @Override
+    public FunctionRequest clone() {
+        return new FunctionRequest(function, at, workspaceName, inputs);
+    }
+
+    @SuppressWarnings( "unchecked" )
+    protected final <T> T convert( String name,
+                                   Class<T> type,
+                                   T defaultValue,
+                                   Map<String, Serializable> values,
+                                   ExecutionContext context ) {
+        Object value = values.get(name);
+        if (value == null) return defaultValue;
+        PropertyType propertyType = PropertyType.discoverType(type);
+        if (propertyType != null) {
+            ValueFactory<?> factory = context.getValueFactories().getValueFactory(propertyType);
+            return (T)factory.create(value);
+        }
+        if (type.isInstance(value)) {
+            return (T)value;
+        }
+        String msg = GraphI18n.errorConvertingType.text(value.getClass().getSimpleName(), type.getSimpleName(), value);
+        throw new ValueFormatException(value, PropertyType.OBJECT, msg);
+    }
+
+    @SuppressWarnings( "unchecked" )
+    protected final <T> T convert( String name,
+                                   PropertyType type,
+                                   T defaultValue,
+                                   Map<String, Serializable> values,
+                                   ExecutionContext context ) {
+        Object value = values.get(name);
+        if (value == null) return defaultValue;
+        ValueFactory<?> factory = context.getValueFactories().getValueFactory(type);
+        return (T)factory.create(value);
+    }
+
+}

--- a/modeshape-graph/src/main/java/org/modeshape/graph/request/RequestBuilder.java
+++ b/modeshape-graph/src/main/java/org/modeshape/graph/request/RequestBuilder.java
@@ -23,6 +23,7 @@
  */
 package org.modeshape.graph.request;
 
+import java.io.Serializable;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -36,6 +37,7 @@ import org.modeshape.graph.property.Property;
 import org.modeshape.graph.request.CloneWorkspaceRequest.CloneConflictBehavior;
 import org.modeshape.graph.request.CreateWorkspaceRequest.CreateConflictBehavior;
 import org.modeshape.graph.request.LockBranchRequest.LockScope;
+import org.modeshape.graph.request.function.Function;
 
 /**
  * A component that can be used to build requests while allowing different strategies for how requests are handled. Subclasses can
@@ -461,8 +463,8 @@ public abstract class RequestBuilder {
      * @param removeExisting whether any nodes in the intoWorkspace with the same UUIDs as a node in the source branch should be
      *        removed (if true) or a {@link UuidAlreadyExistsException} should be thrown.
      * @return the request; never null
-     * @throws IllegalArgumentException if any of the parameters are null except for {@code nameForClone} or {@code
-     *         exactSegmentForClone}. Exactly one of {@code nameForClone} and {@code exactSegmentForClone} must be null.
+     * @throws IllegalArgumentException if any of the parameters are null except for {@code nameForClone} or
+     *         {@code exactSegmentForClone}. Exactly one of {@code nameForClone} and {@code exactSegmentForClone} must be null.
      */
     public CloneBranchRequest cloneBranch( Location from,
                                            String fromWorkspace,
@@ -667,5 +669,22 @@ public abstract class RequestBuilder {
                                          int maxResults,
                                          int offset ) {
         return process(new FullTextSearchRequest(fullTextSearchExpression, workspaceName, maxResults, offset));
+    }
+
+    /**
+     * Create a request to run the supplied function at the given location in the named workspace, using the supplied inputs.
+     * 
+     * @param function the function to be run
+     * @param inputs the input parameters
+     * @param to the scope of the function
+     * @param workspaceName the name of the workspace containing the node
+     * @return the request; never null
+     * @throws IllegalArgumentException if any of the parameters are null
+     */
+    public FunctionRequest applyFunction( Function function,
+                                          Map<String, Serializable> inputs,
+                                          Location to,
+                                          String workspaceName ) {
+        return process(new FunctionRequest(function, to, workspaceName, inputs));
     }
 }

--- a/modeshape-graph/src/main/java/org/modeshape/graph/request/RequestType.java
+++ b/modeshape-graph/src/main/java/org/modeshape/graph/request/RequestType.java
@@ -35,6 +35,8 @@ public enum RequestType {
     UPDATE_VALUES,
     VERIFY_NODE_EXISTS,
     VERIFY_WORKSPACE,
-    /** Used for testing */
-    INVALID
+    INVALID, // used for testing
+    FUNCTION,
+
+    // Never rearrange these literals, or the integer value will change, affecting serialized instances
 }

--- a/modeshape-graph/src/main/java/org/modeshape/graph/request/VerifyWorkspaceRequest.java
+++ b/modeshape-graph/src/main/java/org/modeshape/graph/request/VerifyWorkspaceRequest.java
@@ -30,7 +30,7 @@ import org.modeshape.graph.Location;
  * Verify that a workspace exists with the supplied name. This is useful to determine the name of the "default" workspace for a
  * source.
  */
-public final class VerifyWorkspaceRequest extends Request {
+public final class VerifyWorkspaceRequest extends Request implements Cloneable {
 
     private static final long serialVersionUID = 1L;
 
@@ -159,5 +159,16 @@ public final class VerifyWorkspaceRequest extends Request {
     @Override
     public RequestType getType() {
         return RequestType.VERIFY_WORKSPACE;
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * This method does not clone the results.
+     * </p>
+     */
+    @Override
+    public VerifyWorkspaceRequest clone() {
+        return new VerifyWorkspaceRequest(workspaceName);
     }
 }

--- a/modeshape-graph/src/main/java/org/modeshape/graph/request/function/Function.java
+++ b/modeshape-graph/src/main/java/org/modeshape/graph/request/function/Function.java
@@ -1,0 +1,95 @@
+/*
+ * ModeShape (http://www.modeshape.org)
+ * See the COPYRIGHT.txt file distributed with this work for information
+ * regarding copyright ownership.  Some portions may be licensed
+ * to Red Hat, Inc. under one or more contributor license agreements.
+ * See the AUTHORS.txt file in the distribution for a full listing of 
+ * individual contributors.
+ *
+ * ModeShape is free software. Unless otherwise indicated, all code in ModeShape
+ * is licensed to you under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ * 
+ * ModeShape is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.modeshape.graph.request.function;
+
+import java.io.Serializable;
+
+/**
+ * A serializable function that is to be called within a connector during a single atomic operation. Implementations subclass and
+ * implement the {@link #run(FunctionContext)} method, where the supplied {@link FunctionContext} has all the information
+ * necessary for the function to run: the supplied input parameters, a way to invoke read and change requests on the content, a
+ * place to write the output, etc.
+ * <p>
+ * Here is a sample implementation of the Function interface that merely counts the number of nodes in a subgraph.
+ * 
+ * <pre>
+ * protected static class CountNodesFunction extends Function {
+ *     private static final long serialVersionUID = 1L;
+ * 
+ *     &#064;Override
+ *     public void run( FunctionContext context ) {
+ *         // Read the input parameter(s) ...
+ *         int maxDepth = context.input(&quot;maxDepth&quot;, PropertyType.LONG, new Long(Integer.MAX_VALUE)).intValue();
+ * 
+ *         // Read the subgraph under the location ...
+ *         ReadBranchRequest readSubgraph = context.builder().readBranch(context.appliedAt(), context.workspace(), maxDepth);
+ *         // Process that request ...
+ *         if (readSubgraph.hasError()) {
+ *             context.setError(readSubgraph.getError());
+ *         } else {
+ * 
+ *             // And count the number of nodes within the subgraph ...
+ *             int counter = 0;
+ *             for (Location location : readSubgraph) {
+ *                 if (location != null) ++counter;
+ *             }
+ * 
+ *             // And write the count as an output parameter ...
+ *             context.setOutput(&quot;nodeCount&quot;, counter);
+ *         }
+ *     }
+ * }
+ * </pre>
+ * 
+ * </p>
+ */
+public abstract class Function implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * The method called to invoke the function. The implementation can obtain from the supplied {@link FunctionContext} the
+     * inputs to the function, a {@link FunctionContext#builder()} that can be used to create and immediately execute other
+     * requests, the {@link FunctionContext#getExecutionContext() context of execution}, the {@link FunctionContext#appliedAt()
+     * location in the graph} where the function is being applied, and other information needed during execution. The
+     * implementation even uses the supplied FunctionContext to write {@link FunctionContext#output(String, Class, Object) output}
+     * {@link FunctionContext#output(String, org.modeshape.graph.property.PropertyType, Object) parameters}.
+     * 
+     * @param context the context in which the function is being invoked, and which contains the inputs, the outputs, and methods
+     *        to create and invoke other requests on the connector
+     */
+    public abstract void run( FunctionContext context );
+
+    /**
+     * Return whether this function only reads information.
+     * <p>
+     * This method always returns 'false'.
+     * </p>
+     * 
+     * @return true if this function reads information, or false if it requests that the repository content be changed in some way
+     */
+    public boolean isReadOnly() {
+        return false;
+    }
+}

--- a/modeshape-graph/src/main/java/org/modeshape/graph/request/function/FunctionContext.java
+++ b/modeshape-graph/src/main/java/org/modeshape/graph/request/function/FunctionContext.java
@@ -1,0 +1,195 @@
+/*
+ * ModeShape (http://www.modeshape.org)
+ * See the COPYRIGHT.txt file distributed with this work for information
+ * regarding copyright ownership.  Some portions may be licensed
+ * to Red Hat, Inc. under one or more contributor license agreements.
+ * See the AUTHORS.txt file in the distribution for a full listing of 
+ * individual contributors.
+ *
+ * ModeShape is free software. Unless otherwise indicated, all code in ModeShape
+ * is licensed to you under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ * 
+ * ModeShape is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.modeshape.graph.request.function;
+
+import java.io.Serializable;
+import org.modeshape.graph.ExecutionContext;
+import org.modeshape.graph.Location;
+import org.modeshape.graph.property.DateTime;
+import org.modeshape.graph.property.PropertyType;
+import org.modeshape.graph.property.ValueFactories;
+import org.modeshape.graph.property.ValueFormatException;
+import org.modeshape.graph.request.Request;
+import org.modeshape.graph.request.RequestBuilder;
+
+/**
+ * The context in which a {@link Function} is executed.
+ */
+public interface FunctionContext {
+
+    /**
+     * The context in which this function is executing.
+     * 
+     * @return the execution context; never null
+     */
+    ExecutionContext getExecutionContext();
+
+    /**
+     * Get the location of the node at which the function is to be applied.
+     * 
+     * @return the location where the function is to be applied; never null
+     */
+    Location appliedAt();
+
+    /**
+     * Get the name of the workspace in which this function is being applied.
+     * 
+     * @return the workspace name
+     */
+    String workspace();
+
+    /**
+     * Get the value for the named input to this function. If the actual value corresponds to a {@link PropertyType}, then the
+     * value will be converted to the specified type using the {@link ExecutionContext}'s {@link ValueFactories}. Otherwise, the
+     * value will simply be cast to the supplied type.
+     * 
+     * @param <T> the desired type of the value
+     * @param name the name of the input parameter
+     * @param type the expected type of the value
+     * @return the (possibly null) value for the named input, or null if there is no such named parameter
+     * @throws ValueFormatException if the conversion from to the expected value could not be performed
+     */
+    <T> T input( String name,
+                 Class<T> type );
+
+    /**
+     * Get the value for the named input to this function. If the actual value corresponds to a {@link PropertyType}, then the
+     * value will be converted to the specified type using the {@link ExecutionContext}'s {@link ValueFactories}. Otherwise, the
+     * value will simply be cast to the supplied type.
+     * 
+     * @param <T> the desired type of the value
+     * @param name the name of the input parameter
+     * @param type the expected type of the value
+     * @param defaultValue the default value for the parameter
+     * @return the (possibly null) value for the named input, or the default value if there is no such named parameter
+     * @throws ValueFormatException if the conversion from to the expected value could not be performed
+     */
+    <T> T input( String name,
+                 Class<T> type,
+                 T defaultValue );
+
+    /**
+     * Get the value for the named input to this function. The actual value will be converted to the specified type using the
+     * {@link ExecutionContext}'s {@link ValueFactories}.
+     * 
+     * @param <T> the desired type of the value
+     * @param name the name of the input parameter
+     * @param type the expected type of the value
+     * @param defaultValue the default value for the parameter
+     * @return the (possibly null) value for the named input, or the default value if there is no such named parameter
+     * @throws ValueFormatException if the conversion from to the expected value could not be performed
+     */
+    <T> T input( String name,
+                 PropertyType type,
+                 T defaultValue );
+
+    /**
+     * Get the value for the named output to this function. If the actual value corresponds to a {@link PropertyType}, then the
+     * value will be converted to the specified type using the {@link ExecutionContext}'s {@link ValueFactories}. Otherwise, the
+     * value will simply be cast to the supplied type.
+     * <p>
+     * This is a convenience method, as the value would have already been set by the same function invocation using
+     * {@link #setOutput(String, Serializable)}.
+     * </p>
+     * 
+     * @param <T> the desired type of the value
+     * @param name the name of the output parameter
+     * @param type the expected type of the value
+     * @param defaultValue the default value for the parameter
+     * @return the (possibly null) value for the named output, or the default value if there is no such named parameter
+     * @throws ValueFormatException if the conversion from to the expected value could not be performed
+     */
+    <T> T output( String name,
+                  Class<T> type,
+                  T defaultValue );
+
+    /**
+     * Get the value for the named output to this function. The actual value will be converted to the specified type using the
+     * {@link ExecutionContext}'s {@link ValueFactories}.
+     * <p>
+     * This is a convenience method, as the value would have already been set by the same function invocation using
+     * {@link #setOutput(String, Serializable)}.
+     * </p>
+     * 
+     * @param <T> the desired type of the value
+     * @param name the name of the output parameter
+     * @param type the expected type of the value
+     * @param defaultValue the default value for the parameter
+     * @return the (possibly null) value for the named output, or null if there is no such named parameter
+     * @throws ValueFormatException if the conversion from to the expected value could not be performed
+     */
+    <T> T output( String name,
+                  PropertyType type,
+                  T defaultValue );
+
+    /**
+     * Set the value for the named output parameter for the function.
+     * 
+     * @param name the name of the output parameter; may not be null
+     * @param value the value for the named parameter; must be {@link Serializable}
+     */
+    void setOutput( String name,
+                    Serializable value );
+
+    /**
+     * Immediately execute the supplied request on this connector. Note that the caller is responsible for checking whether the
+     * supplied request {@link Request#hasError() has an error}, and if that error results in an error condition of the caller,
+     * then the caller is responsible for {@link #setError(Throwable) setting the error on this context}.
+     * 
+     * @param request the request to be performed; may not be null
+     * @see #builder()
+     */
+    void execute( Request request );
+
+    /**
+     * Return a build that can be used to build, immediately execute, and return the executed requests. When this is used, there
+     * is no need to {@link #execute(Request)} them manually.
+     * 
+     * @return the builder; never null
+     * @see #execute(Request)
+     */
+    RequestBuilder builder();
+
+    /**
+     * Get the 'current time' for this processor, which is usually a constant during its lifetime.
+     * 
+     * @return the current time in UTC; never null
+     */
+    DateTime getNowInUtc();
+
+    /**
+     * Record that an error occurred.
+     * 
+     * @param t the exception
+     */
+    void setError( Throwable t );
+
+    /**
+     * Determine whether this execution has been cancelled. This should be checked periodically in longer-running functions.
+     * 
+     * @return true if the execution has been cancelled, or false otherwise
+     */
+    boolean isCancelled();
+
+}

--- a/modeshape-graph/src/main/java/org/modeshape/graph/request/function/package-info.java
+++ b/modeshape-graph/src/main/java/org/modeshape/graph/request/function/package-info.java
@@ -1,0 +1,71 @@
+/*
+ * ModeShape (http://www.modeshape.org)
+ * See the COPYRIGHT.txt file distributed with this work for information
+ * regarding copyright ownership.  Some portions may be licensed
+ * to Red Hat, Inc. under one or more contributor license agreements.
+ * See the AUTHORS.txt file in the distribution for a full listing of 
+ * individual contributors. 
+ *
+ * ModeShape is free software. Unless otherwise indicated, all code in ModeShape
+ * is licensed to you under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * ModeShape is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+/**
+ * The {@link org.modeshape.graph.request.function.Function} interface provides a way to inject custom logic 
+ * into a connector, where it can be executed close to the actual data and where it can make decisions about 
+ * what changes should be made to the content. The {@link org.modeshape.graph.request.function.FunctionContext}
+ * interface encapsulates the context in which a function is {@link org.modeshape.graph.request.function.Function#run(FunctionContext) run}, including
+ * the input parameters, output parameters, location in the graph, and ways of building and executing other
+ * requests.
+ * <p>
+ * To use a {@link org.modeshape.graph.request.function.Function}, simply subclass it, implement the 
+ * {@link org.modeshape.graph.request.function.Function#run(FunctionContext)} method, and then used it
+ * via the {@link org.modeshape.graph.Graph Graph API}, either through direct (immediately) interaction:
+ * <pre>
+ *     Graph graph = ...
+ *     Function myFunction = ...
+ *     Map<String,Serializable> output = graph.applyFunction(myFunction)
+ *                                            .with("a","val1")
+ *                                            .and("b",3)
+ *                                            .to("/");
+ *     Object count = output.get("count");
+ * </pre>
+ * or via batch invocation:
+ * <pre>
+ *     Graph graph = ...
+ *     Function myFunction = ...
+ *     Graph.Batch batch = graph.batch();
+ *     batch.applyFunction(myFunction)
+ *          .with("a","val1")
+ *          .and("b",3)
+ *          .to("/")
+ *          .and()
+ *          .read("/myNode");
+ *     Results results = batch.execute();
+ *     List<Request> requests = results.getRequests();
+ *     FunctionRequest functRequest = requests.get(0);
+ *     ReadNodeRequest readRequest = requests.get(1);
+ *     
+ *     // use the results in the requests ...
+ *     long count = functRequest.output("success",PropertyType.LONG,new Long(0)).longValue();
+ *     
+ *     for ( Property prop : readRequest.getProperties() ) {
+ *        // do something ...
+ *     }
+ * </pre>
+ * </p>
+ */
+
+package org.modeshape.graph.request.function;
+

--- a/modeshape-graph/src/test/java/org/modeshape/graph/GraphIntegrationTest.java
+++ b/modeshape-graph/src/test/java/org/modeshape/graph/GraphIntegrationTest.java
@@ -1,0 +1,277 @@
+/*
+ * ModeShape (http://www.modeshape.org)
+ * See the COPYRIGHT.txt file distributed with this work for information
+ * regarding copyright ownership.  Some portions may be licensed
+ * to Red Hat, Inc. under one or more contributor license agreements.
+ * See the AUTHORS.txt file in the distribution for a full listing of 
+ * individual contributors.
+ *
+ * ModeShape is free software. Unless otherwise indicated, all code in ModeShape
+ * is licensed to you under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ * 
+ * ModeShape is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.modeshape.graph;
+
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsNull.notNullValue;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+import java.io.IOException;
+import java.io.Serializable;
+import java.net.URL;
+import java.util.List;
+import java.util.Map;
+import org.junit.Before;
+import org.junit.Test;
+import org.modeshape.graph.Graph.Batch;
+import org.modeshape.graph.connector.inmemory.InMemoryRepositorySource;
+import org.modeshape.graph.property.PathNotFoundException;
+import org.modeshape.graph.property.PropertyType;
+import org.modeshape.graph.request.FunctionRequest;
+import org.modeshape.graph.request.ReadBranchRequest;
+import org.modeshape.graph.request.function.Function;
+import org.modeshape.graph.request.function.FunctionContext;
+import org.xml.sax.SAXException;
+
+public class GraphIntegrationTest {
+
+    private ExecutionContext context;
+    private InMemoryRepositorySource graphSource;
+    private Graph graph;
+    private boolean print = false;
+
+    @Before
+    public void beforeEaach() throws SAXException, IOException {
+        context = new ExecutionContext();
+
+        graphSource = new InMemoryRepositorySource();
+        graphSource.setName("Graph source");
+
+        graph = Graph.create(graphSource, context);
+        graph.importXmlFrom(resourceUrl("aircraft.xml")).into("/");
+    }
+
+    @Test
+    public void shouldHaveNonEmptyInitialContent() {
+        assertNodeExists(graph, "Aircraft");
+    }
+
+    // ----------------------------------------------------------------------------------------------------------------
+    // Apply functions immediately ...
+    // ----------------------------------------------------------------------------------------------------------------
+
+    @Test
+    public void shouldSuccessfullyApplyFunction() {
+        // Create some nodes and get the subgraph of them ...
+        Subgraph subgraph = graph.getSubgraphOfDepth(100).at("/");
+        int count = countNodes(subgraph);
+
+        // Determine the number of nodes using a function ...
+        Map<String, Serializable> output = graph.applyFunction(new CountNodesFunction()).to("/");
+
+        assertThat(output, is(notNullValue()));
+        assertThat(output.get("nodeCount"), is((Object)new Integer(count)));
+    }
+
+    @Test( expected = IllegalStateException.class )
+    public void shouldResultInExceptionIfFunctionResultsInError() {
+        graph.applyFunction(new SetErrorFunction()).to("/");
+    }
+
+    @Test( expected = IllegalStateException.class )
+    public void shouldResultInExceptionIfFunctionThrowsException() {
+        graph.applyFunction(new ThrowErrorFunction()).to("/");
+    }
+
+    @Test
+    public void shouldAllowSpecifyingOneInputParametersWhenApplyingFunction() {
+        // Create some nodes and get the subgraph of them ...
+        Subgraph subgraph = graph.getSubgraphOfDepth(100).at("/");
+        int count = countNodes(subgraph);
+
+        Function function = new CountNodesFunction();
+        Map<String, Serializable> output = graph.applyFunction(function).withInput("a", "value").to("/");
+        assertThat(output.get("nodeCount"), is((Object)new Integer(count)));
+    }
+
+    @Test
+    public void shouldAllowSpecifyingMultipleInputParametersWhenApplyingFunction() {
+        // Create some nodes and get the subgraph of them ...
+        Subgraph subgraph = graph.getSubgraphOfDepth(100).at("/");
+        int count = countNodes(subgraph);
+
+        Function function = new CountNodesFunction();
+        Map<String, Serializable> output = graph.applyFunction(function).withInput("a", "value").and("b", "foo").to("/");
+        assertThat(output.get("nodeCount"), is((Object)new Integer(count)));
+    }
+
+    // ----------------------------------------------------------------------------------------------------------------
+    // Apply functions in batch ...
+    // ----------------------------------------------------------------------------------------------------------------
+
+    @Test
+    public void shouldSuccessfullyApplyFunctionUsingBatch() {
+        // Create some nodes and get the subgraph of them ...
+        Subgraph subgraph = graph.getSubgraphOfDepth(100).at("/");
+        int count = countNodes(subgraph);
+
+        // Determine the number of nodes using a function ...
+        Results results = graph.batch().applyFunction(new CountNodesFunction()).to("/").execute();
+
+        assertThat(results, is(notNullValue()));
+        assertThat(results.getRequests().size(), is(1));
+        FunctionRequest request = (FunctionRequest)results.getRequests().get(0);
+        assertThat(request.output("nodeCount", PropertyType.LONG, (Long)null, context), is(new Long(count)));
+    }
+
+    @Test( expected = IllegalStateException.class )
+    public void shouldResultInExceptionIfFunctionResultsInErrorUsingBatch() {
+        graph.batch().applyFunction(new SetErrorFunction()).to("/").execute();
+    }
+
+    @Test( expected = IllegalStateException.class )
+    public void shouldResultInExceptionIfFunctionThrowsExceptionUsingBatch() {
+        graph.batch().applyFunction(new ThrowErrorFunction()).to("/").execute();
+    }
+
+    @Test
+    public void shouldAllowSpecifyingOneInputParametersWhenApplyingFunctionUsingBatch() {
+        Function function = new ThrowErrorFunction();
+        Batch batch = graph.batch().applyFunction(function).withInput("a", "value").to("/");
+        assertThat(batch.isExecuteRequired(), is(true));
+    }
+
+    @Test
+    public void shouldAllowSpecifyingMultipleInputParametersWhenApplyingFunctionUsingBatch() {
+        Function function = new ThrowErrorFunction();
+        Batch batch = graph.batch().applyFunction(function).withInput("a", "value").and("b", "foo").to("/");
+        assertThat(batch.isExecuteRequired(), is(true));
+    }
+
+    // ----------------------------------------------------------------------------------------------------------------
+    // Function implementations ...
+    // ----------------------------------------------------------------------------------------------------------------
+
+    /**
+     * Counts the nodes in a subgraph at and below the node at which the function is applied, and place the number in the
+     * "nodeCount" output parameter. The optional input parameter "maxDepth" can be used to specify the maximum depth.
+     */
+    protected static class CountNodesFunction extends Function {
+        private static final long serialVersionUID = 1L;
+
+        @Override
+        public void run( FunctionContext context ) {
+            // Read the input parameter(s) ...
+            int maxDepth = context.input("maxDepth", PropertyType.LONG, new Long(Integer.MAX_VALUE)).intValue();
+
+            // Read the subgraph under the location ...
+            ReadBranchRequest readSubgraph = context.builder().readBranch(context.appliedAt(), context.workspace(), maxDepth);
+            // Process that request ...
+            if (readSubgraph.hasError()) {
+                readSubgraph.getError().printStackTrace();
+                context.setError(readSubgraph.getError());
+            } else {
+
+                // And count the number of nodes within the subgraph ...
+                int counter = 0;
+                for (Location location : readSubgraph) {
+                    if (location != null) ++counter;
+                }
+
+                // And write the count as an output parameter ...
+                context.setOutput("nodeCount", counter);
+            }
+        }
+    }
+
+    /**
+     * Always sets an error on the request.
+     */
+    protected static class SetErrorFunction extends Function {
+        private static final long serialVersionUID = 1L;
+
+        @Override
+        public void run( FunctionContext context ) {
+            context.setError(new IllegalStateException("Bogus exceptions"));
+        }
+    }
+
+    /**
+     * Always just throws an exception.
+     */
+    protected static class ThrowErrorFunction extends Function {
+        private static final long serialVersionUID = 1L;
+
+        @Override
+        public void run( FunctionContext context ) {
+            throw new IllegalStateException("Bogus exceptions");
+        }
+    }
+
+    // ----------------------------------------------------------------------------------------------------------------
+    // Utility methods ...
+    // ----------------------------------------------------------------------------------------------------------------
+
+    protected int countNodes( Subgraph subgraph ) {
+        return countNodes(subgraph.getRoot(), subgraph);
+    }
+
+    protected int countNodes( SubgraphNode node,
+                              Subgraph subgraph ) {
+        assertThat(node, is(notNullValue()));
+        assertThat(subgraph, is(notNullValue()));
+        int count = 1;
+        for (Location child : node.getChildren()) {
+            count += countNodes(subgraph.getNode(child), subgraph);
+        }
+        return count;
+    }
+
+    protected void assertNoChildren( Graph graph,
+                                     String path ) {
+        assertNodeExists(graph, path);
+        List<Location> children = graph.getChildren().of(path);
+        assertThat(children.isEmpty(), is(true));
+    }
+
+    protected Node assertNodeExists( Graph graph,
+                                     String path ) {
+        Node node = graph.getNodeAt(path);
+        assertThat(node, is(notNullValue()));
+        return node;
+    }
+
+    protected void assertNodeDoesNotExist( Graph graph,
+                                           String path ) {
+        try {
+            graph.getNodeAt(path);
+            fail("Node does exist at \"" + path + "\"");
+        } catch (PathNotFoundException e) {
+            // expected ...
+        }
+    }
+
+    protected void printSubgraph( Graph graph,
+                                  String path ) {
+        if (print) {
+            Subgraph subgraph = graph.getSubgraphOfDepth(Integer.MAX_VALUE).at(path);
+            System.out.println(subgraph);
+        }
+    }
+
+    protected String resourceUrl( String path ) {
+        URL url = this.getClass().getClassLoader().getResource(path);
+        return url != null ? url.toExternalForm() : path;
+    }
+}

--- a/modeshape-graph/src/test/java/org/modeshape/graph/request/FunctionRequestTest.java
+++ b/modeshape-graph/src/test/java/org/modeshape/graph/request/FunctionRequestTest.java
@@ -1,0 +1,142 @@
+/*
+ * ModeShape (http://www.modeshape.org)
+ * See the COPYRIGHT.txt file distributed with this work for information
+ * regarding copyright ownership.  Some portions may be licensed
+ * to Red Hat, Inc. under one or more contributor license agreements.
+ * See the AUTHORS.txt file in the distribution for a full listing of 
+ * individual contributors. 
+ *
+ * ModeShape is free software. Unless otherwise indicated, all code in ModeShape
+ * is licensed to you under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * ModeShape is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.modeshape.graph.request;
+
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsNull.nullValue;
+import static org.hamcrest.core.IsSame.sameInstance;
+import static org.junit.Assert.assertThat;
+import java.io.Serializable;
+import java.util.Map;
+import org.junit.Before;
+import org.junit.Test;
+import org.modeshape.graph.request.function.Function;
+import org.modeshape.graph.request.function.FunctionContext;
+
+public class FunctionRequestTest extends AbstractRequestTest {
+
+    private Function function;
+    private FunctionRequest request;
+    private FunctionRequest request2;
+    private Map<String, Serializable> inputs;
+    private Map<String, Serializable> inputs2;
+    protected boolean ran = false;
+
+    @SuppressWarnings( "serial" )
+    @Override
+    @Before
+    public void beforeEach() {
+        super.beforeEach();
+        ran = false;
+        inputs = new java.util.HashMap<String, Serializable>();
+        inputs2 = new java.util.HashMap<String, Serializable>();
+        function = new Function() {
+            @Override
+            public void run( FunctionContext context ) {
+                ran = true;
+                context.setOutput("success", Boolean.TRUE);
+            }
+        };
+    }
+
+    @Override
+    protected Request createRequest() {
+        return new FunctionRequest(function, validPathLocation1, workspace1, inputs);
+    }
+
+    @Test( expected = IllegalArgumentException.class )
+    public void shouldNotAllowCreatingRequestWithNullFunction() {
+        new FunctionRequest(null, validPathLocation1, workspace1, inputs);
+    }
+
+    @Test( expected = IllegalArgumentException.class )
+    public void shouldNotAllowCreatingRequestWithNullLocation() {
+        new FunctionRequest(function, null, workspace1, inputs);
+    }
+
+    @Test( expected = IllegalArgumentException.class )
+    public void shouldNotAllowCreatingRequestWithNullWorkspaceName() {
+        new FunctionRequest(function, validPathLocation1, null, inputs);
+    }
+
+    @Test
+    public void shouldAllowCreatingRequestWithNullInputMap() {
+        new FunctionRequest(function, validPathLocation1, workspace1, null);
+    }
+
+    @Test
+    public void shouldCreateValidRequestWithValidLocation() {
+        request = new FunctionRequest(function, validPathLocation1, workspace1, inputs);
+        assertThat(request.function(), is(sameInstance(function)));
+        assertThat(request.at(), is(sameInstance(validPathLocation1)));
+        assertThat(request.inWorkspace(), is(sameInstance(workspace1)));
+        assertThat(request.inputs().isEmpty(), is(true));
+        assertThat(request.hasError(), is(false));
+        assertThat(request.getError(), is(nullValue()));
+    }
+
+    @Test
+    public void shouldConsiderEqualTwoRequestsWithSameLocationAndFunctionAndWorkspace() {
+        request = new FunctionRequest(function, validPathLocation1, workspace1, inputs);
+        request2 = new FunctionRequest(function, validPathLocation1, workspace1, inputs);
+        assertThat(request, is(request2));
+    }
+
+    @Test
+    public void shouldConsiderNotEqualTwoRequestsWithDifferentFunctions() {
+        @SuppressWarnings( "serial" )
+        Function function2 = new Function() {
+            @Override
+            public void run( FunctionContext context ) {
+                ran = true;
+                context.setOutput("success", Boolean.TRUE);
+            }
+        };
+        request = new FunctionRequest(function, validPathLocation1, workspace1, inputs);
+        request2 = new FunctionRequest(function2, validPathLocation1, workspace1, inputs);
+        assertThat(request.equals(request2), is(false));
+    }
+
+    @Test
+    public void shouldConsiderNotEqualTwoRequestsWithDifferentInputs() {
+        inputs2.put("Some input", "value");
+        request = new FunctionRequest(function, validPathLocation1, workspace1, inputs);
+        request2 = new FunctionRequest(function, validPathLocation1, workspace1, inputs2);
+        assertThat(request.equals(request2), is(false));
+    }
+
+    @Test
+    public void shouldConsiderNotEqualTwoRequestsWithDifferentLocations() {
+        request = new FunctionRequest(function, validPathLocation1, workspace1, inputs);
+        request2 = new FunctionRequest(function, validPathLocation2, workspace1, inputs);
+        assertThat(request.equals(request2), is(false));
+    }
+
+    @Test
+    public void shouldConsiderNotEqualTwoRequestsWithDifferentWorkspaceNames() {
+        request = new FunctionRequest(function, validPathLocation1, workspace1, inputs);
+        request2 = new FunctionRequest(function, validPathLocation1, workspace2, inputs);
+        assertThat(request.equals(request2), is(false));
+    }
+}


### PR DESCRIPTION
Added a new function framework to allow Graph users to write custom logic that will be executed within the connector when processing requests.

To use this new framework, a Graph users creates a concrete subclass of the Function abstract class, which has just one 'run(FunctionContext)' method, and submits it to the connector using Graph.applyFunction(...) or Graph.Batch.applyFunction(...). Because the Function.run(...) method will be called by the connector, the implementation can create and execute other requests (such as reading, creating, updating, or removing nodes and/or properties) intermixed with custom logic.

When the Graph.applyFunction(...) or Graph.Batch.applyFunction(...) methods are called, the method encapsulates the function, its inputs, the graph location under which the function will be applied, and the workspace name into an instance of FunctionRequest, which is a concrete subclass of Request. This FunctionRequest essentially encapsulates everything necessary to invoke the function at a later point. The FunctionRequest is even serializable.

Several new unit tests were added to the 'modeshape-graph' module, verifying that the new framework works as expected. Additionally, all other unit and integration test pass.
