### PR TITLE
MODE-1136 Corrected lock and unlock handling in graph batches

### DIFF
--- a/modeshape-graph/src/main/java/org/modeshape/graph/Graph.java
+++ b/modeshape-graph/src/main/java/org/modeshape/graph/Graph.java
@@ -3406,13 +3406,14 @@ public class Graph {
          * @return an object that allows the scope of the lock to be defined
          */
         public LockScope<LockTimeout<BatchConjunction>> lock( Location at ) {
+            assertNotExecuted();
             return new LockAction<BatchConjunction>(this.nextRequests, at) {
                 @Override
                 protected BatchConjunction submit( Location target,
                                                    org.modeshape.graph.request.LockBranchRequest.LockScope lockScope,
                                                    long lockTimeoutInMillis ) {
                     String workspaceName = getCurrentWorkspaceName();
-                    requests.lockBranch(workspaceName, target, lockScope, lockTimeoutInMillis);
+                    requestQueue.lockBranch(workspaceName, target, lockScope, lockTimeoutInMillis);
                     return and();
                 }
             };
@@ -3489,7 +3490,8 @@ public class Graph {
          * @return the interface that can either execute the batched requests or continue to add additional requests to the batch
          */
         public BatchConjunction unlock( Location at ) {
-            requests.unlockBranch(workspaceName, at);
+            assertNotExecuted();
+            requestQueue.unlockBranch(workspaceName, at);
             return this.nextRequests;
         }
 

--- a/modeshape-graph/src/main/java/org/modeshape/graph/connector/federation/JoinRequestProcessor.java
+++ b/modeshape-graph/src/main/java/org/modeshape/graph/connector/federation/JoinRequestProcessor.java
@@ -61,6 +61,7 @@ import org.modeshape.graph.request.DestroyWorkspaceRequest;
 import org.modeshape.graph.request.FullTextSearchRequest;
 import org.modeshape.graph.request.GetWorkspacesRequest;
 import org.modeshape.graph.request.InvalidRequestException;
+import org.modeshape.graph.request.LockBranchRequest;
 import org.modeshape.graph.request.MoveBranchRequest;
 import org.modeshape.graph.request.ReadAllChildrenRequest;
 import org.modeshape.graph.request.ReadAllPropertiesRequest;
@@ -924,6 +925,23 @@ class JoinRequestProcessor extends RequestProcessor {
         if (checkErrorOrCancel(request, source)) return;
         Location sourceLocation = source.getActualLocationOfNode();
         request.setActualLocationOfNode(projectToFederated(request.from(), projected.getProjection(), sourceLocation, request));
+    }
+
+    /**
+     * {@inheritDoc}
+     * 
+     * @see org.modeshape.graph.request.processor.RequestProcessor#process(org.modeshape.graph.request.LockBranchRequest)
+     */
+    @Override
+    public void process( LockBranchRequest request ) {
+        ProjectedRequest projected = federatedRequest.getFirstProjectedRequest();
+        // Check the projection first ...
+        if (checkErrorOrCancel(request, federatedRequest)) return;
+
+        LockBranchRequest source = (LockBranchRequest)projected.getRequest();
+        if (checkErrorOrCancel(request, source)) return;
+        Location sourceLocation = source.getActualLocation();
+        request.setActualLocation(projectToFederated(request.at(), projected.getProjection(), sourceLocation, request));
     }
 
     /**

--- a/modeshape-graph/src/main/java/org/modeshape/graph/observe/NetChangeObserver.java
+++ b/modeshape-graph/src/main/java/org/modeshape/graph/observe/NetChangeObserver.java
@@ -586,6 +586,23 @@ public abstract class NetChangeObserver extends ChangeObserver {
             return false;
         }
 
+        /**
+         * Determine whether this net change includes only the supplied types.
+         * 
+         * @param jcrEventTypes the types to check for
+         * @return true if all of the supplied events are included in this net change, or false otherwise
+         */
+        public boolean includesOnly( ChangeType... jcrEventTypes ) {
+            int length = jcrEventTypes.length;
+            if (length == 0) return false;
+            if (length == 1) {
+                return this.eventTypes.size() == 1 && this.eventTypes.contains(jcrEventTypes[0]);
+            }
+            // Otherwise there are more than one expected type ...
+            EnumSet<ChangeType> expected = EnumSet.of(jcrEventTypes[0], jcrEventTypes);
+            return this.eventTypes.equals(expected);
+        }
+
         public boolean isSameNode( NetChange that ) {
             if (that == this) return true;
             if (this.hc != that.hc) return false;

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrObservationManager.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrObservationManager.java
@@ -969,8 +969,9 @@ final class JcrObservationManager implements ObservationManager {
                         if (root != null && !propertiesByLocation.containsKey(root)) {
                             // The connector doesn't actually have any properties for the root node, so assume 'mode:root' ...
                             // For details, see MODE-959.
-                            Property primaryType = graph.getContext().getPropertyFactory().create(JcrLexicon.PRIMARY_TYPE,
-                                                                                                  ModeShapeLexicon.ROOT);
+                            Property primaryType = graph.getContext()
+                                                        .getPropertyFactory()
+                                                        .create(JcrLexicon.PRIMARY_TYPE, ModeShapeLexicon.ROOT);
                             Map<Name, Property> props = Collections.singletonMap(primaryType.getName(), primaryType);
                             this.propertiesByLocation.put(root, props);
                         }
@@ -1006,11 +1007,6 @@ final class JcrObservationManager implements ObservationManager {
                         // We ignore it ...
                         continue;
                     }
-                }
-
-                // ignore if lock/unlock
-                if (change.includes(ChangeType.NODE_LOCKED) || change.includes(ChangeType.NODE_UNLOCKED)) {
-                    continue;
                 }
 
                 // determine if need to process


### PR DESCRIPTION
Graph.Batch methods related to locking and unlocking were incorrectly being processed immediately rather than being added to the batch (like all other operations). This results in extra sets of operations being pushed to the connector, and inconsistent/incorrect behavior and possible re-ordering of the individual requests.

This change corrects this behavior. When the Graph.Batch operations were changed to correctly use the batch, several unit and TCK tests related to observation failed. Apparently, there was some checks inside JcrObservationManager that was ignoring all net changes for a node if the net change included any lock or unlock operations. Obviously, if the net change included a lock operation and some other operations (e.g., update properties), then these other operations would be ignored and not converted into the appropriate events. Simply removing that check made this work.

After these changes were made, all unit and integration tests pass again.
