### PR TITLE
MODE-1140 Corrected builds to again run the JUnit 3 unit tests

### DIFF
--- a/deploy/jbossas/modeshape-jbossas-console/pom.xml
+++ b/deploy/jbossas/modeshape-jbossas-console/pom.xml
@@ -143,6 +143,13 @@
 			<version>${jopr.jboss.as5.plugin.version}</version>
 		</dependency>
 
+		<!-- See MODE-1140 -->
+		<dependency>
+		  <groupId>junit</groupId>
+		  <artifactId>junit</artifactId>
+		  <version>${junit.version}</version>
+		  <scope>test</scope>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/modeshape-jcr-api/pom.xml
+++ b/modeshape-jcr-api/pom.xml
@@ -28,6 +28,14 @@
       <groupId>javax.jcr</groupId>
       <artifactId>jcr</artifactId>
     </dependency>
+
+    <!-- See MODE-1140 -->
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>${junit.version}</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/modeshape-parent/pom.xml
+++ b/modeshape-parent/pom.xml
@@ -225,7 +225,8 @@
 		Maven plugin versions
 		-->
 		<maven.surefire.report.plugin.version>2.4.3</maven.surefire.report.plugin.version>
-		<maven.surefire.plugin.version>2.7.1</maven.surefire.plugin.version>
+		<maven.surefire.plugin.version>2.8</maven.surefire.plugin.version>
+		<maven.surefire.plugin.junit.version>2.8</maven.surefire.plugin.junit.version>
 		<maven.assembly.plugin.version>2.2</maven.assembly.plugin.version>
 		<maven.install.plugin.version>2.3.1</maven.install.plugin.version>
     <maven.javadoc.plugin.version>2.7</maven.javadoc.plugin.version>
@@ -746,6 +747,16 @@
 			<plugin>
 				<artifactId>maven-surefire-plugin</artifactId>
 				<version>${maven.surefire.plugin.version}</version>
+				<!-- Manually specify the JUnit provider; see MODE-1140 -->
+				<dependencies>
+				  <dependency>
+				    <groupId>org.apache.maven.surefire</groupId>
+				    <!--artifactId>surefire-junit47</artifactId-->
+				    <artifactId>surefire-junit4</artifactId>
+				    <!--artifactId>surefire-junit3</artifactId-->
+				    <version>${maven.surefire.plugin.junit.version}</version>
+				  </dependency>
+				</dependencies>
 				<configuration>
 					<includes>
 						<include>**/*TestCase.java</include>


### PR DESCRIPTION
When we changed to Maven 3, we also upgraded a number of the Maven plugins, in part because Maven 3 encourages specifying each of the version numbers for the plugins to keep your builds stable. When we switched from Surefire 2.6 to 2.7.1, I failed to notice that Surefire 2.7 determines the test classes to run in a vastly different way than 2.6, and one that will purposefully exclude all JUnit 3 test classes. Unfortunately for us, the JCR TCK unit test suites are all JUnit 3, and this means we haven't been running the JCR TCK unit tests (in any configuration) since the move to Maven 3 (and commit f3a8a09a3bb on Feb 22)!

Fixing this was painful and not obvious. It basically boils down to explicitly telling Surefire to use an older JUnit 4 provider (rather than a new "junit-47" provider that does the funky determination).

With these changes, all unit and integration tests pass, including all of the TCK tests. The time to run a full build is a bit faster than with Maven 2, but it's not quite the massive speedup that we thought we got. Oh well.

It is also possible to downgrade Surefire to 2.6, but I thought it better to keep Surefire on the latest possible version (which has performance and size improvements over 2.6).
