### PR TITLE
MODE-1137 Corrected handling of unicode characters in export/import

### DIFF
--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrContentHandler.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrContentHandler.java
@@ -44,8 +44,8 @@ import javax.jcr.ValueFactory;
 import javax.jcr.ValueFormatException;
 import javax.jcr.nodetype.ConstraintViolationException;
 import javax.jcr.version.VersionException;
-import org.modeshape.common.annotation.NotThreadSafe;
 import org.modeshape.common.SystemFailureException;
+import org.modeshape.common.annotation.NotThreadSafe;
 import org.modeshape.common.collection.Collections;
 import org.modeshape.common.text.TextDecoder;
 import org.modeshape.common.text.XmlNameEncoder;
@@ -1038,8 +1038,10 @@ class JcrContentHandler extends DefaultHandler {
             // Add the properties ...
             for (int i = 0; i < atts.getLength(); i++) {
                 String value = atts.getValue(i);
+                if (value == null) continue;
+                value = DOCUMENT_VIEW_NAME_DECODER.decode(value);
                 String propertyName = DOCUMENT_VIEW_NAME_DECODER.decode(atts.getQName(i));
-                current.addPropertyValue(nameFor(propertyName), value, PropertyType.STRING, null);// don't decode the value
+                current.addPropertyValue(nameFor(propertyName), value, PropertyType.STRING, null);
             }
 
             // Now create the node ...

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrDocumentViewExporter.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrDocumentViewExporter.java
@@ -304,7 +304,7 @@ class JcrDocumentViewExporter extends AbstractJcrExporter {
 
         static {
             MAPPED_CHARACTERS = new HashSet<Character>();
-            MAPPED_CHARACTERS.add(' ');
+            // MAPPED_CHARACTERS.add(' '); // See MODE-1137
             MAPPED_CHARACTERS.add('\r');
             MAPPED_CHARACTERS.add('\n');
             MAPPED_CHARACTERS.add('\t');


### PR DESCRIPTION
There were a couple of minor problems, and I think all should be cleared up.

First, the StreamingContentHandler should allow using different encodings, so this class was cleaned up to allow setting the encoding in the constructor and using the correct encoding when writing to the stream. The class is now using an OutputStreamWriter (initialized with the correct encoding) rather than writing the bytes encoded for each call. This should be a bit faster. Also, the reported issue won't always surface, because prior to this fix the code depended upon the platform's default encoding. Only those users with a default encodings other than "UTF-8" would see the problem. The fix should alleviate this issue.

Second, while testing it was discovered that we are always encoding the space character. Contrary to Section 6.4.4 of the JSR-170 specification, the reference implementation never encodes spaces in values. Therefore, this change removes the space character from the list of characters that are encoded upon export.

Third, several new unit tests that use Unicode content were added to the set of export/import round-trip cases, verifying the correct behavior.
