### PR TITLE
MODE-1142 Corrected the use of @Override

### DIFF
--- a/deploy/jbossas/modeshape-jbossas-console/src/main/java/org/modeshape/rhq/plugin/ConnectorDiscoveryComponent.java
+++ b/deploy/jbossas/modeshape-jbossas-console/src/main/java/org/modeshape/rhq/plugin/ConnectorDiscoveryComponent.java
@@ -62,7 +62,8 @@ public class ConnectorDiscoveryComponent implements
 	 * 
 	 * @see org.rhq.core.pluginapi.inventory.ResourceDiscoveryComponent#discoverResources(org.rhq.core.pluginapi.inventory.ResourceDiscoveryContext)
 	 */
-	@SuppressWarnings( "rawtypes" )
+	@Override
+    @SuppressWarnings( "rawtypes" )
     public Set<DiscoveredResourceDetails> discoverResources(
 			ResourceDiscoveryContext discoveryContext)
 			throws InvalidPluginConfigurationException, Exception {

--- a/deploy/jbossas/modeshape-jbossas-console/src/main/java/org/modeshape/rhq/plugin/EngineDiscoveryComponent.java
+++ b/deploy/jbossas/modeshape-jbossas-console/src/main/java/org/modeshape/rhq/plugin/EngineDiscoveryComponent.java
@@ -54,7 +54,8 @@ public class EngineDiscoveryComponent implements
 	 * 
 	 * @see org.rhq.core.pluginapi.inventory.ResourceDiscoveryComponent#discoverResources(org.rhq.core.pluginapi.inventory.ResourceDiscoveryContext)
 	 */
-	@SuppressWarnings( "rawtypes" )
+	@Override
+    @SuppressWarnings( "rawtypes" )
     public Set<DiscoveredResourceDetails> discoverResources(
 			ResourceDiscoveryContext discoveryContext)
 			throws InvalidPluginConfigurationException, Exception {

--- a/deploy/jbossas/modeshape-jbossas-console/src/main/java/org/modeshape/rhq/plugin/Facet.java
+++ b/deploy/jbossas/modeshape-jbossas-console/src/main/java/org/modeshape/rhq/plugin/Facet.java
@@ -133,7 +133,8 @@ public abstract class Facet implements
 	 * 
 	 * @see ResourceComponent#start(ResourceContext)
 	 */
-	public void start(ResourceContext context) {
+	@Override
+    public void start(ResourceContext context) {
 		resourceContext = context;
 		deploymentName = context.getResourceKey();
 	}
@@ -145,7 +146,8 @@ public abstract class Facet implements
 	 * 
 	 * @see ResourceComponent#stop()
 	 */
-	public void stop() {
+	@Override
+    public void stop() {
 		this.isAvailable = false;
 	}
 
@@ -211,7 +213,8 @@ public abstract class Facet implements
 	 * 
 	 * @see org.rhq.core.pluginapi.inventory.ResourceComponent#getAvailability()
 	 */
-	public AvailabilityType getAvailability() {
+	@Override
+    public AvailabilityType getAvailability() {
 
 		LOG.debug("Checking availability of  " + identifier); //$NON-NLS-1$
 
@@ -236,7 +239,8 @@ public abstract class Facet implements
 	 * 
 	 * @see MeasurementFacet#getValues(MeasurementReport, Set)
 	 */
-	public abstract void getValues(MeasurementReport arg0,
+	@Override
+    public abstract void getValues(MeasurementReport arg0,
 			Set<MeasurementScheduleRequest> arg1) throws Exception;
 
 	/**
@@ -247,7 +251,8 @@ public abstract class Facet implements
 	 * 
 	 * @see OperationFacet#invokeOperation(String, Configuration)
 	 */
-	public OperationResult invokeOperation(String name,
+	@Override
+    public OperationResult invokeOperation(String name,
 			Configuration configuration) {
 		Map valueMap = new HashMap<String, Object>();
 
@@ -274,7 +279,8 @@ public abstract class Facet implements
 	 * 
 	 * @see ConfigurationFacet#loadResourceConfiguration()
 	 */
-	public Configuration loadResourceConfiguration() {
+	@Override
+    public Configuration loadResourceConfiguration() {
 		// here we simulate the loading of the managed resource's configuration
 
 		if (resourceConfiguration == null) {
@@ -299,7 +305,8 @@ public abstract class Facet implements
 	 * 
 	 * @see ConfigurationFacet#updateResourceConfiguration(ConfigurationUpdateReport)
 	 */
-	public void updateResourceConfiguration(ConfigurationUpdateReport report) {
+	@Override
+    public void updateResourceConfiguration(ConfigurationUpdateReport report) {
 
 		resourceConfiguration = report.getConfiguration().deepCopy();
 

--- a/deploy/jbossas/modeshape-jbossas-console/src/main/java/org/modeshape/rhq/plugin/RepositoryDiscoveryComponent.java
+++ b/deploy/jbossas/modeshape-jbossas-console/src/main/java/org/modeshape/rhq/plugin/RepositoryDiscoveryComponent.java
@@ -60,7 +60,8 @@ public class RepositoryDiscoveryComponent implements
 	 * 
 	 * @see org.rhq.core.pluginapi.inventory.ResourceDiscoveryComponent#discoverResources(org.rhq.core.pluginapi.inventory.ResourceDiscoveryContext)
 	 */
-	@SuppressWarnings( "rawtypes" )
+	@Override
+    @SuppressWarnings( "rawtypes" )
     public Set<DiscoveredResourceDetails> discoverResources(
 			ResourceDiscoveryContext discoveryContext)
 			throws InvalidPluginConfigurationException, Exception {

--- a/deploy/jbossas/modeshape-jbossas-console/src/main/java/org/modeshape/rhq/plugin/SequencerDiscoveryComponent.java
+++ b/deploy/jbossas/modeshape-jbossas-console/src/main/java/org/modeshape/rhq/plugin/SequencerDiscoveryComponent.java
@@ -63,7 +63,8 @@ public class SequencerDiscoveryComponent implements
 	 * 
 	 * @see org.rhq.core.pluginapi.inventory.ResourceDiscoveryComponent#discoverResources(org.rhq.core.pluginapi.inventory.ResourceDiscoveryContext)
 	 */
-	@SuppressWarnings( "rawtypes" )
+	@Override
+    @SuppressWarnings( "rawtypes" )
     public Set<DiscoveredResourceDetails> discoverResources(
 			ResourceDiscoveryContext discoveryContext)
 			throws InvalidPluginConfigurationException, Exception {

--- a/deploy/jbossas/modeshape-jbossas-console/src/main/java/org/modeshape/rhq/plugin/SequencingServiceDiscoveryComponent.java
+++ b/deploy/jbossas/modeshape-jbossas-console/src/main/java/org/modeshape/rhq/plugin/SequencingServiceDiscoveryComponent.java
@@ -62,6 +62,7 @@ public class SequencingServiceDiscoveryComponent implements
 	 * 
 	 * @see org.rhq.core.pluginapi.inventory.ResourceDiscoveryComponent#discoverResources(org.rhq.core.pluginapi.inventory.ResourceDiscoveryContext)
 	 */
+    @Override
     @SuppressWarnings( "rawtypes" )
 	public Set<DiscoveredResourceDetails> discoverResources(
 			ResourceDiscoveryContext discoveryContext)

--- a/deploy/jbossas/modeshape-jbossas-console/src/main/java/org/modeshape/rhq/plugin/objects/ExecutedOperationResultImpl.java
+++ b/deploy/jbossas/modeshape-jbossas-console/src/main/java/org/modeshape/rhq/plugin/objects/ExecutedOperationResultImpl.java
@@ -82,10 +82,12 @@ public class ExecutedOperationResultImpl implements ExecutedResult {
         init();
     }
 
+    @Override
     public String getComponentType() {
         return this.componentType;
     }
 
+    @Override
     public String getOperationName() {
         return this.operationName;
     }
@@ -94,11 +96,13 @@ public class ExecutedOperationResultImpl implements ExecutedResult {
         return operationResult;
     }
 
+    @Override
     @SuppressWarnings( "unchecked" )
     public List getFieldNameList() {
         return fieldNameList;
     }
 
+    @Override
     public Object getResult() {
         return result;
     }
@@ -122,11 +126,13 @@ public class ExecutedOperationResultImpl implements ExecutedResult {
         operationResult.getComplexResults().put(list);
     }
 
+    @Override
     public void setContent( Collection content ) {
         this.content = content;
         setComplexResult();
     }
 
+    @Override
     public void setContent( String content ) {
         this.content = content;
         this.result = content;
@@ -158,6 +164,7 @@ public class ExecutedOperationResultImpl implements ExecutedResult {
     /**
      * @param managedOperation Sets managedOperation to the specified value.
      */
+    @Override
     public void setManagedOperation( ManagedOperation managedOperation ) {
         this.managedOperation = managedOperation;
     }

--- a/deploy/jbossas/modeshape-jbossas-console/src/main/java/org/modeshape/rhq/plugin/objects/ExecutedResourceConfigurationResultImpl.java
+++ b/deploy/jbossas/modeshape-jbossas-console/src/main/java/org/modeshape/rhq/plugin/objects/ExecutedResourceConfigurationResultImpl.java
@@ -69,19 +69,23 @@ public class ExecutedResourceConfigurationResultImpl implements ExecutedResult {
         content = null;
     }
 
+    @Override
     public String getComponentType() {
         return this.componentType;
     }
 
+    @Override
     public String getOperationName() {
         return this.operationName;
     }
 
+    @Override
     @SuppressWarnings( "unchecked" )
     public List getFieldNameList() {
         return fieldNameList;
     }
 
+    @Override
     public Object getResult() {
         return result;
     }
@@ -105,11 +109,13 @@ public class ExecutedResourceConfigurationResultImpl implements ExecutedResult {
         result = list;
     }
 
+    @Override
     public void setContent( Collection content ) {
         this.content = content;
         setComplexResult();
     }
 
+    @Override
     public void setContent( String content ) {
         this.content = content;
     }

--- a/docs/examples/gettingstarted/repositories/src/main/java/org/modeshape/example/repository/ConsoleInput.java
+++ b/docs/examples/gettingstarted/repositories/src/main/java/org/modeshape/example/repository/ConsoleInput.java
@@ -81,6 +81,7 @@ public class ConsoleInput implements UserInterface {
 
                 private boolean quit = false;
 
+                @Override
                 @SuppressWarnings( "synthetic-access" )
                 public void run() {
                     try {
@@ -273,6 +274,7 @@ public class ConsoleInput implements UserInterface {
      * @param activity the activity; may not be null but may be empty
      * @param t the exception; may not be null
      */
+    @Override
     public void displayError( String activity,
                               Throwable t ) {
         assert activity != null;
@@ -295,6 +297,7 @@ public class ConsoleInput implements UserInterface {
      * 
      * @see org.modeshape.example.repository.UserInterface#getLocationOfRepositoryFiles()
      */
+    @Override
     public String getLocationOfRepositoryFiles() {
         return new File("").getAbsolutePath();
     }
@@ -304,6 +307,7 @@ public class ConsoleInput implements UserInterface {
      * 
      * @see org.modeshape.example.repository.UserInterface#getRepositoryConfiguration()
      */
+    @Override
     public File getRepositoryConfiguration() {
         return new File("configRepository.xml");
     }
@@ -313,6 +317,7 @@ public class ConsoleInput implements UserInterface {
      * 
      * @see org.modeshape.example.repository.UserInterface#getCallbackHandler()
      */
+    @Override
     public CallbackHandler getCallbackHandler() {
         return new JaasSecurityContext.UserPasswordCallbackHandler("jsmith", "secret".toCharArray());
     }

--- a/docs/examples/gettingstarted/sequencers/src/main/java/org/modeshape/example/sequencer/ConsoleInput.java
+++ b/docs/examples/gettingstarted/sequencers/src/main/java/org/modeshape/example/sequencer/ConsoleInput.java
@@ -51,6 +51,7 @@ public class ConsoleInput implements UserInterface {
 
                 private boolean quit = false;
 
+                @Override
                 public void run() {
                     try {
                         while (!quit) {
@@ -138,6 +139,7 @@ public class ConsoleInput implements UserInterface {
     /**
      * {@inheritDoc}
      */
+    @Override
     public URL getFileToUpload() throws IllegalArgumentException, IOException {
         System.out.println("Please enter the file to upload:");
         String path = in.readLine();
@@ -155,6 +157,7 @@ public class ConsoleInput implements UserInterface {
         return file.toURI().toURL();
     }
 
+    @Override
     public String getRepositoryPath( String defaultPath ) throws IllegalArgumentException, IOException {
         if (defaultPath != null) defaultPath = defaultPath.trim();
         if (defaultPath.length() == 0) defaultPath = null;
@@ -170,6 +173,7 @@ public class ConsoleInput implements UserInterface {
         return path;
     }
 
+    @Override
     public void displaySearchResults( List<ContentInfo> contentInfos ) {
         System.out.println();
         if (contentInfos.isEmpty()) {
@@ -199,6 +203,7 @@ public class ConsoleInput implements UserInterface {
         return sb.toString();
     }
 
+    @Override
     public void displayError( Exception e ) {
         System.err.println(e.getMessage());
     }

--- a/docs/examples/gettingstarted/sequencers/src/main/java/org/modeshape/example/sequencer/SequencingClient.java
+++ b/docs/examples/gettingstarted/sequencers/src/main/java/org/modeshape/example/sequencer/SequencingClient.java
@@ -593,6 +593,7 @@ public class SequencingClient {
          * 
          * @see org.modeshape.jcr.api.SecurityContext#getUserName()
          */
+        @Override
         public String getUserName() {
             return "Fred";
         }
@@ -602,6 +603,7 @@ public class SequencingClient {
          * 
          * @see org.modeshape.jcr.api.SecurityContext#hasRole(java.lang.String)
          */
+        @Override
         public boolean hasRole( String roleName ) {
             return true;
         }
@@ -611,6 +613,7 @@ public class SequencingClient {
          * 
          * @see org.modeshape.jcr.api.SecurityContext#logout()
          */
+        @Override
         public void logout() {
             // do something
         }

--- a/docs/examples/gettingstarted/sequencers/src/test/java/org/modeshape/example/sequencer/MockUserInterface.java
+++ b/docs/examples/gettingstarted/sequencers/src/test/java/org/modeshape/example/sequencer/MockUserInterface.java
@@ -48,6 +48,7 @@ public class MockUserInterface implements UserInterface {
     /**
      * {@inheritDoc}
      */
+    @Override
     public void displaySearchResults( List<ContentInfo> infos ) {
         assertThat(infos.size(), is(this.numberOfSearchResults));
         for (ContentInfo info : infos) {
@@ -59,6 +60,7 @@ public class MockUserInterface implements UserInterface {
     /**
      * {@inheritDoc}
      */
+    @Override
     public URL getFileToUpload() {
         return this.fileToUpload;
     }
@@ -66,6 +68,7 @@ public class MockUserInterface implements UserInterface {
     /**
      * {@inheritDoc}
      */
+    @Override
     public String getRepositoryPath( String defaultPath ) {
         return this.repositoryPath != null ? this.repositoryPath : defaultPath;
     }
@@ -75,6 +78,7 @@ public class MockUserInterface implements UserInterface {
      * 
      * @see org.modeshape.example.sequencer.UserInterface#displayError(java.lang.Exception)
      */
+    @Override
     public void displayError( Exception e ) {
         // Do nothing
     }

--- a/extensions/modeshape-classloader-maven/src/main/java/org/modeshape/maven/MavenId.java
+++ b/extensions/modeshape-classloader-maven/src/main/java/org/modeshape/maven/MavenId.java
@@ -312,6 +312,7 @@ public class MavenId implements Comparable<MavenId>, Cloneable {
     /**
      * {@inheritDoc}
      */
+    @Override
     public int compareTo( MavenId that ) {
         if (that == null) return 1;
         if (this == that) return 0;
@@ -381,6 +382,7 @@ public class MavenId implements Comparable<MavenId>, Cloneable {
         /**
          * {@inheritDoc}
          */
+        @Override
         public int compareTo( Version that ) {
             if (that == null) return 1;
             Object[] thisComponents = this.getComponents();

--- a/extensions/modeshape-classloader-maven/src/main/java/org/modeshape/maven/MavenRepository.java
+++ b/extensions/modeshape-classloader-maven/src/main/java/org/modeshape/maven/MavenRepository.java
@@ -110,6 +110,7 @@ public class MavenRepository implements ClassLoaderFactory {
      * @return the class loader
      * @throws IllegalArgumentException if no coordinates are passed in or if any of the coordinate references is null
      */
+    @Override
     public ClassLoader getClassLoader( String... coordinates ) {
         return getClassLoader(null, coordinates);
     }

--- a/extensions/modeshape-classloader-maven/src/main/java/org/modeshape/maven/spi/AbstractMavenUrlProvider.java
+++ b/extensions/modeshape-classloader-maven/src/main/java/org/modeshape/maven/spi/AbstractMavenUrlProvider.java
@@ -39,6 +39,7 @@ public abstract class AbstractMavenUrlProvider implements MavenUrlProvider {
     /**
      * {@inheritDoc}
      */
+    @Override
     public void configure( Properties properties ) {
         this.properties = new UnmodifiableProperties(properties);
     }

--- a/extensions/modeshape-classloader-maven/src/main/java/org/modeshape/maven/spi/JcrMavenUrlProvider.java
+++ b/extensions/modeshape-classloader-maven/src/main/java/org/modeshape/maven/spi/JcrMavenUrlProvider.java
@@ -195,6 +195,7 @@ public class JcrMavenUrlProvider extends AbstractMavenUrlProvider {
     /**
      * {@inheritDoc}
      */
+    @Override
     public URL getUrl( MavenId mavenId,
                        ArtifactType artifactType,
                        SignatureType signatureType,

--- a/extensions/modeshape-connector-filesystem/src/main/java/org/modeshape/connector/filesystem/FileSystemSource.java
+++ b/extensions/modeshape-connector-filesystem/src/main/java/org/modeshape/connector/filesystem/FileSystemSource.java
@@ -202,6 +202,7 @@ public class FileSystemSource extends AbstractRepositorySource implements Object
      * 
      * @see org.modeshape.graph.connector.RepositorySource#getCapabilities()
      */
+    @Override
     public RepositorySourceCapabilities getCapabilities() {
         return capabilities;
     }
@@ -351,6 +352,7 @@ public class FileSystemSource extends AbstractRepositorySource implements Object
             filenameFilter = new FilenameFilter() {
                 Pattern filter = Pattern.compile(filterPattern);
 
+                @Override
                 public boolean accept( File dir,
                                        String name ) {
                     return !filter.matcher(name).matches();
@@ -402,6 +404,7 @@ public class FileSystemSource extends AbstractRepositorySource implements Object
      * 
      * @return the name of the workspace that should be used by default; never null
      */
+    @Override
     public String getDefaultWorkspaceName() {
         return defaultWorkspaceName;
     }
@@ -491,6 +494,7 @@ public class FileSystemSource extends AbstractRepositorySource implements Object
      *        allowed.
      * @see #areUpdatesAllowed()
      */
+    @Override
     public synchronized void setUpdatesAllowed( boolean allowUpdates ) {
         capabilities = new RepositorySourceCapabilities(capabilities.supportsSameNameSiblings(), allowUpdates,
                                                         capabilities.supportsEvents(), capabilities.supportsCreatingWorkspaces(),
@@ -622,6 +626,7 @@ public class FileSystemSource extends AbstractRepositorySource implements Object
      * 
      * @see javax.naming.Referenceable#getReference()
      */
+    @Override
     public synchronized Reference getReference() {
         String className = getClass().getName();
         String factoryClassName = this.getClass().getName();
@@ -659,6 +664,7 @@ public class FileSystemSource extends AbstractRepositorySource implements Object
     /**
      * {@inheritDoc}
      */
+    @Override
     public Object getObjectInstance( Object obj,
                                      javax.naming.Name name,
                                      Context nameCtx,
@@ -709,6 +715,7 @@ public class FileSystemSource extends AbstractRepositorySource implements Object
      * 
      * @see org.modeshape.graph.connector.RepositorySource#getConnection()
      */
+    @Override
     public synchronized RepositoryConnection getConnection() throws RepositorySourceException {
         String sourceName = getName();
         if (sourceName == null || sourceName.trim().length() == 0) {

--- a/extensions/modeshape-connector-filesystem/src/main/java/org/modeshape/connector/filesystem/StoreProperties.java
+++ b/extensions/modeshape-connector-filesystem/src/main/java/org/modeshape/connector/filesystem/StoreProperties.java
@@ -124,6 +124,7 @@ public class StoreProperties extends BasePropertiesFactory {
         final Pattern resourceExtensionFilter = Pattern.compile(resourceExtension.replaceAll("\\.", "\\\\.") + "$");
         return new FilenameFilter() {
 
+            @Override
             public boolean accept( File dir,
                                    String name ) {
                 if (extensionFilter.matcher(name).matches()) return false;

--- a/extensions/modeshape-connector-filesystem/src/test/java/org/modeshape/connector/filesystem/FileSystemSourceTest.java
+++ b/extensions/modeshape-connector-filesystem/src/test/java/org/modeshape/connector/filesystem/FileSystemSourceTest.java
@@ -57,21 +57,26 @@ public class FileSystemSourceTest {
         this.source.setWorkspaceRootPath("target");
         this.source.initialize(new RepositoryContext() {
 
+            @Override
             public Subgraph getConfiguration( int depth ) {
                 return null;
             }
 
+            @Override
             public ExecutionContext getExecutionContext() {
                 return context;
             }
 
+            @Override
             public Observer getObserver() {
                 return null;
             }
 
+            @Override
             public RepositoryConnectionFactory getRepositoryConnectionFactory() {
                 return new RepositoryConnectionFactory() {
 
+                    @Override
                     @SuppressWarnings( "synthetic-access" )
                     public RepositoryConnection createConnection( String sourceName ) throws RepositorySourceException {
                         return source.getConnection();

--- a/extensions/modeshape-connector-infinispan/src/main/java/org/modeshape/connector/infinispan/BaseInfinispanSource.java
+++ b/extensions/modeshape-connector-infinispan/src/main/java/org/modeshape/connector/infinispan/BaseInfinispanSource.java
@@ -135,6 +135,7 @@ public abstract class BaseInfinispanSource implements BaseRepositorySource, Obje
      * 
      * @see org.modeshape.graph.connector.RepositorySource#initialize(org.modeshape.graph.connector.RepositoryContext)
      */
+    @Override
     public void initialize( RepositoryContext context ) throws RepositorySourceException {
         this.repositoryContext = context;
     }
@@ -142,6 +143,7 @@ public abstract class BaseInfinispanSource implements BaseRepositorySource, Obje
     /**
      * {@inheritDoc}
      */
+    @Override
     public String getName() {
         return this.name;
     }
@@ -151,6 +153,7 @@ public abstract class BaseInfinispanSource implements BaseRepositorySource, Obje
      * 
      * @see org.modeshape.graph.connector.RepositorySource#getCapabilities()
      */
+    @Override
     public RepositorySourceCapabilities getCapabilities() {
         return capabilities;
     }
@@ -160,6 +163,7 @@ public abstract class BaseInfinispanSource implements BaseRepositorySource, Obje
      * 
      * @see org.modeshape.graph.connector.RepositorySource#getRetryLimit()
      */
+    @Override
     public int getRetryLimit() {
         return retryLimit;
     }
@@ -169,6 +173,7 @@ public abstract class BaseInfinispanSource implements BaseRepositorySource, Obje
      * 
      * @see org.modeshape.graph.connector.RepositorySource#setRetryLimit(int)
      */
+    @Override
     public synchronized void setRetryLimit( int limit ) {
         retryLimit = limit < 0 ? 0 : limit;
     }
@@ -188,6 +193,7 @@ public abstract class BaseInfinispanSource implements BaseRepositorySource, Obje
      * 
      * @return the default cache policy, or null if this source has no explicit default cache policy
      */
+    @Override
     public CachePolicy getDefaultCachePolicy() {
         return defaultCachePolicy;
     }
@@ -217,6 +223,7 @@ public abstract class BaseInfinispanSource implements BaseRepositorySource, Obje
      * 
      * @return the UUID of the root node for the cache.
      */
+    @Override
     public UUID getRootNodeUuidObject() {
         return this.rootNodeUuid;
     }
@@ -240,6 +247,7 @@ public abstract class BaseInfinispanSource implements BaseRepositorySource, Obje
      * 
      * @return the name of the workspace that should be used by default; never null
      */
+    @Override
     public String getDefaultWorkspaceName() {
         return defaultWorkspace;
     }
@@ -325,6 +333,7 @@ public abstract class BaseInfinispanSource implements BaseRepositorySource, Obje
      * 
      * @see org.modeshape.graph.connector.RepositorySource#close()
      */
+    @Override
     public synchronized void close() {
         if (this.repository != null) {
             try {
@@ -338,6 +347,7 @@ public abstract class BaseInfinispanSource implements BaseRepositorySource, Obje
     /**
      * @return repositoryContext
      */
+    @Override
     public RepositoryContext getRepositoryContext() {
         return repositoryContext;
     }
@@ -354,10 +364,12 @@ public abstract class BaseInfinispanSource implements BaseRepositorySource, Obje
         this.jndiContext = context;
     }
 
+    @Override
     public boolean areUpdatesAllowed() {
         return this.updatesAllowed;
     }
 
+    @Override
     public void setUpdatesAllowed( boolean updatesAllowed ) {
         this.updatesAllowed = updatesAllowed;
     }
@@ -367,6 +379,7 @@ public abstract class BaseInfinispanSource implements BaseRepositorySource, Obje
      * 
      * @see org.modeshape.graph.connector.RepositorySource#getConnection()
      */
+    @Override
     public synchronized RepositoryConnection getConnection() throws RepositorySourceException {
         if (getName() == null) {
             I18n msg = InfinispanConnectorI18n.propertyIsRequired;
@@ -395,6 +408,7 @@ public abstract class BaseInfinispanSource implements BaseRepositorySource, Obje
     /**
      * {@inheritDoc}
      */
+    @Override
     public synchronized Reference getReference() {
         String className = getClass().getName();
         String managerClassName = this.getClass().getName();

--- a/extensions/modeshape-connector-infinispan/src/main/java/org/modeshape/connector/infinispan/InfinispanSource.java
+++ b/extensions/modeshape-connector-infinispan/src/main/java/org/modeshape/connector/infinispan/InfinispanSource.java
@@ -272,6 +272,7 @@ public class InfinispanSource extends BaseInfinispanSource {
     /**
      * {@inheritDoc}
      */
+    @Override
     public Object getObjectInstance( Object obj,
                                      javax.naming.Name name,
                                      Context nameCtx,

--- a/extensions/modeshape-connector-infinispan/src/main/java/org/modeshape/connector/infinispan/InfinispanTransaction.java
+++ b/extensions/modeshape-connector-infinispan/src/main/java/org/modeshape/connector/infinispan/InfinispanTransaction.java
@@ -68,6 +68,7 @@ public class InfinispanTransaction extends MapTransaction<InfinispanNode, Infini
      * @see org.modeshape.graph.connector.base.Transaction#getWorkspace(java.lang.String,
      *      org.modeshape.graph.connector.base.Workspace)
      */
+    @Override
     public InfinispanWorkspace getWorkspace( String name,
                                              InfinispanWorkspace originalToClone ) {
         Cache<UUID, InfinispanNode> workspaceCache = repository.getCacheContainer().getCache(name);
@@ -86,6 +87,7 @@ public class InfinispanTransaction extends MapTransaction<InfinispanNode, Infini
      * 
      * @see org.modeshape.graph.connector.base.Transaction#destroyWorkspace(org.modeshape.graph.connector.base.Workspace)
      */
+    @Override
     public boolean destroyWorkspace( InfinispanWorkspace workspace ) {
         // Can't seem to tell Infinispan to destroy the cache, so perhaps we should destroy all the content ...
         workspace.destroy();

--- a/extensions/modeshape-connector-jbosscache/src/main/java/org/modeshape/connector/jbosscache/JBossCacheSource.java
+++ b/extensions/modeshape-connector-jbosscache/src/main/java/org/modeshape/connector/jbosscache/JBossCacheSource.java
@@ -179,6 +179,7 @@ public class JBossCacheSource implements BaseRepositorySource, ObjectFactory {
      * 
      * @see org.modeshape.graph.connector.RepositorySource#initialize(org.modeshape.graph.connector.RepositoryContext)
      */
+    @Override
     public void initialize( RepositoryContext context ) throws RepositorySourceException {
         this.repositoryContext = context;
     }
@@ -186,6 +187,7 @@ public class JBossCacheSource implements BaseRepositorySource, ObjectFactory {
     /**
      * {@inheritDoc}
      */
+    @Override
     public String getName() {
         return this.name;
     }
@@ -195,6 +197,7 @@ public class JBossCacheSource implements BaseRepositorySource, ObjectFactory {
      * 
      * @see org.modeshape.graph.connector.RepositorySource#getCapabilities()
      */
+    @Override
     public RepositorySourceCapabilities getCapabilities() {
         return capabilities;
     }
@@ -204,6 +207,7 @@ public class JBossCacheSource implements BaseRepositorySource, ObjectFactory {
      * 
      * @see org.modeshape.graph.connector.RepositorySource#getRetryLimit()
      */
+    @Override
     public int getRetryLimit() {
         return retryLimit;
     }
@@ -213,6 +217,7 @@ public class JBossCacheSource implements BaseRepositorySource, ObjectFactory {
      * 
      * @see org.modeshape.graph.connector.RepositorySource#setRetryLimit(int)
      */
+    @Override
     public synchronized void setRetryLimit( int limit ) {
         retryLimit = limit < 0 ? 0 : limit;
     }
@@ -232,6 +237,7 @@ public class JBossCacheSource implements BaseRepositorySource, ObjectFactory {
      * 
      * @return the default cache policy, or null if this source has no explicit default cache policy
      */
+    @Override
     public CachePolicy getDefaultCachePolicy() {
         return defaultCachePolicy;
     }
@@ -385,6 +391,7 @@ public class JBossCacheSource implements BaseRepositorySource, ObjectFactory {
      * 
      * @return the UUID of the root node for the cache.
      */
+    @Override
     public UUID getRootNodeUuidObject() {
         return this.rootNodeUuid;
     }
@@ -408,6 +415,7 @@ public class JBossCacheSource implements BaseRepositorySource, ObjectFactory {
      * 
      * @return the name of the workspace that should be used by default; never null
      */
+    @Override
     public String getDefaultWorkspaceName() {
         return defaultWorkspace;
     }
@@ -482,6 +490,7 @@ public class JBossCacheSource implements BaseRepositorySource, ObjectFactory {
      * 
      * @see org.modeshape.graph.connector.RepositorySource#getConnection()
      */
+    @Override
     @SuppressWarnings( "unchecked" )
     public synchronized RepositoryConnection getConnection() throws RepositorySourceException {
         if (getName() == null) {
@@ -530,6 +539,7 @@ public class JBossCacheSource implements BaseRepositorySource, ObjectFactory {
      * 
      * @see org.modeshape.graph.connector.RepositorySource#close()
      */
+    @Override
     public synchronized void close() {
         // Null the reference to the repository; open connections still reference it and can continue to work ...
         this.repository = null;
@@ -580,6 +590,7 @@ public class JBossCacheSource implements BaseRepositorySource, ObjectFactory {
     /**
      * @return repositoryContext
      */
+    @Override
     public RepositoryContext getRepositoryContext() {
         return repositoryContext;
     }
@@ -596,10 +607,12 @@ public class JBossCacheSource implements BaseRepositorySource, ObjectFactory {
         this.jndiContext = context;
     }
 
+    @Override
     public boolean areUpdatesAllowed() {
         return this.updatesAllowed;
     }
 
+    @Override
     public void setUpdatesAllowed( boolean updatesAllowed ) {
         this.updatesAllowed = updatesAllowed;
     }
@@ -630,6 +643,7 @@ public class JBossCacheSource implements BaseRepositorySource, ObjectFactory {
     /**
      * {@inheritDoc}
      */
+    @Override
     public synchronized Reference getReference() {
         String className = getClass().getName();
         String factoryClassName = this.getClass().getName();
@@ -666,6 +680,7 @@ public class JBossCacheSource implements BaseRepositorySource, ObjectFactory {
     /**
      * {@inheritDoc}
      */
+    @Override
     public Object getObjectInstance( Object obj,
                                      javax.naming.Name name,
                                      Context nameCtx,

--- a/extensions/modeshape-connector-jbosscache/src/main/java/org/modeshape/connector/jbosscache/JBossCacheTransaction.java
+++ b/extensions/modeshape-connector-jbosscache/src/main/java/org/modeshape/connector/jbosscache/JBossCacheTransaction.java
@@ -68,6 +68,7 @@ public class JBossCacheTransaction extends MapTransaction<JBossCacheNode, JBossC
      * @see org.modeshape.graph.connector.base.Transaction#getWorkspace(java.lang.String,
      *      org.modeshape.graph.connector.base.Workspace)
      */
+    @Override
     public JBossCacheWorkspace getWorkspace( String name,
                                              JBossCacheWorkspace originalToClone ) {
         Cache<UUID, JBossCacheNode> workspaceCache = repository.getCache();
@@ -86,6 +87,7 @@ public class JBossCacheTransaction extends MapTransaction<JBossCacheNode, JBossC
      * 
      * @see org.modeshape.graph.connector.base.Transaction#destroyWorkspace(org.modeshape.graph.connector.base.Workspace)
      */
+    @Override
     public boolean destroyWorkspace( JBossCacheWorkspace workspace ) {
         // Can't seem to tell Infinispan to destroy the cache, so perhaps we should destroy all the content ...
         workspace.removeAll();

--- a/extensions/modeshape-connector-jcr/src/main/java/org/modeshape/connector/jcr/JcrRepositoryConnection.java
+++ b/extensions/modeshape-connector-jcr/src/main/java/org/modeshape/connector/jcr/JcrRepositoryConnection.java
@@ -59,6 +59,7 @@ public class JcrRepositoryConnection implements RepositoryConnection {
     /**
      * {@inheritDoc}
      */
+    @Override
     public String getSourceName() {
         return source.getName();
     }
@@ -66,6 +67,7 @@ public class JcrRepositoryConnection implements RepositoryConnection {
     /**
      * {@inheritDoc}
      */
+    @Override
     public CachePolicy getDefaultCachePolicy() {
         return source.getDefaultCachePolicy();
     }
@@ -73,6 +75,7 @@ public class JcrRepositoryConnection implements RepositoryConnection {
     /**
      * {@inheritDoc}
      */
+    @Override
     public XAResource getXAResource() {
         return null;
     }
@@ -80,6 +83,7 @@ public class JcrRepositoryConnection implements RepositoryConnection {
     /**
      * {@inheritDoc}
      */
+    @Override
     public boolean ping( long time,
                          TimeUnit unit ) {
         return true;
@@ -88,6 +92,7 @@ public class JcrRepositoryConnection implements RepositoryConnection {
     /**
      * {@inheritDoc}
      */
+    @Override
     public void close() {
         // do nothing
     }
@@ -98,6 +103,7 @@ public class JcrRepositoryConnection implements RepositoryConnection {
      * @see org.modeshape.graph.connector.RepositoryConnection#execute(org.modeshape.graph.ExecutionContext,
      *      org.modeshape.graph.request.Request)
      */
+    @Override
     public void execute( final ExecutionContext context,
                          Request request ) throws RepositorySourceException {
         Logger logger = context.getLogger(getClass());

--- a/extensions/modeshape-connector-jcr/src/main/java/org/modeshape/connector/jcr/JcrRepositorySource.java
+++ b/extensions/modeshape-connector-jcr/src/main/java/org/modeshape/connector/jcr/JcrRepositorySource.java
@@ -151,6 +151,7 @@ public class JcrRepositorySource implements RepositorySource, ObjectFactory {
      * 
      * @see org.modeshape.graph.connector.RepositorySource#getName()
      */
+    @Override
     public String getName() {
         return name;
     }
@@ -173,6 +174,7 @@ public class JcrRepositorySource implements RepositorySource, ObjectFactory {
      * 
      * @see org.modeshape.graph.connector.RepositorySource#getCapabilities()
      */
+    @Override
     public RepositorySourceCapabilities getCapabilities() {
         return capabilities;
     }
@@ -277,6 +279,7 @@ public class JcrRepositorySource implements RepositorySource, ObjectFactory {
      * 
      * @see org.modeshape.graph.connector.RepositorySource#getRetryLimit()
      */
+    @Override
     public int getRetryLimit() {
         return retryLimit;
     }
@@ -286,6 +289,7 @@ public class JcrRepositorySource implements RepositorySource, ObjectFactory {
      * 
      * @see org.modeshape.graph.connector.RepositorySource#setRetryLimit(int)
      */
+    @Override
     public synchronized void setRetryLimit( int limit ) {
         retryLimit = limit < 0 ? 0 : limit;
     }
@@ -295,6 +299,7 @@ public class JcrRepositorySource implements RepositorySource, ObjectFactory {
      * 
      * @see org.modeshape.graph.connector.RepositorySource#initialize(org.modeshape.graph.connector.RepositoryContext)
      */
+    @Override
     public void initialize( RepositoryContext context ) throws RepositorySourceException {
         this.repositoryContext = context;
     }
@@ -324,6 +329,7 @@ public class JcrRepositorySource implements RepositorySource, ObjectFactory {
      * 
      * @see javax.naming.Referenceable#getReference()
      */
+    @Override
     public synchronized Reference getReference() {
         String className = getClass().getName();
         String factoryClassName = this.getClass().getName();
@@ -367,6 +373,7 @@ public class JcrRepositorySource implements RepositorySource, ObjectFactory {
     /**
      * {@inheritDoc}
      */
+    @Override
     public Object getObjectInstance( Object obj,
                                      javax.naming.Name name,
                                      Context nameCtx,
@@ -424,6 +431,7 @@ public class JcrRepositorySource implements RepositorySource, ObjectFactory {
      * 
      * @see org.modeshape.graph.connector.RepositorySource#getConnection()
      */
+    @Override
     public synchronized RepositoryConnection getConnection() throws RepositorySourceException {
         if (name == null || name.trim().length() == 0) {
             I18n msg = JcrConnectorI18n.propertyIsRequired;
@@ -481,6 +489,7 @@ public class JcrRepositorySource implements RepositorySource, ObjectFactory {
      * 
      * @see org.modeshape.graph.connector.RepositorySource#close()
      */
+    @Override
     public void close() {
         // Null the repository context and Repository references ...
         this.repositoryContext = null;

--- a/extensions/modeshape-connector-jcr/src/test/java/org/modeshape/connector/jcr/JcrRepositorySourceTest.java
+++ b/extensions/modeshape-connector-jcr/src/test/java/org/modeshape/connector/jcr/JcrRepositorySourceTest.java
@@ -73,21 +73,26 @@ public class JcrRepositorySourceTest {
         // Initialize ...
         this.source.initialize(new RepositoryContext() {
 
+            @Override
             public Subgraph getConfiguration( int depth ) {
                 return null;
             }
 
+            @Override
             public ExecutionContext getExecutionContext() {
                 return context;
             }
 
+            @Override
             public Observer getObserver() {
                 return null;
             }
 
+            @Override
             public RepositoryConnectionFactory getRepositoryConnectionFactory() {
                 return new RepositoryConnectionFactory() {
 
+                    @Override
                     @SuppressWarnings( "synthetic-access" )
                     public RepositoryConnection createConnection( String sourceName ) throws RepositorySourceException {
                         return source.getConnection();

--- a/extensions/modeshape-connector-store-jpa/src/main/java/org/modeshape/connector/store/jpa/JpaSource.java
+++ b/extensions/modeshape-connector-store-jpa/src/main/java/org/modeshape/connector/store/jpa/JpaSource.java
@@ -363,6 +363,7 @@ public class JpaSource implements RepositorySource, ObjectFactory {
      * 
      * @see org.modeshape.graph.connector.RepositorySource#getName()
      */
+    @Override
     public String getName() {
         return name;
     }
@@ -389,6 +390,7 @@ public class JpaSource implements RepositorySource, ObjectFactory {
      * 
      * @see org.modeshape.graph.connector.RepositorySource#getCapabilities()
      */
+    @Override
     public RepositorySourceCapabilities getCapabilities() {
         return capabilities;
     }
@@ -483,6 +485,7 @@ public class JpaSource implements RepositorySource, ObjectFactory {
      * 
      * @see org.modeshape.graph.connector.RepositorySource#getRetryLimit()
      */
+    @Override
     public int getRetryLimit() {
         return retryLimit;
     }
@@ -492,6 +495,7 @@ public class JpaSource implements RepositorySource, ObjectFactory {
      * 
      * @see org.modeshape.graph.connector.RepositorySource#setRetryLimit(int)
      */
+    @Override
     public synchronized void setRetryLimit( int limit ) {
         if (limit < 0) limit = 0;
         this.retryLimit = limit;
@@ -983,6 +987,7 @@ public class JpaSource implements RepositorySource, ObjectFactory {
      * 
      * @see org.modeshape.graph.connector.RepositorySource#initialize(org.modeshape.graph.connector.RepositoryContext)
      */
+    @Override
     public void initialize( RepositoryContext context ) throws RepositorySourceException {
         this.repositoryContext = context;
     }
@@ -992,6 +997,7 @@ public class JpaSource implements RepositorySource, ObjectFactory {
      * 
      * @see javax.naming.Referenceable#getReference()
      */
+    @Override
     public Reference getReference() {
         String className = getClass().getName();
         String factoryClassName = this.getClass().getName();
@@ -1046,6 +1052,7 @@ public class JpaSource implements RepositorySource, ObjectFactory {
     /**
      * {@inheritDoc}
      */
+    @Override
     public Object getObjectInstance( Object obj,
                                      javax.naming.Name name,
                                      Context nameCtx,
@@ -1133,6 +1140,7 @@ public class JpaSource implements RepositorySource, ObjectFactory {
      * 
      * @see org.modeshape.graph.connector.RepositorySource#getConnection()
      */
+    @Override
     public synchronized RepositoryConnection getConnection() throws RepositorySourceException {
         if (this.name == null || this.name.trim().length() == 0) {
             throw new RepositorySourceException(JpaConnectorI18n.repositorySourceMustHaveName.text());
@@ -1286,6 +1294,7 @@ public class JpaSource implements RepositorySource, ObjectFactory {
      * 
      * @see org.modeshape.graph.connector.RepositorySource#close()
      */
+    @Override
     public synchronized void close() {
         if (entityManagers != null) {
             try {
@@ -1364,6 +1373,7 @@ public class JpaSource implements RepositorySource, ObjectFactory {
             this.ttl = ttl;
         }
 
+        @Override
         public long getTimeToLive() {
             return ttl;
         }

--- a/extensions/modeshape-connector-store-jpa/src/main/java/org/modeshape/connector/store/jpa/model/simple/SimpleJpaConnection.java
+++ b/extensions/modeshape-connector-store-jpa/src/main/java/org/modeshape/connector/store/jpa/model/simple/SimpleJpaConnection.java
@@ -54,6 +54,7 @@ public class SimpleJpaConnection implements RepositoryConnection {
 
     }
 
+    @Override
     public boolean ping( long time,
                          TimeUnit unit ) {
         // Most pings will occur before or after an execute() call, when there is no entityManger
@@ -61,14 +62,17 @@ public class SimpleJpaConnection implements RepositoryConnection {
         return entityManager == null || entityManager.isOpen();
     }
 
+    @Override
     public CachePolicy getDefaultCachePolicy() {
         return source.getCachePolicy();
     }
 
+    @Override
     public String getSourceName() {
         return source.getName();
     }
 
+    @Override
     public XAResource getXAResource() {
         return null;
     }
@@ -96,6 +100,7 @@ public class SimpleJpaConnection implements RepositoryConnection {
 
     }
 
+    @Override
     public void close() {
     }
 
@@ -105,6 +110,7 @@ public class SimpleJpaConnection implements RepositoryConnection {
      * @see org.modeshape.graph.connector.RepositoryConnection#execute(org.modeshape.graph.ExecutionContext,
      *      org.modeshape.graph.request.Request)
      */
+    @Override
     public void execute( ExecutionContext context,
                          Request request ) throws RepositorySourceException {
         Logger logger = context.getLogger(getClass());

--- a/extensions/modeshape-connector-store-jpa/src/main/java/org/modeshape/connector/store/jpa/model/simple/SimpleJpaRepository.java
+++ b/extensions/modeshape-connector-store-jpa/src/main/java/org/modeshape/connector/store/jpa/model/simple/SimpleJpaRepository.java
@@ -519,6 +519,7 @@ public class SimpleJpaRepository extends MapRepository {
          * @param lockTimeoutInMillis
          * @throws LockFailedException
          */
+        @Override
         public void lockNode( MapNode node,
                               LockScope lockScope,
                               long lockTimeoutInMillis ) throws LockFailedException {
@@ -530,6 +531,7 @@ public class SimpleJpaRepository extends MapRepository {
          * 
          * @param node the node to be unlocked
          */
+        @Override
         public void unlockNode( MapNode node ) {
             // Locking is not supported by this connector
         }
@@ -562,15 +564,18 @@ public class SimpleJpaRepository extends MapRepository {
             return (JpaNode)node;
         }
 
+        @Override
         public void addChild( int index,
                               MapNode child ) {
             entity.addChild(index, jpaNodeFor(child).entity);
         }
 
+        @Override
         public void addChild( MapNode child ) {
             entity.addChild(jpaNodeFor(child).entity);
         }
 
+        @Override
         public List<MapNode> getChildren() {
             List<MapNode> children = new ArrayList<MapNode>(entity.getChildren().size());
 
@@ -581,11 +586,13 @@ public class SimpleJpaRepository extends MapRepository {
             return Collections.unmodifiableList(children);
         }
 
+        @Override
         public Segment getName() {
             return pathFactory.createSegment(nameFactory.create(entity.getChildNamespace().getUri(), entity.getChildName()),
                                              entity.getSameNameSiblingIndex());
         }
 
+        @Override
         public MapNode getParent() {
             if (entity.getParent() == null) return null;
             return new JpaNode(entity.getParent());
@@ -656,6 +663,7 @@ public class SimpleJpaRepository extends MapRepository {
             }
         }
 
+        @Override
         public MapNode removeProperty( Name propertyName ) {
             ensurePropertiesLoaded();
 
@@ -666,21 +674,25 @@ public class SimpleJpaRepository extends MapRepository {
             return this;
         }
 
+        @Override
         public Map<Name, Property> getProperties() {
             ensurePropertiesLoaded();
             return properties;
         }
 
+        @Override
         public Property getProperty( ExecutionContext context,
                                      String name ) {
             return getProperty(context.getValueFactories().getNameFactory().create(name));
         }
 
+        @Override
         public Property getProperty( Name name ) {
             ensurePropertiesLoaded();
             return properties.get(name);
         }
 
+        @Override
         public Set<Name> getUniqueChildNames() {
             List<NodeEntity> children = entity.getChildren();
             Set<Name> uniqueNames = new HashSet<Name>(children.size());
@@ -692,11 +704,13 @@ public class SimpleJpaRepository extends MapRepository {
             return uniqueNames;
         }
 
+        @Override
         public UUID getUuid() {
             if (entity.getNodeUuidString() == null) return null;
             return UUID.fromString(entity.getNodeUuidString());
         }
 
+        @Override
         public boolean removeChild( MapNode child ) {
 
             /*
@@ -729,10 +743,12 @@ public class SimpleJpaRepository extends MapRepository {
             return true;
         }
 
+        @Override
         public void clearChildren() {
             entity.getChildren().clear();
         }
 
+        @Override
         public void setName( Segment name ) {
             entity.setChildNamespace(namespaceEntities.get(name.getName().getNamespaceUri(), true));
             // entity.setChildNamespace(NamespaceEntity.findByUri(entityManager, name.getName().getNamespaceUri(), true));
@@ -740,6 +756,7 @@ public class SimpleJpaRepository extends MapRepository {
             entity.setSameNameSiblingIndex(name.getIndex());
         }
 
+        @Override
         public void setParent( MapNode parent ) {
             if (parent == null) {
                 entity.setParent(null);
@@ -748,6 +765,7 @@ public class SimpleJpaRepository extends MapRepository {
             }
         }
 
+        @Override
         public MapNode setProperty( ExecutionContext context,
                                     String name,
                                     Object... values ) {
@@ -756,6 +774,7 @@ public class SimpleJpaRepository extends MapRepository {
             return this.setProperty(propertyFactory.create(nameFactory.create(name), values));
         }
 
+        @Override
         public MapNode setProperty( Property property ) {
             ensurePropertiesLoaded();
 
@@ -765,6 +784,7 @@ public class SimpleJpaRepository extends MapRepository {
             return this;
         }
 
+        @Override
         public MapNode setProperties( Iterable<Property> properties ) {
             ensurePropertiesLoaded();
 
@@ -818,6 +838,7 @@ public class SimpleJpaRepository extends MapRepository {
          * 
          * @see org.modeshape.connector.store.jpa.util.Serializer.LargeValues#getMinimumSize()
          */
+        @Override
         public long getMinimumSize() {
             return minimumSizeOfLargeValuesInBytes;
         }
@@ -828,6 +849,7 @@ public class SimpleJpaRepository extends MapRepository {
          * @see org.modeshape.connector.store.jpa.util.Serializer.LargeValues#read(org.modeshape.graph.property.ValueFactories,
          *      byte[], long)
          */
+        @Override
         public Object read( ValueFactories valueFactories,
                             byte[] hash,
                             long length ) throws IOException {
@@ -856,6 +878,7 @@ public class SimpleJpaRepository extends MapRepository {
          * @see org.modeshape.connector.store.jpa.util.Serializer.LargeValues#write(byte[], long,
          *      org.modeshape.graph.property.PropertyType, java.lang.Object)
          */
+        @Override
         public void write( byte[] hash,
                            long length,
                            PropertyType type,

--- a/extensions/modeshape-connector-store-jpa/src/main/java/org/modeshape/connector/store/jpa/model/simple/SimpleJpaTransaction.java
+++ b/extensions/modeshape-connector-store-jpa/src/main/java/org/modeshape/connector/store/jpa/model/simple/SimpleJpaTransaction.java
@@ -48,6 +48,7 @@ public class SimpleJpaTransaction implements MapRepositoryTransaction {
      * 
      * @see org.modeshape.graph.connector.map.MapRepositoryTransaction#commit()
      */
+    @Override
     public void commit() {
         if (txn != null) txn.commit();
     }
@@ -57,6 +58,7 @@ public class SimpleJpaTransaction implements MapRepositoryTransaction {
      * 
      * @see org.modeshape.graph.connector.map.MapRepositoryTransaction#rollback()
      */
+    @Override
     public void rollback() {
         if (txn != null) this.txn.rollback();
     }

--- a/extensions/modeshape-connector-store-jpa/src/main/java/org/modeshape/connector/store/jpa/util/Serializer.java
+++ b/extensions/modeshape-connector-store-jpa/src/main/java/org/modeshape/connector/store/jpa/util/Serializer.java
@@ -99,16 +99,19 @@ public class Serializer {
     }
 
     protected static class NoLargeValues implements LargeValues {
+        @Override
         public long getMinimumSize() {
             return Long.MAX_VALUE;
         }
 
+        @Override
         public void write( byte[] hash,
                            long length,
                            PropertyType type,
                            Object value ) {
         }
 
+        @Override
         public Object read( ValueFactories valueFactories,
                             byte[] hash,
                             long length ) {
@@ -130,12 +133,15 @@ public class Serializer {
     }
 
     protected static class NoReferenceValues implements ReferenceValues {
+        @Override
         public void read( Reference arg0 ) {
         }
 
+        @Override
         public void remove( Reference arg0 ) {
         }
 
+        @Override
         public void write( Reference arg0 ) {
         }
     }

--- a/extensions/modeshape-connector-store-jpa/src/test/java/org/modeshape/connector/store/jpa/model/simple/SimpleJpaSourceTest.java
+++ b/extensions/modeshape-connector-store-jpa/src/test/java/org/modeshape/connector/store/jpa/model/simple/SimpleJpaSourceTest.java
@@ -57,18 +57,22 @@ public class SimpleJpaSourceTest {
 
             private final ExecutionContext context = new ExecutionContext();
 
+            @Override
             public Subgraph getConfiguration( int depth ) {
                 return null;
             }
 
+            @Override
             public ExecutionContext getExecutionContext() {
                 return context;
             }
 
+            @Override
             public Observer getObserver() {
                 return null;
             }
 
+            @Override
             public RepositoryConnectionFactory getRepositoryConnectionFactory() {
                 return null;
             }

--- a/extensions/modeshape-connector-store-jpa/src/test/java/org/modeshape/connector/store/jpa/util/SerializerTest.java
+++ b/extensions/modeshape-connector-store-jpa/src/test/java/org/modeshape/connector/store/jpa/util/SerializerTest.java
@@ -486,6 +486,7 @@ public class SerializerTest {
          * 
          * @see org.modeshape.connector.store.jpa.util.Serializer.LargeValues#getMinimumSize()
          */
+        @Override
         public long getMinimumSize() {
             return minimumSize;
         }
@@ -496,6 +497,7 @@ public class SerializerTest {
          * @see org.modeshape.connector.store.jpa.util.Serializer.LargeValues#read(org.modeshape.graph.property.ValueFactories,
          *      byte[], long)
          */
+        @Override
         public Object read( ValueFactories valueFactories,
                             byte[] hash,
                             long length ) {
@@ -509,6 +511,7 @@ public class SerializerTest {
          * @see org.modeshape.connector.store.jpa.util.Serializer.LargeValues#write(byte[], long,
          *      org.modeshape.graph.property.PropertyType, java.lang.Object)
          */
+        @Override
         public void write( byte[] hash,
                            long length,
                            PropertyType type,
@@ -542,6 +545,7 @@ public class SerializerTest {
          * 
          * @see org.modeshape.connector.store.jpa.util.Serializer.LargeValues#getMinimumSize()
          */
+        @Override
         public long getMinimumSize() {
             return minimumSize;
         }
@@ -564,6 +568,7 @@ public class SerializerTest {
          * @see org.modeshape.connector.store.jpa.util.Serializer.LargeValues#read(org.modeshape.graph.property.ValueFactories,
          *      byte[], long)
          */
+        @Override
         public Object read( ValueFactories valueFactories,
                             byte[] hash,
                             long length ) {
@@ -591,6 +596,7 @@ public class SerializerTest {
          * @see org.modeshape.connector.store.jpa.util.Serializer.LargeValues#write(byte[], long,
          *      org.modeshape.graph.property.PropertyType, java.lang.Object)
          */
+        @Override
         public void write( byte[] hash,
                            long length,
                            PropertyType type,

--- a/extensions/modeshape-connector-svn/src/main/java/org/modeshape/connector/svn/SvnRepositorySource.java
+++ b/extensions/modeshape-connector-svn/src/main/java/org/modeshape/connector/svn/SvnRepositorySource.java
@@ -147,6 +147,7 @@ public class SvnRepositorySource extends AbstractRepositorySource implements Obj
      * 
      * @see org.modeshape.graph.connector.RepositorySource#getCapabilities()
      */
+    @Override
     public RepositorySourceCapabilities getCapabilities() {
         return capabilities;
     }
@@ -213,6 +214,7 @@ public class SvnRepositorySource extends AbstractRepositorySource implements Obj
      * @return the file system path to the directory representing the default workspace, or null if the default should be the
      *         current working directory
      */
+    @Override
     public String getDefaultWorkspaceName() {
         return defaultWorkspace;
     }
@@ -308,6 +310,7 @@ public class SvnRepositorySource extends AbstractRepositorySource implements Obj
      *        allowed.
      * @see #areUpdatesAllowed()
      */
+    @Override
     public synchronized void setUpdatesAllowed( boolean allowUpdates ) {
         capabilities = new RepositorySourceCapabilities(capabilities.supportsSameNameSiblings(), allowUpdates,
                                                         capabilities.supportsEvents(), capabilities.supportsCreatingWorkspaces(),
@@ -342,6 +345,7 @@ public class SvnRepositorySource extends AbstractRepositorySource implements Obj
      * 
      * @see javax.naming.Referenceable#getReference()
      */
+    @Override
     public synchronized Reference getReference() {
         String className = getClass().getName();
         String factoryClassName = this.getClass().getName();
@@ -377,6 +381,7 @@ public class SvnRepositorySource extends AbstractRepositorySource implements Obj
      * @see javax.naming.spi.ObjectFactory#getObjectInstance(java.lang.Object, javax.naming.Name, javax.naming.Context,
      *      java.util.Hashtable)
      */
+    @Override
     public Object getObjectInstance( Object obj,
                                      Name name,
                                      Context nameCtx,
@@ -419,6 +424,7 @@ public class SvnRepositorySource extends AbstractRepositorySource implements Obj
      * 
      * @see org.modeshape.graph.connector.RepositorySource#getConnection()
      */
+    @Override
     public synchronized RepositoryConnection getConnection() throws RepositorySourceException {
 
         String sourceName = getName();

--- a/extensions/modeshape-connector-svn/src/main/java/org/modeshape/connector/svn/mgnt/AddDirectory.java
+++ b/extensions/modeshape-connector-svn/src/main/java/org/modeshape/connector/svn/mgnt/AddDirectory.java
@@ -41,6 +41,7 @@ public class AddDirectory implements ScmAction {
         this.childDirPath = childDirPath;
     }
 
+    @Override
     public void applyAction( Object context ) throws SVNException {
 
         ISVNEditor editor = (ISVNEditor)context;

--- a/extensions/modeshape-connector-svn/src/main/java/org/modeshape/connector/svn/mgnt/AddFile.java
+++ b/extensions/modeshape-connector-svn/src/main/java/org/modeshape/connector/svn/mgnt/AddFile.java
@@ -41,6 +41,7 @@ public class AddFile implements ScmAction {
         this.content = content;
     }
 
+    @Override
     public void applyAction( Object context ) throws Exception {
         ISVNEditor editor = (ISVNEditor)context;
         ISVNEditorUtil.openDirectories(editor, this.path);

--- a/extensions/modeshape-connector-svn/src/main/java/org/modeshape/connector/svn/mgnt/DeleteEntry.java
+++ b/extensions/modeshape-connector-svn/src/main/java/org/modeshape/connector/svn/mgnt/DeleteEntry.java
@@ -42,6 +42,7 @@ public class DeleteEntry implements ScmAction {
      * 
      * @see org.modeshape.connector.scm.ScmAction#applyAction(java.lang.Object)
      */
+    @Override
     public void applyAction( Object context ) throws Exception {
 
         ISVNEditor editor = (ISVNEditor)context;

--- a/extensions/modeshape-connector-svn/src/main/java/org/modeshape/connector/svn/mgnt/UpdateFile.java
+++ b/extensions/modeshape-connector-svn/src/main/java/org/modeshape/connector/svn/mgnt/UpdateFile.java
@@ -44,6 +44,7 @@ public class UpdateFile implements ScmAction {
         this.newData = newData;
     }
 
+    @Override
     public void applyAction( Object context ) throws Exception {
         ISVNEditor editor = (ISVNEditor)context;
         ISVNEditorUtil.openDirectories(editor, this.path);

--- a/extensions/modeshape-connector-svn/src/test/java/org/modeshape/connector/svn/SvnIntegrationTest.java
+++ b/extensions/modeshape-connector-svn/src/test/java/org/modeshape/connector/svn/SvnIntegrationTest.java
@@ -65,22 +65,27 @@ public class SvnIntegrationTest {
         source.setCreatingWorkspacesAllowed(false);
         source.initialize(new RepositoryContext() {
 
+            @Override
             public Subgraph getConfiguration( int depth ) {
                 return null;
             }
 
+            @Override
             @SuppressWarnings( "synthetic-access" )
             public ExecutionContext getExecutionContext() {
                 return context;
             }
 
+            @Override
             public Observer getObserver() {
                 return null;
             }
 
+            @Override
             public RepositoryConnectionFactory getRepositoryConnectionFactory() {
                 return new RepositoryConnectionFactory() {
 
+                    @Override
                     public RepositoryConnection createConnection( String sourceName ) throws RepositorySourceException {
                         return null;
                     }

--- a/extensions/modeshape-connector-svn/src/test/java/org/modeshape/connector/svn/SvnRepositorySourceTest.java
+++ b/extensions/modeshape-connector-svn/src/test/java/org/modeshape/connector/svn/SvnRepositorySourceTest.java
@@ -84,22 +84,27 @@ public class SvnRepositorySourceTest {
         this.source.setRepositoryRootUrl(url);
         this.source.initialize(new RepositoryContext() {
 
+            @Override
             public Subgraph getConfiguration( int depth ) {
                 return null;
             }
 
+            @Override
             @SuppressWarnings( "synthetic-access" )
             public ExecutionContext getExecutionContext() {
                 return context;
             }
 
+            @Override
             public Observer getObserver() {
                 return null;
             }
 
+            @Override
             public RepositoryConnectionFactory getRepositoryConnectionFactory() {
                 return new RepositoryConnectionFactory() {
 
+                    @Override
                     public RepositoryConnection createConnection( String sourceName ) throws RepositorySourceException {
                         return null;
                     }

--- a/extensions/modeshape-mimetype-detector-aperture/src/main/java/org/modeshape/mimetype/aperture/ApertureMimeTypeDetector.java
+++ b/extensions/modeshape-mimetype-detector-aperture/src/main/java/org/modeshape/mimetype/aperture/ApertureMimeTypeDetector.java
@@ -41,6 +41,7 @@ public class ApertureMimeTypeDetector implements MimeTypeDetector {
      * @throws IOException
      * @see org.modeshape.graph.mimetype.MimeTypeDetector#mimeTypeOf(java.lang.String, java.io.InputStream)
      */
+    @Override
     public String mimeTypeOf( String name,
                               InputStream content ) throws IOException {
         /*

--- a/extensions/modeshape-search-lucene/src/main/java/org/modeshape/search/lucene/IndexRules.java
+++ b/extensions/modeshape-search-lucene/src/main/java/org/modeshape/search/lucene/IndexRules.java
@@ -93,6 +93,7 @@ public class IndexRules {
          * 
          * @see Rule#getType()
          */
+        @Override
         public FieldType getType() {
             return FieldType.STRING;
         }
@@ -102,6 +103,7 @@ public class IndexRules {
          * 
          * @see Rule#isSkipped()
          */
+        @Override
         public boolean isSkipped() {
             return true;
         }
@@ -131,6 +133,7 @@ public class IndexRules {
          * 
          * @see Rule#getIndexOption()
          */
+        @Override
         public Index getIndexOption() {
             return Field.Index.NO;
         }
@@ -140,6 +143,7 @@ public class IndexRules {
          * 
          * @see Rule#getStoreOption()
          */
+        @Override
         public Store getStoreOption() {
             return Field.Store.NO;
         }
@@ -173,6 +177,7 @@ public class IndexRules {
          * 
          * @see IndexRules.Rule#getType()
          */
+        @Override
         public FieldType getType() {
             return type;
         }
@@ -182,6 +187,7 @@ public class IndexRules {
          * 
          * @see IndexRules.Rule#isSkipped()
          */
+        @Override
         public boolean isSkipped() {
             return false;
         }
@@ -211,6 +217,7 @@ public class IndexRules {
          * 
          * @see IndexRules.Rule#getIndexOption()
          */
+        @Override
         public Index getIndexOption() {
             return index;
         }
@@ -220,6 +227,7 @@ public class IndexRules {
          * 
          * @see IndexRules.Rule#getStoreOption()
          */
+        @Override
         public Store getStoreOption() {
             return store;
         }
@@ -257,6 +265,7 @@ public class IndexRules {
          * 
          * @see IndexRules.NumericRule#getMaximum()
          */
+        @Override
         public T getMaximum() {
             return maxValue;
         }
@@ -266,6 +275,7 @@ public class IndexRules {
          * 
          * @see IndexRules.NumericRule#getMinimum()
          */
+        @Override
         public T getMinimum() {
             return minValue;
         }

--- a/extensions/modeshape-search-lucene/src/main/java/org/modeshape/search/lucene/LuceneConfigurations.java
+++ b/extensions/modeshape-search-lucene/src/main/java/org/modeshape/search/lucene/LuceneConfigurations.java
@@ -140,6 +140,7 @@ public class LuceneConfigurations {
          * 
          * @see LuceneConfiguration#getDirectory(java.lang.String, java.lang.String)
          */
+        @Override
         public Directory getDirectory( String workspaceName,
                                        String indexName ) throws SearchEngineException {
             CheckArg.isNotNull(workspaceName, "workspaceName");
@@ -158,6 +159,7 @@ public class LuceneConfigurations {
          * 
          * @see LuceneConfiguration#destroyDirectory(java.lang.String, java.lang.String)
          */
+        @Override
         public boolean destroyDirectory( String workspaceName,
                                          String indexName ) throws SearchEngineException {
             CheckArg.isNotNull(workspaceName, "workspaceName");

--- a/extensions/modeshape-search-lucene/src/main/java/org/modeshape/search/lucene/LuceneSearchEngine.java
+++ b/extensions/modeshape-search-lucene/src/main/java/org/modeshape/search/lucene/LuceneSearchEngine.java
@@ -248,6 +248,7 @@ public class LuceneSearchEngine extends AbstractLuceneSearchEngine<LuceneSearchW
      * 
      * @see org.modeshape.graph.search.SearchEngine#index(org.modeshape.graph.ExecutionContext, java.lang.Iterable)
      */
+    @Override
     public void index( ExecutionContext context,
                        final Iterable<ChangeRequest> changes ) throws SearchEngineException {
         // Process the changes to determine what work needs to be done ...
@@ -301,6 +302,7 @@ public class LuceneSearchEngine extends AbstractLuceneSearchEngine<LuceneSearchW
             return work;
         }
 
+        @Override
         public Iterator<WorkspaceWork> iterator() {
             return byWorkspaceName.values().iterator();
         }
@@ -333,6 +335,7 @@ public class LuceneSearchEngine extends AbstractLuceneSearchEngine<LuceneSearchW
             this.workspaceName = workspaceName;
         }
 
+        @Override
         public Iterator<WorkRequest> iterator() {
             return requestByPath.values().iterator();
         }

--- a/extensions/modeshape-search-lucene/src/main/java/org/modeshape/search/lucene/LuceneSearchSession.java
+++ b/extensions/modeshape-search-lucene/src/main/java/org/modeshape/search/lucene/LuceneSearchSession.java
@@ -136,6 +136,7 @@ public class LuceneSearchSession implements WorkspaceSession {
     protected static final FieldSelector LOCATION_FIELDS_SELECTOR = new FieldSelector() {
         private static final long serialVersionUID = 1L;
 
+        @Override
         public FieldSelectorResult accept( String fieldName ) {
             if (ContentIndex.PATH.equals(fieldName) || ContentIndex.LOCATION_ID_PROPERTIES.equals(fieldName)) {
                 return FieldSelectorResult.LOAD;
@@ -172,6 +173,7 @@ public class LuceneSearchSession implements WorkspaceSession {
      * 
      * @see org.modeshape.search.lucene.AbstractLuceneSearchEngine.WorkspaceSession#getWorkspaceName()
      */
+    @Override
     public String getWorkspaceName() {
         return workspace.getWorkspaceName();
     }
@@ -207,6 +209,7 @@ public class LuceneSearchSession implements WorkspaceSession {
         return contentWriter;
     }
 
+    @Override
     public IndexSearcher getContentSearcher() throws IOException {
         if (contentSearcher == null) {
             contentSearcher = new IndexSearcher(getContentReader());
@@ -219,6 +222,7 @@ public class LuceneSearchSession implements WorkspaceSession {
      * 
      * @see org.modeshape.search.lucene.AbstractLuceneSearchEngine.WorkspaceSession#getAnalyzer()
      */
+    @Override
     public Analyzer getAnalyzer() {
         return workspace.analyzer;
     }
@@ -233,6 +237,7 @@ public class LuceneSearchSession implements WorkspaceSession {
         return workspace.getVersion();
     }
 
+    @Override
     public boolean hasWriters() {
         return contentWriter != null;
     }
@@ -251,6 +256,7 @@ public class LuceneSearchSession implements WorkspaceSession {
      * 
      * @see org.modeshape.search.lucene.AbstractLuceneSearchEngine.WorkspaceSession#getChangeCount()
      */
+    @Override
     public final int getChangeCount() {
         return numChanges;
     }
@@ -260,6 +266,7 @@ public class LuceneSearchSession implements WorkspaceSession {
      * 
      * @see org.modeshape.search.lucene.AbstractLuceneSearchEngine.WorkspaceSession#commit()
      */
+    @Override
     public void commit() {
         if (logger.isTraceEnabled() && numChanges > 0) {
             logger.trace("index for \"{0}\" workspace: COMMIT", workspace.getWorkspaceName());
@@ -315,6 +322,7 @@ public class LuceneSearchSession implements WorkspaceSession {
      * 
      * @see org.modeshape.search.lucene.AbstractLuceneSearchEngine.WorkspaceSession#rollback()
      */
+    @Override
     public void rollback() {
         if (logger.isTraceEnabled() && numChanges > 0) {
             logger.trace("index for \"{0}\" workspace: ROLLBACK", workspace.getWorkspaceName());
@@ -720,6 +728,7 @@ public class LuceneSearchSession implements WorkspaceSession {
      * 
      * @see org.modeshape.search.lucene.AbstractLuceneSearchEngine.WorkspaceSession#createTupleCollector(org.modeshape.graph.query.QueryResults.Columns)
      */
+    @Override
     public TupleCollector createTupleCollector( Columns columns ) {
         return new DualIndexTupleCollector(this, columns);
     }
@@ -737,6 +746,7 @@ public class LuceneSearchSession implements WorkspaceSession {
         return tuples.isEmpty() ? Location.create(processor.pathFactory.createRootPath()) : (Location)tuples.get(0)[0];
     }
 
+    @Override
     public Query findAllNodesBelow( Path parentPath ) {
         // Find the path of the parent ...
         String stringifiedPath = processor.pathAsString(parentPath);
@@ -747,6 +757,7 @@ public class LuceneSearchSession implements WorkspaceSession {
         return new PrefixQuery(new Term(ContentIndex.PATH, stringifiedPath));
     }
 
+    @Override
     public Query findAllNodesAtOrBelow( Path parentPath ) {
         if (parentPath.isRoot()) {
             return new MatchAllDocsQuery();
@@ -765,6 +776,7 @@ public class LuceneSearchSession implements WorkspaceSession {
      * @param parentPath the path of the parent node.
      * @return the query; never null
      */
+    @Override
     public Query findChildNodes( Path parentPath ) {
         // Find the path of the parent ...
         String stringifiedPath = processor.pathAsString(parentPath);
@@ -789,6 +801,7 @@ public class LuceneSearchSession implements WorkspaceSession {
      * @param path the path of the node
      * @return the query; never null
      */
+    @Override
     public Query findNodeAt( Path path ) {
         if (path.isRoot()) {
             // Look for the root node ...
@@ -798,6 +811,7 @@ public class LuceneSearchSession implements WorkspaceSession {
         return new TermQuery(new Term(ContentIndex.PATH, stringifiedPath));
     }
 
+    @Override
     public Query findNodesLike( String fieldName,
                                 String likeExpression,
                                 boolean caseSensitive ) {
@@ -805,6 +819,7 @@ public class LuceneSearchSession implements WorkspaceSession {
         return CompareStringQuery.createQueryForNodesWithFieldLike(likeExpression, fieldName, factories, caseSensitive);
     }
 
+    @Override
     public Query findNodesWith( Length propertyLength,
                                 Operator operator,
                                 Object value ) {
@@ -835,6 +850,7 @@ public class LuceneSearchSession implements WorkspaceSession {
         return null;
     }
 
+    @Override
     @SuppressWarnings( "unchecked" )
     public Query findNodesWith( PropertyValue propertyValue,
                                 Operator operator,
@@ -1115,6 +1131,7 @@ public class LuceneSearchSession implements WorkspaceSession {
         return null;
     }
 
+    @Override
     public Query findNodesWithNumericRange( PropertyValue propertyValue,
                                             Object lowerValue,
                                             Object upperValue,
@@ -1124,6 +1141,7 @@ public class LuceneSearchSession implements WorkspaceSession {
         return findNodesWithNumericRange(field, lowerValue, upperValue, includesLower, includesUpper);
     }
 
+    @Override
     public Query findNodesWithNumericRange( NodeDepth depth,
                                             Object lowerValue,
                                             Object upperValue,
@@ -1219,6 +1237,7 @@ public class LuceneSearchSession implements WorkspaceSession {
         return sb.toString();
     }
 
+    @Override
     public Query findNodesWith( NodePath nodePath,
                                 Operator operator,
                                 Object value,
@@ -1279,6 +1298,7 @@ public class LuceneSearchSession implements WorkspaceSession {
         return query;
     }
 
+    @Override
     public Query findNodesWith( NodeName nodeName,
                                 Operator operator,
                                 Object value,
@@ -1386,6 +1406,7 @@ public class LuceneSearchSession implements WorkspaceSession {
         return query;
     }
 
+    @Override
     public Query findNodesWith( NodeLocalName nodeName,
                                 Operator operator,
                                 Object value,
@@ -1438,6 +1459,7 @@ public class LuceneSearchSession implements WorkspaceSession {
         return query;
     }
 
+    @Override
     public Query findNodesWith( NodeDepth depthConstraint,
                                 Operator operator,
                                 Object value ) {
@@ -1584,6 +1606,7 @@ public class LuceneSearchSession implements WorkspaceSession {
             this.fieldSelector = new FieldSelector() {
                 private static final long serialVersionUID = 1L;
 
+                @Override
                 public FieldSelectorResult accept( String fieldName ) {
                     return fieldNames.contains(fieldName) ? FieldSelectorResult.LOAD : FieldSelectorResult.NO_LOAD;
                 }

--- a/extensions/modeshape-search-lucene/src/main/java/org/modeshape/search/lucene/LuceneSearchWorkspace.java
+++ b/extensions/modeshape-search-lucene/src/main/java/org/modeshape/search/lucene/LuceneSearchWorkspace.java
@@ -99,6 +99,7 @@ public class LuceneSearchWorkspace implements SearchEngineWorkspace {
      * 
      * @see org.modeshape.graph.search.SearchEngineWorkspace#getWorkspaceName()
      */
+    @Override
     public String getWorkspaceName() {
         return workspaceName;
     }
@@ -108,6 +109,7 @@ public class LuceneSearchWorkspace implements SearchEngineWorkspace {
      * 
      * @see org.modeshape.graph.search.SearchEngineWorkspace#destroy(org.modeshape.graph.ExecutionContext)
      */
+    @Override
     public void destroy( ExecutionContext context ) {
         configuration.destroyDirectory(workspaceDirectoryName, INDEX_NAME);
     }

--- a/extensions/modeshape-search-lucene/src/main/java/org/modeshape/search/lucene/query/CompareLengthQuery.java
+++ b/extensions/modeshape-search-lucene/src/main/java/org/modeshape/search/lucene/query/CompareLengthQuery.java
@@ -45,6 +45,7 @@ public class CompareLengthQuery extends CompareQuery<Integer> {
     protected static final Evaluator<Integer> EQUAL_TO = new Evaluator<Integer>() {
         private static final long serialVersionUID = 1L;
 
+        @Override
         public boolean satisfiesConstraint( Integer nodeValue,
                                             Integer length ) {
             return nodeValue == length;
@@ -58,6 +59,7 @@ public class CompareLengthQuery extends CompareQuery<Integer> {
     protected static final Evaluator<Integer> NOT_EQUAL_TO = new Evaluator<Integer>() {
         private static final long serialVersionUID = 1L;
 
+        @Override
         public boolean satisfiesConstraint( Integer nodeValue,
                                             Integer length ) {
             return nodeValue == length;
@@ -71,6 +73,7 @@ public class CompareLengthQuery extends CompareQuery<Integer> {
     protected static final Evaluator<Integer> IS_LESS_THAN = new Evaluator<Integer>() {
         private static final long serialVersionUID = 1L;
 
+        @Override
         public boolean satisfiesConstraint( Integer nodeValue,
                                             Integer length ) {
             return nodeValue < length;
@@ -84,6 +87,7 @@ public class CompareLengthQuery extends CompareQuery<Integer> {
     protected static final Evaluator<Integer> IS_LESS_THAN_OR_EQUAL_TO = new Evaluator<Integer>() {
         private static final long serialVersionUID = 1L;
 
+        @Override
         public boolean satisfiesConstraint( Integer nodeValue,
                                             Integer length ) {
             return nodeValue < length;
@@ -97,6 +101,7 @@ public class CompareLengthQuery extends CompareQuery<Integer> {
     protected static final Evaluator<Integer> IS_GREATER_THAN = new Evaluator<Integer>() {
         private static final long serialVersionUID = 1L;
 
+        @Override
         public boolean satisfiesConstraint( Integer nodeValue,
                                             Integer length ) {
             return nodeValue < length;
@@ -110,6 +115,7 @@ public class CompareLengthQuery extends CompareQuery<Integer> {
     protected static final Evaluator<Integer> IS_GREATER_THAN_OR_EQUAL_TO = new Evaluator<Integer>() {
         private static final long serialVersionUID = 1L;
 
+        @Override
         public boolean satisfiesConstraint( Integer nodeValue,
                                             Integer length ) {
             return nodeValue < length;

--- a/extensions/modeshape-search-lucene/src/main/java/org/modeshape/search/lucene/query/CompareNameQuery.java
+++ b/extensions/modeshape-search-lucene/src/main/java/org/modeshape/search/lucene/query/CompareNameQuery.java
@@ -50,6 +50,7 @@ public class CompareNameQuery extends CompareQuery<Path.Segment> {
     protected static final Evaluator<Path.Segment> IS_LESS_THAN = new Evaluator<Path.Segment>() {
         private static final long serialVersionUID = 1L;
 
+        @Override
         public boolean satisfiesConstraint( Path.Segment nodeValue,
                                             Path.Segment constraintValue ) {
             return ValueComparators.PATH_SEGMENT_COMPARATOR.compare(nodeValue, constraintValue) < 0;
@@ -63,6 +64,7 @@ public class CompareNameQuery extends CompareQuery<Path.Segment> {
     protected static final Evaluator<Path.Segment> IS_LESS_THAN_OR_EQUAL_TO = new Evaluator<Path.Segment>() {
         private static final long serialVersionUID = 1L;
 
+        @Override
         public boolean satisfiesConstraint( Path.Segment nodeValue,
                                             Path.Segment constraintValue ) {
             return ValueComparators.PATH_SEGMENT_COMPARATOR.compare(nodeValue, constraintValue) <= 0;
@@ -76,6 +78,7 @@ public class CompareNameQuery extends CompareQuery<Path.Segment> {
     protected static final Evaluator<Path.Segment> IS_GREATER_THAN = new Evaluator<Path.Segment>() {
         private static final long serialVersionUID = 1L;
 
+        @Override
         public boolean satisfiesConstraint( Path.Segment nodeValue,
                                             Path.Segment constraintValue ) {
             return ValueComparators.PATH_SEGMENT_COMPARATOR.compare(nodeValue, constraintValue) > 0;
@@ -89,6 +92,7 @@ public class CompareNameQuery extends CompareQuery<Path.Segment> {
     protected static final Evaluator<Path.Segment> IS_GREATER_THAN_OR_EQUAL_TO = new Evaluator<Path.Segment>() {
         private static final long serialVersionUID = 1L;
 
+        @Override
         public boolean satisfiesConstraint( Path.Segment nodeValue,
                                             Path.Segment constraintValue ) {
             return ValueComparators.PATH_SEGMENT_COMPARATOR.compare(nodeValue, constraintValue) >= 0;
@@ -103,6 +107,7 @@ public class CompareNameQuery extends CompareQuery<Path.Segment> {
     protected static final Evaluator<Path.Segment> IS_LESS_THAN_NO_SNS = new Evaluator<Path.Segment>() {
         private static final long serialVersionUID = 1L;
 
+        @Override
         public boolean satisfiesConstraint( Path.Segment nodeValue,
                                             Path.Segment constraintValue ) {
             return ValueComparators.PATH_SEGMENT_NAME_COMPARATOR.compare(nodeValue, constraintValue) < 0;
@@ -116,6 +121,7 @@ public class CompareNameQuery extends CompareQuery<Path.Segment> {
     protected static final Evaluator<Path.Segment> IS_LESS_THAN_OR_EQUAL_TO_NO_SNS = new Evaluator<Path.Segment>() {
         private static final long serialVersionUID = 1L;
 
+        @Override
         public boolean satisfiesConstraint( Path.Segment nodeValue,
                                             Path.Segment constraintValue ) {
             return ValueComparators.PATH_SEGMENT_NAME_COMPARATOR.compare(nodeValue, constraintValue) <= 0;
@@ -129,6 +135,7 @@ public class CompareNameQuery extends CompareQuery<Path.Segment> {
     protected static final Evaluator<Path.Segment> IS_GREATER_THAN_NO_SNS = new Evaluator<Path.Segment>() {
         private static final long serialVersionUID = 1L;
 
+        @Override
         public boolean satisfiesConstraint( Path.Segment nodeValue,
                                             Path.Segment constraintValue ) {
             return ValueComparators.PATH_SEGMENT_NAME_COMPARATOR.compare(nodeValue, constraintValue) > 0;
@@ -142,6 +149,7 @@ public class CompareNameQuery extends CompareQuery<Path.Segment> {
     protected static final Evaluator<Path.Segment> IS_GREATER_THAN_OR_EQUAL_TO_NO_SNS = new Evaluator<Path.Segment>() {
         private static final long serialVersionUID = 1L;
 
+        @Override
         public boolean satisfiesConstraint( Path.Segment nodeValue,
                                             Path.Segment constraintValue ) {
             return ValueComparators.PATH_SEGMENT_NAME_COMPARATOR.compare(nodeValue, constraintValue) >= 0;
@@ -279,6 +287,7 @@ public class CompareNameQuery extends CompareQuery<Path.Segment> {
         super(localNameField, constraintValue, null, stringFactory, evaluator, new FieldSelector() {
             private static final long serialVersionUID = 1L;
 
+            @Override
             public FieldSelectorResult accept( String fieldName ) {
                 if (fieldName.equals(localNameField)) return FieldSelectorResult.LOAD;
                 if (fieldName.equals(snsIndexFieldName)) return FieldSelectorResult.LOAD;

--- a/extensions/modeshape-search-lucene/src/main/java/org/modeshape/search/lucene/query/ComparePathQuery.java
+++ b/extensions/modeshape-search-lucene/src/main/java/org/modeshape/search/lucene/query/ComparePathQuery.java
@@ -47,6 +47,7 @@ public class ComparePathQuery extends CompareQuery<Path> {
     protected static final Evaluator<Path> PATH_IS_LESS_THAN = new Evaluator<Path>() {
         private static final long serialVersionUID = 1L;
 
+        @Override
         public boolean satisfiesConstraint( Path nodePath,
                                             Path constraintPath ) {
             return ValueComparators.PATH_COMPARATOR.compare(nodePath, constraintPath) < 0;
@@ -60,6 +61,7 @@ public class ComparePathQuery extends CompareQuery<Path> {
     protected static final Evaluator<Path> PATH_IS_LESS_THAN_OR_EQUAL_TO = new Evaluator<Path>() {
         private static final long serialVersionUID = 1L;
 
+        @Override
         public boolean satisfiesConstraint( Path nodePath,
                                             Path constraintPath ) {
             return ValueComparators.PATH_COMPARATOR.compare(nodePath, constraintPath) <= 0;
@@ -73,6 +75,7 @@ public class ComparePathQuery extends CompareQuery<Path> {
     protected static final Evaluator<Path> PATH_IS_GREATER_THAN = new Evaluator<Path>() {
         private static final long serialVersionUID = 1L;
 
+        @Override
         public boolean satisfiesConstraint( Path nodePath,
                                             Path constraintPath ) {
             return ValueComparators.PATH_COMPARATOR.compare(nodePath, constraintPath) > 0;
@@ -86,6 +89,7 @@ public class ComparePathQuery extends CompareQuery<Path> {
     protected static final Evaluator<Path> PATH_IS_GREATER_THAN_OR_EQUAL_TO = new Evaluator<Path>() {
         private static final long serialVersionUID = 1L;
 
+        @Override
         public boolean satisfiesConstraint( Path nodePath,
                                             Path constraintPath ) {
             return ValueComparators.PATH_COMPARATOR.compare(nodePath, constraintPath) >= 0;

--- a/extensions/modeshape-search-lucene/src/main/java/org/modeshape/search/lucene/query/CompareQuery.java
+++ b/extensions/modeshape-search-lucene/src/main/java/org/modeshape/search/lucene/query/CompareQuery.java
@@ -113,6 +113,7 @@ public abstract class CompareQuery<ValueType> extends Query {
         this.fieldSelector = fieldSelector != null ? fieldSelector : new FieldSelector() {
             private static final long serialVersionUID = 1L;
 
+            @Override
             public FieldSelectorResult accept( String fieldName ) {
                 return CompareQuery.this.fieldName.equals(fieldName) ? FieldSelectorResult.LOAD_AND_BREAK : FieldSelectorResult.NO_LOAD;
             }

--- a/extensions/modeshape-search-lucene/src/main/java/org/modeshape/search/lucene/query/CompareStringQuery.java
+++ b/extensions/modeshape-search-lucene/src/main/java/org/modeshape/search/lucene/query/CompareStringQuery.java
@@ -53,6 +53,7 @@ public class CompareStringQuery extends CompareQuery<String> {
     protected static final Evaluator<String> EQUAL_TO = new Evaluator<String>() {
         private static final long serialVersionUID = 1L;
 
+        @Override
         public boolean satisfiesConstraint( String nodeValue,
                                             String constraintValue ) {
             return constraintValue.equals(nodeValue);
@@ -66,6 +67,7 @@ public class CompareStringQuery extends CompareQuery<String> {
     protected static final Evaluator<String> IS_LESS_THAN = new Evaluator<String>() {
         private static final long serialVersionUID = 1L;
 
+        @Override
         public boolean satisfiesConstraint( String nodeValue,
                                             String constraintValue ) {
             return ValueComparators.STRING_COMPARATOR.compare(nodeValue, constraintValue) < 0;
@@ -79,6 +81,7 @@ public class CompareStringQuery extends CompareQuery<String> {
     protected static final Evaluator<String> IS_LESS_THAN_OR_EQUAL_TO = new Evaluator<String>() {
         private static final long serialVersionUID = 1L;
 
+        @Override
         public boolean satisfiesConstraint( String nodeValue,
                                             String constraintValue ) {
             return ValueComparators.STRING_COMPARATOR.compare(nodeValue, constraintValue) <= 0;
@@ -92,6 +95,7 @@ public class CompareStringQuery extends CompareQuery<String> {
     protected static final Evaluator<String> IS_GREATER_THAN = new Evaluator<String>() {
         private static final long serialVersionUID = 1L;
 
+        @Override
         public boolean satisfiesConstraint( String nodeValue,
                                             String constraintValue ) {
             return ValueComparators.STRING_COMPARATOR.compare(nodeValue, constraintValue) > 0;
@@ -105,6 +109,7 @@ public class CompareStringQuery extends CompareQuery<String> {
     protected static final Evaluator<String> IS_GREATER_THAN_OR_EQUAL_TO = new Evaluator<String>() {
         private static final long serialVersionUID = 1L;
 
+        @Override
         public boolean satisfiesConstraint( String nodeValue,
                                             String constraintValue ) {
             return ValueComparators.STRING_COMPARATOR.compare(nodeValue, constraintValue) >= 0;

--- a/extensions/modeshape-search-lucene/src/main/java/org/modeshape/search/lucene/query/HasValueQuery.java
+++ b/extensions/modeshape-search-lucene/src/main/java/org/modeshape/search/lucene/query/HasValueQuery.java
@@ -55,6 +55,7 @@ public class HasValueQuery extends Query {
         this.fieldSelector = new FieldSelector() {
             private static final long serialVersionUID = 1L;
 
+            @Override
             public FieldSelectorResult accept( String fieldName ) {
                 return HasValueQuery.this.fieldName.equals(fieldName) ? FieldSelectorResult.LOAD_AND_BREAK : FieldSelectorResult.NO_LOAD;
             }

--- a/extensions/modeshape-search-lucene/src/main/java/org/modeshape/search/lucene/query/IdsQuery.java
+++ b/extensions/modeshape-search-lucene/src/main/java/org/modeshape/search/lucene/query/IdsQuery.java
@@ -67,6 +67,7 @@ public class IdsQuery extends Query {
         this.fieldSelector = new FieldSelector() {
             private static final long serialVersionUID = 1L;
 
+            @Override
             public FieldSelectorResult accept( String fieldName ) {
                 return fieldName.equals(fieldName) ? FieldSelectorResult.LOAD_AND_BREAK : FieldSelectorResult.NO_LOAD;
             }

--- a/extensions/modeshape-search-lucene/src/test/java/org/modeshape/search/lucene/AbstractLuceneSearchEngineTest.java
+++ b/extensions/modeshape-search-lucene/src/test/java/org/modeshape/search/lucene/AbstractLuceneSearchEngineTest.java
@@ -318,6 +318,7 @@ public class AbstractLuceneSearchEngineTest {
          * 
          * @see org.modeshape.graph.search.SearchEngineWorkspace#destroy(org.modeshape.graph.ExecutionContext)
          */
+        @Override
         public void destroy( ExecutionContext context ) {
             destroyed = true;
         }
@@ -331,6 +332,7 @@ public class AbstractLuceneSearchEngineTest {
          * 
          * @see org.modeshape.graph.search.SearchEngineWorkspace#getWorkspaceName()
          */
+        @Override
         public String getWorkspaceName() {
             return name;
         }

--- a/extensions/modeshape-search-lucene/src/test/java/org/modeshape/search/lucene/LuceneSearchEngineObservationTest.java
+++ b/extensions/modeshape-search-lucene/src/test/java/org/modeshape/search/lucene/LuceneSearchEngineObservationTest.java
@@ -130,6 +130,7 @@ public class LuceneSearchEngineObservationTest {
              * 
              * @see org.modeshape.graph.connector.RepositoryConnectionFactory#createConnection(java.lang.String)
              */
+            @Override
             @SuppressWarnings( "synthetic-access" )
             public RepositoryConnection createConnection( String name ) throws RepositorySourceException {
                 assertThat(sourceName, is(name));
@@ -155,20 +156,25 @@ public class LuceneSearchEngineObservationTest {
         // Initialize the source so that the search engine observes the events ...
         @SuppressWarnings( "synthetic-access" )
         RepositoryContext repositoryContext = new RepositoryContext() {
+            @Override
             public Subgraph getConfiguration( int depth ) {
                 return null;
             }
 
+            @Override
             public ExecutionContext getExecutionContext() {
                 return context;
             }
 
+            @Override
             public RepositoryConnectionFactory getRepositoryConnectionFactory() {
                 return connectionFactory;
             }
 
+            @Override
             public Observer getObserver() {
                 return new Observer() {
+                    @Override
                     public void notify( Changes changes ) {
                         // -----------------------------------------------------------
                         // NOTE THAT THE SEARCH ENGINE IS UPDATED IN-THREAD !!!!!!!!!!

--- a/extensions/modeshape-search-lucene/src/test/java/org/modeshape/search/lucene/LuceneSearchEngineTest.java
+++ b/extensions/modeshape-search-lucene/src/test/java/org/modeshape/search/lucene/LuceneSearchEngineTest.java
@@ -110,6 +110,7 @@ public class LuceneSearchEngineTest {
 
         // Set up the connection factory ...
         connectionFactory = new RepositoryConnectionFactory() {
+            @Override
             @SuppressWarnings( "synthetic-access" )
             public RepositoryConnection createConnection( String sourceName ) throws RepositorySourceException {
                 return source.getConnection();

--- a/extensions/modeshape-sequencer-classfile/src/main/java/org/modeshape/sequencer/classfile/ClassFileSequencer.java
+++ b/extensions/modeshape-sequencer-classfile/src/main/java/org/modeshape/sequencer/classfile/ClassFileSequencer.java
@@ -38,6 +38,7 @@ public class ClassFileSequencer implements StreamSequencer {
 
     private ClassFileRecorder classFileRecorder = DEFAULT_CLASS_FILE_RECORDER;
 
+    @Override
     public void sequence( InputStream stream,
                           SequencerOutput output,
                           StreamSequencerContext context ) {

--- a/extensions/modeshape-sequencer-classfile/src/main/java/org/modeshape/sequencer/classfile/DefaultClassFileRecorder.java
+++ b/extensions/modeshape-sequencer-classfile/src/main/java/org/modeshape/sequencer/classfile/DefaultClassFileRecorder.java
@@ -41,6 +41,7 @@ import org.modeshape.sequencer.classfile.metadata.MethodMetadata;
 
 public class DefaultClassFileRecorder implements ClassFileRecorder {
 
+    @Override
     public void recordClass( StreamSequencerContext context,
                              SequencerOutput output,
                              ClassMetadata classMetadata ) {

--- a/extensions/modeshape-sequencer-classfile/src/main/java/org/modeshape/sequencer/classfile/metadata/FieldMetadata.java
+++ b/extensions/modeshape-sequencer-classfile/src/main/java/org/modeshape/sequencer/classfile/metadata/FieldMetadata.java
@@ -91,6 +91,7 @@ public class FieldMetadata implements Comparable<FieldMetadata> {
         return annotations;
     }
 
+    @Override
     public int compareTo( FieldMetadata o ) {
         if (this.isStatic() && !o.isStatic()) {
             return 1;

--- a/extensions/modeshape-sequencer-classfile/src/main/java/org/modeshape/sequencer/classfile/metadata/MethodMetadata.java
+++ b/extensions/modeshape-sequencer-classfile/src/main/java/org/modeshape/sequencer/classfile/metadata/MethodMetadata.java
@@ -153,6 +153,7 @@ public class MethodMetadata implements Comparable<MethodMetadata> {
         return AccessFlag.SYNCHRONIZED == (AccessFlag.SYNCHRONIZED & method.getAccessFlags());
     }
 
+    @Override
     public int compareTo( MethodMetadata o ) {
         if (this.isStatic() && !o.isStatic()) {
             return -1;

--- a/extensions/modeshape-sequencer-classfile/src/test/java/org/modeshape/sequencer/classfile/ClassFileSequencerTest.java
+++ b/extensions/modeshape-sequencer-classfile/src/test/java/org/modeshape/sequencer/classfile/ClassFileSequencerTest.java
@@ -115,6 +115,7 @@ public class ClassFileSequencerTest {
     public static class MockClassFileRecorder implements ClassFileRecorder {
         static boolean called = false;
 
+        @Override
         public void recordClass( StreamSequencerContext context,
                                  SequencerOutput output,
                                  ClassMetadata classMetadata ) {

--- a/extensions/modeshape-sequencer-ddl/src/main/java/org/modeshape/sequencer/ddl/DdlParsers.java
+++ b/extensions/modeshape-sequencer-ddl/src/main/java/org/modeshape/sequencer/ddl/DdlParsers.java
@@ -183,6 +183,7 @@ public class DdlParsers {
          * 
          * @see java.lang.Comparable#compareTo(java.lang.Object)
          */
+        @Override
         public int compareTo( ScoredParser that ) {
             if (that == null) return 1;
             return that.getScorer().getScore() - this.getScorer().getScore();

--- a/extensions/modeshape-sequencer-ddl/src/main/java/org/modeshape/sequencer/ddl/DdlSequencer.java
+++ b/extensions/modeshape-sequencer-ddl/src/main/java/org/modeshape/sequencer/ddl/DdlSequencer.java
@@ -116,6 +116,7 @@ public class DdlSequencer implements StreamSequencer {
      * @see org.modeshape.graph.sequencer.StreamSequencer#sequence(java.io.InputStream,
      *      org.modeshape.graph.sequencer.SequencerOutput, org.modeshape.graph.sequencer.StreamSequencerContext)
      */
+    @Override
     public void sequence( InputStream stream,
                           SequencerOutput output,
                           StreamSequencerContext context ) {

--- a/extensions/modeshape-sequencer-ddl/src/main/java/org/modeshape/sequencer/ddl/DdlTokenStream.java
+++ b/extensions/modeshape-sequencer-ddl/src/main/java/org/modeshape/sequencer/ddl/DdlTokenStream.java
@@ -323,6 +323,7 @@ public class DdlTokenStream extends TokenStream {
          * 
          * @see org.modeshape.common.text.TokenStream.Tokenizer#tokenize(CharacterStream, Tokens)
          */
+        @Override
         public void tokenize( CharacterStream input,
                               Tokens tokens ) throws ParsingException {
             int startIndex;

--- a/extensions/modeshape-sequencer-ddl/src/main/java/org/modeshape/sequencer/ddl/StandardDdlParser.java
+++ b/extensions/modeshape-sequencer-ddl/src/main/java/org/modeshape/sequencer/ddl/StandardDdlParser.java
@@ -184,6 +184,7 @@ public class StandardDdlParser implements DdlParser, DdlConstants, DdlConstants.
      * @see org.modeshape.sequencer.ddl.DdlParser#score(java.lang.String, java.lang.String,
      *      org.modeshape.sequencer.ddl.DdlParserScorer)
      */
+    @Override
     public Object score( String ddl,
                          String fileName,
                          DdlParserScorer scorer ) throws ParsingException {
@@ -238,6 +239,7 @@ public class StandardDdlParser implements DdlParser, DdlConstants, DdlConstants.
      * @see org.modeshape.sequencer.ddl.DdlParser#parse(java.lang.String, org.modeshape.sequencer.ddl.node.AstNode,
      *      java.lang.Object)
      */
+    @Override
     public void parse( String ddl,
                        AstNode rootNode,
                        Object scoreReturnObject ) throws ParsingException {
@@ -2862,6 +2864,7 @@ public class StandardDdlParser implements DdlParser, DdlConstants, DdlConstants.
      * 
      * @see org.modeshape.sequencer.ddl.DdlParser#getId()
      */
+    @Override
     public String getId() {
         return parserId;
     }

--- a/extensions/modeshape-sequencer-ddl/src/main/java/org/modeshape/sequencer/ddl/node/AstNode.java
+++ b/extensions/modeshape-sequencer-ddl/src/main/java/org/modeshape/sequencer/ddl/node/AstNode.java
@@ -471,6 +471,7 @@ public class AstNode implements Iterable<AstNode> {
      * 
      * @see java.lang.Iterable#iterator()
      */
+    @Override
     public Iterator<AstNode> iterator() {
         return childrenView.iterator();
     }

--- a/extensions/modeshape-sequencer-images/src/main/java/org/modeshape/sequencer/image/ImageMetadataSequencer.java
+++ b/extensions/modeshape-sequencer-images/src/main/java/org/modeshape/sequencer/image/ImageMetadataSequencer.java
@@ -71,6 +71,7 @@ public class ImageMetadataSequencer implements StreamSequencer {
      * 
      * @see StreamSequencer#sequence(InputStream, SequencerOutput, StreamSequencerContext)
      */
+    @Override
     public void sequence( InputStream stream,
                           SequencerOutput output,
                           StreamSequencerContext context ) {

--- a/extensions/modeshape-sequencer-java/src/main/java/org/modeshape/sequencer/java/ClassSourceFileRecorder.java
+++ b/extensions/modeshape-sequencer-java/src/main/java/org/modeshape/sequencer/java/ClassSourceFileRecorder.java
@@ -27,6 +27,7 @@ import org.modeshape.sequencer.java.metadata.TypeMetadata;
  */
 public class ClassSourceFileRecorder implements SourceFileRecorder {
 
+    @Override
     public void record( StreamSequencerContext context,
                         SequencerOutput output,
                         JavaMetadata javaMetadata ) {

--- a/extensions/modeshape-sequencer-java/src/main/java/org/modeshape/sequencer/java/JavaMetadataSequencer.java
+++ b/extensions/modeshape-sequencer-java/src/main/java/org/modeshape/sequencer/java/JavaMetadataSequencer.java
@@ -41,6 +41,7 @@ public class JavaMetadataSequencer implements StreamSequencer {
      * @see org.modeshape.graph.sequencer.StreamSequencer#sequence(java.io.InputStream,
      *      org.modeshape.graph.sequencer.SequencerOutput, org.modeshape.graph.sequencer.StreamSequencerContext)
      */
+    @Override
     public void sequence( InputStream stream,
                           SequencerOutput output,
                           StreamSequencerContext context ) {

--- a/extensions/modeshape-sequencer-java/src/main/java/org/modeshape/sequencer/java/OriginalFormatSourceFileRecorder.java
+++ b/extensions/modeshape-sequencer-java/src/main/java/org/modeshape/sequencer/java/OriginalFormatSourceFileRecorder.java
@@ -165,6 +165,7 @@ import org.modeshape.sequencer.java.metadata.Variable;
  */
 public class OriginalFormatSourceFileRecorder implements SourceFileRecorder {
 
+    @Override
     public void record( StreamSequencerContext context,
                         SequencerOutput output,
                         JavaMetadata javaMetadata ) {

--- a/extensions/modeshape-sequencer-java/src/test/java/org/modeshape/sequencer/java/ClassSourceFileRecorderTest.java
+++ b/extensions/modeshape-sequencer-java/src/test/java/org/modeshape/sequencer/java/ClassSourceFileRecorderTest.java
@@ -121,6 +121,7 @@ public class ClassSourceFileRecorderTest {
     public static class MockSourceFileRecorder implements SourceFileRecorder {
         static boolean called = false;
 
+        @Override
         public void record( StreamSequencerContext context,
                             SequencerOutput output,
                             JavaMetadata javaMetadata ) {

--- a/extensions/modeshape-sequencer-mp3/src/main/java/org/modeshape/sequencer/mp3/Mp3MetadataSequencer.java
+++ b/extensions/modeshape-sequencer-mp3/src/main/java/org/modeshape/sequencer/mp3/Mp3MetadataSequencer.java
@@ -55,6 +55,7 @@ public class Mp3MetadataSequencer implements StreamSequencer {
      * 
      * @see StreamSequencer#sequence(InputStream, SequencerOutput, StreamSequencerContext)
      */
+    @Override
     public void sequence( InputStream stream,
                           SequencerOutput output,
                           StreamSequencerContext context ) {

--- a/extensions/modeshape-sequencer-msoffice/src/main/java/org/modeshape/sequencer/msoffice/MSOfficeMetadata.java
+++ b/extensions/modeshape-sequencer-msoffice/src/main/java/org/modeshape/sequencer/msoffice/MSOfficeMetadata.java
@@ -55,6 +55,7 @@ public class MSOfficeMetadata implements POIFSReaderListener {
     private byte[] thumbnail;
     private static final Logger LOGGER = Logger.getLogger(MSOfficeMetadata.class);
 
+    @Override
     public void processPOIFSReaderEvent( POIFSReaderEvent event ) {
         try {
             SummaryInformation si = (SummaryInformation)PropertySetFactory.create(event.getStream());

--- a/extensions/modeshape-sequencer-msoffice/src/main/java/org/modeshape/sequencer/msoffice/MSOfficeMetadataSequencer.java
+++ b/extensions/modeshape-sequencer-msoffice/src/main/java/org/modeshape/sequencer/msoffice/MSOfficeMetadataSequencer.java
@@ -85,6 +85,7 @@ public class MSOfficeMetadataSequencer implements StreamSequencer {
     /**
      * {@inheritDoc}
      */
+    @Override
     public void sequence( InputStream stream,
                           SequencerOutput output,
                           StreamSequencerContext context ) {

--- a/extensions/modeshape-sequencer-text/src/main/java/org/modeshape/sequencer/text/AbstractTextSequencer.java
+++ b/extensions/modeshape-sequencer-text/src/main/java/org/modeshape/sequencer/text/AbstractTextSequencer.java
@@ -53,6 +53,7 @@ public abstract class AbstractTextSequencer implements StreamSequencer {
     /**
      * {@inheritDoc}
      */
+    @Override
     public void sequence( InputStream stream,
                           SequencerOutput output,
                           StreamSequencerContext context ) {

--- a/extensions/modeshape-sequencer-text/src/main/java/org/modeshape/sequencer/text/DefaultRowFactory.java
+++ b/extensions/modeshape-sequencer-text/src/main/java/org/modeshape/sequencer/text/DefaultRowFactory.java
@@ -51,6 +51,7 @@ public class DefaultRowFactory implements RowFactory {
     
     private int rowNumber = 1;
 
+    @Override
     public void recordRow( StreamSequencerContext context,
                         SequencerOutput output,
                         String[] columns ) {

--- a/extensions/modeshape-sequencer-text/src/test/java/org/modeshape/sequencer/text/DelimitedTextSequencerTest.java
+++ b/extensions/modeshape-sequencer-text/src/test/java/org/modeshape/sequencer/text/DelimitedTextSequencerTest.java
@@ -268,6 +268,7 @@ public class DelimitedTextSequencerTest {
 
         int rowNum = 1;
 
+        @Override
         public void recordRow( StreamSequencerContext context,
                             SequencerOutput output,
                             String[] columns ) {

--- a/extensions/modeshape-sequencer-text/src/test/java/org/modeshape/sequencer/text/FixedWidthTextSequencerTest.java
+++ b/extensions/modeshape-sequencer-text/src/test/java/org/modeshape/sequencer/text/FixedWidthTextSequencerTest.java
@@ -213,6 +213,7 @@ public class FixedWidthTextSequencerTest {
 
         int rowNum = 1;
 
+        @Override
         public void recordRow( StreamSequencerContext context,
                             SequencerOutput output,
                             String[] columns ) {

--- a/extensions/modeshape-sequencer-xml/src/main/java/org/modeshape/sequencer/xml/XmlSequencer.java
+++ b/extensions/modeshape-sequencer-xml/src/main/java/org/modeshape/sequencer/xml/XmlSequencer.java
@@ -84,6 +84,7 @@ public class XmlSequencer implements StreamSequencer {
      * 
      * @see org.modeshape.graph.sequencer.StreamSequencer#sequence(InputStream, SequencerOutput, StreamSequencerContext)
      */
+    @Override
     public void sequence( InputStream stream,
                           SequencerOutput output,
                           StreamSequencerContext context ) {

--- a/extensions/modeshape-sequencer-zip/src/main/java/org/modeshape/sequencer/zip/ZipSequencer.java
+++ b/extensions/modeshape-sequencer-zip/src/main/java/org/modeshape/sequencer/zip/ZipSequencer.java
@@ -54,6 +54,7 @@ public class ZipSequencer implements StreamSequencer {
      * @see org.modeshape.graph.sequencer.StreamSequencer#sequence(java.io.InputStream,
      *      org.modeshape.graph.sequencer.SequencerOutput, org.modeshape.graph.sequencer.StreamSequencerContext)
      */
+    @Override
     public void sequence( InputStream stream,
                           SequencerOutput output,
                           StreamSequencerContext context ) {

--- a/modeshape-common/src/main/java/org/modeshape/common/collection/AbstractProblems.java
+++ b/modeshape-common/src/main/java/org/modeshape/common/collection/AbstractProblems.java
@@ -37,17 +37,20 @@ public abstract class AbstractProblems implements Problems {
 
     protected static final List<Problem> EMPTY_PROBLEMS = Collections.emptyList();
 
+    @Override
     public void addError( I18n message,
                           Object... params ) {
         addProblem(new Problem(Problem.Status.ERROR, Problem.DEFAULT_CODE, message, params, null, null, null));
     }
 
+    @Override
     public void addError( Throwable throwable,
                           I18n message,
                           Object... params ) {
         addProblem(new Problem(Problem.Status.ERROR, Problem.DEFAULT_CODE, message, params, null, null, throwable));
     }
 
+    @Override
     public void addError( String resource,
                           String location,
                           I18n message,
@@ -55,6 +58,7 @@ public abstract class AbstractProblems implements Problems {
         addProblem(new Problem(Problem.Status.ERROR, Problem.DEFAULT_CODE, message, params, resource, location, null));
     }
 
+    @Override
     public void addError( Throwable throwable,
                           String resource,
                           String location,
@@ -63,12 +67,14 @@ public abstract class AbstractProblems implements Problems {
         addProblem(new Problem(Problem.Status.ERROR, Problem.DEFAULT_CODE, message, params, resource, location, throwable));
     }
 
+    @Override
     public void addError( int code,
                           I18n message,
                           Object... params ) {
         addProblem(new Problem(Problem.Status.ERROR, code, message, params, null, null, null));
     }
 
+    @Override
     public void addError( Throwable throwable,
                           int code,
                           I18n message,
@@ -76,6 +82,7 @@ public abstract class AbstractProblems implements Problems {
         addProblem(new Problem(Problem.Status.ERROR, code, message, params, null, null, throwable));
     }
 
+    @Override
     public void addError( int code,
                           String resource,
                           String location,
@@ -84,6 +91,7 @@ public abstract class AbstractProblems implements Problems {
         addProblem(new Problem(Problem.Status.ERROR, code, message, params, resource, location, null));
     }
 
+    @Override
     public void addError( Throwable throwable,
                           int code,
                           String resource,
@@ -93,17 +101,20 @@ public abstract class AbstractProblems implements Problems {
         addProblem(new Problem(Problem.Status.ERROR, code, message, params, resource, location, throwable));
     }
 
+    @Override
     public void addWarning( I18n message,
                             Object... params ) {
         addProblem(new Problem(Problem.Status.WARNING, Problem.DEFAULT_CODE, message, params, null, null, null));
     }
 
+    @Override
     public void addWarning( Throwable throwable,
                             I18n message,
                             Object... params ) {
         addProblem(new Problem(Problem.Status.WARNING, Problem.DEFAULT_CODE, message, params, null, null, throwable));
     }
 
+    @Override
     public void addWarning( String resource,
                             String location,
                             I18n message,
@@ -111,6 +122,7 @@ public abstract class AbstractProblems implements Problems {
         addProblem(new Problem(Problem.Status.WARNING, Problem.DEFAULT_CODE, message, params, resource, location, null));
     }
 
+    @Override
     public void addWarning( Throwable throwable,
                             String resource,
                             String location,
@@ -119,12 +131,14 @@ public abstract class AbstractProblems implements Problems {
         addProblem(new Problem(Problem.Status.WARNING, Problem.DEFAULT_CODE, message, params, resource, location, throwable));
     }
 
+    @Override
     public void addWarning( int code,
                             I18n message,
                             Object... params ) {
         addProblem(new Problem(Problem.Status.WARNING, code, message, params, null, null, null));
     }
 
+    @Override
     public void addWarning( Throwable throwable,
                             int code,
                             I18n message,
@@ -132,6 +146,7 @@ public abstract class AbstractProblems implements Problems {
         addProblem(new Problem(Problem.Status.WARNING, code, message, params, null, null, throwable));
     }
 
+    @Override
     public void addWarning( int code,
                             String resource,
                             String location,
@@ -140,6 +155,7 @@ public abstract class AbstractProblems implements Problems {
         addProblem(new Problem(Problem.Status.WARNING, code, message, params, resource, location, null));
     }
 
+    @Override
     public void addWarning( Throwable throwable,
                             int code,
                             String resource,
@@ -149,17 +165,20 @@ public abstract class AbstractProblems implements Problems {
         addProblem(new Problem(Problem.Status.WARNING, code, message, params, resource, location, throwable));
     }
 
+    @Override
     public void addInfo( I18n message,
                          Object... params ) {
         addProblem(new Problem(Problem.Status.INFO, Problem.DEFAULT_CODE, message, params, null, null, null));
     }
 
+    @Override
     public void addInfo( Throwable throwable,
                          I18n message,
                          Object... params ) {
         addProblem(new Problem(Problem.Status.INFO, Problem.DEFAULT_CODE, message, params, null, null, throwable));
     }
 
+    @Override
     public void addInfo( String resource,
                          String location,
                          I18n message,
@@ -167,6 +186,7 @@ public abstract class AbstractProblems implements Problems {
         addProblem(new Problem(Problem.Status.INFO, Problem.DEFAULT_CODE, message, params, resource, location, null));
     }
 
+    @Override
     public void addInfo( Throwable throwable,
                          String resource,
                          String location,
@@ -175,12 +195,14 @@ public abstract class AbstractProblems implements Problems {
         addProblem(new Problem(Problem.Status.INFO, Problem.DEFAULT_CODE, message, params, resource, location, throwable));
     }
 
+    @Override
     public void addInfo( int code,
                          I18n message,
                          Object... params ) {
         addProblem(new Problem(Problem.Status.INFO, code, message, params, null, null, null));
     }
 
+    @Override
     public void addInfo( Throwable throwable,
                          int code,
                          I18n message,
@@ -188,6 +210,7 @@ public abstract class AbstractProblems implements Problems {
         addProblem(new Problem(Problem.Status.INFO, code, message, params, null, null, throwable));
     }
 
+    @Override
     public void addInfo( int code,
                          String resource,
                          String location,
@@ -196,6 +219,7 @@ public abstract class AbstractProblems implements Problems {
         addProblem(new Problem(Problem.Status.INFO, code, message, params, resource, location, null));
     }
 
+    @Override
     public void addInfo( Throwable throwable,
                          int code,
                          String resource,
@@ -205,10 +229,12 @@ public abstract class AbstractProblems implements Problems {
         addProblem(new Problem(Problem.Status.INFO, code, message, params, resource, location, throwable));
     }
 
+    @Override
     public boolean hasProblems() {
         return getProblems().size() > 0;
     }
 
+    @Override
     public boolean hasErrors() {
         for (Problem problem : this.getProblems()) {
             if (problem.getStatus() == Problem.Status.ERROR) return true;
@@ -216,6 +242,7 @@ public abstract class AbstractProblems implements Problems {
         return false;
     }
 
+    @Override
     public boolean hasWarnings() {
         for (Problem problem : this.getProblems()) {
             if (problem.getStatus() == Problem.Status.WARNING) return true;
@@ -223,6 +250,7 @@ public abstract class AbstractProblems implements Problems {
         return false;
     }
 
+    @Override
     public boolean hasInfo() {
         for (Problem problem : this.getProblems()) {
             if (problem.getStatus() == Problem.Status.INFO) return true;
@@ -230,10 +258,12 @@ public abstract class AbstractProblems implements Problems {
         return false;
     }
 
+    @Override
     public boolean isEmpty() {
         return getProblems().isEmpty();
     }
 
+    @Override
     public int size() {
         return getProblems().size();
     }
@@ -243,6 +273,7 @@ public abstract class AbstractProblems implements Problems {
      * 
      * @see org.modeshape.common.collection.Problems#iterator()
      */
+    @Override
     public Iterator<Problem> iterator() {
         return getProblems().iterator();
     }

--- a/modeshape-common/src/main/java/org/modeshape/common/collection/EmptyIterator.java
+++ b/modeshape-common/src/main/java/org/modeshape/common/collection/EmptyIterator.java
@@ -41,6 +41,7 @@ public final class EmptyIterator<T> implements Iterator<T> {
      * 
      * @see java.util.Iterator#hasNext()
      */
+    @Override
     public boolean hasNext() {
         return false;
     }
@@ -50,6 +51,7 @@ public final class EmptyIterator<T> implements Iterator<T> {
      * 
      * @see java.util.Iterator#next()
      */
+    @Override
     public T next() {
         throw new NoSuchElementException();
     }
@@ -59,6 +61,7 @@ public final class EmptyIterator<T> implements Iterator<T> {
      * 
      * @see java.util.Iterator#remove()
      */
+    @Override
     public void remove() {
         throw new UnsupportedOperationException();
     }

--- a/modeshape-common/src/main/java/org/modeshape/common/collection/ImmutableAppendedList.java
+++ b/modeshape-common/src/main/java/org/modeshape/common/collection/ImmutableAppendedList.java
@@ -68,6 +68,7 @@ public class ImmutableAppendedList<T> implements List<T> {
      * 
      * @see java.util.List#contains(java.lang.Object)
      */
+    @Override
     public boolean contains( Object o ) {
         return element == o || (element != null && element.equals(o)) || parent.contains(o);
     }
@@ -77,6 +78,7 @@ public class ImmutableAppendedList<T> implements List<T> {
      * 
      * @see java.util.List#containsAll(java.util.Collection)
      */
+    @Override
     public boolean containsAll( Collection<?> c ) {
         Iterator<?> e = c.iterator();
         while (e.hasNext()) {
@@ -90,6 +92,7 @@ public class ImmutableAppendedList<T> implements List<T> {
      * 
      * @see java.util.List#get(int)
      */
+    @Override
     public T get( int index ) {
         if (index == (size - 1)) return element;
         return parent.get(index);
@@ -100,6 +103,7 @@ public class ImmutableAppendedList<T> implements List<T> {
      * 
      * @see java.util.List#indexOf(java.lang.Object)
      */
+    @Override
     public int indexOf( Object o ) {
         int index = parent.indexOf(o);
         if (index == -1) {
@@ -113,6 +117,7 @@ public class ImmutableAppendedList<T> implements List<T> {
      * 
      * @see java.util.List#isEmpty()
      */
+    @Override
     public boolean isEmpty() {
         return false;
     }
@@ -122,16 +127,19 @@ public class ImmutableAppendedList<T> implements List<T> {
      * 
      * @see java.util.List#iterator()
      */
+    @Override
     @SuppressWarnings( "synthetic-access" )
     public Iterator<T> iterator() {
         final Iterator<T> parentIterator = parent.iterator();
         return new Iterator<T>() {
             boolean finished = false;
 
+            @Override
             public boolean hasNext() {
                 return parentIterator.hasNext() || !finished;
             }
 
+            @Override
             public T next() {
                 if (parentIterator.hasNext()) return parentIterator.next();
                 if (finished) throw new NoSuchElementException();
@@ -139,6 +147,7 @@ public class ImmutableAppendedList<T> implements List<T> {
                 return element;
             }
 
+            @Override
             public void remove() {
                 throw new UnsupportedOperationException();
             }
@@ -150,6 +159,7 @@ public class ImmutableAppendedList<T> implements List<T> {
      * 
      * @see java.util.List#lastIndexOf(java.lang.Object)
      */
+    @Override
     public int lastIndexOf( Object o ) {
         if (element == o || (element != null && element.equals(o))) return size - 1;
         return parent.lastIndexOf(o);
@@ -160,6 +170,7 @@ public class ImmutableAppendedList<T> implements List<T> {
      * 
      * @see java.util.List#listIterator()
      */
+    @Override
     public ListIterator<T> listIterator() {
         return listIterator(0);
     }
@@ -169,15 +180,18 @@ public class ImmutableAppendedList<T> implements List<T> {
      * 
      * @see java.util.List#listIterator(int)
      */
+    @Override
     @SuppressWarnings( "synthetic-access" )
     public ListIterator<T> listIterator( final int index ) {
         return new ListIterator<T>() {
             int cursor = index;
 
+            @Override
             public boolean hasNext() {
                 return cursor < size;
             }
 
+            @Override
             public T next() {
                 try {
                     T next = get(cursor);
@@ -188,14 +202,17 @@ public class ImmutableAppendedList<T> implements List<T> {
                 }
             }
 
+            @Override
             public boolean hasPrevious() {
                 return cursor != 0;
             }
 
+            @Override
             public int nextIndex() {
                 return cursor;
             }
 
+            @Override
             public T previous() {
                 try {
                     int i = cursor - 1;
@@ -207,18 +224,22 @@ public class ImmutableAppendedList<T> implements List<T> {
                 }
             }
 
+            @Override
             public int previousIndex() {
                 return cursor - 1;
             }
 
+            @Override
             public void set( T o ) {
                 throw new UnsupportedOperationException();
             }
 
+            @Override
             public void remove() {
                 throw new UnsupportedOperationException();
             }
 
+            @Override
             public void add( T o ) {
                 throw new UnsupportedOperationException();
             }
@@ -231,6 +252,7 @@ public class ImmutableAppendedList<T> implements List<T> {
      * 
      * @see java.util.List#size()
      */
+    @Override
     public int size() {
         return size;
     }
@@ -240,6 +262,7 @@ public class ImmutableAppendedList<T> implements List<T> {
      * 
      * @see java.util.List#subList(int, int)
      */
+    @Override
     public List<T> subList( int fromIndex,
                             int toIndex ) {
         if (fromIndex == 0 && toIndex == size) {
@@ -266,6 +289,7 @@ public class ImmutableAppendedList<T> implements List<T> {
      * 
      * @see java.util.List#toArray()
      */
+    @Override
     public Object[] toArray() {
         Object[] result = new Object[size];
         int i = 0;
@@ -281,6 +305,7 @@ public class ImmutableAppendedList<T> implements List<T> {
      * 
      * @see java.util.List#toArray(T[])
      */
+    @Override
     @SuppressWarnings( "unchecked" )
     public <X> X[] toArray( X[] a ) {
         if (a.length < size) a = (X[])java.lang.reflect.Array.newInstance(a.getClass().getComponentType(), size);
@@ -366,6 +391,7 @@ public class ImmutableAppendedList<T> implements List<T> {
      * 
      * @see java.util.List#add(int, Object)
      */
+    @Override
     public void add( int index,
                      T element ) {
         throw new UnsupportedOperationException();
@@ -376,6 +402,7 @@ public class ImmutableAppendedList<T> implements List<T> {
      * 
      * @see java.util.List#add(Object)
      */
+    @Override
     public boolean add( T o ) {
         throw new UnsupportedOperationException();
     }
@@ -385,6 +412,7 @@ public class ImmutableAppendedList<T> implements List<T> {
      * 
      * @see java.util.List#addAll(java.util.Collection)
      */
+    @Override
     public boolean addAll( Collection<? extends T> c ) {
         throw new UnsupportedOperationException();
     }
@@ -394,6 +422,7 @@ public class ImmutableAppendedList<T> implements List<T> {
      * 
      * @see java.util.List#addAll(int, java.util.Collection)
      */
+    @Override
     public boolean addAll( int index,
                            Collection<? extends T> c ) {
         throw new UnsupportedOperationException();
@@ -404,6 +433,7 @@ public class ImmutableAppendedList<T> implements List<T> {
      * 
      * @see java.util.List#clear()
      */
+    @Override
     public void clear() {
         throw new UnsupportedOperationException();
     }
@@ -413,6 +443,7 @@ public class ImmutableAppendedList<T> implements List<T> {
      * 
      * @see java.util.List#remove(java.lang.Object)
      */
+    @Override
     public boolean remove( Object o ) {
         throw new UnsupportedOperationException();
     }
@@ -422,6 +453,7 @@ public class ImmutableAppendedList<T> implements List<T> {
      * 
      * @see java.util.List#remove(int)
      */
+    @Override
     public T remove( int index ) {
         throw new UnsupportedOperationException();
     }
@@ -431,6 +463,7 @@ public class ImmutableAppendedList<T> implements List<T> {
      * 
      * @see java.util.List#removeAll(java.util.Collection)
      */
+    @Override
     public boolean removeAll( Collection<?> c ) {
         throw new UnsupportedOperationException();
     }
@@ -440,6 +473,7 @@ public class ImmutableAppendedList<T> implements List<T> {
      * 
      * @see java.util.List#retainAll(java.util.Collection)
      */
+    @Override
     public boolean retainAll( Collection<?> c ) {
         throw new UnsupportedOperationException();
     }
@@ -449,6 +483,7 @@ public class ImmutableAppendedList<T> implements List<T> {
      * 
      * @see java.util.List#set(int, java.lang.Object)
      */
+    @Override
     public T set( int index,
                   T element ) {
         throw new UnsupportedOperationException();

--- a/modeshape-common/src/main/java/org/modeshape/common/collection/ImmutableProblems.java
+++ b/modeshape-common/src/main/java/org/modeshape/common/collection/ImmutableProblems.java
@@ -47,6 +47,7 @@ public class ImmutableProblems implements Problems {
      * 
      * @see org.modeshape.common.collection.Problems#addError(org.modeshape.common.i18n.I18n, java.lang.Object[])
      */
+    @Override
     public void addError( I18n message,
                           Object... params ) {
         throw new UnsupportedOperationException();
@@ -58,6 +59,7 @@ public class ImmutableProblems implements Problems {
      * @see org.modeshape.common.collection.Problems#addError(java.lang.String, java.lang.String, org.modeshape.common.i18n.I18n,
      *      java.lang.Object[])
      */
+    @Override
     public void addError( String resource,
                           String location,
                           I18n message,
@@ -70,6 +72,7 @@ public class ImmutableProblems implements Problems {
      * 
      * @see org.modeshape.common.collection.Problems#addError(int, org.modeshape.common.i18n.I18n, java.lang.Object[])
      */
+    @Override
     public void addError( int code,
                           I18n message,
                           Object... params ) {
@@ -81,6 +84,7 @@ public class ImmutableProblems implements Problems {
      * 
      * @see org.modeshape.common.collection.Problems#addError(int, String, String, I18n, Object...)
      */
+    @Override
     public void addError( int code,
                           String resource,
                           String location,
@@ -95,6 +99,7 @@ public class ImmutableProblems implements Problems {
      * @see org.modeshape.common.collection.Problems#addError(java.lang.Throwable, org.modeshape.common.i18n.I18n,
      *      java.lang.Object[])
      */
+    @Override
     public void addError( Throwable throwable,
                           I18n message,
                           Object... params ) {
@@ -107,6 +112,7 @@ public class ImmutableProblems implements Problems {
      * @see org.modeshape.common.collection.Problems#addError(java.lang.Throwable, java.lang.String, java.lang.String,
      *      org.modeshape.common.i18n.I18n,java.lang.Object[])
      */
+    @Override
     public void addError( Throwable throwable,
                           String resource,
                           String location,
@@ -121,6 +127,7 @@ public class ImmutableProblems implements Problems {
      * @see org.modeshape.common.collection.Problems#addError(java.lang.Throwable, int, org.modeshape.common.i18n.I18n,
      *      java.lang.Object[])
      */
+    @Override
     public void addError( Throwable throwable,
                           int code,
                           I18n message,
@@ -134,6 +141,7 @@ public class ImmutableProblems implements Problems {
      * @see org.modeshape.common.collection.Problems#addError(java.lang.Throwable, int, java.lang.String, java.lang.String,
      *      org.modeshape.common.i18n.I18n, java.lang.Object[])
      */
+    @Override
     public void addError( Throwable throwable,
                           int code,
                           String resource,
@@ -148,6 +156,7 @@ public class ImmutableProblems implements Problems {
      * 
      * @see org.modeshape.common.collection.Problems#addInfo(org.modeshape.common.i18n.I18n, java.lang.Object[])
      */
+    @Override
     public void addInfo( I18n message,
                          Object... params ) {
         throw new UnsupportedOperationException();
@@ -159,6 +168,7 @@ public class ImmutableProblems implements Problems {
      * @see org.modeshape.common.collection.Problems#addInfo(java.lang.String, java.lang.String, org.modeshape.common.i18n.I18n,
      *      java.lang.Object[])
      */
+    @Override
     public void addInfo( String resource,
                          String location,
                          I18n message,
@@ -171,6 +181,7 @@ public class ImmutableProblems implements Problems {
      * 
      * @see org.modeshape.common.collection.Problems#addInfo(int, org.modeshape.common.i18n.I18n, java.lang.Object[])
      */
+    @Override
     public void addInfo( int code,
                          I18n message,
                          Object... params ) {
@@ -183,6 +194,7 @@ public class ImmutableProblems implements Problems {
      * @see org.modeshape.common.collection.Problems#addInfo(int, java.lang.String, java.lang.String,
      *      org.modeshape.common.i18n.I18n, java.lang.Object[])
      */
+    @Override
     public void addInfo( int code,
                          String resource,
                          String location,
@@ -197,6 +209,7 @@ public class ImmutableProblems implements Problems {
      * @see org.modeshape.common.collection.Problems#addInfo(java.lang.Throwable, org.modeshape.common.i18n.I18n,
      *      java.lang.Object[])
      */
+    @Override
     public void addInfo( Throwable throwable,
                          I18n message,
                          Object... params ) {
@@ -209,6 +222,7 @@ public class ImmutableProblems implements Problems {
      * @see org.modeshape.common.collection.Problems#addInfo(java.lang.Throwable, java.lang.String, java.lang.String,
      *      org.modeshape.common.i18n.I18n, java.lang.Object[])
      */
+    @Override
     public void addInfo( Throwable throwable,
                          String resource,
                          String location,
@@ -223,6 +237,7 @@ public class ImmutableProblems implements Problems {
      * @see org.modeshape.common.collection.Problems#addInfo(java.lang.Throwable, int, org.modeshape.common.i18n.I18n,
      *      java.lang.Object[])
      */
+    @Override
     public void addInfo( Throwable throwable,
                          int code,
                          I18n message,
@@ -236,6 +251,7 @@ public class ImmutableProblems implements Problems {
      * @see org.modeshape.common.collection.Problems#addInfo(java.lang.Throwable, int, java.lang.String, java.lang.String,
      *      org.modeshape.common.i18n.I18n, java.lang.Object[])
      */
+    @Override
     public void addInfo( Throwable throwable,
                          int code,
                          String resource,
@@ -250,6 +266,7 @@ public class ImmutableProblems implements Problems {
      * 
      * @see org.modeshape.common.collection.Problems#addWarning(org.modeshape.common.i18n.I18n, java.lang.Object[])
      */
+    @Override
     public void addWarning( I18n message,
                             Object... params ) {
         throw new UnsupportedOperationException();
@@ -261,6 +278,7 @@ public class ImmutableProblems implements Problems {
      * @see org.modeshape.common.collection.Problems#addWarning(java.lang.String, java.lang.String,
      *      org.modeshape.common.i18n.I18n, java.lang.Object[])
      */
+    @Override
     public void addWarning( String resource,
                             String location,
                             I18n message,
@@ -273,6 +291,7 @@ public class ImmutableProblems implements Problems {
      * 
      * @see org.modeshape.common.collection.Problems#addWarning(int, org.modeshape.common.i18n.I18n, java.lang.Object[])
      */
+    @Override
     public void addWarning( int code,
                             I18n message,
                             Object... params ) {
@@ -285,6 +304,7 @@ public class ImmutableProblems implements Problems {
      * @see org.modeshape.common.collection.Problems#addWarning(int, java.lang.String, java.lang.String,
      *      org.modeshape.common.i18n.I18n, java.lang.Object[])
      */
+    @Override
     public void addWarning( int code,
                             String resource,
                             String location,
@@ -299,6 +319,7 @@ public class ImmutableProblems implements Problems {
      * @see org.modeshape.common.collection.Problems#addWarning(java.lang.Throwable, org.modeshape.common.i18n.I18n,
      *      java.lang.Object[])
      */
+    @Override
     public void addWarning( Throwable throwable,
                             I18n message,
                             Object... params ) {
@@ -311,6 +332,7 @@ public class ImmutableProblems implements Problems {
      * @see org.modeshape.common.collection.Problems#addWarning(java.lang.Throwable, java.lang.String, java.lang.String ,
      *      org.modeshape.common.i18n.I18n,java.lang.Object[])
      */
+    @Override
     public void addWarning( Throwable throwable,
                             String resource,
                             String location,
@@ -325,6 +347,7 @@ public class ImmutableProblems implements Problems {
      * @see org.modeshape.common.collection.Problems#addWarning(java.lang.Throwable, int, org.modeshape.common.i18n.I18n,
      *      java.lang.Object[])
      */
+    @Override
     public void addWarning( Throwable throwable,
                             int code,
                             I18n message,
@@ -338,6 +361,7 @@ public class ImmutableProblems implements Problems {
      * @see org.modeshape.common.collection.Problems#addWarning(java.lang.Throwable, int, java.lang.String, java.lang.String,
      *      org.modeshape.common.i18n.I18n,java.lang.Object[])
      */
+    @Override
     public void addWarning( Throwable throwable,
                             int code,
                             String resource,
@@ -352,6 +376,7 @@ public class ImmutableProblems implements Problems {
      * 
      * @see org.modeshape.common.collection.Problems#addAll(java.lang.Iterable)
      */
+    @Override
     public void addAll( Iterable<Problem> problems ) {
         if (problems != null && problems != this && problems != delegate) this.delegate.addAll(problems);
     }
@@ -361,6 +386,7 @@ public class ImmutableProblems implements Problems {
      * 
      * @see org.modeshape.common.collection.Problems#hasErrors()
      */
+    @Override
     public boolean hasErrors() {
         return delegate.hasErrors();
     }
@@ -370,6 +396,7 @@ public class ImmutableProblems implements Problems {
      * 
      * @see org.modeshape.common.collection.Problems#hasInfo()
      */
+    @Override
     public boolean hasInfo() {
         return delegate.hasInfo();
     }
@@ -379,6 +406,7 @@ public class ImmutableProblems implements Problems {
      * 
      * @see org.modeshape.common.collection.Problems#hasProblems()
      */
+    @Override
     public boolean hasProblems() {
         return delegate.hasProblems();
     }
@@ -388,6 +416,7 @@ public class ImmutableProblems implements Problems {
      * 
      * @see org.modeshape.common.collection.Problems#hasWarnings()
      */
+    @Override
     public boolean hasWarnings() {
         return delegate.hasWarnings();
     }
@@ -397,6 +426,7 @@ public class ImmutableProblems implements Problems {
      * 
      * @see org.modeshape.common.collection.Problems#isEmpty()
      */
+    @Override
     public boolean isEmpty() {
         return delegate.isEmpty();
     }
@@ -406,6 +436,7 @@ public class ImmutableProblems implements Problems {
      * 
      * @see org.modeshape.common.collection.Problems#iterator()
      */
+    @Override
     public Iterator<Problem> iterator() {
         return new ReadOnlyIterator<Problem>(delegate.iterator());
     }
@@ -415,6 +446,7 @@ public class ImmutableProblems implements Problems {
      * 
      * @see org.modeshape.common.collection.Problems#size()
      */
+    @Override
     public int size() {
         return delegate.size();
     }

--- a/modeshape-common/src/main/java/org/modeshape/common/collection/Problems.java
+++ b/modeshape-common/src/main/java/org/modeshape/common/collection/Problems.java
@@ -420,5 +420,6 @@ public interface Problems extends Iterable<Problem>, Serializable {
      * 
      * @see java.lang.Iterable#iterator()
      */
+    @Override
     Iterator<Problem> iterator();
 }

--- a/modeshape-common/src/main/java/org/modeshape/common/collection/ReadOnlyIterator.java
+++ b/modeshape-common/src/main/java/org/modeshape/common/collection/ReadOnlyIterator.java
@@ -45,6 +45,7 @@ public final class ReadOnlyIterator<T> implements Iterator<T> {
      * 
      * @see java.util.Iterator#hasNext()
      */
+    @Override
     public boolean hasNext() {
         return delegate.hasNext();
     }
@@ -54,6 +55,7 @@ public final class ReadOnlyIterator<T> implements Iterator<T> {
      * 
      * @see java.util.Iterator#next()
      */
+    @Override
     public T next() {
         return delegate.next();
     }
@@ -63,6 +65,7 @@ public final class ReadOnlyIterator<T> implements Iterator<T> {
      * 
      * @see java.util.Iterator#remove()
      */
+    @Override
     public void remove() {
         throw new UnsupportedOperationException();
     }

--- a/modeshape-common/src/main/java/org/modeshape/common/collection/SimpleProblems.java
+++ b/modeshape-common/src/main/java/org/modeshape/common/collection/SimpleProblems.java
@@ -64,6 +64,7 @@ public class SimpleProblems extends AbstractProblems {
      * 
      * @see org.modeshape.common.collection.Problems#addAll(java.lang.Iterable)
      */
+    @Override
     public void addAll( Iterable<Problem> problems ) {
         if (problems != null) {
             if (problems == this) return;

--- a/modeshape-common/src/main/java/org/modeshape/common/collection/ThreadSafeProblems.java
+++ b/modeshape-common/src/main/java/org/modeshape/common/collection/ThreadSafeProblems.java
@@ -152,6 +152,7 @@ public class ThreadSafeProblems extends AbstractProblems {
      * 
      * @see org.modeshape.common.collection.Problems#addAll(java.lang.Iterable)
      */
+    @Override
     public void addAll( Iterable<Problem> problems ) {
         if (problems == this) return;
         try {

--- a/modeshape-common/src/main/java/org/modeshape/common/component/ComponentConfig.java
+++ b/modeshape-common/src/main/java/org/modeshape/common/component/ComponentConfig.java
@@ -215,6 +215,7 @@ public class ComponentConfig implements Comparable<ComponentConfig> {
     /**
      * {@inheritDoc}
      */
+    @Override
     public int compareTo( ComponentConfig that ) {
         if (that == this) return 0;
         int diff = this.getName().compareToIgnoreCase(that.getName());

--- a/modeshape-common/src/main/java/org/modeshape/common/component/StandardClassLoaderFactory.java
+++ b/modeshape-common/src/main/java/org/modeshape/common/component/StandardClassLoaderFactory.java
@@ -52,6 +52,7 @@ public class StandardClassLoaderFactory implements ClassLoaderFactory {
     /**
      * {@inheritDoc}
      */
+    @Override
     public ClassLoader getClassLoader( String... classpath ) {
         ClassLoader result = null;
         if (this.useCurrentThreadContextClassLoader) result = Thread.currentThread().getContextClassLoader();

--- a/modeshape-common/src/main/java/org/modeshape/common/i18n/ClasspathLocalizationRepository.java
+++ b/modeshape-common/src/main/java/org/modeshape/common/i18n/ClasspathLocalizationRepository.java
@@ -64,6 +64,7 @@ public class ClasspathLocalizationRepository implements LocalizationRepository {
     /**
      * {@inheritDoc}
      */
+    @Override
     public URL getLocalizationBundle( String bundleName,
                                       Locale locale ) {
         URL url = null;

--- a/modeshape-common/src/main/java/org/modeshape/common/math/DoubleOperations.java
+++ b/modeshape-common/src/main/java/org/modeshape/common/math/DoubleOperations.java
@@ -34,10 +34,12 @@ import org.modeshape.common.annotation.Immutable;
 @Immutable
 public class DoubleOperations implements MathOperations<Double>, Comparator<Double> {
 
+    @Override
     public Class<Double> getOperandClass() {
         return Double.class;
     }
 
+    @Override
     public Double add( Double value1,
                        Double value2 ) {
         if (value1 == null) return value2 != null ? value2 : createZeroValue();
@@ -45,6 +47,7 @@ public class DoubleOperations implements MathOperations<Double>, Comparator<Doub
         return (value1 + value2);
     }
 
+    @Override
     public Double subtract( Double value1,
                             Double value2 ) {
         if (value1 == null) return negate(value2);
@@ -52,28 +55,33 @@ public class DoubleOperations implements MathOperations<Double>, Comparator<Doub
         return (value1 - value2);
     }
 
+    @Override
     public Double multiply( Double value1,
                             Double value2 ) {
         if (value1 == null || value2 == null) return createZeroValue();
         return (value1 * value2);
     }
 
+    @Override
     public double divide( Double value1,
                           Double value2 ) {
         if (value1 == null || value2 == null) throw new IllegalArgumentException();
         return value1 / value2;
     }
 
+    @Override
     public Double negate( Double value ) {
         if (value == null) return createZeroValue();
         return (value * -1);
     }
 
+    @Override
     public Double increment( Double value ) {
         if (value == null) return createZeroValue();
         return (value + 1);
     }
 
+    @Override
     public Double maximum( Double value1,
                            Double value2 ) {
         if (value1 == null) return value2;
@@ -81,6 +89,7 @@ public class DoubleOperations implements MathOperations<Double>, Comparator<Doub
         return Math.max(value1, value2);
     }
 
+    @Override
     public Double minimum( Double value1,
                            Double value2 ) {
         if (value1 == null) return value2;
@@ -88,6 +97,7 @@ public class DoubleOperations implements MathOperations<Double>, Comparator<Doub
         return Math.min(value1, value2);
     }
 
+    @Override
     public int compare( Double value1,
                         Double value2 ) {
         if (value1 == null) return value2 != null ? -1 : 0;
@@ -95,38 +105,47 @@ public class DoubleOperations implements MathOperations<Double>, Comparator<Doub
         return value1.compareTo(value2);
     }
 
+    @Override
     public BigDecimal asBigDecimal( Double value ) {
         return value != null ? new BigDecimal(value) : null;
     }
 
+    @Override
     public Double fromBigDecimal( BigDecimal value ) {
         return value != null ? value.doubleValue() : null;
     }
 
+    @Override
     public Double createZeroValue() {
         return 0.0d;
     }
 
+    @Override
     public Double create( int value ) {
         return (double)value;
     }
 
+    @Override
     public Double create( long value ) {
         return (double)value;
     }
 
+    @Override
     public Double create( double value ) {
         return value;
     }
 
+    @Override
     public double sqrt( Double value ) {
         return Math.sqrt(value);
     }
 
+    @Override
     public Comparator<Double> getComparator() {
         return this;
     }
 
+    @Override
     public Double random( Double minimum,
                           Double maximum,
                           Random rng ) {
@@ -134,26 +153,32 @@ public class DoubleOperations implements MathOperations<Double>, Comparator<Doub
         return minimum + difference.doubleValue() * rng.nextDouble();
     }
 
+    @Override
     public double doubleValue( Double value ) {
         return value.doubleValue();
     }
 
+    @Override
     public float floatValue( Double value ) {
         return value.floatValue();
     }
 
+    @Override
     public int intValue( Double value ) {
         return value.intValue();
     }
 
+    @Override
     public long longValue( Double value ) {
         return value.longValue();
     }
 
+    @Override
     public short shortValue( Double value ) {
         return value.shortValue();
     }
 
+    @Override
     public int getExponentInScientificNotation( Double value ) {
         double v = Math.abs(value);
         int exp = 0;
@@ -172,6 +197,7 @@ public class DoubleOperations implements MathOperations<Double>, Comparator<Doub
         return exp;
     }
 
+    @Override
     public Double roundUp( Double value,
                            int decimalShift ) {
         if (value == 0) return 0.0d;
@@ -180,6 +206,7 @@ public class DoubleOperations implements MathOperations<Double>, Comparator<Doub
         return roundedValue * Math.pow(10.0d, -decimalShift);
     }
 
+    @Override
     public Double roundDown( Double value,
                              int decimalShift ) {
         if (value == 0) return 0.0d;
@@ -188,6 +215,7 @@ public class DoubleOperations implements MathOperations<Double>, Comparator<Doub
         return roundedValue * Math.pow(10.0d, -decimalShift);
     }
 
+    @Override
     public Double keepSignificantFigures( Double value,
                                           int numSigFigs ) {
         if (numSigFigs < 0) return value;

--- a/modeshape-common/src/main/java/org/modeshape/common/math/Duration.java
+++ b/modeshape-common/src/main/java/org/modeshape/common/math/Duration.java
@@ -176,6 +176,7 @@ public class Duration extends Number implements Comparable<Duration> {
     /**
      * {@inheritDoc}
      */
+    @Override
     public int compareTo( Duration that ) {
         if (that == null) return 1;
         return this.durationInNanos < that.durationInNanos ? -1 : this.durationInNanos > that.durationInNanos ? 1 : 0;

--- a/modeshape-common/src/main/java/org/modeshape/common/math/DurationOperations.java
+++ b/modeshape-common/src/main/java/org/modeshape/common/math/DurationOperations.java
@@ -35,10 +35,12 @@ import org.modeshape.common.annotation.Immutable;
 @Immutable
 public class DurationOperations implements MathOperations<Duration>, Comparator<Duration> {
 
+    @Override
     public Class<Duration> getOperandClass() {
         return Duration.class;
     }
 
+    @Override
     public Duration add( Duration value1,
                          Duration value2 ) {
         if (value1 == null) return value2 != null ? value2 : createZeroValue();
@@ -46,6 +48,7 @@ public class DurationOperations implements MathOperations<Duration>, Comparator<
         return value1.add(value2);
     }
 
+    @Override
     public Duration subtract( Duration value1,
                               Duration value2 ) {
         if (value1 == null) return negate(value2);
@@ -53,28 +56,33 @@ public class DurationOperations implements MathOperations<Duration>, Comparator<
         return value1.subtract(value2);
     }
 
+    @Override
     public Duration multiply( Duration value1,
                               Duration value2 ) {
         if (value1 == null || value2 == null) return createZeroValue();
         return value1.multiply(value2.longValue());
     }
 
+    @Override
     public double divide( Duration value1,
                           Duration value2 ) {
         if (value1 == null || value2 == null) throw new IllegalArgumentException();
         return value1.divide(value2);
     }
 
+    @Override
     public Duration negate( Duration value ) {
         if (value == null) return createZeroValue();
         return value.multiply(value.longValue() * -1);
     }
 
+    @Override
     public Duration increment( Duration value ) {
         if (value == null) return createZeroValue();
         return value.add(1l, TimeUnit.NANOSECONDS);
     }
 
+    @Override
     public Duration maximum( Duration value1,
                              Duration value2 ) {
         if (value1 == null) return value2;
@@ -82,6 +90,7 @@ public class DurationOperations implements MathOperations<Duration>, Comparator<
         return new Duration(Math.max(value1.longValue(), value2.longValue()));
     }
 
+    @Override
     public Duration minimum( Duration value1,
                              Duration value2 ) {
         if (value1 == null) return value2;
@@ -89,6 +98,7 @@ public class DurationOperations implements MathOperations<Duration>, Comparator<
         return new Duration(Math.min(value1.longValue(), value2.longValue()));
     }
 
+    @Override
     public int compare( Duration value1,
                         Duration value2 ) {
         if (value1 == null) return value2 != null ? -1 : 0;
@@ -96,38 +106,47 @@ public class DurationOperations implements MathOperations<Duration>, Comparator<
         return value1.compareTo(value2);
     }
 
+    @Override
     public BigDecimal asBigDecimal( Duration value ) {
         return value != null ? value.toBigDecimal() : null;
     }
 
+    @Override
     public Duration fromBigDecimal( BigDecimal value ) {
         return value != null ? new Duration(value.longValue()) : null;
     }
 
+    @Override
     public Duration createZeroValue() {
         return new Duration(0l);
     }
 
+    @Override
     public Duration create( int value ) {
         return new Duration(value);
     }
 
+    @Override
     public Duration create( long value ) {
         return new Duration(value);
     }
 
+    @Override
     public Duration create( double value ) {
         return new Duration((long)value);
     }
 
+    @Override
     public double sqrt( Duration value ) {
         return Math.sqrt(value.longValue());
     }
 
+    @Override
     public Comparator<Duration> getComparator() {
         return this;
     }
 
+    @Override
     public Duration random( Duration minimum,
                             Duration maximum,
                             Random rng ) {
@@ -135,26 +154,32 @@ public class DurationOperations implements MathOperations<Duration>, Comparator<
         return new Duration(minimum.getDuratinInNanoseconds() + rng.nextInt(difference.intValue()));
     }
 
+    @Override
     public double doubleValue( Duration value ) {
         return value.doubleValue();
     }
 
+    @Override
     public float floatValue( Duration value ) {
         return value.floatValue();
     }
 
+    @Override
     public int intValue( Duration value ) {
         return value.intValue();
     }
 
+    @Override
     public long longValue( Duration value ) {
         return value.longValue();
     }
 
+    @Override
     public short shortValue( Duration value ) {
         return value.shortValue();
     }
 
+    @Override
     public int getExponentInScientificNotation( Duration value ) {
         long v = Math.abs(value.getDuratinInNanoseconds());
         int exp = 0;
@@ -167,6 +192,7 @@ public class DurationOperations implements MathOperations<Duration>, Comparator<
         return exp;
     }
 
+    @Override
     public Duration roundUp( Duration durationValue,
                              int decimalShift ) {
         long value = durationValue.longValue();
@@ -184,6 +210,7 @@ public class DurationOperations implements MathOperations<Duration>, Comparator<
         return new Duration(shiftedValue);
     }
 
+    @Override
     public Duration roundDown( Duration durationValue,
                                int decimalShift ) {
         long value = durationValue.longValue();
@@ -198,6 +225,7 @@ public class DurationOperations implements MathOperations<Duration>, Comparator<
         return new Duration(shiftedValue);
     }
 
+    @Override
     public Duration keepSignificantFigures( Duration value,
                                             int numSigFigs ) {
         if (numSigFigs < 0) return value;

--- a/modeshape-common/src/main/java/org/modeshape/common/math/FloatOperations.java
+++ b/modeshape-common/src/main/java/org/modeshape/common/math/FloatOperations.java
@@ -34,10 +34,12 @@ import org.modeshape.common.annotation.Immutable;
 @Immutable
 public class FloatOperations implements MathOperations<Float>, Comparator<Float> {
 
+    @Override
     public Class<Float> getOperandClass() {
         return Float.class;
     }
 
+    @Override
     public Float add( Float value1,
                       Float value2 ) {
         if (value1 == null) return value2 != null ? value2 : createZeroValue();
@@ -45,6 +47,7 @@ public class FloatOperations implements MathOperations<Float>, Comparator<Float>
         return (value1 + value2);
     }
 
+    @Override
     public Float subtract( Float value1,
                            Float value2 ) {
         if (value1 == null) return negate(value2);
@@ -52,28 +55,33 @@ public class FloatOperations implements MathOperations<Float>, Comparator<Float>
         return (value1 - value2);
     }
 
+    @Override
     public Float multiply( Float value1,
                            Float value2 ) {
         if (value1 == null || value2 == null) return createZeroValue();
         return (value1 * value2);
     }
 
+    @Override
     public double divide( Float value1,
                           Float value2 ) {
         if (value1 == null || value2 == null) throw new IllegalArgumentException();
         return value1 / value2;
     }
 
+    @Override
     public Float negate( Float value ) {
         if (value == null) return createZeroValue();
         return (value * -1);
     }
 
+    @Override
     public Float increment( Float value ) {
         if (value == null) return createZeroValue();
         return (value + 1);
     }
 
+    @Override
     public Float maximum( Float value1,
                           Float value2 ) {
         if (value1 == null) return value2;
@@ -81,6 +89,7 @@ public class FloatOperations implements MathOperations<Float>, Comparator<Float>
         return Math.max(value1, value2);
     }
 
+    @Override
     public Float minimum( Float value1,
                           Float value2 ) {
         if (value1 == null) return value2;
@@ -88,6 +97,7 @@ public class FloatOperations implements MathOperations<Float>, Comparator<Float>
         return Math.min(value1, value2);
     }
 
+    @Override
     public int compare( Float value1,
                         Float value2 ) {
         if (value1 == null) return value2 != null ? -1 : 0;
@@ -95,38 +105,47 @@ public class FloatOperations implements MathOperations<Float>, Comparator<Float>
         return value1.compareTo(value2);
     }
 
+    @Override
     public BigDecimal asBigDecimal( Float value ) {
         return value != null ? new BigDecimal(value) : null;
     }
 
+    @Override
     public Float fromBigDecimal( BigDecimal value ) {
         return value != null ? value.floatValue() : null;
     }
 
+    @Override
     public Float createZeroValue() {
         return 0.0f;
     }
 
+    @Override
     public Float create( int value ) {
         return (float)value;
     }
 
+    @Override
     public Float create( long value ) {
         return (float)value;
     }
 
+    @Override
     public Float create( double value ) {
         return (float)value;
     }
 
+    @Override
     public double sqrt( Float value ) {
         return Math.sqrt(value);
     }
 
+    @Override
     public Comparator<Float> getComparator() {
         return this;
     }
 
+    @Override
     public Float random( Float minimum,
                          Float maximum,
                          Random rng ) {
@@ -134,26 +153,32 @@ public class FloatOperations implements MathOperations<Float>, Comparator<Float>
         return minimum + difference.floatValue() * rng.nextFloat();
     }
 
+    @Override
     public double doubleValue( Float value ) {
         return value.doubleValue();
     }
 
+    @Override
     public float floatValue( Float value ) {
         return value.floatValue();
     }
 
+    @Override
     public int intValue( Float value ) {
         return value.intValue();
     }
 
+    @Override
     public long longValue( Float value ) {
         return value.longValue();
     }
 
+    @Override
     public short shortValue( Float value ) {
         return value.shortValue();
     }
 
+    @Override
     public int getExponentInScientificNotation( Float value ) {
         double v = Math.abs(value);
         int exp = 0;
@@ -172,6 +197,7 @@ public class FloatOperations implements MathOperations<Float>, Comparator<Float>
         return exp;
     }
 
+    @Override
     public Float roundUp( Float value,
                           int decimalShift ) {
         if (value == 0) return 0.0f;
@@ -180,6 +206,7 @@ public class FloatOperations implements MathOperations<Float>, Comparator<Float>
         return (float)(roundedValue * Math.pow(10.0d, -decimalShift));
     }
 
+    @Override
     public Float roundDown( Float value,
                             int decimalShift ) {
         if (value == 0) return 0.0f;
@@ -189,6 +216,7 @@ public class FloatOperations implements MathOperations<Float>, Comparator<Float>
         return (float)(roundedValue * Math.pow(10.0d, -decimalShift));
     }
 
+    @Override
     public Float keepSignificantFigures( Float value,
                                          int numSigFigs ) {
         int currentExp = getExponentInScientificNotation(value);

--- a/modeshape-common/src/main/java/org/modeshape/common/math/IntegerOperations.java
+++ b/modeshape-common/src/main/java/org/modeshape/common/math/IntegerOperations.java
@@ -34,10 +34,12 @@ import org.modeshape.common.annotation.Immutable;
 @Immutable
 public class IntegerOperations implements MathOperations<Integer>, Comparator<Integer> {
 
+    @Override
     public Class<Integer> getOperandClass() {
         return Integer.class;
     }
 
+    @Override
     public Integer add( Integer value1,
                         Integer value2 ) {
         if (value1 == null) return value2 != null ? value2 : createZeroValue();
@@ -45,6 +47,7 @@ public class IntegerOperations implements MathOperations<Integer>, Comparator<In
         return value1 + value2;
     }
 
+    @Override
     public Integer subtract( Integer value1,
                              Integer value2 ) {
         if (value1 == null) return negate(value2);
@@ -52,28 +55,33 @@ public class IntegerOperations implements MathOperations<Integer>, Comparator<In
         return value1 - value2;
     }
 
+    @Override
     public Integer multiply( Integer value1,
                              Integer value2 ) {
         if (value1 == null || value2 == null) return createZeroValue();
         return value1 * value2;
     }
 
+    @Override
     public double divide( Integer value1,
                           Integer value2 ) {
         if (value1 == null || value2 == null) throw new IllegalArgumentException();
         return value1 / value2;
     }
 
+    @Override
     public Integer negate( Integer value ) {
         if (value == null) return createZeroValue();
         return value * -1;
     }
 
+    @Override
     public Integer increment( Integer value ) {
         if (value == null) return createZeroValue();
         return value + 1;
     }
 
+    @Override
     public Integer maximum( Integer value1,
                             Integer value2 ) {
         if (value1 == null) return value2;
@@ -81,6 +89,7 @@ public class IntegerOperations implements MathOperations<Integer>, Comparator<In
         return Math.max(value1, value2);
     }
 
+    @Override
     public Integer minimum( Integer value1,
                             Integer value2 ) {
         if (value1 == null) return value2;
@@ -88,6 +97,7 @@ public class IntegerOperations implements MathOperations<Integer>, Comparator<In
         return Math.min(value1, value2);
     }
 
+    @Override
     public int compare( Integer value1,
                         Integer value2 ) {
         if (value1 == null) return value2 != null ? -1 : 0;
@@ -95,38 +105,47 @@ public class IntegerOperations implements MathOperations<Integer>, Comparator<In
         return value1.compareTo(value2);
     }
 
+    @Override
     public BigDecimal asBigDecimal( Integer value ) {
         return value != null ? new BigDecimal(value) : null;
     }
 
+    @Override
     public Integer fromBigDecimal( BigDecimal value ) {
         return value != null ? value.intValue() : null;
     }
 
+    @Override
     public Integer createZeroValue() {
         return 0;
     }
 
+    @Override
     public Integer create( int value ) {
         return value;
     }
 
+    @Override
     public Integer create( long value ) {
         return (int)value;
     }
 
+    @Override
     public Integer create( double value ) {
         return (int)value;
     }
 
+    @Override
     public double sqrt( Integer value ) {
         return Math.sqrt(value);
     }
 
+    @Override
     public Comparator<Integer> getComparator() {
         return this;
     }
 
+    @Override
     public Integer random( Integer minimum,
                            Integer maximum,
                            Random rng ) {
@@ -134,26 +153,32 @@ public class IntegerOperations implements MathOperations<Integer>, Comparator<In
         return minimum + rng.nextInt(difference);
     }
 
+    @Override
     public double doubleValue( Integer value ) {
         return value.doubleValue();
     }
 
+    @Override
     public float floatValue( Integer value ) {
         return value.floatValue();
     }
 
+    @Override
     public int intValue( Integer value ) {
         return value.intValue();
     }
 
+    @Override
     public long longValue( Integer value ) {
         return value.longValue();
     }
 
+    @Override
     public short shortValue( Integer value ) {
         return value.shortValue();
     }
 
+    @Override
     public int getExponentInScientificNotation( Integer value ) {
         int v = Math.abs(value);
         int exp = 0;
@@ -166,6 +191,7 @@ public class IntegerOperations implements MathOperations<Integer>, Comparator<In
         return exp;
     }
 
+    @Override
     public Integer roundUp( Integer value,
                             int decimalShift ) {
         if (value == 0) return 0;
@@ -182,6 +208,7 @@ public class IntegerOperations implements MathOperations<Integer>, Comparator<In
         return shiftedValue;
     }
 
+    @Override
     public Integer roundDown( Integer value,
                               int decimalShift ) {
         if (value == 0) return 0;
@@ -195,6 +222,7 @@ public class IntegerOperations implements MathOperations<Integer>, Comparator<In
         return shiftedValue;
     }
 
+    @Override
     public Integer keepSignificantFigures( Integer value,
                                            int numSigFigs ) {
         if (numSigFigs < 0) return value;

--- a/modeshape-common/src/main/java/org/modeshape/common/math/LongOperations.java
+++ b/modeshape-common/src/main/java/org/modeshape/common/math/LongOperations.java
@@ -34,10 +34,12 @@ import org.modeshape.common.annotation.Immutable;
 @Immutable
 public class LongOperations implements MathOperations<Long>, Comparator<Long> {
 
+    @Override
     public Class<Long> getOperandClass() {
         return Long.class;
     }
 
+    @Override
     public Long add( Long value1,
                      Long value2 ) {
         if (value1 == null) return value2 != null ? value2 : createZeroValue();
@@ -45,6 +47,7 @@ public class LongOperations implements MathOperations<Long>, Comparator<Long> {
         return (value1 + value2);
     }
 
+    @Override
     public Long subtract( Long value1,
                           Long value2 ) {
         if (value1 == null) return negate(value2);
@@ -52,28 +55,33 @@ public class LongOperations implements MathOperations<Long>, Comparator<Long> {
         return (value1 - value2);
     }
 
+    @Override
     public Long multiply( Long value1,
                           Long value2 ) {
         if (value1 == null || value2 == null) return createZeroValue();
         return (value1 * value2);
     }
 
+    @Override
     public double divide( Long value1,
                           Long value2 ) {
         if (value1 == null || value2 == null) throw new IllegalArgumentException();
         return value1 / value2;
     }
 
+    @Override
     public Long negate( Long value ) {
         if (value == null) return createZeroValue();
         return (value * -1);
     }
 
+    @Override
     public Long increment( Long value ) {
         if (value == null) return createZeroValue();
         return (value + 1);
     }
 
+    @Override
     public Long maximum( Long value1,
                          Long value2 ) {
         if (value1 == null) return value2;
@@ -81,6 +89,7 @@ public class LongOperations implements MathOperations<Long>, Comparator<Long> {
         return Math.max(value1, value2);
     }
 
+    @Override
     public Long minimum( Long value1,
                          Long value2 ) {
         if (value1 == null) return value2;
@@ -88,6 +97,7 @@ public class LongOperations implements MathOperations<Long>, Comparator<Long> {
         return Math.min(value1, value2);
     }
 
+    @Override
     public int compare( Long value1,
                         Long value2 ) {
         if (value1 == null) return value2 != null ? -1 : 0;
@@ -95,38 +105,47 @@ public class LongOperations implements MathOperations<Long>, Comparator<Long> {
         return value1.compareTo(value2);
     }
 
+    @Override
     public BigDecimal asBigDecimal( Long value ) {
         return value != null ? new BigDecimal(value) : null;
     }
 
+    @Override
     public Long fromBigDecimal( BigDecimal value ) {
         return value != null ? value.longValue() : null;
     }
 
+    @Override
     public Long createZeroValue() {
         return 0l;
     }
 
+    @Override
     public Long create( int value ) {
         return (long)value;
     }
 
+    @Override
     public Long create( long value ) {
         return value;
     }
 
+    @Override
     public Long create( double value ) {
         return (long)value;
     }
 
+    @Override
     public double sqrt( Long value ) {
         return Math.sqrt(value);
     }
 
+    @Override
     public Comparator<Long> getComparator() {
         return this;
     }
 
+    @Override
     public Long random( Long minimum,
                         Long maximum,
                         Random rng ) {
@@ -134,26 +153,32 @@ public class LongOperations implements MathOperations<Long>, Comparator<Long> {
         return minimum + rng.nextInt(difference.intValue());
     }
 
+    @Override
     public double doubleValue( Long value ) {
         return value.doubleValue();
     }
 
+    @Override
     public float floatValue( Long value ) {
         return value.floatValue();
     }
 
+    @Override
     public int intValue( Long value ) {
         return value.intValue();
     }
 
+    @Override
     public long longValue( Long value ) {
         return value.longValue();
     }
 
+    @Override
     public short shortValue( Long value ) {
         return value.shortValue();
     }
 
+    @Override
     public int getExponentInScientificNotation( Long value ) {
         long v = Math.abs(value);
         int exp = 0;
@@ -172,6 +197,7 @@ public class LongOperations implements MathOperations<Long>, Comparator<Long> {
         return exp;
     }
 
+    @Override
     public Long roundUp( Long value,
                          int decimalShift ) {
         if (value == 0) return 0l;
@@ -188,6 +214,7 @@ public class LongOperations implements MathOperations<Long>, Comparator<Long> {
         return shiftedValue;
     }
 
+    @Override
     public Long roundDown( Long value,
                            int decimalShift ) {
         if (value == 0) return 0l;
@@ -201,6 +228,7 @@ public class LongOperations implements MathOperations<Long>, Comparator<Long> {
         return shiftedValue;
     }
 
+    @Override
     public Long keepSignificantFigures( Long value,
                                         int numSigFigs ) {
         if (value == 0l) return value;

--- a/modeshape-common/src/main/java/org/modeshape/common/math/ShortOperations.java
+++ b/modeshape-common/src/main/java/org/modeshape/common/math/ShortOperations.java
@@ -34,10 +34,12 @@ import org.modeshape.common.annotation.Immutable;
 @Immutable
 public class ShortOperations implements MathOperations<Short>, Comparator<Short> {
 
+    @Override
     public Class<Short> getOperandClass() {
         return Short.class;
     }
 
+    @Override
     public Short add( Short value1,
                       Short value2 ) {
         if (value1 == null) return value2 != null ? value2 : createZeroValue();
@@ -45,6 +47,7 @@ public class ShortOperations implements MathOperations<Short>, Comparator<Short>
         return (short)(value1 + value2);
     }
 
+    @Override
     public Short subtract( Short value1,
                            Short value2 ) {
         if (value1 == null) return negate(value2);
@@ -52,28 +55,33 @@ public class ShortOperations implements MathOperations<Short>, Comparator<Short>
         return (short)(value1 - value2);
     }
 
+    @Override
     public Short multiply( Short value1,
                            Short value2 ) {
         if (value1 == null || value2 == null) return createZeroValue();
         return (short)(value1 * value2);
     }
 
+    @Override
     public double divide( Short value1,
                           Short value2 ) {
         if (value1 == null || value2 == null) throw new IllegalArgumentException();
         return value1 / value2;
     }
 
+    @Override
     public Short negate( Short value ) {
         if (value == null) return createZeroValue();
         return (short)(value * -1);
     }
 
+    @Override
     public Short increment( Short value ) {
         if (value == null) return createZeroValue();
         return (short)(value + 1);
     }
 
+    @Override
     public Short maximum( Short value1,
                           Short value2 ) {
         if (value1 == null) return value2;
@@ -81,6 +89,7 @@ public class ShortOperations implements MathOperations<Short>, Comparator<Short>
         return (short)Math.max(value1, value2);
     }
 
+    @Override
     public Short minimum( Short value1,
                           Short value2 ) {
         if (value1 == null) return value2;
@@ -88,6 +97,7 @@ public class ShortOperations implements MathOperations<Short>, Comparator<Short>
         return (short)Math.min(value1, value2);
     }
 
+    @Override
     public int compare( Short value1,
                         Short value2 ) {
         if (value1 == null) return value2 != null ? -1 : 0;
@@ -95,38 +105,47 @@ public class ShortOperations implements MathOperations<Short>, Comparator<Short>
         return value1.compareTo(value2);
     }
 
+    @Override
     public BigDecimal asBigDecimal( Short value ) {
         return value != null ? new BigDecimal(value) : null;
     }
 
+    @Override
     public Short fromBigDecimal( BigDecimal value ) {
         return value != null ? value.shortValue() : null;
     }
 
+    @Override
     public Short createZeroValue() {
         return 0;
     }
 
+    @Override
     public Short create( int value ) {
         return (short)value;
     }
 
+    @Override
     public Short create( long value ) {
         return (short)value;
     }
 
+    @Override
     public Short create( double value ) {
         return (short)value;
     }
 
+    @Override
     public double sqrt( Short value ) {
         return Math.sqrt(value);
     }
 
+    @Override
     public Comparator<Short> getComparator() {
         return this;
     }
 
+    @Override
     public Short random( Short minimum,
                          Short maximum,
                          Random rng ) {
@@ -135,26 +154,32 @@ public class ShortOperations implements MathOperations<Short>, Comparator<Short>
         return new Integer(minimum + increment).shortValue();
     }
 
+    @Override
     public double doubleValue( Short value ) {
         return value.doubleValue();
     }
 
+    @Override
     public float floatValue( Short value ) {
         return value.floatValue();
     }
 
+    @Override
     public int intValue( Short value ) {
         return value.intValue();
     }
 
+    @Override
     public long longValue( Short value ) {
         return value.longValue();
     }
 
+    @Override
     public short shortValue( Short value ) {
         return value.shortValue();
     }
 
+    @Override
     public int getExponentInScientificNotation( Short value ) {
         int v = Math.abs(value);
         int exp = 0;
@@ -172,6 +197,7 @@ public class ShortOperations implements MathOperations<Short>, Comparator<Short>
         return exp;
     }
 
+    @Override
     public Short roundUp( Short value,
                           int decimalShift ) {
         if (value == 0) return 0;
@@ -188,6 +214,7 @@ public class ShortOperations implements MathOperations<Short>, Comparator<Short>
         return (short)shiftedValue;
     }
 
+    @Override
     public Short roundDown( Short value,
                             int decimalShift ) {
         if (value == 0) return 0;
@@ -201,6 +228,7 @@ public class ShortOperations implements MathOperations<Short>, Comparator<Short>
         return (short)shiftedValue;
     }
 
+    @Override
     public Short keepSignificantFigures( Short value,
                                          int numSigFigs ) {
         if (numSigFigs < 0) return value;

--- a/modeshape-common/src/main/java/org/modeshape/common/naming/SingletonInitialContext.java
+++ b/modeshape-common/src/main/java/org/modeshape/common/naming/SingletonInitialContext.java
@@ -135,6 +135,7 @@ public class SingletonInitialContext implements Context {
     /**
      * {@inheritDoc}
      */
+    @Override
     public Object addToEnvironment( String propName,
                                     Object propVal ) {
         return environment.put(propName, propVal);
@@ -143,6 +144,7 @@ public class SingletonInitialContext implements Context {
     /**
      * {@inheritDoc}
      */
+    @Override
     public Object removeFromEnvironment( String propName ) {
         return environment.remove(propName);
     }
@@ -150,6 +152,7 @@ public class SingletonInitialContext implements Context {
     /**
      * {@inheritDoc}
      */
+    @Override
     public void bind( Name name,
                       Object obj ) throws NamingException {
         bind(name.toString(), obj);
@@ -158,6 +161,7 @@ public class SingletonInitialContext implements Context {
     /**
      * {@inheritDoc}
      */
+    @Override
     public void bind( String name,
                       Object obj ) throws NamingException {
         if (this.registry.putIfAbsent(name, obj) != null) {
@@ -168,6 +172,7 @@ public class SingletonInitialContext implements Context {
     /**
      * {@inheritDoc}
      */
+    @Override
     public void rebind( Name name,
                         Object obj ) {
         rebind(name.toString(), obj);
@@ -176,6 +181,7 @@ public class SingletonInitialContext implements Context {
     /**
      * {@inheritDoc}
      */
+    @Override
     public void rebind( String name,
                         Object obj ) {
         this.registry.put(name, obj);
@@ -184,6 +190,7 @@ public class SingletonInitialContext implements Context {
     /**
      * {@inheritDoc}
      */
+    @Override
     public void unbind( String name ) {
         this.registry.remove(name);
     }
@@ -191,6 +198,7 @@ public class SingletonInitialContext implements Context {
     /**
      * {@inheritDoc}
      */
+    @Override
     public void unbind( Name name ) {
         unbind(name.toString());
     }
@@ -198,6 +206,7 @@ public class SingletonInitialContext implements Context {
     /**
      * {@inheritDoc}
      */
+    @Override
     public Object lookup( Name name ) throws NamingException {
         return lookup(name.toString());
     }
@@ -205,6 +214,7 @@ public class SingletonInitialContext implements Context {
     /**
      * {@inheritDoc}
      */
+    @Override
     public Object lookup( String name ) throws NamingException {
         Object result = this.registry.get(name);
         if (result == null) {
@@ -216,6 +226,7 @@ public class SingletonInitialContext implements Context {
     /**
      * {@inheritDoc}
      */
+    @Override
     public Object lookupLink( String name ) {
         throw new UnsupportedOperationException();
     }
@@ -223,6 +234,7 @@ public class SingletonInitialContext implements Context {
     /**
      * {@inheritDoc}
      */
+    @Override
     public Object lookupLink( Name name ) {
         throw new UnsupportedOperationException();
     }
@@ -230,6 +242,7 @@ public class SingletonInitialContext implements Context {
     /**
      * {@inheritDoc}
      */
+    @Override
     public void rename( Name oldName,
                         Name newName ) {
         throw new UnsupportedOperationException();
@@ -238,6 +251,7 @@ public class SingletonInitialContext implements Context {
     /**
      * {@inheritDoc}
      */
+    @Override
     public void rename( String oldName,
                         String newName ) {
         throw new UnsupportedOperationException();
@@ -246,12 +260,14 @@ public class SingletonInitialContext implements Context {
     /**
      * {@inheritDoc}
      */
+    @Override
     public void close() {
     }
 
     /**
      * {@inheritDoc}
      */
+    @Override
     public Name composeName( Name name,
                              Name prefix ) {
         throw new UnsupportedOperationException();
@@ -260,6 +276,7 @@ public class SingletonInitialContext implements Context {
     /**
      * {@inheritDoc}
      */
+    @Override
     public String composeName( String name,
                                String prefix ) {
         throw new UnsupportedOperationException();
@@ -268,6 +285,7 @@ public class SingletonInitialContext implements Context {
     /**
      * {@inheritDoc}
      */
+    @Override
     public Context createSubcontext( Name name ) {
         throw new UnsupportedOperationException();
     }
@@ -275,6 +293,7 @@ public class SingletonInitialContext implements Context {
     /**
      * {@inheritDoc}
      */
+    @Override
     public Context createSubcontext( String name ) {
         throw new UnsupportedOperationException();
     }
@@ -282,6 +301,7 @@ public class SingletonInitialContext implements Context {
     /**
      * {@inheritDoc}
      */
+    @Override
     public void destroySubcontext( Name name ) {
         throw new UnsupportedOperationException();
     }
@@ -289,6 +309,7 @@ public class SingletonInitialContext implements Context {
     /**
      * {@inheritDoc}
      */
+    @Override
     public void destroySubcontext( String name ) {
         throw new UnsupportedOperationException();
     }
@@ -296,6 +317,7 @@ public class SingletonInitialContext implements Context {
     /**
      * {@inheritDoc}
      */
+    @Override
     public Hashtable<?, ?> getEnvironment() {
         Hashtable<String, String> hashtable = new Hashtable<String, String>();
         Map<?, ?> map = this.environment;
@@ -308,6 +330,7 @@ public class SingletonInitialContext implements Context {
     /**
      * {@inheritDoc}
      */
+    @Override
     public String getNameInNamespace() {
         throw new UnsupportedOperationException();
     }
@@ -315,6 +338,7 @@ public class SingletonInitialContext implements Context {
     /**
      * {@inheritDoc}
      */
+    @Override
     public NameParser getNameParser( Name name ) {
         throw new UnsupportedOperationException();
     }
@@ -322,6 +346,7 @@ public class SingletonInitialContext implements Context {
     /**
      * {@inheritDoc}
      */
+    @Override
     public NameParser getNameParser( String name ) {
         throw new UnsupportedOperationException();
     }
@@ -329,6 +354,7 @@ public class SingletonInitialContext implements Context {
     /**
      * {@inheritDoc}
      */
+    @Override
     public NamingEnumeration<NameClassPair> list( Name name ) {
         throw new UnsupportedOperationException();
     }
@@ -336,6 +362,7 @@ public class SingletonInitialContext implements Context {
     /**
      * {@inheritDoc}
      */
+    @Override
     public NamingEnumeration<NameClassPair> list( String name ) {
         throw new UnsupportedOperationException();
     }
@@ -343,6 +370,7 @@ public class SingletonInitialContext implements Context {
     /**
      * {@inheritDoc}
      */
+    @Override
     public NamingEnumeration<Binding> listBindings( Name name ) {
         throw new UnsupportedOperationException();
     }
@@ -350,6 +378,7 @@ public class SingletonInitialContext implements Context {
     /**
      * {@inheritDoc}
      */
+    @Override
     public NamingEnumeration<Binding> listBindings( String name ) {
         throw new UnsupportedOperationException();
     }

--- a/modeshape-common/src/main/java/org/modeshape/common/naming/SingletonInitialContextFactory.java
+++ b/modeshape-common/src/main/java/org/modeshape/common/naming/SingletonInitialContextFactory.java
@@ -68,6 +68,7 @@ public class SingletonInitialContextFactory implements InitialContextFactory {
     /**
      * {@inheritDoc}
      */
+    @Override
     public Context getInitialContext( Hashtable<?, ?> environment ) {
         return getInstance(environment);
     }

--- a/modeshape-common/src/main/java/org/modeshape/common/statistic/Histogram.java
+++ b/modeshape-common/src/main/java/org/modeshape/common/statistic/Histogram.java
@@ -431,6 +431,7 @@ public class Histogram<T extends Number> {
             return 0;
         }
 
+        @Override
         public int compareTo( Bucket that ) {
             // This is lower if 'that' has a lowerBound that is greater than 'this' lower bound ...
             if (Histogram.this.math.compare(this.lowerBound, that.lowerBound) < 0) return -1;

--- a/modeshape-common/src/main/java/org/modeshape/common/statistic/Stopwatch.java
+++ b/modeshape-common/src/main/java/org/modeshape/common/statistic/Stopwatch.java
@@ -212,6 +212,7 @@ public class Stopwatch implements Comparable<Stopwatch> {
         this.stats.reset();
     }
 
+    @Override
     public int compareTo( Stopwatch that ) {
         return this.getTotalDuration().compareTo(that.getTotalDuration());
     }

--- a/modeshape-common/src/main/java/org/modeshape/common/text/Jsr283Encoder.java
+++ b/modeshape-common/src/main/java/org/modeshape/common/text/Jsr283Encoder.java
@@ -68,6 +68,7 @@ public class Jsr283Encoder implements TextEncoder, TextDecoder {
     /**
      * {@inheritDoc}
      */
+    @Override
     public String encode( String publicName ) {
         if (publicName == null) return null;
         StringBuilder sb = new StringBuilder();
@@ -95,6 +96,7 @@ public class Jsr283Encoder implements TextEncoder, TextDecoder {
     /**
      * {@inheritDoc}
      */
+    @Override
     public String decode( String jcrNodeName ) {
         if (jcrNodeName == null) return null;
         StringBuilder sb = new StringBuilder();

--- a/modeshape-common/src/main/java/org/modeshape/common/text/NoOpEncoder.java
+++ b/modeshape-common/src/main/java/org/modeshape/common/text/NoOpEncoder.java
@@ -41,6 +41,7 @@ public class NoOpEncoder implements TextEncoder, TextDecoder {
     /**
      * {@inheritDoc}
      */
+    @Override
     public String encode( String text ) {
         return text;
     }
@@ -48,6 +49,7 @@ public class NoOpEncoder implements TextEncoder, TextDecoder {
     /**
      * {@inheritDoc}
      */
+    @Override
     public String decode( String encodedText ) {
         return encodedText;
     }

--- a/modeshape-common/src/main/java/org/modeshape/common/text/QuoteEncoder.java
+++ b/modeshape-common/src/main/java/org/modeshape/common/text/QuoteEncoder.java
@@ -54,6 +54,7 @@ public class QuoteEncoder implements TextDecoder, TextEncoder {
      * 
      * @see org.modeshape.common.text.TextDecoder#decode(java.lang.String)
      */
+    @Override
     public String decode( String encodedText ) {
         if (encodedText == null) return null;
         if (encodedText.length() == 0) return "";
@@ -86,6 +87,7 @@ public class QuoteEncoder implements TextDecoder, TextEncoder {
      * 
      * @see org.modeshape.common.text.TextEncoder#encode(java.lang.String)
      */
+    @Override
     public String encode( String text ) {
         final StringBuilder result = new StringBuilder();
         final CharacterIterator iter = new StringCharacterIterator(text);

--- a/modeshape-common/src/main/java/org/modeshape/common/text/SecureHashTextEncoder.java
+++ b/modeshape-common/src/main/java/org/modeshape/common/text/SecureHashTextEncoder.java
@@ -85,6 +85,7 @@ public class SecureHashTextEncoder implements TextEncoder {
      * 
      * @see org.modeshape.common.text.TextEncoder#encode(java.lang.String)
      */
+    @Override
     public String encode( String text ) {
         try {
             byte[] hash = SecureHash.getHash(algorithm, text.getBytes());

--- a/modeshape-common/src/main/java/org/modeshape/common/text/TokenStream.java
+++ b/modeshape-common/src/main/java/org/modeshape/common/text/TokenStream.java
@@ -1658,6 +1658,7 @@ public class TokenStream {
          * 
          * @see org.modeshape.common.text.TokenStream.Token#withType(int)
          */
+        @Override
         public Token withType( int typeMask ) {
             int type = this.type | typeMask;
             return new CaseSensitiveToken(startIndex, endIndex, type, position);
@@ -1668,6 +1669,7 @@ public class TokenStream {
          * 
          * @see org.modeshape.common.text.TokenStream.Token#type()
          */
+        @Override
         public final int type() {
             return type;
         }
@@ -1677,6 +1679,7 @@ public class TokenStream {
          * 
          * @see org.modeshape.common.text.TokenStream.Token#startIndex()
          */
+        @Override
         public final int startIndex() {
             return startIndex;
         }
@@ -1686,6 +1689,7 @@ public class TokenStream {
          * 
          * @see org.modeshape.common.text.TokenStream.Token#endIndex()
          */
+        @Override
         public final int endIndex() {
             return endIndex;
         }
@@ -1695,6 +1699,7 @@ public class TokenStream {
          * 
          * @see org.modeshape.common.text.TokenStream.Token#length()
          */
+        @Override
         public final int length() {
             return endIndex - startIndex;
         }
@@ -1704,6 +1709,7 @@ public class TokenStream {
          * 
          * @see org.modeshape.common.text.TokenStream.Token#matches(char)
          */
+        @Override
         public final boolean matches( char expected ) {
             return length() == 1 && matchString().charAt(startIndex) == expected;
         }
@@ -1713,6 +1719,7 @@ public class TokenStream {
          * 
          * @see org.modeshape.common.text.TokenStream.Token#matches(java.lang.String)
          */
+        @Override
         public final boolean matches( String expected ) {
             return matchString().substring(startIndex, endIndex).equals(expected);
         }
@@ -1722,6 +1729,7 @@ public class TokenStream {
          * 
          * @see org.modeshape.common.text.TokenStream.Token#matches(int)
          */
+        @Override
         public final boolean matches( int expectedType ) {
             return expectedType == ANY_TYPE || (currentToken().type() & expectedType) == expectedType;
         }
@@ -1731,6 +1739,7 @@ public class TokenStream {
          * 
          * @see org.modeshape.common.text.TokenStream.Token#value()
          */
+        @Override
         public final String value() {
             return inputString.substring(startIndex, endIndex);
         }
@@ -1740,6 +1749,7 @@ public class TokenStream {
          * 
          * @see org.modeshape.common.text.TokenStream.Token#position()
          */
+        @Override
         public Position position() {
             return position;
         }
@@ -1798,6 +1808,7 @@ public class TokenStream {
          * 
          * @see org.modeshape.common.text.TokenStream.Tokens#addToken(Position, int)
          */
+        @Override
         public void addToken( Position position,
                               int index ) {
             addToken(position, index, index + 1, 0);
@@ -1808,6 +1819,7 @@ public class TokenStream {
          * 
          * @see org.modeshape.common.text.TokenStream.Tokens#addToken(Position, int, int)
          */
+        @Override
         public final void addToken( Position position,
                                     int startIndex,
                                     int endIndex ) {
@@ -1828,6 +1840,7 @@ public class TokenStream {
          * 
          * @see org.modeshape.common.text.TokenStream.TokenFactory#addToken(Position,int, int, int)
          */
+        @Override
         public void addToken( Position position,
                               int startIndex,
                               int endIndex,
@@ -1842,6 +1855,7 @@ public class TokenStream {
          * 
          * @see org.modeshape.common.text.TokenStream.TokenFactory#addToken(Position,int, int, int)
          */
+        @Override
         public void addToken( Position position,
                               int startIndex,
                               int endIndex,
@@ -1871,6 +1885,7 @@ public class TokenStream {
          * 
          * @see org.modeshape.common.text.TokenStream.CharacterStream#hasNext()
          */
+        @Override
         public boolean hasNext() {
             return lastIndex < maxIndex;
         }
@@ -1880,6 +1895,7 @@ public class TokenStream {
          * 
          * @see org.modeshape.common.text.TokenStream.CharacterStream#index()
          */
+        @Override
         public int index() {
             return lastIndex;
         }
@@ -1891,6 +1907,7 @@ public class TokenStream {
          * @return the position of the token. never null
          * @see org.modeshape.common.text.TokenStream.CharacterStream#position(int)
          */
+        @Override
         public Position position( int startIndex ) {
             return new Position(startIndex, lineNumber, columnNumber);
         }
@@ -1900,6 +1917,7 @@ public class TokenStream {
          * 
          * @see org.modeshape.common.text.TokenStream.CharacterStream#next()
          */
+        @Override
         public char next() {
             if (lastIndex >= maxIndex) {
                 throw new NoSuchElementException();
@@ -1924,6 +1942,7 @@ public class TokenStream {
          * 
          * @see org.modeshape.common.text.TokenStream.CharacterStream#isNext(char)
          */
+        @Override
         public boolean isNext( char c ) {
             int nextIndex = lastIndex + 1;
             return nextIndex <= maxIndex && content[nextIndex] == c;
@@ -1934,6 +1953,7 @@ public class TokenStream {
          * 
          * @see org.modeshape.common.text.TokenStream.CharacterStream#isNext(char, char)
          */
+        @Override
         public boolean isNext( char nextChar1,
                                char nextChar2 ) {
             int nextIndex1 = lastIndex + 1;
@@ -1946,6 +1966,7 @@ public class TokenStream {
          * 
          * @see org.modeshape.common.text.TokenStream.CharacterStream#isNext(char, char, char)
          */
+        @Override
         public boolean isNext( char nextChar1,
                                char nextChar2,
                                char nextChar3 ) {
@@ -1961,6 +1982,7 @@ public class TokenStream {
          * 
          * @see org.modeshape.common.text.TokenStream.CharacterStream#isNextAnyOf(char[])
          */
+        @Override
         public boolean isNextAnyOf( char[] characters ) {
             int nextIndex = lastIndex + 1;
             if (nextIndex <= maxIndex) {
@@ -1977,6 +1999,7 @@ public class TokenStream {
          * 
          * @see org.modeshape.common.text.TokenStream.CharacterStream#isNextAnyOf(java.lang.String)
          */
+        @Override
         public boolean isNextAnyOf( String characters ) {
             int nextIndex = lastIndex + 1;
             if (nextIndex <= maxIndex) {
@@ -1991,6 +2014,7 @@ public class TokenStream {
          * 
          * @see org.modeshape.common.text.TokenStream.CharacterStream#isNextWhitespace()
          */
+        @Override
         public boolean isNextWhitespace() {
             int nextIndex = lastIndex + 1;
             return nextIndex <= maxIndex && Character.isWhitespace(content[nextIndex]);
@@ -2001,6 +2025,7 @@ public class TokenStream {
          * 
          * @see org.modeshape.common.text.TokenStream.CharacterStream#isNextLetterOrDigit()
          */
+        @Override
         public boolean isNextLetterOrDigit() {
             int nextIndex = lastIndex + 1;
             return nextIndex <= maxIndex && Character.isLetterOrDigit(content[nextIndex]);
@@ -2011,6 +2036,7 @@ public class TokenStream {
          * 
          * @see org.modeshape.common.text.TokenStream.CharacterStream#isNextValidXmlCharacter()
          */
+        @Override
         public boolean isNextValidXmlCharacter() {
             int nextIndex = lastIndex + 1;
             return nextIndex <= maxIndex && XmlCharacters.isValid(content[nextIndex]);
@@ -2021,6 +2047,7 @@ public class TokenStream {
          * 
          * @see org.modeshape.common.text.TokenStream.CharacterStream#isNextValidXmlNameCharacter()
          */
+        @Override
         public boolean isNextValidXmlNameCharacter() {
             int nextIndex = lastIndex + 1;
             return nextIndex <= maxIndex && XmlCharacters.isValidName(content[nextIndex]);
@@ -2031,6 +2058,7 @@ public class TokenStream {
          * 
          * @see org.modeshape.common.text.TokenStream.CharacterStream#isNextValidXmlNcNameCharacter()
          */
+        @Override
         public boolean isNextValidXmlNcNameCharacter() {
             int nextIndex = lastIndex + 1;
             return nextIndex <= maxIndex && XmlCharacters.isValidNcName(content[nextIndex]);
@@ -2103,6 +2131,7 @@ public class TokenStream {
          * 
          * @see org.modeshape.common.text.TokenStream.Tokenizer#tokenize(CharacterStream, Tokens)
          */
+        @Override
         public void tokenize( CharacterStream input,
                               Tokens tokens ) throws ParsingException {
             while (input.hasNext()) {

--- a/modeshape-common/src/main/java/org/modeshape/common/text/UrlEncoder.java
+++ b/modeshape-common/src/main/java/org/modeshape/common/text/UrlEncoder.java
@@ -76,6 +76,7 @@ public class UrlEncoder implements TextEncoder, TextDecoder {
     /**
      * {@inheritDoc}
      */
+    @Override
     public String encode( String text ) {
         if (text == null) return null;
         if (text.length() == 0) return text;
@@ -103,6 +104,7 @@ public class UrlEncoder implements TextEncoder, TextDecoder {
     /**
      * {@inheritDoc}
      */
+    @Override
     public String decode( String encodedText ) {
         if (encodedText == null) return null;
         if (encodedText.length() == 0) return encodedText;

--- a/modeshape-common/src/main/java/org/modeshape/common/text/XmlNameEncoder.java
+++ b/modeshape-common/src/main/java/org/modeshape/common/text/XmlNameEncoder.java
@@ -400,6 +400,7 @@ public class XmlNameEncoder implements TextDecoder, TextEncoder {
      * 
      * @see org.modeshape.common.text.TextDecoder#decode(java.lang.String)
      */
+    @Override
     public String decode( String encodedText ) {
         if (encodedText == null) return null;
         if (encodedText.length() < 7) {
@@ -471,6 +472,7 @@ public class XmlNameEncoder implements TextDecoder, TextEncoder {
      * 
      * @see org.modeshape.common.text.TextEncoder#encode(java.lang.String)
      */
+    @Override
     public String encode( String text ) {
         if (text == null) return null;
         if (text.length() == 0) return text;

--- a/modeshape-common/src/main/java/org/modeshape/common/text/XmlValueEncoder.java
+++ b/modeshape-common/src/main/java/org/modeshape/common/text/XmlValueEncoder.java
@@ -83,6 +83,7 @@ public class XmlValueEncoder implements TextEncoder, TextDecoder {
      * 
      * @see org.modeshape.common.text.TextEncoder#encode(java.lang.String)
      */
+    @Override
     public String encode( String text ) {
         if (text == null) return null;
         StringBuilder sb = new StringBuilder();
@@ -116,6 +117,7 @@ public class XmlValueEncoder implements TextEncoder, TextDecoder {
      * 
      * @see org.modeshape.common.text.TextDecoder#decode(java.lang.String)
      */
+    @Override
     public String decode( String encodedText ) {
         if (encodedText == null) return null;
         StringBuilder sb = new StringBuilder();

--- a/modeshape-common/src/main/java/org/modeshape/common/util/ClassUtil.java
+++ b/modeshape-common/src/main/java/org/modeshape/common/util/ClassUtil.java
@@ -109,6 +109,7 @@ public final class ClassUtil {
             } else {
                 AccessController.doPrivileged(new PrivilegedAction<Object>() {
 
+                    @Override
                     public Object run() {
                         object.setAccessible(true);
                         return null;

--- a/modeshape-common/src/main/java/org/modeshape/common/util/FileUtil.java
+++ b/modeshape-common/src/main/java/org/modeshape/common/util/FileUtil.java
@@ -45,6 +45,7 @@ public class FileUtil {
 
     private static FilenameFilter ACCEPT_ALL = new FilenameFilter() {
 
+        @Override
         public boolean accept( File dir,
                                String name ) {
             return true;

--- a/modeshape-common/src/main/java/org/modeshape/common/util/NamedThreadFactory.java
+++ b/modeshape-common/src/main/java/org/modeshape/common/util/NamedThreadFactory.java
@@ -45,6 +45,7 @@ public class NamedThreadFactory implements ThreadFactory {
                      + "-thread-";
     }
 
+    @Override
     public Thread newThread( Runnable r ) {
         Thread t = new Thread(group, r, namePrefix + threadNumber.getAndIncrement(), 0);
         if (t.isDaemon()) t.setDaemon(false);

--- a/modeshape-common/src/main/java/org/modeshape/common/util/Reflection.java
+++ b/modeshape-common/src/main/java/org/modeshape/common/util/Reflection.java
@@ -1230,6 +1230,7 @@ public class Reflection {
          * 
          * @see java.lang.Comparable#compareTo(java.lang.Object)
          */
+        @Override
         public int compareTo( Property that ) {
             if (this == that) return 0;
             if (that == null) return 1;

--- a/modeshape-common/src/main/java/org/modeshape/common/xml/SimpleNamespaceContext.java
+++ b/modeshape-common/src/main/java/org/modeshape/common/xml/SimpleNamespaceContext.java
@@ -39,6 +39,7 @@ public class SimpleNamespaceContext implements NamespaceContext {
     /**
      * {@inheritDoc}
      */
+    @Override
     public String getNamespaceURI( String prefix ) {
         return this.prefixToNamespace.get(prefix);
     }
@@ -46,6 +47,7 @@ public class SimpleNamespaceContext implements NamespaceContext {
     /**
      * {@inheritDoc}
      */
+    @Override
     public String getPrefix( String namespaceURI ) {
         for (Map.Entry<String, String> entry : this.prefixToNamespace.entrySet()) {
             if (entry.getValue().equals(namespaceURI)) return entry.getKey();
@@ -62,6 +64,7 @@ public class SimpleNamespaceContext implements NamespaceContext {
     /**
      * {@inheritDoc}
      */
+    @Override
     public Iterator<String> getPrefixes( String namespaceURI ) {
         return this.prefixToNamespace.keySet().iterator();
     }

--- a/modeshape-common/src/test/java/org/modeshape/common/collection/IsIteratorContaining.java
+++ b/modeshape-common/src/test/java/org/modeshape/common/collection/IsIteratorContaining.java
@@ -55,6 +55,7 @@ public class IsIteratorContaining<T> extends TypeSafeMatcher<Iterator<T>> {
         return false;
     }
 
+    @Override
     public void describeTo( Description description ) {
         description.appendText("a iterator containing ").appendDescriptionOf(elementMatcher);
     }

--- a/modeshape-common/src/test/java/org/modeshape/common/component/MockComponentA.java
+++ b/modeshape-common/src/test/java/org/modeshape/common/component/MockComponentA.java
@@ -42,6 +42,7 @@ public class MockComponentA implements SampleComponent {
     /**
      * {@inheritDoc}
      */
+    @Override
     public void setConfiguration( SampleComponentConfig config ) {
         this.config = config;
     }
@@ -49,6 +50,7 @@ public class MockComponentA implements SampleComponent {
     /**
      * {@inheritDoc}
      */
+    @Override
     public void doSomething() {
         // increment the counter and record the progress ...
         this.counter.incrementAndGet();
@@ -65,6 +67,7 @@ public class MockComponentA implements SampleComponent {
     /**
      * @return config
      */
+    @Override
     public SampleComponentConfig getConfiguration() {
         return this.config;
     }

--- a/modeshape-common/src/test/java/org/modeshape/common/component/MockComponentB.java
+++ b/modeshape-common/src/test/java/org/modeshape/common/component/MockComponentB.java
@@ -42,6 +42,7 @@ public class MockComponentB implements SampleComponent {
     /**
      * {@inheritDoc}
      */
+    @Override
     public void setConfiguration( SampleComponentConfig config ) {
         this.config = config;
     }
@@ -49,6 +50,7 @@ public class MockComponentB implements SampleComponent {
     /**
      * {@inheritDoc}
      */
+    @Override
     public void doSomething() {
         // increment the counter and record the progress ...
         this.counter.incrementAndGet();
@@ -65,6 +67,7 @@ public class MockComponentB implements SampleComponent {
     /**
      * @return config
      */
+    @Override
     public SampleComponentConfig getConfiguration() {
         return this.config;
     }

--- a/modeshape-common/src/test/java/org/modeshape/common/text/StringMatcher.java
+++ b/modeshape-common/src/test/java/org/modeshape/common/text/StringMatcher.java
@@ -43,6 +43,7 @@ public class StringMatcher extends TypeSafeMatcher<String> {
         return item.startsWith(item);
     }
 
+    @Override
     public void describeTo( Description description ) {
         description.appendText("a string starts with ").appendValue(substring);
     }

--- a/modeshape-common/src/test/java/org/modeshape/common/text/TokenStreamBasicTokenizerTest.java
+++ b/modeshape-common/src/test/java/org/modeshape/common/text/TokenStreamBasicTokenizerTest.java
@@ -46,12 +46,14 @@ public class TokenStreamBasicTokenizerTest {
         tokenizer = TokenStream.basicTokenizer(true);
         final LinkedList<int[]> tokenValues = new LinkedList<int[]>();
         tokenFactory = new Tokens() {
+            @Override
             public void addToken( Position position,
                                   int index ) {
                 int[] token = new int[] {index, index + 1, 0};
                 tokenValues.add(token);
             }
 
+            @Override
             public void addToken( Position position,
                                   int startIndex,
                                   int endIndex ) {
@@ -59,6 +61,7 @@ public class TokenStreamBasicTokenizerTest {
                 tokenValues.add(token);
             }
 
+            @Override
             public void addToken( Position position,
                                   int startIndex,
                                   int endIndex,

--- a/modeshape-graph/src/main/java/org/modeshape/graph/Graph.java
+++ b/modeshape-graph/src/main/java/org/modeshape/graph/Graph.java
@@ -2492,7 +2492,6 @@ public class Graph {
              * 
              * @see org.modeshape.graph.Graph.WithInput#withInput(java.lang.String, java.lang.Object)
              */
-            @Override
             public WithInput<Map<String, Serializable>> withInput( String parameterName,
                                                                    Object parameterValue ) {
                 CheckArg.isNotEmpty(parameterName, "parameterName");
@@ -2509,7 +2508,6 @@ public class Graph {
              * 
              * @see org.modeshape.graph.Graph.WithInput#and(java.lang.String, java.lang.Object)
              */
-            @Override
             public WithInput<Map<String, Serializable>> and( String parameterName,
                                                              Object parameterValue ) {
                 return withInput(parameterName, parameterValue);
@@ -2520,7 +2518,6 @@ public class Graph {
              * 
              * @see org.modeshape.graph.Graph.To#to(org.modeshape.graph.Location)
              */
-            @Override
             public Map<String, Serializable> to( Location desiredLocation ) {
                 return requests.applyFunction(function, inputs, desiredLocation, getCurrentWorkspaceName()).outputs();
             }
@@ -2530,7 +2527,6 @@ public class Graph {
              * 
              * @see org.modeshape.graph.Graph.To#to(org.modeshape.graph.property.Path)
              */
-            @Override
             public Map<String, Serializable> to( Path desiredPath ) {
                 return to(Location.create(desiredPath));
             }
@@ -8327,7 +8323,6 @@ public class Graph {
          * 
          * @see org.modeshape.graph.Graph.To#to(org.modeshape.graph.Location)
          */
-        @Override
         public T to( Location desiredLocation ) {
             CheckArg.isNotNull(desiredLocation, "desiredLocation");
             this.to = desiredLocation;
@@ -8339,7 +8334,6 @@ public class Graph {
          * 
          * @see org.modeshape.graph.Graph.To#to(java.lang.String)
          */
-        @Override
         public T to( String desiredPath ) {
             CheckArg.isNotEmpty(desiredPath, "desiredPath");
             return to(Location.create(createPath(desiredPath)));
@@ -8350,7 +8344,6 @@ public class Graph {
          * 
          * @see org.modeshape.graph.Graph.To#to(org.modeshape.graph.property.Path)
          */
-        @Override
         public T to( Path desiredPath ) {
             CheckArg.isNotNull(desiredPath, "desiredPath");
             return to(Location.create(desiredPath));
@@ -8361,7 +8354,6 @@ public class Graph {
          * 
          * @see org.modeshape.graph.Graph.WithInput#withInput(java.lang.String, java.lang.Object)
          */
-        @Override
         public WithInput<T> withInput( String parameterName,
                                        Object parameterValue ) {
             CheckArg.isNotEmpty(parameterName, "parameterName");
@@ -8378,7 +8370,6 @@ public class Graph {
          * 
          * @see org.modeshape.graph.Graph.WithInput#and(java.lang.String, java.lang.Object)
          */
-        @Override
         public WithInput<T> and( String parameterName,
                                  Object parameterValue ) {
             CheckArg.isNotEmpty(parameterName, "parameterName");

--- a/modeshape-graph/src/main/java/org/modeshape/graph/io/GraphBatchDestination.java
+++ b/modeshape-graph/src/main/java/org/modeshape/graph/io/GraphBatchDestination.java
@@ -133,7 +133,6 @@ public class GraphBatchDestination implements Destination {
      * @see org.modeshape.graph.io.Destination#create(org.modeshape.graph.NodeConflictBehavior, org.modeshape.graph.property.Path,
      *      org.modeshape.graph.property.Property, org.modeshape.graph.property.Property[])
      */
-    @Override
     public void create( NodeConflictBehavior behavior,
                         Path path,
                         Property firstProperty,
@@ -182,7 +181,6 @@ public class GraphBatchDestination implements Destination {
      * 
      * @see org.modeshape.graph.io.Destination#setProperties(org.modeshape.graph.property.Path, java.lang.Iterable)
      */
-    @Override
     public void setProperties( Path path,
                                Iterable<Property> properties ) {
         if (properties == null) return;

--- a/modeshape-graph/src/main/java/org/modeshape/graph/property/PropertyType.java
+++ b/modeshape-graph/src/main/java/org/modeshape/graph/property/PropertyType.java
@@ -91,14 +91,12 @@ public enum PropertyType {
     }
 
     protected final static class StrongReferenceTypeChecker implements TypeChecker {
-        @Override
         public boolean isTypeFor( Object value ) {
             return value instanceof Reference && !((Reference)value).isWeak();
         }
     }
 
     protected final static class WeakReferenceTypeChecker implements TypeChecker {
-        @Override
         public boolean isTypeFor( Object value ) {
             return value instanceof Reference && ((Reference)value).isWeak();
         }
@@ -112,7 +110,6 @@ public enum PropertyType {
             assert this.valueClass != null;
         }
 
-        @Override
         public boolean isTypeFor( Object value ) {
             return this.valueClass.isInstance(value);
         }

--- a/modeshape-graph/src/main/java/org/modeshape/graph/property/basic/GraphNamespaceRegistry.java
+++ b/modeshape-graph/src/main/java/org/modeshape/graph/property/basic/GraphNamespaceRegistry.java
@@ -166,7 +166,6 @@ public class GraphNamespaceRegistry implements NamespaceRegistry {
      * 
      * @see org.modeshape.graph.property.NamespaceRegistry#register(java.lang.Iterable)
      */
-    @Override
     public void register( Iterable<Namespace> namespaces ) {
         Map<String, String> urisByPrefix = new HashMap<String, String>();
         for (Namespace namespace : namespaces) {

--- a/modeshape-graph/src/main/java/org/modeshape/graph/property/basic/NamespaceRegistryWithAliases.java
+++ b/modeshape-graph/src/main/java/org/modeshape/graph/property/basic/NamespaceRegistryWithAliases.java
@@ -163,7 +163,6 @@ public class NamespaceRegistryWithAliases implements NamespaceRegistry {
      * 
      * @see org.modeshape.graph.property.NamespaceRegistry#register(java.lang.Iterable)
      */
-    @Override
     public void register( Iterable<Namespace> namespaces ) {
         // Let the delegate registry handle this, including cases where an aliased namespace is changed ...
         delegate.register(namespaces);

--- a/modeshape-graph/src/main/java/org/modeshape/graph/property/basic/SimpleNamespaceRegistry.java
+++ b/modeshape-graph/src/main/java/org/modeshape/graph/property/basic/SimpleNamespaceRegistry.java
@@ -124,7 +124,6 @@ public class SimpleNamespaceRegistry implements NamespaceRegistry {
      * 
      * @see org.modeshape.graph.property.NamespaceRegistry#register(java.lang.Iterable)
      */
-    @Override
     public void register( Iterable<Namespace> namespaces ) {
         for (Namespace namespace : namespaces) {
             register(namespace.getPrefix(), namespace.getNamespaceUri());

--- a/modeshape-graph/src/main/java/org/modeshape/graph/property/basic/ThreadSafeNamespaceRegistry.java
+++ b/modeshape-graph/src/main/java/org/modeshape/graph/property/basic/ThreadSafeNamespaceRegistry.java
@@ -133,7 +133,6 @@ public class ThreadSafeNamespaceRegistry implements NamespaceRegistry {
      * 
      * @see org.modeshape.graph.property.NamespaceRegistry#register(java.lang.Iterable)
      */
-    @Override
     public void register( Iterable<Namespace> namespaces ) {
         CheckArg.isNotNull(namespaces, "namespaces");
         Lock lock = this.registryLock.writeLock();

--- a/modeshape-graph/src/main/java/org/modeshape/graph/request/processor/RequestProcessor.java
+++ b/modeshape-graph/src/main/java/org/modeshape/graph/request/processor/RequestProcessor.java
@@ -1068,7 +1068,6 @@ public abstract class RequestProcessor {
                 }
             };
 
-            @Override
             public void execute( Request request ) {
                 RequestProcessor.this.process(request);
                 if (!request.hasError() && !request.isCancelled()) {
@@ -1090,7 +1089,6 @@ public abstract class RequestProcessor {
              * 
              * @see org.modeshape.graph.request.function.FunctionContext#builder()
              */
-            @Override
             public RequestBuilder builder() {
                 // Create a builder that
                 return builder;
@@ -1101,7 +1099,6 @@ public abstract class RequestProcessor {
              * 
              * @see org.modeshape.graph.request.function.FunctionContext#setError(java.lang.Throwable)
              */
-            @Override
             public void setError( Throwable t ) {
                 functionRequest.setError(t);
             }
@@ -1111,12 +1108,10 @@ public abstract class RequestProcessor {
              * 
              * @see org.modeshape.graph.request.function.FunctionContext#isCancelled()
              */
-            @Override
             public boolean isCancelled() {
                 return functionRequest.isCancelled();
             }
 
-            @Override
             public ExecutionContext getExecutionContext() {
                 return RequestProcessor.this.getExecutionContext();
             }
@@ -1126,7 +1121,6 @@ public abstract class RequestProcessor {
              * 
              * @see org.modeshape.graph.request.function.FunctionContext#appliedAt()
              */
-            @Override
             public Location appliedAt() {
                 return functionRequest.at();
             }
@@ -1136,7 +1130,6 @@ public abstract class RequestProcessor {
              * 
              * @see org.modeshape.graph.request.function.FunctionContext#workspace()
              */
-            @Override
             public String workspace() {
                 return functionRequest.inWorkspace();
             }
@@ -1146,7 +1139,6 @@ public abstract class RequestProcessor {
              * 
              * @see org.modeshape.graph.request.function.FunctionContext#getNowInUtc()
              */
-            @Override
             public DateTime getNowInUtc() {
                 return RequestProcessor.this.getNowInUtc();
             }
@@ -1156,7 +1148,6 @@ public abstract class RequestProcessor {
              * 
              * @see org.modeshape.graph.request.function.FunctionContext#input(java.lang.String)
              */
-            @Override
             public Object input( String name ) {
                 return functionRequest.input(name);
             }
@@ -1166,7 +1157,6 @@ public abstract class RequestProcessor {
              * 
              * @see org.modeshape.graph.request.function.FunctionContext#input(java.lang.String, java.lang.Class)
              */
-            @Override
             public <T> T input( String name,
                                 Class<T> type ) {
                 return functionRequest.input(name, type, null, getExecutionContext());
@@ -1178,7 +1168,6 @@ public abstract class RequestProcessor {
              * @see org.modeshape.graph.request.function.FunctionContext#input(java.lang.String, java.lang.Class,
              *      java.lang.Object)
              */
-            @Override
             public <T> T input( String name,
                                 Class<T> type,
                                 T defaultValue ) {
@@ -1191,7 +1180,6 @@ public abstract class RequestProcessor {
              * @see org.modeshape.graph.request.function.FunctionContext#input(java.lang.String,
              *      org.modeshape.graph.property.PropertyType, java.lang.Object)
              */
-            @Override
             public <T> T input( String name,
                                 PropertyType type,
                                 T defaultValue ) {
@@ -1204,7 +1192,6 @@ public abstract class RequestProcessor {
              * @see org.modeshape.graph.request.function.FunctionContext#output(java.lang.String, java.lang.Class,
              *      java.lang.Object)
              */
-            @Override
             public <T> T output( String name,
                                  Class<T> type,
                                  T defaultValue ) {
@@ -1217,7 +1204,6 @@ public abstract class RequestProcessor {
              * @see org.modeshape.graph.request.function.FunctionContext#output(java.lang.String,
              *      org.modeshape.graph.property.PropertyType, java.lang.Object)
              */
-            @Override
             public <T> T output( String name,
                                  PropertyType type,
                                  T defaultValue ) {
@@ -1229,7 +1215,6 @@ public abstract class RequestProcessor {
              * 
              * @see org.modeshape.graph.request.function.FunctionContext#setOutput(java.lang.String, java.io.Serializable)
              */
-            @Override
             public void setOutput( String name,
                                    Serializable value ) {
                 functionRequest.setOutput(name, value);

--- a/modeshape-graph/src/main/java/org/modeshape/graph/text/TextExtractors.java
+++ b/modeshape-graph/src/main/java/org/modeshape/graph/text/TextExtractors.java
@@ -114,7 +114,6 @@ public final class TextExtractors implements TextExtractor {
      * 
      * @see org.modeshape.graph.text.TextExtractor#supportsMimeType(java.lang.String)
      */
-    @Override
     public boolean supportsMimeType( String mimeType ) {
         for (TextExtractor extractor : library.getInstances()) {
             if (extractor.supportsMimeType(mimeType)) return true;
@@ -128,7 +127,6 @@ public final class TextExtractors implements TextExtractor {
      * @see org.modeshape.graph.text.TextExtractor#extractFrom(java.io.InputStream, org.modeshape.graph.text.TextExtractorOutput,
      *      org.modeshape.graph.text.TextExtractorContext)
      */
-    @Override
     public void extractFrom( InputStream stream,
                              TextExtractorOutput output,
                              TextExtractorContext context ) throws IOException {

--- a/modeshape-graph/src/test/java/org/modeshape/graph/xml/XmlHandlerTest.java
+++ b/modeshape-graph/src/test/java/org/modeshape/graph/xml/XmlHandlerTest.java
@@ -563,7 +563,6 @@ public class XmlHandlerTest {
          * @see org.modeshape.graph.io.Destination#create(org.modeshape.graph.NodeConflictBehavior,
          *      org.modeshape.graph.property.Path, org.modeshape.graph.property.Property, org.modeshape.graph.property.Property[])
          */
-        @Override
         public void create( NodeConflictBehavior behavior,
                             Path path,
                             Property firstProperty,
@@ -589,7 +588,6 @@ public class XmlHandlerTest {
          * 
          * @see org.modeshape.graph.io.Destination#setProperties(org.modeshape.graph.property.Path, java.lang.Iterable)
          */
-        @Override
         public void setProperties( Path path,
                                    Iterable<Property> properties ) {
             Property firstProp = null;

--- a/modeshape-integration-tests/src/test/java/org/modeshape/test/integration/jdbc/JcrDriverIntegrationTest.java
+++ b/modeshape-integration-tests/src/test/java/org/modeshape/test/integration/jdbc/JcrDriverIntegrationTest.java
@@ -136,6 +136,7 @@ public class JcrDriverIntegrationTest extends ModeShapeMultiUseTest {
         // Set up the mock JNDI context ...
         MockitoAnnotations.initMocks(this);
         when(jndi.lookup(jndiNameForRepository)).thenAnswer(new Answer<Repository>() {
+            @Override
             @SuppressWarnings( "synthetic-access" )
             public Repository answer( InvocationOnMock invocation ) throws Throwable {
                 return repository();

--- a/modeshape-integration-tests/src/test/java/org/modeshape/test/integration/jpa/JcrRepositoryWithJpaConfigurationTest.java
+++ b/modeshape-integration-tests/src/test/java/org/modeshape/test/integration/jpa/JcrRepositoryWithJpaConfigurationTest.java
@@ -139,6 +139,7 @@ public class JcrRepositoryWithJpaConfigurationTest {
                     // No need to provide a credentials, so just login with the name of the workspace.
                     // However, we DO need to do this from within a doPrivilege block.
                     session = AccessController.doPrivileged(new PrivilegedExceptionAction<Session>() {
+                        @Override
                         public Session run() throws Exception {
                             return myRepository.login(workspaceName);
                         }
@@ -204,14 +205,17 @@ public class JcrRepositoryWithJpaConfigurationTest {
             this.username = username;
         }
 
+        @Override
         public String getUserName() {
             return username;
         }
 
+        @Override
         public boolean hasRole( String roleName ) {
             return true;
         }
 
+        @Override
         public void logout() {
         }
 

--- a/modeshape-integration-tests/src/test/java/org/modeshape/test/integration/performance/JcrRepositoryPerformanceTest.java
+++ b/modeshape-integration-tests/src/test/java/org/modeshape/test/integration/performance/JcrRepositoryPerformanceTest.java
@@ -402,6 +402,7 @@ public class JcrRepositoryPerformanceTest extends ModeShapeSingleUseTest {
     }
 
     protected class VerifyContent extends BasicOperation {
+        @Override
         public void run( Session s ) throws Exception {
             // Verify the file was imported ...
             assertNode(s, "/drools:repository", "nt:folder");
@@ -421,6 +422,7 @@ public class JcrRepositoryPerformanceTest extends ModeShapeSingleUseTest {
             this.path = path;
         }
 
+        @Override
         public void run( Session s ) throws Exception {
             // Verify the file was imported ...
             Node node = s.getNode(path);
@@ -440,6 +442,7 @@ public class JcrRepositoryPerformanceTest extends ModeShapeSingleUseTest {
             this.path = path;
         }
 
+        @Override
         public void run( Session s ) throws RepositoryException {
             // Verify the file was imported ...
             Node assetNode = s.getNode(path);
@@ -456,6 +459,7 @@ public class JcrRepositoryPerformanceTest extends ModeShapeSingleUseTest {
             this.path = path;
         }
 
+        @Override
         @SuppressWarnings( "synthetic-access" )
         public void run( Session s ) throws RepositoryException {
             Node assetNode = s.getNode(path);
@@ -496,6 +500,7 @@ public class JcrRepositoryPerformanceTest extends ModeShapeSingleUseTest {
             this.comment = comment;
         }
 
+        @Override
         public void run( Session s ) throws RepositoryException {
             createPackageSnapshot(s, packageName, snapshotName);
             Node pkgItem = loadPackageSnapshot(s, packageName, snapshotName);
@@ -516,6 +521,7 @@ public class JcrRepositoryPerformanceTest extends ModeShapeSingleUseTest {
             this.snapshotName = snapshotName;
         }
 
+        @Override
         public void run( Session s ) throws RepositoryException {
             loadPackageSnapshot(s, packageName, snapshotName);
         }
@@ -528,6 +534,7 @@ public class JcrRepositoryPerformanceTest extends ModeShapeSingleUseTest {
             this.packageName = packageName;
         }
 
+        @Override
         public void run( Session s ) throws RepositoryException, IOException {
             buildPackage(s, packageName);
             getPackageAssets(s, packageName);

--- a/modeshape-integration-tests/src/test/java/org/modeshape/test/integration/sequencer/ddl/DdlIntegrationTestUtil.java
+++ b/modeshape-integration-tests/src/test/java/org/modeshape/test/integration/sequencer/ddl/DdlIntegrationTestUtil.java
@@ -133,6 +133,7 @@ public class DdlIntegrationTestUtil {
          * 
          * @see org.modeshape.graph.SecurityContext#getUserName()
          */
+        @Override
         public String getUserName() {
             return "Fred";
         }
@@ -142,6 +143,7 @@ public class DdlIntegrationTestUtil {
          * 
          * @see org.modeshape.graph.SecurityContext#hasRole(java.lang.String)
          */
+        @Override
         public boolean hasRole( String roleName ) {
             return true;
         }
@@ -151,6 +153,7 @@ public class DdlIntegrationTestUtil {
          * 
          * @see org.modeshape.graph.SecurityContext#logout()
          */
+        @Override
         public void logout() {
             // do something
         }

--- a/modeshape-integration-tests/src/test/java/org/modeshape/test/integration/svn/JcrAndLocalSvnRepositoryTest.java
+++ b/modeshape-integration-tests/src/test/java/org/modeshape/test/integration/svn/JcrAndLocalSvnRepositoryTest.java
@@ -175,6 +175,7 @@ public class JcrAndLocalSvnRepositoryTest {
          * 
          * @see org.modeshape.graph.SecurityContext#getUserName()
          */
+        @Override
         public String getUserName() {
             return "Fred";
         }
@@ -184,6 +185,7 @@ public class JcrAndLocalSvnRepositoryTest {
          * 
          * @see org.modeshape.graph.SecurityContext#hasRole(java.lang.String)
          */
+        @Override
         public boolean hasRole( String roleName ) {
             return true;
         }
@@ -193,6 +195,7 @@ public class JcrAndLocalSvnRepositoryTest {
          * 
          * @see org.modeshape.graph.SecurityContext#logout()
          */
+        @Override
         public void logout() {
             // do something
         }

--- a/modeshape-integration-tests/src/test/java/org/modeshape/test/integration/svn/SvnAndJcrIntegrationTest.java
+++ b/modeshape-integration-tests/src/test/java/org/modeshape/test/integration/svn/SvnAndJcrIntegrationTest.java
@@ -112,6 +112,7 @@ public class SvnAndJcrIntegrationTest {
          * 
          * @see org.modeshape.graph.SecurityContext#getUserName()
          */
+        @Override
         public String getUserName() {
             return "Fred";
         }
@@ -121,6 +122,7 @@ public class SvnAndJcrIntegrationTest {
          * 
          * @see org.modeshape.graph.SecurityContext#hasRole(java.lang.String)
          */
+        @Override
         public boolean hasRole( String roleName ) {
             return true;
         }
@@ -130,6 +132,7 @@ public class SvnAndJcrIntegrationTest {
          * 
          * @see org.modeshape.graph.SecurityContext#logout()
          */
+        @Override
         public void logout() {
             // do something
         }

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/AbstractJcrNode.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/AbstractJcrNode.java
@@ -349,7 +349,6 @@ abstract class AbstractJcrNode extends AbstractJcrItem implements javax.jcr.Node
      * 
      * @see javax.jcr.Node#getIdentifier()
      */
-    @Override
     public String getIdentifier() throws RepositoryException {
         return identifier();
     }
@@ -713,7 +712,6 @@ abstract class AbstractJcrNode extends AbstractJcrItem implements javax.jcr.Node
      * 
      * @see javax.jcr.Node#getWeakReferences()
      */
-    @Override
     public PropertyIterator getWeakReferences() throws RepositoryException {
         return getWeakReferences(null);
     }
@@ -723,7 +721,6 @@ abstract class AbstractJcrNode extends AbstractJcrItem implements javax.jcr.Node
      * 
      * @see javax.jcr.Node#getWeakReferences(java.lang.String)
      */
-    @Override
     public PropertyIterator getWeakReferences( String propertyName ) throws RepositoryException {
         checkSession();
         return propertiesOnOtherNodesReferencingThis(propertyName, PropertyType.WEAKREFERENCE);
@@ -1569,7 +1566,6 @@ abstract class AbstractJcrNode extends AbstractJcrItem implements javax.jcr.Node
      * 
      * @see javax.jcr.Node#setProperty(java.lang.String, Binary)
      */
-    @Override
     public Property setProperty( String name,
                                  Binary value )
         throws ValueFormatException, VersionException, LockException, ConstraintViolationException, RepositoryException {
@@ -1581,7 +1577,6 @@ abstract class AbstractJcrNode extends AbstractJcrItem implements javax.jcr.Node
      * 
      * @see javax.jcr.Node#setProperty(java.lang.String, BigDecimal)
      */
-    @Override
     public Property setProperty( String name,
                                  BigDecimal value )
         throws ValueFormatException, VersionException, LockException, ConstraintViolationException, RepositoryException {
@@ -2277,7 +2272,6 @@ abstract class AbstractJcrNode extends AbstractJcrItem implements javax.jcr.Node
      * @see javax.jcr.Node#followLifecycleTransition(java.lang.String)
      */
     @SuppressWarnings( "unused" )
-    @Override
     public void followLifecycleTransition( String transition )
         throws UnsupportedRepositoryOperationException, InvalidLifecycleTransitionException, RepositoryException {
         throw new UnsupportedRepositoryOperationException();
@@ -2288,7 +2282,6 @@ abstract class AbstractJcrNode extends AbstractJcrItem implements javax.jcr.Node
      * 
      * @see javax.jcr.Node#getAllowedLifecycleTransistions()
      */
-    @Override
     public String[] getAllowedLifecycleTransistions() throws UnsupportedRepositoryOperationException, RepositoryException {
         throw new UnsupportedRepositoryOperationException();
     }
@@ -2298,7 +2291,6 @@ abstract class AbstractJcrNode extends AbstractJcrItem implements javax.jcr.Node
      * 
      * @see javax.jcr.Node#getSharedSet()
      */
-    @Override
     public NodeIterator getSharedSet() throws RepositoryException {
         if (isShareable()) {
             // Find the nodes that make up this shared set ...
@@ -2342,7 +2334,6 @@ abstract class AbstractJcrNode extends AbstractJcrItem implements javax.jcr.Node
      * 
      * @see javax.jcr.Node#removeShare()
      */
-    @Override
     public void removeShare() throws VersionException, LockException, ConstraintViolationException, RepositoryException {
         if (isShareable()) {
             // Get the nodes in the shared set ...
@@ -2397,7 +2388,6 @@ abstract class AbstractJcrNode extends AbstractJcrItem implements javax.jcr.Node
      * 
      * @see javax.jcr.Node#removeSharedSet()
      */
-    @Override
     public void removeSharedSet() throws VersionException, LockException, ConstraintViolationException, RepositoryException {
         if (isShareable()) {
             // Remove all of the node is the shared set ...
@@ -2429,7 +2419,6 @@ abstract class AbstractJcrNode extends AbstractJcrItem implements javax.jcr.Node
      * 
      * @see javax.jcr.Item#remove()
      */
-    @Override
     public void remove()
         throws VersionException, LockException, ConstraintViolationException, AccessDeniedException, RepositoryException {
         // Since this node might be shareable, we want to implement 'remove()' by calling 'removeShare()',

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/GraphNodeTypeReader.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/GraphNodeTypeReader.java
@@ -358,7 +358,6 @@ class GraphNodeTypeReader implements Iterable<NodeTypeDefinition> {
      * 
      * @see java.lang.Iterable#iterator()
      */
-    @Override
     public Iterator<NodeTypeDefinition> iterator() {
         return immutableTypes.iterator();
     }

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrBinary.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrBinary.java
@@ -48,7 +48,6 @@ class JcrBinary implements javax.jcr.Binary, org.modeshape.jcr.api.Binary {
      * 
      * @see org.modeshape.jcr.api.Binary#dispose()
      */
-    @Override
     public void dispose() {
         this.binary.release();
     }
@@ -58,7 +57,6 @@ class JcrBinary implements javax.jcr.Binary, org.modeshape.jcr.api.Binary {
      * 
      * @see org.modeshape.jcr.api.Binary#getSize()
      */
-    @Override
     public long getSize() {
         try {
             this.binary.acquire();
@@ -73,7 +71,6 @@ class JcrBinary implements javax.jcr.Binary, org.modeshape.jcr.api.Binary {
      * 
      * @see org.modeshape.jcr.api.Binary#getStream()
      */
-    @Override
     public InputStream getStream() {
         return new SelfClosingInputStream(this.binary);
     }
@@ -83,7 +80,6 @@ class JcrBinary implements javax.jcr.Binary, org.modeshape.jcr.api.Binary {
      * 
      * @see org.modeshape.jcr.api.Binary#read(byte[], long)
      */
-    @Override
     public int read( byte[] b,
                      long position ) throws IOException {
         if (getSize() <= position) return -1;

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrConfiguration.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrConfiguration.java
@@ -33,8 +33,8 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
-import org.modeshape.common.annotation.NotThreadSafe;
 import org.modeshape.cnd.CndImporter;
+import org.modeshape.common.annotation.NotThreadSafe;
 import org.modeshape.common.collection.Problem;
 import org.modeshape.common.collection.Problem.Status;
 import org.modeshape.common.component.ClassLoaderFactory;
@@ -660,7 +660,6 @@ public class JcrConfiguration extends ModeShapeConfiguration {
          * @see org.modeshape.jcr.JcrConfiguration.RepositoryDefinition#setInitialContent(java.lang.String, java.lang.String,
          *      java.lang.String[])
          */
-        @Override
         public RepositoryDefinition<ReturnType> setInitialContent( String path,
                                                                    String firstWorkspace,
                                                                    String... otherWorkspaces ) {
@@ -676,7 +675,6 @@ public class JcrConfiguration extends ModeShapeConfiguration {
          * @see org.modeshape.jcr.JcrConfiguration.RepositoryDefinition#setInitialContent(java.io.File, java.lang.String,
          *      java.lang.String[])
          */
-        @Override
         public RepositoryDefinition<ReturnType> setInitialContent( File file,
                                                                    String firstWorkspace,
                                                                    String... otherWorkspaces ) {

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrContentHandler.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrContentHandler.java
@@ -962,7 +962,6 @@ class JcrContentHandler extends DefaultHandler {
          * @see org.modeshape.jcr.JcrContentHandler.NodeHandlerFactory#createFor(org.modeshape.graph.property.Name,
          *      org.modeshape.jcr.JcrContentHandler.NodeHandler,int)
          */
-        @Override
         public NodeHandler createFor( Name name,
                                       NodeHandler parentHandler,
                                       int uuidBehavior ) throws SAXException {

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrLockManager.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrLockManager.java
@@ -59,7 +59,6 @@ public class JcrLockManager implements LockManager {
         lockTokens = new HashSet<String>();
     }
 
-    @Override
     public void addLockToken( String lockToken ) throws LockException {
         CheckArg.isNotNull(lockToken, "lock token");
 
@@ -76,7 +75,6 @@ public class JcrLockManager implements LockManager {
         lockTokens.add(lockToken);
     }
 
-    @Override
     public Lock getLock( String absPath ) throws PathNotFoundException, LockException, AccessDeniedException, RepositoryException {
         AbstractJcrNode node = session.getNode(absPath);
         return getLock(node);
@@ -88,7 +86,6 @@ public class JcrLockManager implements LockManager {
         throw new LockException(JcrI18n.notLocked.text(node.location()));
     }
 
-    @Override
     public String[] getLockTokens() {
         Set<String> publicTokens = new HashSet<String>(lockTokens);
 
@@ -105,7 +102,6 @@ public class JcrLockManager implements LockManager {
         return this.lockTokens;
     }
 
-    @Override
     public boolean holdsLock( String absPath ) throws PathNotFoundException, RepositoryException {
         AbstractJcrNode node = session.getNode(absPath);
         return holdsLock(node);
@@ -118,7 +114,6 @@ public class JcrLockManager implements LockManager {
 
     }
 
-    @Override
     public boolean isLocked( String absPath ) throws PathNotFoundException, RepositoryException {
         AbstractJcrNode node = session.getNode(absPath);
         return isLocked(node);
@@ -128,7 +123,6 @@ public class JcrLockManager implements LockManager {
         return lockFor(node) != null;
     }
 
-    @Override
     public Lock lock( String absPath,
                       boolean isDeep,
                       boolean isSessionScoped,
@@ -180,7 +174,6 @@ public class JcrLockManager implements LockManager {
 
     }
 
-    @Override
     public void removeLockToken( String lockToken ) throws LockException {
         CheckArg.isNotNull(lockToken, "lockToken");
         // A LockException is thrown if the lock associated with the specified lock token is session-scoped.
@@ -209,7 +202,6 @@ public class JcrLockManager implements LockManager {
         lockTokens.remove(lockToken);
     }
 
-    @Override
     public void unlock( String absPath )
         throws PathNotFoundException, LockException, AccessDeniedException, InvalidItemStateException, RepositoryException {
         AbstractJcrNode node = session.getNode(absPath);

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrMultiValueProperty.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrMultiValueProperty.java
@@ -334,27 +334,22 @@ final class JcrMultiValueProperty extends AbstractJcrProperty {
         throw new ValueFormatException(JcrI18n.invalidMethodForMultiValuedProperty.text());
     }
 
-    @Override
     public Binary getBinary() throws ValueFormatException, RepositoryException {
         throw new ValueFormatException(JcrI18n.invalidMethodForMultiValuedProperty.text());
     }
 
-    @Override
     public BigDecimal getDecimal() throws ValueFormatException, RepositoryException {
         throw new ValueFormatException(JcrI18n.invalidMethodForMultiValuedProperty.text());
     }
 
-    @Override
     public javax.jcr.Property getProperty() throws ValueFormatException, RepositoryException {
         throw new ValueFormatException(JcrI18n.invalidMethodForMultiValuedProperty.text());
     }
 
-    @Override
     public void setValue( BigDecimal value ) throws ValueFormatException, RepositoryException {
         throw new ValueFormatException(JcrI18n.invalidMethodForMultiValuedProperty.text());
     }
 
-    @Override
     public void setValue( Binary value ) throws ValueFormatException, RepositoryException {
         throw new ValueFormatException(JcrI18n.invalidMethodForMultiValuedProperty.text());
     }

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrObservationManager.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrObservationManager.java
@@ -295,7 +295,6 @@ final class JcrObservationManager implements ObservationManager {
      * 
      * @see javax.jcr.observation.ObservationManager#setUserData(java.lang.String)
      */
-    @Override
     public void setUserData( String userData ) {
         // User data value may be null
         session.setSessionData(OBSERVATION_USER_DATA_KEY, userData);
@@ -309,7 +308,6 @@ final class JcrObservationManager implements ObservationManager {
      * 
      * @see javax.jcr.observation.ObservationManager#getEventJournal()
      */
-    @Override
     public EventJournal getEventJournal() {
         return null; // per the JavaDoc
     }
@@ -323,7 +321,6 @@ final class JcrObservationManager implements ObservationManager {
      * @see javax.jcr.observation.ObservationManager#getEventJournal(int, java.lang.String, boolean, java.lang.String[],
      *      java.lang.String[])
      */
-    @Override
     public EventJournal getEventJournal( int eventTypes,
                                          String absPath,
                                          boolean isDeep,
@@ -587,7 +584,6 @@ final class JcrObservationManager implements ObservationManager {
          * 
          * @see javax.jcr.observation.Event#getDate()
          */
-        @Override
         public long getDate() {
             return bundle.getDate().getMilliseconds();
         }
@@ -597,7 +593,6 @@ final class JcrObservationManager implements ObservationManager {
          * 
          * @see javax.jcr.observation.Event#getIdentifier()
          */
-        @Override
         public String getIdentifier() {
             return id;
         }
@@ -607,7 +602,6 @@ final class JcrObservationManager implements ObservationManager {
          * 
          * @see javax.jcr.observation.Event#getUserData()
          */
-        @Override
         public String getUserData() {
             return bundle.getUserData();
         }
@@ -618,7 +612,6 @@ final class JcrObservationManager implements ObservationManager {
          * @see javax.jcr.observation.Event#getInfo()
          * @see JcrMoveEvent#getInfo()
          */
-        @Override
         public Map<String, String> getInfo() {
             return Collections.emptyMap();
         }

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrPropertyDefinition.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrPropertyDefinition.java
@@ -213,7 +213,6 @@ class JcrPropertyDefinition extends JcrItemDefinition implements PropertyDefinit
      * 
      * @see javax.jcr.nodetype.PropertyDefinition#getAvailableQueryOperators()
      */
-    @Override
     public String[] getAvailableQueryOperators() {
         return queryOperators;
     }

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrQueryManager.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrQueryManager.java
@@ -91,7 +91,6 @@ class JcrQueryManager implements QueryManager {
      * 
      * @see javax.jcr.query.QueryManager#getQOMFactory()
      */
-    @Override
     public javax.jcr.query.qom.QueryObjectModelFactory getQOMFactory() {
         return factory;
     }
@@ -1394,7 +1393,6 @@ class JcrQueryManager implements QueryManager {
          * 
          * @see org.modeshape.jcr.query.JcrQueryContext#createValue(int, java.lang.Object)
          */
-        @Override
         public Value createValue( int propertyType,
                                   Object value ) {
             return new JcrValue(factories, cache, propertyType, value);
@@ -1405,7 +1403,6 @@ class JcrQueryManager implements QueryManager {
          * 
          * @see org.modeshape.jcr.query.JcrQueryContext#emptyNodeIterator()
          */
-        @Override
         public NodeIterator emptyNodeIterator() {
             return new JcrEmptyNodeIterator();
         }
@@ -1416,7 +1413,6 @@ class JcrQueryManager implements QueryManager {
          * @see org.modeshape.jcr.query.JcrQueryContext#execute(org.modeshape.graph.query.model.QueryCommand,
          *      org.modeshape.graph.query.plan.PlanHints, java.util.Map)
          */
-        @Override
         public QueryResults execute( QueryCommand query,
                                      PlanHints hints,
                                      Map<String, Object> variables ) throws RepositoryException {
@@ -1431,7 +1427,6 @@ class JcrQueryManager implements QueryManager {
          * 
          * @see org.modeshape.jcr.query.JcrQueryContext#getExecutionContext()
          */
-        @Override
         public ExecutionContext getExecutionContext() {
             return session.getExecutionContext();
         }
@@ -1441,7 +1436,6 @@ class JcrQueryManager implements QueryManager {
          * 
          * @see org.modeshape.jcr.query.JcrQueryContext#getNode(Location)
          */
-        @Override
         public Node getNode( Location location ) throws RepositoryException {
             if (!session.wasRemovedInSession(location)) {
                 try {
@@ -1460,7 +1454,6 @@ class JcrQueryManager implements QueryManager {
          * 
          * @see org.modeshape.jcr.query.JcrQueryContext#getSchemata()
          */
-        @Override
         public Schemata getSchemata() {
             return session.nodeTypeManager().schemata();
         }
@@ -1470,7 +1463,6 @@ class JcrQueryManager implements QueryManager {
          * 
          * @see org.modeshape.jcr.query.JcrQueryContext#isLive()
          */
-        @Override
         public boolean isLive() {
             return session.isLive();
         }
@@ -1480,14 +1472,12 @@ class JcrQueryManager implements QueryManager {
          * 
          * @see org.modeshape.jcr.query.JcrQueryContext#search(java.lang.String, int, int)
          */
-        @Override
         public QueryResults search( String searchExpression,
                                     int maxRowCount,
                                     int offset ) throws RepositoryException {
-            return session.repository().queryManager().search(session.workspace().getName(),
-                                                              searchExpression,
-                                                              maxRowCount,
-                                                              offset);
+            return session.repository()
+                          .queryManager()
+                          .search(session.workspace().getName(), searchExpression, maxRowCount, offset);
         }
 
         /**
@@ -1496,7 +1486,6 @@ class JcrQueryManager implements QueryManager {
          * @see org.modeshape.jcr.query.JcrQueryContext#store(java.lang.String, org.modeshape.graph.property.Name,
          *      java.lang.String, java.lang.String)
          */
-        @Override
         public Node store( String absolutePath,
                            Name nodeType,
                            String language,
@@ -1538,88 +1527,71 @@ class JcrQueryManager implements QueryManager {
             this.delegate = session.getExecutionContext().getValueFactories().getTypeSystem();
         }
 
-        @Override
         public Set<String> getTypeNames() {
             return delegate.getTypeNames();
         }
 
-        @Override
         public TypeFactory<?> getTypeFactory( Object prototype ) {
             return delegate.getTypeFactory(prototype);
         }
 
-        @Override
         public TypeFactory<?> getTypeFactory( String typeName ) {
             return delegate.getTypeFactory(typeName);
         }
 
-        @Override
         public TypeFactory<String> getStringFactory() {
             return delegate.getStringFactory();
         }
 
-        @Override
         public TypeFactory<?> getReferenceFactory() {
             return delegate.getReferenceFactory();
         }
 
-        @Override
         public TypeFactory<?> getPathFactory() {
             return delegate.getPathFactory();
         }
 
-        @Override
         public TypeFactory<Long> getLongFactory() {
             return delegate.getLongFactory();
         }
 
-        @Override
         public TypeFactory<Double> getDoubleFactory() {
             return delegate.getDoubleFactory();
         }
 
-        @Override
         public String getDefaultType() {
             return delegate.getDefaultType();
         }
 
-        @Override
         public Comparator<Object> getDefaultComparator() {
             return delegate.getDefaultComparator();
         }
 
-        @Override
         public TypeFactory<BigDecimal> getDecimalFactory() {
             return delegate.getDecimalFactory();
         }
 
-        @Override
         public TypeFactory<?> getDateTimeFactory() {
             return delegate.getDateTimeFactory();
         }
 
-        @Override
         public String getCompatibleType( String type1,
                                          String type2 ) {
             return delegate.getCompatibleType(type1, type2);
         }
 
-        @Override
         public TypeFactory<Boolean> getBooleanFactory() {
             return delegate.getBooleanFactory();
         }
 
-        @Override
         public TypeFactory<?> getBinaryFactory() {
             return delegate.getBinaryFactory();
         }
 
-        @Override
         public String asString( Object value ) {
             return delegate.asString(value);
         }
 
-        @Override
         public ValueFactory getValueFactory() {
             return session.getValueFactory();
         }

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrRepository.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrRepository.java
@@ -806,22 +806,18 @@ public class JcrRepository implements Repository {
             final Observer observer = this.repositoryObservationManager;
             final ExecutionContext context = executionContext;
             transientSystemSource.initialize(new RepositoryContext() {
-                @Override
                 public Observer getObserver() {
                     return observer;
                 }
 
-                @Override
                 public ExecutionContext getExecutionContext() {
                     return context;
                 }
 
-                @Override
                 public Subgraph getConfiguration( int depth ) {
                     return null; // not needed for the in-memory transient repository
                 }
 
-                @Override
                 public RepositoryConnectionFactory getRepositoryConnectionFactory() {
                     return null; // not needed for the in-memory transient repository
                 }
@@ -1392,17 +1388,14 @@ public class JcrRepository implements Repository {
         assert jcrSecurityContext != null;
 
         return new SecurityContext() {
-            @Override
             public String getUserName() {
                 return jcrSecurityContext.getUserName();
             }
 
-            @Override
             public boolean hasRole( String roleName ) {
                 return jcrSecurityContext.hasRole(roleName);
             }
 
-            @Override
             public void logout() {
                 jcrSecurityContext.logout();
             }
@@ -2011,7 +2004,6 @@ public class JcrRepository implements Repository {
             assert systemWorkspaceName != null;
         }
 
-        @Override
         public void notify( Changes changes ) {
             // Don't process changes from outside the system graph
             if (!changes.getSourceName().equals(systemSourceName)) {

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrRepositoryFactory.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrRepositoryFactory.java
@@ -123,7 +123,6 @@ public class JcrRepositoryFactory implements RepositoryFactory {
      * @see RepositoryFactory#getRepository(Map)
      */
     @SuppressWarnings( {"unchecked", "rawtypes"} )
-    @Override
     public Repository getRepository( Map parameters ) {
         LOG.debug("Trying to load ModeShape JCR Repository with parameters: " + parameters);
         if (parameters == null) return null;
@@ -286,7 +285,6 @@ public class JcrRepositoryFactory implements RepositoryFactory {
         }
     }
 
-    @Override
     public void shutdown() {
         synchronized (ENGINES) {
             for (JcrEngine engine : ENGINES.values()) {
@@ -297,7 +295,6 @@ public class JcrRepositoryFactory implements RepositoryFactory {
         }
     }
 
-    @Override
     public boolean shutdown( long timeout,
                              TimeUnit unit ) throws InterruptedException {
         synchronized (ENGINES) {
@@ -475,7 +472,6 @@ public class JcrRepositoryFactory implements RepositoryFactory {
         return repositoryName;
     }
 
-    @Override
     public Repositories getRepositories( String jcrUrl ) {
         URL url = urlFor(jcrUrl);
         if (url == null) return null;

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrSession.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrSession.java
@@ -814,7 +814,6 @@ class JcrSession implements Session {
      * 
      * @see javax.jcr.Session#getNodeByIdentifier(java.lang.String)
      */
-    @Override
     public AbstractJcrNode getNodeByIdentifier( String id ) throws ItemNotFoundException, RepositoryException {
         // Attempt to create a UUID from the identifier ...
         try {
@@ -1288,7 +1287,6 @@ class JcrSession implements Session {
      * 
      * @see javax.jcr.Session#getAccessControlManager()
      */
-    @Override
     public AccessControlManager getAccessControlManager() throws UnsupportedRepositoryOperationException, RepositoryException {
         throw new UnsupportedRepositoryOperationException();
     }
@@ -1298,7 +1296,6 @@ class JcrSession implements Session {
      * 
      * @see javax.jcr.Session#getRetentionManager()
      */
-    @Override
     public RetentionManager getRetentionManager() throws UnsupportedRepositoryOperationException, RepositoryException {
         throw new UnsupportedRepositoryOperationException();
     }

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrSingleValueProperty.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrSingleValueProperty.java
@@ -111,7 +111,6 @@ final class JcrSingleValueProperty extends AbstractJcrProperty {
         }
     }
 
-    @Override
     public BigDecimal getDecimal() throws ValueFormatException, RepositoryException {
         checkSession();
         try {
@@ -187,7 +186,6 @@ final class JcrSingleValueProperty extends AbstractJcrProperty {
      * 
      * @see javax.jcr.Property#getProperty()
      */
-    @Override
     public Property getProperty() throws ItemNotFoundException, ValueFormatException, RepositoryException {
         checkSession();
         Path path = null;
@@ -236,7 +234,6 @@ final class JcrSingleValueProperty extends AbstractJcrProperty {
         }
     }
 
-    @Override
     public javax.jcr.Binary getBinary() throws ValueFormatException, RepositoryException {
         checkSession();
         try {
@@ -436,7 +433,6 @@ final class JcrSingleValueProperty extends AbstractJcrProperty {
         setValue(createValue(uuid, PropertyType.REFERENCE).asType(this.getType()));
     }
 
-    @Override
     public void setValue( javax.jcr.Binary value )
         throws ValueFormatException, VersionException, LockException, ConstraintViolationException, RepositoryException {
         // Get the Graph Binary object out of the value ...
@@ -454,7 +450,6 @@ final class JcrSingleValueProperty extends AbstractJcrProperty {
         setValue(createValue(binary, PropertyType.BINARY).asType(this.getType()));
     }
 
-    @Override
     public void setValue( BigDecimal value )
         throws ValueFormatException, VersionException, LockException, ConstraintViolationException, RepositoryException {
         if (value == null) {

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrValue.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrValue.java
@@ -33,8 +33,8 @@ import javax.jcr.PropertyType;
 import javax.jcr.RepositoryException;
 import javax.jcr.Value;
 import javax.jcr.ValueFormatException;
-import org.modeshape.common.annotation.NotThreadSafe;
 import org.modeshape.common.SystemFailureException;
+import org.modeshape.common.annotation.NotThreadSafe;
 import org.modeshape.common.util.IoUtil;
 import org.modeshape.graph.property.Binary;
 import org.modeshape.graph.property.BinaryFactory;
@@ -156,7 +156,6 @@ final class JcrValue implements org.modeshape.jcr.api.Value {
      * 
      * @see javax.jcr.Value#getDecimal()
      */
-    @Override
     public BigDecimal getDecimal() throws ValueFormatException, RepositoryException {
         try {
             BigDecimal convertedValue = valueFactories.getDecimalFactory().create(value);

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrValueFactory.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrValueFactory.java
@@ -74,13 +74,11 @@ class JcrValueFactory implements ValueFactory {
         return jcrValues;
     }
 
-    @Override
     public JcrValue createValue( String value,
                                  int propertyType ) throws ValueFormatException {
         return new JcrValue(valueFactories, sessionCache, propertyType, convertValueToType(value, propertyType));
     }
 
-    @Override
     public JcrValue createValue( Node value ) throws RepositoryException {
         if (!value.isNodeType(JcrMixLexicon.REFERENCEABLE.getString(namespaces))) {
             throw new RepositoryException(JcrI18n.nodeNotReferenceable.text());
@@ -89,7 +87,6 @@ class JcrValueFactory implements ValueFactory {
         return new JcrValue(valueFactories, sessionCache, PropertyType.REFERENCE, ref);
     }
 
-    @Override
     public JcrValue createValue( Node value,
                                  boolean weak ) throws RepositoryException {
         if (!value.isNodeType(JcrMixLexicon.REFERENCEABLE.getString(namespaces))) {
@@ -101,50 +98,41 @@ class JcrValueFactory implements ValueFactory {
         return new JcrValue(valueFactories, sessionCache, refType, ref);
     }
 
-    @Override
     public JcrValue createValue( javax.jcr.Binary value ) {
         return new JcrValue(valueFactories, sessionCache, PropertyType.BINARY, value);
     }
 
-    @Override
     public JcrValue createValue( InputStream value ) {
         Binary binary = valueFactories.getBinaryFactory().create(value);
         return new JcrValue(valueFactories, sessionCache, PropertyType.BINARY, binary);
     }
 
-    @Override
     public JcrBinary createBinary( InputStream value ) {
         Binary binary = valueFactories.getBinaryFactory().create(value);
         return new JcrBinary(binary);
     }
 
-    @Override
     public JcrValue createValue( Calendar value ) {
         DateTime dateTime = valueFactories.getDateFactory().create(value);
         return new JcrValue(valueFactories, sessionCache, PropertyType.DATE, dateTime);
     }
 
-    @Override
     public JcrValue createValue( boolean value ) {
         return new JcrValue(valueFactories, sessionCache, PropertyType.BOOLEAN, value);
     }
 
-    @Override
     public JcrValue createValue( double value ) {
         return new JcrValue(valueFactories, sessionCache, PropertyType.DOUBLE, value);
     }
 
-    @Override
     public JcrValue createValue( long value ) {
         return new JcrValue(valueFactories, sessionCache, PropertyType.LONG, value);
     }
 
-    @Override
     public JcrValue createValue( String value ) {
         return new JcrValue(valueFactories, sessionCache, PropertyType.STRING, value);
     }
 
-    @Override
     public JcrValue createValue( BigDecimal value ) {
         return new JcrValue(valueFactories, sessionCache, PropertyType.DECIMAL, value);
     }

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrVersionHistoryNode.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrVersionHistoryNode.java
@@ -76,17 +76,19 @@ class JcrVersionHistoryNode extends JcrNode implements VersionHistory {
     }
 
     /**
-     * @{inheritDoc
+     * {@inheritDoc}
+     * 
+     * @see javax.jcr.version.VersionHistory#getAllVersions()
      */
-    @Override
     public VersionIterator getAllVersions() throws RepositoryException {
         return new JcrVersionIterator(getNodes());
     }
 
     /**
-     * @{inheritDoc
+     * {@inheritDoc}
+     * 
+     * @see javax.jcr.version.VersionHistory#getRootVersion()
      */
-    @Override
     public JcrVersionNode getRootVersion() throws RepositoryException {
         // Copied from AbstractJcrNode.getNode(String) to avoid double conversion. Needs to be refactored.
         Segment segment = context().getValueFactories().getPathFactory().createSegment(JcrLexicon.ROOT_VERSION);
@@ -101,9 +103,10 @@ class JcrVersionHistoryNode extends JcrNode implements VersionHistory {
     }
 
     /**
-     * @{inheritDoc
+     * {@inheritDoc}
+     * 
+     * @see javax.jcr.version.VersionHistory#getVersion(java.lang.String)
      */
-    @Override
     public JcrVersionNode getVersion( String versionName ) throws VersionException, RepositoryException {
         try {
             AbstractJcrNode version = getNode(versionName);
@@ -114,9 +117,10 @@ class JcrVersionHistoryNode extends JcrNode implements VersionHistory {
     }
 
     /**
-     * @{inheritDoc
+     * {@inheritDoc}
+     * 
+     * @see javax.jcr.version.VersionHistory#getVersionByLabel(java.lang.String)
      */
-    @Override
     public JcrVersionNode getVersionByLabel( String label ) throws VersionException, RepositoryException {
         Property prop = versionLabels().getProperty(label);
         if (prop == null) throw new VersionException(JcrI18n.invalidVersionLabel.text(label, getPath()));
@@ -129,9 +133,10 @@ class JcrVersionHistoryNode extends JcrNode implements VersionHistory {
     }
 
     /**
-     * @{inheritDoc
+     * {@inheritDoc}
+     * 
+     * @see javax.jcr.version.VersionHistory#getVersionLabels()
      */
-    @Override
     public String[] getVersionLabels() throws RepositoryException {
         PropertyIterator iter = versionLabels().getProperties();
 
@@ -173,33 +178,37 @@ class JcrVersionHistoryNode extends JcrNode implements VersionHistory {
     }
 
     /**
-     * @{inheritDoc
+     * {@inheritDoc}
+     * 
+     * @see javax.jcr.version.VersionHistory#getVersionLabels(javax.jcr.version.Version)
      */
-    @Override
     public String[] getVersionLabels( Version version ) throws RepositoryException {
         return versionLabelsFor(version).toArray(EMPTY_STRING_ARRAY);
     }
 
     /**
-     * @{inheritDoc
+     * {@inheritDoc}
+     * 
+     * @see javax.jcr.version.VersionHistory#getVersionableUUID()
      */
-    @Override
     public String getVersionableUUID() throws RepositoryException {
         return getProperty(JcrLexicon.VERSIONABLE_UUID).getString();
     }
 
     /**
-     * @{inheritDoc
+     * {@inheritDoc}
+     * 
+     * @see javax.jcr.version.VersionHistory#hasVersionLabel(java.lang.String)
      */
-    @Override
     public boolean hasVersionLabel( String label ) throws RepositoryException {
         return versionLabels().hasProperty(label);
     }
 
     /**
-     * @{inheritDoc
+     * {@inheritDoc}
+     * 
+     * @see javax.jcr.version.VersionHistory#hasVersionLabel(javax.jcr.version.Version, java.lang.String)
      */
-    @Override
     public boolean hasVersionLabel( Version version,
                                     String label ) throws RepositoryException {
         Collection<String> labels = versionLabelsFor(version);
@@ -208,10 +217,11 @@ class JcrVersionHistoryNode extends JcrNode implements VersionHistory {
     }
 
     /**
-     * @{inheritDoc
+     * {@inheritDoc}
+     * 
+     * @see javax.jcr.version.VersionHistory#removeVersion(java.lang.String)
      */
     @SuppressWarnings( "deprecation" )
-    @Override
     public void removeVersion( String versionName )
         throws ReferentialIntegrityException, AccessDeniedException, UnsupportedRepositoryOperationException, VersionException,
         RepositoryException {
@@ -299,10 +309,11 @@ class JcrVersionHistoryNode extends JcrNode implements VersionHistory {
     }
 
     /**
-     * @{inheritDoc
+     * {@inheritDoc}
+     * 
+     * @see javax.jcr.version.VersionHistory#addVersionLabel(java.lang.String, java.lang.String, boolean)
      */
     @SuppressWarnings( "deprecation" )
-    @Override
     public void addVersionLabel( String versionName,
                                  String label,
                                  boolean moveLabel ) throws VersionException, RepositoryException {
@@ -327,9 +338,10 @@ class JcrVersionHistoryNode extends JcrNode implements VersionHistory {
     }
 
     /**
-     * @{inheritDoc
+     * {@inheritDoc}
+     * 
+     * @see javax.jcr.version.VersionHistory#removeVersionLabel(java.lang.String)
      */
-    @Override
     public void removeVersionLabel( String label ) throws VersionException, RepositoryException {
         AbstractJcrNode versionLabels = versionLabels();
 
@@ -347,17 +359,14 @@ class JcrVersionHistoryNode extends JcrNode implements VersionHistory {
         versionLabels.refresh(false);
     }
 
-    @Override
     public NodeIterator getAllFrozenNodes() throws RepositoryException {
         return new FrozenNodeIterator(getAllVersions());
     }
 
-    @Override
     public NodeIterator getAllLinearFrozenNodes() throws RepositoryException {
         return new FrozenNodeIterator(getAllLinearVersions());
     }
 
-    @Override
     public VersionIterator getAllLinearVersions() throws RepositoryException {
         AbstractJcrNode existingNode = session().getNodeByIdentifier(getVersionableIdentifier());
         if (existingNode == null) return getAllVersions();
@@ -375,7 +384,6 @@ class JcrVersionHistoryNode extends JcrNode implements VersionHistory {
         return new LinearVersionIterator(versions, versions.size());
     }
 
-    @Override
     public String getVersionableIdentifier() throws RepositoryException {
         // ModeShape uses a node's UUID as it's identifier
         return getVersionableUUID();
@@ -398,9 +406,10 @@ class JcrVersionHistoryNode extends JcrNode implements VersionHistory {
         }
 
         /**
-         * @{inheritDoc
+         * {@inheritDoc}
+         * 
+         * @see javax.jcr.version.VersionIterator#nextVersion()
          */
-        @Override
         public Version nextVersion() {
             Version next = this.next;
 
@@ -439,17 +448,19 @@ class JcrVersionHistoryNode extends JcrNode implements VersionHistory {
         }
 
         /**
-         * @{inheritDoc
+         * {@inheritDoc}
+         * 
+         * @see javax.jcr.RangeIterator#getPosition()
          */
-        @Override
         public long getPosition() {
             return position;
         }
 
         /**
-         * @{inheritDoc
+         * {@inheritDoc}
+         * 
+         * @see javax.jcr.RangeIterator#getSize()
          */
-        @Override
         public long getSize() {
             // The number of version nodes is the number of child nodes of the version history - 1
             // (the jcr:versionLabels node)
@@ -457,9 +468,10 @@ class JcrVersionHistoryNode extends JcrNode implements VersionHistory {
         }
 
         /**
-         * @{inheritDoc
+         * {@inheritDoc}
+         * 
+         * @see javax.jcr.RangeIterator#skip(long)
          */
-        @Override
         public void skip( long count ) {
             // Walk through the list to make sure that we don't accidentally count jcr:rootVersion or jcr:versionLabels as a
             // skipped node
@@ -469,9 +481,10 @@ class JcrVersionHistoryNode extends JcrNode implements VersionHistory {
         }
 
         /**
-         * @{inheritDoc
+         * {@inheritDoc}
+         * 
+         * @see java.util.Iterator#hasNext()
          */
-        @Override
         public boolean hasNext() {
             if (this.next != null) return true;
 
@@ -481,17 +494,19 @@ class JcrVersionHistoryNode extends JcrNode implements VersionHistory {
         }
 
         /**
-         * @{inheritDoc
+         * {@inheritDoc}
+         * 
+         * @see java.util.Iterator#next()
          */
-        @Override
         public Object next() {
             return nextVersion();
         }
 
         /**
-         * @{inheritDoc
+         * {@inheritDoc}
+         * 
+         * @see java.util.Iterator#remove()
          */
-        @Override
         public void remove() {
             throw new UnsupportedOperationException();
         }
@@ -515,17 +530,14 @@ class JcrVersionHistoryNode extends JcrNode implements VersionHistory {
             this.pos = 0;
         }
 
-        @Override
         public long getPosition() {
             return pos;
         }
 
-        @Override
         public long getSize() {
             return this.size;
         }
 
-        @Override
         public void skip( long skipNum ) {
             while (skipNum-- > 0 && versions.hasNext()) {
                 versions.next();
@@ -534,22 +546,18 @@ class JcrVersionHistoryNode extends JcrNode implements VersionHistory {
 
         }
 
-        @Override
         public Version nextVersion() {
             return versions.next();
         }
 
-        @Override
         public boolean hasNext() {
             return versions.hasNext();
         }
 
-        @Override
         public Object next() {
             return nextVersion();
         }
 
-        @Override
         public void remove() {
             throw new UnsupportedOperationException();
         }
@@ -562,22 +570,18 @@ class JcrVersionHistoryNode extends JcrNode implements VersionHistory {
             this.versions = versionIter;
         }
 
-        @Override
         public boolean hasNext() {
             return versions.hasNext();
         }
 
-        @Override
         public Object next() {
             return nextNode();
         }
 
-        @Override
         public void remove() {
             throw new UnsupportedOperationException();
         }
 
-        @Override
         public Node nextNode() {
             try {
                 return versions.nextVersion().getFrozenNode();
@@ -587,17 +591,14 @@ class JcrVersionHistoryNode extends JcrNode implements VersionHistory {
             }
         }
 
-        @Override
         public long getPosition() {
             return versions.getPosition();
         }
 
-        @Override
         public long getSize() {
             return versions.getSize();
         }
 
-        @Override
         public void skip( long skipNum ) {
             versions.skip(skipNum);
         }

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrVersionManager.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrVersionManager.java
@@ -554,7 +554,6 @@ final class JcrVersionManager implements VersionManager {
      * @throws RepositoryException if an error occurs accessing the repository
      * @see javax.jcr.Workspace#restore(Version[], boolean)
      */
-    @Override
     public void restore( Version[] versions,
                          boolean removeExisting ) throws RepositoryException {
         session.checkLive();
@@ -1641,7 +1640,6 @@ final class JcrVersionManager implements VersionManager {
 
     }
 
-    @Override
     public void cancelMerge( String absPath,
                              Version version ) throws VersionException, InvalidItemStateException, RepositoryException {
         cancelMerge(session.getNode(absPath), version);
@@ -1661,18 +1659,15 @@ final class JcrVersionManager implements VersionManager {
         }
     }
 
-    @Override
     public Version checkin( String absPath )
         throws VersionException, InvalidItemStateException, LockException, RepositoryException {
         return checkin(session.getNode(absPath));
     }
 
-    @Override
     public void checkout( String absPath ) throws LockException, RepositoryException {
         checkout(session.getNode(absPath));
     }
 
-    @Override
     public Version checkpoint( String absPath )
         throws VersionException, InvalidItemStateException, LockException, RepositoryException {
         Version version = checkin(absPath);
@@ -1680,42 +1675,35 @@ final class JcrVersionManager implements VersionManager {
         return version;
     }
 
-    @Override
     public void doneMerge( String absPath,
                            Version version ) throws VersionException, InvalidItemStateException, RepositoryException {
         doneMerge(session.getNode(absPath), version);
     }
 
-    @Override
     public javax.jcr.Node getActivity() throws UnsupportedRepositoryOperationException, RepositoryException {
         throw new UnsupportedRepositoryOperationException();
     }
 
-    @Override
     public Version getBaseVersion( String absPath ) throws RepositoryException {
         return session.getNode(absPath).getBaseVersion();
     }
 
-    @Override
     public VersionHistory getVersionHistory( String absPath ) throws UnsupportedRepositoryOperationException, RepositoryException {
         return session.getNode(absPath).getVersionHistory();
     }
 
-    @Override
     public boolean isCheckedOut( String absPath ) throws RepositoryException {
         AbstractJcrNode node = session.getNode(absPath);
         return node.isCheckedOut();
     }
 
     @SuppressWarnings( "unused" )
-    @Override
     public NodeIterator merge( javax.jcr.Node activityNode )
         throws VersionException, AccessDeniedException, MergeException, LockException, InvalidItemStateException,
         RepositoryException {
         throw new UnsupportedRepositoryOperationException();
     }
 
-    @Override
     public NodeIterator merge( String absPath,
                                String srcWorkspace,
                                boolean bestEffort,
@@ -1729,7 +1717,6 @@ final class JcrVersionManager implements VersionManager {
         return merge(node, srcWorkspace, bestEffort, isShallow);
     }
 
-    @Override
     public NodeIterator merge( String absPath,
                                String srcWorkspace,
                                boolean bestEffort )
@@ -1738,7 +1725,6 @@ final class JcrVersionManager implements VersionManager {
         return merge(absPath, srcWorkspace, bestEffort, false);
     }
 
-    @Override
     public void restore( String absPath,
                          String versionName,
                          boolean removeExisting )
@@ -1763,7 +1749,6 @@ final class JcrVersionManager implements VersionManager {
         restore(path, version, null, removeExisting);
     }
 
-    @Override
     public void restore( String absPath,
                          Version version,
                          boolean removeExisting )
@@ -1774,7 +1759,6 @@ final class JcrVersionManager implements VersionManager {
         restore(path, version, null, removeExisting);
     }
 
-    @Override
     public void restore( Version version,
                          boolean removeExisting )
         throws VersionException, ItemExistsException, InvalidItemStateException, LockException, RepositoryException {
@@ -1784,7 +1768,6 @@ final class JcrVersionManager implements VersionManager {
         restore(path, version, null, removeExisting);
     }
 
-    @Override
     public void restoreByLabel( String absPath,
                                 String versionLabel,
                                 boolean removeExisting )
@@ -1792,25 +1775,21 @@ final class JcrVersionManager implements VersionManager {
         session.getNode(absPath).restoreByLabel(versionLabel, removeExisting);
     }
 
-    @Override
     public javax.jcr.Node setActivity( javax.jcr.Node activity )
         throws UnsupportedRepositoryOperationException, RepositoryException {
         throw new UnsupportedRepositoryOperationException();
     }
 
     @SuppressWarnings( "unused" )
-    @Override
     public void removeActivity( javax.jcr.Node activityNode )
         throws UnsupportedRepositoryOperationException, VersionException, RepositoryException {
         throw new UnsupportedRepositoryOperationException();
     }
 
-    @Override
     public javax.jcr.Node createActivity( String title ) throws UnsupportedRepositoryOperationException, RepositoryException {
         throw new UnsupportedRepositoryOperationException();
     }
 
-    @Override
     public javax.jcr.Node createConfiguration( String absPath )
         throws UnsupportedRepositoryOperationException, RepositoryException {
         throw new UnsupportedRepositoryOperationException();
@@ -1839,7 +1818,6 @@ final class JcrVersionManager implements VersionManager {
             super(versionStoragePath, context);
         }
 
-        @Override
         public Path versionHistoryPathFor( UUID uuid ) {
             String uuidStr = uuid.toString();
             Name p1 = names.create(uuidStr.substring(0, 2));
@@ -1857,7 +1835,6 @@ final class JcrVersionManager implements VersionManager {
             super(versionStoragePath, context);
         }
 
-        @Override
         public Path versionHistoryPathFor( UUID uuid ) {
             return paths.createAbsolutePath(JcrLexicon.SYSTEM, JcrLexicon.VERSION_STORAGE, names.create(uuid.toString()));
         }

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrVersionNode.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrVersionNode.java
@@ -47,17 +47,19 @@ class JcrVersionNode extends JcrNode implements Version {
     }
 
     /**
-     * @{inheritDoc
+     * {@inheritDoc}
+     * 
+     * @see javax.jcr.version.Version#getContainingHistory()
      */
-    @Override
     public JcrVersionHistoryNode getContainingHistory() throws RepositoryException {
         return new JcrVersionHistoryNode(getParent());
     }
 
     /**
-     * @{inheritDoc
+     * {@inheritDoc}
+     * 
+     * @see javax.jcr.version.Version#getCreated()
      */
-    @Override
     public Calendar getCreated() throws RepositoryException {
         return getProperty(JcrLexicon.CREATED).getDate();
     }
@@ -75,18 +77,23 @@ class JcrVersionNode extends JcrNode implements Version {
     }
 
     /**
-     * @{inheritDoc
+     * {@inheritDoc}
+     * 
+     * @see javax.jcr.version.Version#getPredecessors()
      */
-    @Override
     public Version[] getPredecessors() throws RepositoryException {
         return getNodesForProperty(JcrLexicon.PREDECESSORS);
     }
 
     /**
+     * {@inheritDoc}
+     * <p>
      * Returns the successor versions of this version. This corresponds to returning all the nt:version nodes referenced by the
      * jcr:successors multi-value property in the nt:version node that represents this version.
+     * </p>
+     * 
+     * @see javax.jcr.version.Version#getSuccessors()
      */
-    @Override
     public Version[] getSuccessors() throws RepositoryException {
         return getNodesForProperty(JcrLexicon.SUCCESSORS);
     }
@@ -144,12 +151,10 @@ class JcrVersionNode extends JcrNode implements Version {
         return false;
     }
 
-    @Override
     public JcrVersionNode getLinearPredecessor() throws RepositoryException {
         return getFirstNodeForProperty(JcrLexicon.PREDECESSORS);
     }
 
-    @Override
     public JcrVersionNode getLinearSuccessor() throws RepositoryException {
         return getFirstNodeForProperty(JcrLexicon.SUCCESSORS);
     }

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrWorkspace.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrWorkspace.java
@@ -899,7 +899,6 @@ class JcrWorkspace implements Workspace {
      * 
      * @see javax.jcr.Workspace#createWorkspace(java.lang.String, java.lang.String)
      */
-    @Override
     public void createWorkspace( String name,
                                  String srcWorkspace )
         throws AccessDeniedException, UnsupportedRepositoryOperationException, NoSuchWorkspaceException, RepositoryException {
@@ -927,7 +926,6 @@ class JcrWorkspace implements Workspace {
      * 
      * @see javax.jcr.Workspace#createWorkspace(java.lang.String)
      */
-    @Override
     public void createWorkspace( String name )
         throws AccessDeniedException, UnsupportedRepositoryOperationException, RepositoryException {
         CheckArg.isNotNull(name, "name");
@@ -953,7 +951,6 @@ class JcrWorkspace implements Workspace {
      * 
      * @see javax.jcr.Workspace#deleteWorkspace(java.lang.String)
      */
-    @Override
     public void deleteWorkspace( String name )
         throws AccessDeniedException, UnsupportedRepositoryOperationException, NoSuchWorkspaceException, RepositoryException {
         CheckArg.isNotNull(name, "name");
@@ -975,7 +972,6 @@ class JcrWorkspace implements Workspace {
      * 
      * @see javax.jcr.Workspace#getVersionManager()
      */
-    @Override
     public VersionManager getVersionManager() {
         return versionManager;
     }

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/RepositoryLockManager.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/RepositoryLockManager.java
@@ -150,12 +150,10 @@ class RepositoryLockManager implements JcrSystemObserver {
      * 
      * @see org.modeshape.jcr.JcrSystemObserver#getObservedPath()
      */
-    @Override
     public Path getObservedPath() {
         return locksPath;
     }
 
-    @Override
     public void notify( Changes changes ) {
         for (ChangeRequest change : changes.getChangeRequests()) {
             assert change.changedLocation().hasPath();

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/RepositoryNodeTypeManager.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/RepositoryNodeTypeManager.java
@@ -2288,12 +2288,10 @@ class RepositoryNodeTypeManager implements JcrSystemObserver {
         }
     }
 
-    @Override
     public Path getObservedPath() {
         return this.nodeTypesPath;
     }
 
-    @Override
     public void notify( Changes changes ) {
         Collection<Name> createdNodeTypeNames = new HashSet<Name>();
         Collection<Name> deletedNodeTypeNames = new HashSet<Name>();

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/RepositoryQueryManager.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/RepositoryQueryManager.java
@@ -308,7 +308,6 @@ abstract class RepositoryQueryManager {
                      * 
                      * @see java.util.concurrent.ThreadFactory#newThread(java.lang.Runnable)
                      */
-                    @Override
                     public Thread newThread( Runnable r ) {
                         Thread thread = new Thread("modeshape-indexing");
                         thread.setPriority(Thread.NORM_PRIORITY + 3);

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/WorkspaceLockManager.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/WorkspaceLockManager.java
@@ -134,10 +134,10 @@ class WorkspaceLockManager {
     }
 
     ModeShapeLock lockNodeInternally( String lockOwner,
-                             UUID lockUuid,
-                             UUID lockedNodeUuid,
-                             boolean isDeep,
-                             boolean isSessionScoped ) {
+                                      UUID lockUuid,
+                                      UUID lockedNodeUuid,
+                                      boolean isDeep,
+                                      boolean isSessionScoped ) {
         ModeShapeLock lock = createLock(lockOwner, lockUuid, lockedNodeUuid, isDeep, isSessionScoped);
 
         workspaceLocksByNodeUuid.put(lockedNodeUuid, lock);
@@ -168,8 +168,8 @@ class WorkspaceLockManager {
      * by calling {@link #unlock(ExecutionContext, ModeShapeLock)} and will throw a {@code RepositoryException}.
      * </p>
      * <p>
-     * This method does not modify the system graph. In other words, it will not create the record for the lock in the {@code
-     * /jcr:system/dna:locks} subgraph.
+     * This method does not modify the system graph. In other words, it will not create the record for the lock in the
+     * {@code /jcr:system/dna:locks} subgraph.
      * </p>
      * 
      * @param session the session in which the node is being locked and that loaded the node
@@ -191,14 +191,15 @@ class WorkspaceLockManager {
         Property lockIsDeepProp = propFactory.create(JcrLexicon.LOCK_IS_DEEP, isDeep);
 
         // Write them directly to the underlying graph
-        Graph.Batch workspaceBatch = repositoryLockManager.createWorkspaceGraph(workspaceName, session.getExecutionContext()).batch();
+        Graph.Batch workspaceBatch = repositoryLockManager.createWorkspaceGraph(workspaceName, session.getExecutionContext())
+                                                          .batch();
         workspaceBatch.set(lockOwnerProp, lockIsDeepProp).on(nodeUuid);
         if (isDeep) {
             workspaceBatch.lock(nodeUuid).andItsDescendants().withDefaultTimeout();
         } else {
             workspaceBatch.lock(nodeUuid).only().withDefaultTimeout();
         }
-            workspaceBatch.execute();
+        workspaceBatch.execute();
 
     }
 
@@ -225,7 +226,9 @@ class WorkspaceLockManager {
                      // This gets set after the lock succeeds and the lock token gets added to the session
                      propFactory.create(ModeShapeLexicon.IS_HELD_BY_SESSION, false),
                      propFactory.create(JcrLexicon.LOCK_OWNER, lockOwner),
-                     propFactory.create(JcrLexicon.LOCK_IS_DEEP, lockIsDeep)).ifAbsent().and();
+                     propFactory.create(JcrLexicon.LOCK_IS_DEEP, lockIsDeep))
+             .ifAbsent()
+             .and();
 
     }
 
@@ -263,8 +266,8 @@ class WorkspaceLockManager {
      * {@code jcr:lockIsDeep} properties on the node and sends an {@link Graph#unlock(Location) unlock request} to the underlying
      * repository to clear any locks that it is holding on the node.
      * <p>
-     * This method does not modify the system graph. In other words, it will not remove the record for the lock in the {@code
-     * /jcr:system/dna:locks} subgraph.
+     * This method does not modify the system graph. In other words, it will not remove the record for the lock in the
+     * {@code /jcr:system/dna:locks} subgraph.
      * </p>
      * 
      * @param sessionExecutionContext the execution context of the session in which the node is being unlocked
@@ -272,7 +275,8 @@ class WorkspaceLockManager {
      */
     void unlockNodeInRepository( ExecutionContext sessionExecutionContext,
                                  ModeShapeLock lock ) {
-        Graph.Batch workspaceBatch = repositoryLockManager.createWorkspaceGraph(this.workspaceName, sessionExecutionContext).batch();
+        Graph.Batch workspaceBatch = repositoryLockManager.createWorkspaceGraph(this.workspaceName, sessionExecutionContext)
+                                                          .batch();
 
         workspaceBatch.remove(JcrLexicon.LOCK_OWNER, JcrLexicon.LOCK_IS_DEEP).on(lock.nodeUuid);
         workspaceBatch.unlock(lock.nodeUuid);
@@ -310,8 +314,9 @@ class WorkspaceLockManager {
         PathFactory pathFactory = context.getValueFactories().getPathFactory();
 
         try {
-            org.modeshape.graph.Node lockNode = repositoryLockManager.createSystemGraph(context).getNodeAt(pathFactory.create(locksPath,
-                                                                                                                              pathFactory.createSegment(lockToken)));
+            org.modeshape.graph.Node lockNode = repositoryLockManager.createSystemGraph(context)
+                                                                     .getNodeAt(pathFactory.create(locksPath,
+                                                                                                   pathFactory.createSegment(lockToken)));
 
             return booleanFactory.create(lockNode.getProperty(ModeShapeLexicon.IS_HELD_BY_SESSION).getFirstValue());
         } catch (PathNotFoundException pnfe) {
@@ -339,8 +344,9 @@ class WorkspaceLockManager {
         PropertyFactory propFactory = context.getPropertyFactory();
         PathFactory pathFactory = context.getValueFactories().getPathFactory();
 
-        repositoryLockManager.createSystemGraph(context).set(propFactory.create(ModeShapeLexicon.IS_HELD_BY_SESSION, value)).on(pathFactory.create(locksPath,
-                                                                                                                                                   pathFactory.createSegment(lockToken)));
+        repositoryLockManager.createSystemGraph(context)
+                             .set(propFactory.create(ModeShapeLexicon.IS_HELD_BY_SESSION, value))
+                             .on(pathFactory.create(locksPath, pathFactory.createSegment(lockToken)));
     }
 
     /**
@@ -538,12 +544,10 @@ class WorkspaceLockManager {
                     }
                 }
 
-                @Override
                 public long getSecondsRemaining() {
                     return isLockOwningSession() ? Integer.MAX_VALUE : Integer.MIN_VALUE;
                 }
 
-                @Override
                 public boolean isLockOwningSession() {
                     String uuidString = lockUuid.toString();
                     return session.lockManager().lockTokens().contains(uuidString);

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/query/JcrQuery.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/query/JcrQuery.java
@@ -126,7 +126,6 @@ public class JcrQuery extends JcrAbstractQuery {
      * 
      * @see javax.jcr.query.Query#bindValue(java.lang.String, javax.jcr.Value)
      */
-    @Override
     public void bindValue( String varName,
                            Value value ) throws IllegalArgumentException, RepositoryException {
         CheckArg.isNotNull(varName, "varName");
@@ -139,7 +138,6 @@ public class JcrQuery extends JcrAbstractQuery {
      * 
      * @see javax.jcr.query.Query#getBindVariableNames()
      */
-    @Override
     public String[] getBindVariableNames() {
         Set<String> keys = variables.keySet();
         return keys.toArray(new String[keys.size()]);
@@ -150,7 +148,6 @@ public class JcrQuery extends JcrAbstractQuery {
      * 
      * @see javax.jcr.query.Query#setLimit(long)
      */
-    @Override
     public void setLimit( long limit ) {
         if (limit > Integer.MAX_VALUE) limit = Integer.MAX_VALUE;
         query = query.withLimit((int)limit); // may not actually change if the limit matches the existing query
@@ -161,7 +158,6 @@ public class JcrQuery extends JcrAbstractQuery {
      * 
      * @see javax.jcr.query.Query#setOffset(long)
      */
-    @Override
     public void setOffset( long offset ) {
         if (offset > Integer.MAX_VALUE) offset = Integer.MAX_VALUE;
         query = query.withOffset((int)offset); // may not actually change if the offset matches the existing query

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/query/JcrQueryResult.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/query/JcrQueryResult.java
@@ -116,7 +116,6 @@ public class JcrQueryResult implements org.modeshape.jcr.api.query.QueryResult {
      * 
      * @see org.modeshape.jcr.api.query.QueryResult#getColumnTypes()
      */
-    @Override
     public String[] getColumnTypes() {
         List<String> types = getColumnTypeList();
         return types.toArray(new String[types.size()]); // make a defensive copy ...
@@ -127,7 +126,6 @@ public class JcrQueryResult implements org.modeshape.jcr.api.query.QueryResult {
      * 
      * @see org.modeshape.jcr.api.query.QueryResult#getSelectorNames()
      */
-    @Override
     public String[] getSelectorNames() {
         if (columnTables == null) {
             // Discover the types ...
@@ -518,7 +516,6 @@ public class JcrQueryResult implements org.modeshape.jcr.api.query.QueryResult {
          * 
          * @see org.modeshape.jcr.api.query.Row#getNode(java.lang.String)
          */
-        @Override
         public Node getNode( String selectorName ) throws RepositoryException {
             if (!iterator.hasSelector(selectorName)) {
                 throw new RepositoryException(JcrI18n.selectorNotUsedInQuery.text(selectorName, iterator.query));
@@ -579,17 +576,14 @@ public class JcrQueryResult implements org.modeshape.jcr.api.query.QueryResult {
             return values;
         }
 
-        @Override
         public Node getNode() {
             return node;
         }
 
-        @Override
         public String getPath() throws RepositoryException {
             return node.getPath();
         }
 
-        @Override
         public String getPath( String selectorName ) throws RepositoryException {
             if (!iterator.hasSelector(selectorName)) {
                 throw new RepositoryException(JcrI18n.selectorNotUsedInQuery.text(selectorName, iterator.query));
@@ -597,7 +591,6 @@ public class JcrQueryResult implements org.modeshape.jcr.api.query.QueryResult {
             return node.getPath();
         }
 
-        @Override
         public double getScore() throws RepositoryException {
             int index = iterator.scoreIndex;
             if (index == -1) {
@@ -607,7 +600,6 @@ public class JcrQueryResult implements org.modeshape.jcr.api.query.QueryResult {
             return score instanceof Float ? ((Float)score).doubleValue() : (Double)score;
         }
 
-        @Override
         public double getScore( String selectorName ) throws RepositoryException {
             if (!iterator.hasSelector(selectorName)) {
                 throw new RepositoryException(JcrI18n.selectorNotUsedInQuery.text(selectorName, iterator.query));
@@ -638,7 +630,6 @@ public class JcrQueryResult implements org.modeshape.jcr.api.query.QueryResult {
          * 
          * @see org.modeshape.jcr.api.query.Row#getNode(java.lang.String)
          */
-        @Override
         public Node getNode( String selectorName ) throws RepositoryException {
             int locationIndex = iterator.columns.getLocationIndex(selectorName);
             if (locationIndex == -1) {
@@ -707,30 +698,25 @@ public class JcrQueryResult implements org.modeshape.jcr.api.query.QueryResult {
             return values;
         }
 
-        @Override
         public Node getNode() throws RepositoryException {
             throw new RepositoryException(
                                           JcrI18n.multipleSelectorsAppearInQueryRequireSpecifyingSelectorName.text(iterator.query));
         }
 
-        @Override
         public String getPath() throws RepositoryException {
             throw new RepositoryException(
                                           JcrI18n.multipleSelectorsAppearInQueryRequireSpecifyingSelectorName.text(iterator.query));
         }
 
-        @Override
         public double getScore() throws RepositoryException {
             throw new RepositoryException(
                                           JcrI18n.multipleSelectorsAppearInQueryRequireSpecifyingSelectorName.text(iterator.query));
         }
 
-        @Override
         public String getPath( String selectorName ) throws RepositoryException {
             return getNode(selectorName).getPath();
         }
 
-        @Override
         public double getScore( String selectorName ) throws RepositoryException {
             if (!iterator.hasSelector(selectorName)) {
                 throw new RepositoryException(JcrI18n.selectorNotUsedInQuery.text(selectorName, iterator.query));

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/query/JcrSearch.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/query/JcrSearch.java
@@ -82,23 +82,19 @@ public class JcrSearch extends JcrAbstractQuery {
         return language + " -> " + statement;
     }
 
-    @Override
     public void bindValue( String varName,
                            Value value ) throws IllegalArgumentException, RepositoryException {
         throw new UnsupportedRepositoryOperationException();
     }
 
-    @Override
     public String[] getBindVariableNames() throws RepositoryException {
         throw new UnsupportedRepositoryOperationException();
     }
 
-    @Override
     public void setLimit( long limit ) {
         throw new IllegalStateException();
     }
 
-    @Override
     public void setOffset( long offset ) {
         throw new IllegalStateException();
     }

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/query/JcrSqlQueryParser.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/query/JcrSqlQueryParser.java
@@ -59,8 +59,8 @@ import org.modeshape.graph.query.model.SetCriteria;
 import org.modeshape.graph.query.model.Source;
 import org.modeshape.graph.query.model.StaticOperand;
 import org.modeshape.graph.query.model.TypeSystem;
-import org.modeshape.graph.query.model.Visitor;
 import org.modeshape.graph.query.model.TypeSystem.TypeFactory;
+import org.modeshape.graph.query.model.Visitor;
 import org.modeshape.graph.query.parse.FullTextSearchParser;
 import org.modeshape.graph.query.parse.SqlQueryParser;
 import org.modeshape.jcr.JcrI18n;
@@ -836,7 +836,6 @@ public class JcrSqlQueryParser extends SqlQueryParser {
          * 
          * @see org.modeshape.graph.query.model.Visitable#accept(org.modeshape.graph.query.model.Visitor)
          */
-        @Override
         public void accept( Visitor visitor ) {
         }
 

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/query/qom/JcrAnd.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/query/qom/JcrAnd.java
@@ -66,7 +66,6 @@ public class JcrAnd extends And implements javax.jcr.query.qom.And, JcrConstrain
      * 
      * @see javax.jcr.query.qom.And#getConstraint1()
      */
-    @Override
     public JcrConstraint getConstraint1() {
         return left();
     }
@@ -76,7 +75,6 @@ public class JcrAnd extends And implements javax.jcr.query.qom.And, JcrConstrain
      * 
      * @see javax.jcr.query.qom.And#getConstraint2()
      */
-    @Override
     public JcrConstraint getConstraint2() {
         return right();
     }

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/query/qom/JcrArithmeticOperand.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/query/qom/JcrArithmeticOperand.java
@@ -76,7 +76,6 @@ public class JcrArithmeticOperand extends ArithmeticOperand
      * 
      * @see org.modeshape.jcr.api.query.qom.ArithmeticOperand#getLeft()
      */
-    @Override
     public DynamicOperand getLeft() {
         return left();
     }
@@ -86,7 +85,6 @@ public class JcrArithmeticOperand extends ArithmeticOperand
      * 
      * @see org.modeshape.jcr.api.query.qom.ArithmeticOperand#getRight()
      */
-    @Override
     public DynamicOperand getRight() {
         return right();
     }
@@ -96,7 +94,6 @@ public class JcrArithmeticOperand extends ArithmeticOperand
      * 
      * @see org.modeshape.jcr.api.query.qom.ArithmeticOperand#getOperator()
      */
-    @Override
     public String getOperator() {
         switch (operator()) {
             case ADD:

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/query/qom/JcrBetween.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/query/qom/JcrBetween.java
@@ -88,7 +88,6 @@ public class JcrBetween extends Between implements JcrConstraint, org.modeshape.
      * 
      * @see org.modeshape.jcr.api.query.qom.Between#getLowerBound()
      */
-    @Override
     public StaticOperand getLowerBound() {
         return lowerBound();
     }
@@ -98,7 +97,6 @@ public class JcrBetween extends Between implements JcrConstraint, org.modeshape.
      * 
      * @see org.modeshape.jcr.api.query.qom.Between#getUpperBound()
      */
-    @Override
     public StaticOperand getUpperBound() {
         return upperBound();
     }
@@ -108,7 +106,6 @@ public class JcrBetween extends Between implements JcrConstraint, org.modeshape.
      * 
      * @see org.modeshape.jcr.api.query.qom.Between#getOperand()
      */
-    @Override
     public DynamicOperand getOperand() {
         return operand();
     }

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/query/qom/JcrBindVariableName.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/query/qom/JcrBindVariableName.java
@@ -46,7 +46,6 @@ public class JcrBindVariableName extends BindVariableName implements BindVariabl
      * 
      * @see javax.jcr.query.qom.BindVariableValue#getBindVariableName()
      */
-    @Override
     public String getBindVariableName() {
         return variableName();
     }

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/query/qom/JcrChildNode.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/query/qom/JcrChildNode.java
@@ -47,7 +47,6 @@ public class JcrChildNode extends ChildNode implements javax.jcr.query.qom.Child
      * 
      * @see javax.jcr.query.qom.ChildNode#getParentPath()
      */
-    @Override
     public String getParentPath() {
         return parentPath();
     }
@@ -57,7 +56,6 @@ public class JcrChildNode extends ChildNode implements javax.jcr.query.qom.Child
      * 
      * @see javax.jcr.query.qom.PropertyValue#getSelectorName()
      */
-    @Override
     public String getSelectorName() {
         return selectorName().name();
     }

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/query/qom/JcrChildNodeJoinCondition.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/query/qom/JcrChildNodeJoinCondition.java
@@ -51,7 +51,6 @@ public class JcrChildNodeJoinCondition extends ChildNodeJoinCondition
      * 
      * @see javax.jcr.query.qom.ChildNodeJoinCondition#getChildSelectorName()
      */
-    @Override
     public String getChildSelectorName() {
         return childSelectorName().name();
     }
@@ -61,7 +60,6 @@ public class JcrChildNodeJoinCondition extends ChildNodeJoinCondition
      * 
      * @see javax.jcr.query.qom.ChildNodeJoinCondition#getParentSelectorName()
      */
-    @Override
     public String getParentSelectorName() {
         return parentSelectorName().name();
     }

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/query/qom/JcrColumn.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/query/qom/JcrColumn.java
@@ -60,7 +60,6 @@ public class JcrColumn extends Column implements javax.jcr.query.qom.Column {
      * 
      * @see javax.jcr.query.qom.Column#getSelectorName()
      */
-    @Override
     public String getSelectorName() {
         return selectorName().name();
     }
@@ -70,7 +69,6 @@ public class JcrColumn extends Column implements javax.jcr.query.qom.Column {
      * 
      * @see javax.jcr.query.qom.Column#getPropertyName()
      */
-    @Override
     public String getPropertyName() {
         return propertyName();
     }
@@ -80,7 +78,6 @@ public class JcrColumn extends Column implements javax.jcr.query.qom.Column {
      * 
      * @see javax.jcr.query.qom.Column#getColumnName()
      */
-    @Override
     public String getColumnName() {
         return columnName();
     }

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/query/qom/JcrComparison.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/query/qom/JcrComparison.java
@@ -72,7 +72,6 @@ public class JcrComparison extends Comparison implements JcrConstraint, javax.jc
      * 
      * @see javax.jcr.query.qom.Comparison#getOperand1()
      */
-    @Override
     public DynamicOperand getOperand1() {
         return operand1();
     }
@@ -82,7 +81,6 @@ public class JcrComparison extends Comparison implements JcrConstraint, javax.jc
      * 
      * @see javax.jcr.query.qom.Comparison#getOperand2()
      */
-    @Override
     public StaticOperand getOperand2() {
         return operand2();
     }
@@ -92,7 +90,6 @@ public class JcrComparison extends Comparison implements JcrConstraint, javax.jc
      * 
      * @see javax.jcr.query.qom.Comparison#getOperator()
      */
-    @Override
     public String getOperator() {
         switch (operator()) {
             case EQUAL_TO:

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/query/qom/JcrDescendantNode.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/query/qom/JcrDescendantNode.java
@@ -47,7 +47,6 @@ public class JcrDescendantNode extends DescendantNode implements javax.jcr.query
      * 
      * @see javax.jcr.query.qom.DescendantNode#getAncestorPath()
      */
-    @Override
     public String getAncestorPath() {
         return ancestorPath();
     }
@@ -57,7 +56,6 @@ public class JcrDescendantNode extends DescendantNode implements javax.jcr.query
      * 
      * @see javax.jcr.query.qom.PropertyValue#getSelectorName()
      */
-    @Override
     public String getSelectorName() {
         return selectorName().name();
     }

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/query/qom/JcrDescendantNodeJoinCondition.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/query/qom/JcrDescendantNodeJoinCondition.java
@@ -51,7 +51,6 @@ public class JcrDescendantNodeJoinCondition extends DescendantNodeJoinCondition
      * 
      * @see javax.jcr.query.qom.DescendantNodeJoinCondition#getAncestorSelectorName()
      */
-    @Override
     public String getAncestorSelectorName() {
         return ancestorSelectorName().name();
     }
@@ -61,7 +60,6 @@ public class JcrDescendantNodeJoinCondition extends DescendantNodeJoinCondition
      * 
      * @see javax.jcr.query.qom.DescendantNodeJoinCondition#getDescendantSelectorName()
      */
-    @Override
     public String getDescendantSelectorName() {
         return descendantSelectorName().name();
     }

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/query/qom/JcrEquiJoinCondition.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/query/qom/JcrEquiJoinCondition.java
@@ -67,7 +67,6 @@ public class JcrEquiJoinCondition extends EquiJoinCondition implements javax.jcr
      * 
      * @see javax.jcr.query.qom.EquiJoinCondition#getProperty1Name()
      */
-    @Override
     public String getProperty1Name() {
         return property1Name();
     }
@@ -77,7 +76,6 @@ public class JcrEquiJoinCondition extends EquiJoinCondition implements javax.jcr
      * 
      * @see javax.jcr.query.qom.EquiJoinCondition#getProperty2Name()
      */
-    @Override
     public String getProperty2Name() {
         return property2Name();
     }
@@ -87,7 +85,6 @@ public class JcrEquiJoinCondition extends EquiJoinCondition implements javax.jcr
      * 
      * @see javax.jcr.query.qom.EquiJoinCondition#getSelector1Name()
      */
-    @Override
     public String getSelector1Name() {
         return selector1Name().name();
     }
@@ -97,7 +94,6 @@ public class JcrEquiJoinCondition extends EquiJoinCondition implements javax.jcr
      * 
      * @see javax.jcr.query.qom.EquiJoinCondition#getSelector2Name()
      */
-    @Override
     public String getSelector2Name() {
         return selector2Name().name();
     }

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/query/qom/JcrFullTextSearch.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/query/qom/JcrFullTextSearch.java
@@ -82,47 +82,38 @@ public class JcrFullTextSearch extends FullTextSearch implements javax.jcr.query
         super(selectorName, propertyName, fullTextSearchExpression, term);
         this.fullTextSearchOperand = new JcrLiteral(new Value() {
 
-            @Override
             public int getType() {
                 return PropertyType.STRING;
             }
 
-            @Override
             public String getString() {
                 return fullTextSearchExpression;
             }
 
-            @Override
             public InputStream getStream() throws RepositoryException {
                 throw new ValueFormatException();
             }
 
-            @Override
             public long getLong() throws ValueFormatException, RepositoryException {
                 throw new ValueFormatException();
             }
 
-            @Override
             public double getDouble() throws ValueFormatException, RepositoryException {
                 throw new ValueFormatException();
             }
 
-            @Override
             public BigDecimal getDecimal() throws ValueFormatException, RepositoryException {
                 throw new ValueFormatException();
             }
 
-            @Override
             public Calendar getDate() throws ValueFormatException, RepositoryException {
                 throw new ValueFormatException();
             }
 
-            @Override
             public boolean getBoolean() throws ValueFormatException, RepositoryException {
                 throw new ValueFormatException();
             }
 
-            @Override
             public Binary getBinary() throws RepositoryException {
                 throw new ValueFormatException();
             }
@@ -134,7 +125,6 @@ public class JcrFullTextSearch extends FullTextSearch implements javax.jcr.query
      * 
      * @see javax.jcr.query.qom.PropertyValue#getPropertyName()
      */
-    @Override
     public String getPropertyName() {
         return propertyName();
     }
@@ -144,7 +134,6 @@ public class JcrFullTextSearch extends FullTextSearch implements javax.jcr.query
      * 
      * @see javax.jcr.query.qom.FullTextSearch#getFullTextSearchExpression()
      */
-    @Override
     public StaticOperand getFullTextSearchExpression() {
         return fullTextSearchOperand;
     }
@@ -154,7 +143,6 @@ public class JcrFullTextSearch extends FullTextSearch implements javax.jcr.query
      * 
      * @see javax.jcr.query.qom.PropertyValue#getSelectorName()
      */
-    @Override
     public String getSelectorName() {
         return selectorName().name();
     }

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/query/qom/JcrFullTextSearchScore.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/query/qom/JcrFullTextSearchScore.java
@@ -48,7 +48,6 @@ public class JcrFullTextSearchScore extends FullTextSearchScore
      * 
      * @see javax.jcr.query.qom.FullTextSearchScore#getSelectorName()
      */
-    @Override
     public String getSelectorName() {
         return selectorName().getString();
     }

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/query/qom/JcrJoin.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/query/qom/JcrJoin.java
@@ -86,7 +86,6 @@ public class JcrJoin extends Join implements javax.jcr.query.qom.Join, JcrSource
      * 
      * @see javax.jcr.query.qom.Join#getJoinCondition()
      */
-    @Override
     public JoinCondition getJoinCondition() {
         return joinCondition();
     }
@@ -96,7 +95,6 @@ public class JcrJoin extends Join implements javax.jcr.query.qom.Join, JcrSource
      * 
      * @see javax.jcr.query.qom.Join#getJoinType()
      */
-    @Override
     public String getJoinType() {
         switch (type()) {
             case CROSS:
@@ -119,7 +117,6 @@ public class JcrJoin extends Join implements javax.jcr.query.qom.Join, JcrSource
      * 
      * @see javax.jcr.query.qom.Join#getLeft()
      */
-    @Override
     public JcrSource getLeft() {
         return left();
     }
@@ -129,7 +126,6 @@ public class JcrJoin extends Join implements javax.jcr.query.qom.Join, JcrSource
      * 
      * @see javax.jcr.query.qom.Join#getRight()
      */
-    @Override
     public JcrSource getRight() {
         return right();
     }

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/query/qom/JcrLength.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/query/qom/JcrLength.java
@@ -44,7 +44,6 @@ public class JcrLength extends Length implements javax.jcr.query.qom.Length, Jcr
      * 
      * @see javax.jcr.query.qom.Length#getPropertyValue()
      */
-    @Override
     public JcrPropertyValue getPropertyValue() {
         return (JcrPropertyValue)propertyValue();
     }

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/query/qom/JcrLimit.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/query/qom/JcrLimit.java
@@ -61,7 +61,6 @@ public class JcrLimit extends Limit implements org.modeshape.jcr.api.query.qom.L
      * 
      * @see org.modeshape.jcr.api.query.qom.Limit#getOffset()
      */
-    @Override
     public int getOffset() {
         return offset();
     }
@@ -71,7 +70,6 @@ public class JcrLimit extends Limit implements org.modeshape.jcr.api.query.qom.L
      * 
      * @see org.modeshape.jcr.api.query.qom.Limit#getRowLimit()
      */
-    @Override
     public int getRowLimit() {
         return rowLimit();
     }

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/query/qom/JcrLiteral.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/query/qom/JcrLiteral.java
@@ -82,7 +82,6 @@ public class JcrLiteral extends Literal implements javax.jcr.query.qom.Literal, 
      * 
      * @see javax.jcr.query.qom.Literal#getLiteralValue()
      */
-    @Override
     public Value getLiteralValue() {
         return jcrValue;
     }

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/query/qom/JcrLowerCase.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/query/qom/JcrLowerCase.java
@@ -44,7 +44,6 @@ public class JcrLowerCase extends LowerCase implements javax.jcr.query.qom.Lower
      * 
      * @see javax.jcr.query.qom.LowerCase#getOperand()
      */
-    @Override
     public JcrDynamicOperand getOperand() {
         return (JcrDynamicOperand)operand();
     }

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/query/qom/JcrNamedSelector.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/query/qom/JcrNamedSelector.java
@@ -62,7 +62,6 @@ public class JcrNamedSelector extends NamedSelector implements Selector, JcrSour
      * 
      * @see javax.jcr.query.qom.Selector#getNodeTypeName()
      */
-    @Override
     public String getNodeTypeName() {
         return name().name();
     }
@@ -72,7 +71,6 @@ public class JcrNamedSelector extends NamedSelector implements Selector, JcrSour
      * 
      * @see javax.jcr.query.qom.Selector#getSelectorName()
      */
-    @Override
     public String getSelectorName() {
         return alias().name();
     }

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/query/qom/JcrNodeDepth.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/query/qom/JcrNodeDepth.java
@@ -48,7 +48,6 @@ public class JcrNodeDepth extends NodeDepth implements org.modeshape.jcr.api.que
      * 
      * @see org.modeshape.jcr.api.query.qom.NodeDepth#getSelectorName()
      */
-    @Override
     public String getSelectorName() {
         return selectorName().name();
     }

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/query/qom/JcrNodeLocalName.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/query/qom/JcrNodeLocalName.java
@@ -45,7 +45,6 @@ public class JcrNodeLocalName extends NodeLocalName implements javax.jcr.query.q
      * 
      * @see javax.jcr.query.qom.NodeLocalName#getSelectorName()
      */
-    @Override
     public String getSelectorName() {
         return selectorName().name();
     }

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/query/qom/JcrNodeName.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/query/qom/JcrNodeName.java
@@ -45,7 +45,6 @@ public class JcrNodeName extends NodeName implements javax.jcr.query.qom.NodeNam
      * 
      * @see javax.jcr.query.qom.NodeLocalName#getSelectorName()
      */
-    @Override
     public String getSelectorName() {
         return selectorName().name();
     }

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/query/qom/JcrNodePath.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/query/qom/JcrNodePath.java
@@ -48,7 +48,6 @@ public class JcrNodePath extends NodePath implements org.modeshape.jcr.api.query
      * 
      * @see org.modeshape.jcr.api.query.qom.NodePath#getSelectorName()
      */
-    @Override
     public String getSelectorName() {
         return selectorName().name();
     }

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/query/qom/JcrNot.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/query/qom/JcrNot.java
@@ -54,7 +54,6 @@ public class JcrNot extends Not implements javax.jcr.query.qom.Not, JcrConstrain
      * 
      * @see javax.jcr.query.qom.Not#getConstraint()
      */
-    @Override
     public JcrConstraint getConstraint() {
         return constraint();
     }

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/query/qom/JcrOr.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/query/qom/JcrOr.java
@@ -66,7 +66,6 @@ public class JcrOr extends Or implements javax.jcr.query.qom.Or, JcrConstraint {
      * 
      * @see javax.jcr.query.qom.And#getConstraint1()
      */
-    @Override
     public JcrConstraint getConstraint1() {
         return left();
     }
@@ -76,7 +75,6 @@ public class JcrOr extends Or implements javax.jcr.query.qom.Or, JcrConstraint {
      * 
      * @see javax.jcr.query.qom.And#getConstraint2()
      */
-    @Override
     public JcrConstraint getConstraint2() {
         return right();
     }

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/query/qom/JcrOrdering.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/query/qom/JcrOrdering.java
@@ -61,7 +61,6 @@ public class JcrOrdering extends Ordering implements javax.jcr.query.qom.Orderin
      * 
      * @see javax.jcr.query.qom.Ordering#getOperand()
      */
-    @Override
     public JcrDynamicOperand getOperand() {
         return operand();
     }
@@ -71,7 +70,6 @@ public class JcrOrdering extends Ordering implements javax.jcr.query.qom.Orderin
      * 
      * @see javax.jcr.query.qom.Ordering#getOrder()
      */
-    @Override
     public String getOrder() {
         switch (order()) {
             case ASCENDING:

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/query/qom/JcrPropertyExistence.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/query/qom/JcrPropertyExistence.java
@@ -47,7 +47,6 @@ public class JcrPropertyExistence extends PropertyExistence implements javax.jcr
      * 
      * @see javax.jcr.query.qom.PropertyValue#getPropertyName()
      */
-    @Override
     public String getPropertyName() {
         return propertyName();
     }
@@ -57,7 +56,6 @@ public class JcrPropertyExistence extends PropertyExistence implements javax.jcr
      * 
      * @see javax.jcr.query.qom.PropertyValue#getSelectorName()
      */
-    @Override
     public String getSelectorName() {
         return selectorName().name();
     }

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/query/qom/JcrPropertyValue.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/query/qom/JcrPropertyValue.java
@@ -47,7 +47,6 @@ public class JcrPropertyValue extends PropertyValue implements javax.jcr.query.q
      * 
      * @see javax.jcr.query.qom.PropertyValue#getPropertyName()
      */
-    @Override
     public String getPropertyName() {
         return propertyName();
     }
@@ -57,7 +56,6 @@ public class JcrPropertyValue extends PropertyValue implements javax.jcr.query.q
      * 
      * @see javax.jcr.query.qom.PropertyValue#getSelectorName()
      */
-    @Override
     public String getSelectorName() {
         return selectorName().name();
     }

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/query/qom/JcrQueryObjectModel.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/query/qom/JcrQueryObjectModel.java
@@ -73,7 +73,6 @@ public class JcrQueryObjectModel extends JcrQuery implements QueryObjectModel {
      * 
      * @see javax.jcr.query.qom.QueryObjectModel#getSource()
      */
-    @Override
     public Source getSource() {
         return query().source();
     }
@@ -83,7 +82,6 @@ public class JcrQueryObjectModel extends JcrQuery implements QueryObjectModel {
      * 
      * @see javax.jcr.query.qom.QueryObjectModel#getConstraint()
      */
-    @Override
     public Constraint getConstraint() {
         return query().constraint();
     }
@@ -93,7 +91,6 @@ public class JcrQueryObjectModel extends JcrQuery implements QueryObjectModel {
      * 
      * @see javax.jcr.query.qom.QueryObjectModel#getColumns()
      */
-    @Override
     public Column[] getColumns() {
         return query().getColumns();
     }
@@ -103,7 +100,6 @@ public class JcrQueryObjectModel extends JcrQuery implements QueryObjectModel {
      * 
      * @see javax.jcr.query.qom.QueryObjectModel#getOrderings()
      */
-    @Override
     public Ordering[] getOrderings() {
         return query().getOrderings();
     }

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/query/qom/JcrQueryObjectModelFactory.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/query/qom/JcrQueryObjectModelFactory.java
@@ -103,7 +103,6 @@ public class JcrQueryObjectModelFactory implements org.modeshape.jcr.api.query.q
      * @see javax.jcr.query.qom.QueryObjectModelFactory#createQuery(javax.jcr.query.qom.Source, javax.jcr.query.qom.Constraint,
      *      javax.jcr.query.qom.Ordering[], javax.jcr.query.qom.Column[])
      */
-    @Override
     public JcrQueryObjectModel createQuery( Source source,
                                             Constraint constraint,
                                             Ordering[] orderings,
@@ -126,7 +125,6 @@ public class JcrQueryObjectModelFactory implements org.modeshape.jcr.api.query.q
      *      javax.jcr.query.qom.Constraint, javax.jcr.query.qom.Ordering[], javax.jcr.query.qom.Column[],
      *      org.modeshape.jcr.api.query.qom.Limit, boolean)
      */
-    @Override
     public JcrSelectQuery select( Source source,
                                   Constraint constraint,
                                   Ordering[] orderings,
@@ -161,7 +159,6 @@ public class JcrQueryObjectModelFactory implements org.modeshape.jcr.api.query.q
      * 
      * @see org.modeshape.jcr.api.query.qom.QueryObjectModelFactory#union(QueryCommand, QueryCommand, Ordering[], Limit, boolean)
      */
-    @Override
     public SetQuery union( QueryCommand left,
                            QueryCommand right,
                            Ordering[] orderings,
@@ -177,7 +174,6 @@ public class JcrQueryObjectModelFactory implements org.modeshape.jcr.api.query.q
      *      org.modeshape.jcr.api.query.qom.QueryCommand, javax.jcr.query.qom.Ordering[], org.modeshape.jcr.api.query.qom.Limit,
      *      boolean)
      */
-    @Override
     public SetQuery intersect( QueryCommand left,
                                QueryCommand right,
                                Ordering[] orderings,
@@ -193,7 +189,6 @@ public class JcrQueryObjectModelFactory implements org.modeshape.jcr.api.query.q
      *      org.modeshape.jcr.api.query.qom.QueryCommand, javax.jcr.query.qom.Ordering[], org.modeshape.jcr.api.query.qom.Limit,
      *      boolean)
      */
-    @Override
     public SetQuery except( QueryCommand left,
                             QueryCommand right,
                             Ordering[] orderings,
@@ -223,7 +218,6 @@ public class JcrQueryObjectModelFactory implements org.modeshape.jcr.api.query.q
      * 
      * @see javax.jcr.query.qom.QueryObjectModelFactory#selector(java.lang.String, java.lang.String)
      */
-    @Override
     public JcrNamedSelector selector( String nodeTypeName,
                                       String selectorName ) {
         CheckArg.isNotNull(nodeTypeName, "nodeTypeName");
@@ -236,7 +230,6 @@ public class JcrQueryObjectModelFactory implements org.modeshape.jcr.api.query.q
      * 
      * @see javax.jcr.query.qom.QueryObjectModelFactory#column(java.lang.String, java.lang.String, java.lang.String)
      */
-    @Override
     public JcrColumn column( String selectorName,
                              String propertyName,
                              String columnName ) {
@@ -253,7 +246,6 @@ public class JcrQueryObjectModelFactory implements org.modeshape.jcr.api.query.q
      * 
      * @see javax.jcr.query.qom.QueryObjectModelFactory#ascending(javax.jcr.query.qom.DynamicOperand)
      */
-    @Override
     public JcrOrdering ascending( DynamicOperand operand ) {
         JcrDynamicOperand jcrOperand = CheckArg.getInstanceOf(operand, JcrDynamicOperand.class, "operand");
         return new JcrOrdering(jcrOperand, Order.ASCENDING);
@@ -264,7 +256,6 @@ public class JcrQueryObjectModelFactory implements org.modeshape.jcr.api.query.q
      * 
      * @see javax.jcr.query.qom.QueryObjectModelFactory#descending(javax.jcr.query.qom.DynamicOperand)
      */
-    @Override
     public JcrOrdering descending( DynamicOperand operand ) {
         JcrDynamicOperand jcrOperand = CheckArg.getInstanceOf(operand, JcrDynamicOperand.class, "operand");
         return new JcrOrdering(jcrOperand, Order.DESCENDING);
@@ -275,7 +266,6 @@ public class JcrQueryObjectModelFactory implements org.modeshape.jcr.api.query.q
      * 
      * @see javax.jcr.query.qom.QueryObjectModelFactory#and(javax.jcr.query.qom.Constraint, javax.jcr.query.qom.Constraint)
      */
-    @Override
     public And and( Constraint constraint1,
                     Constraint constraint2 ) {
         JcrConstraint jcrConstraint1 = CheckArg.getInstanceOf(constraint1, JcrConstraint.class, "constraint1");
@@ -288,7 +278,6 @@ public class JcrQueryObjectModelFactory implements org.modeshape.jcr.api.query.q
      * 
      * @see javax.jcr.query.qom.QueryObjectModelFactory#bindVariable(java.lang.String)
      */
-    @Override
     public BindVariableValue bindVariable( String bindVariableName ) {
         CheckArg.isNotNull(bindVariableName, "bindVariableName");
         return new JcrBindVariableName(bindVariableName);
@@ -299,7 +288,6 @@ public class JcrQueryObjectModelFactory implements org.modeshape.jcr.api.query.q
      * 
      * @see javax.jcr.query.qom.QueryObjectModelFactory#childNode(java.lang.String, java.lang.String)
      */
-    @Override
     public ChildNode childNode( String selectorName,
                                 String path ) {
         CheckArg.isNotNull(selectorName, "selectorName");
@@ -312,7 +300,6 @@ public class JcrQueryObjectModelFactory implements org.modeshape.jcr.api.query.q
      * 
      * @see javax.jcr.query.qom.QueryObjectModelFactory#childNodeJoinCondition(java.lang.String, java.lang.String)
      */
-    @Override
     public ChildNodeJoinCondition childNodeJoinCondition( String childSelectorName,
                                                           String parentSelectorName ) {
         CheckArg.isNotNull(childSelectorName, "childSelectorName");
@@ -326,7 +313,6 @@ public class JcrQueryObjectModelFactory implements org.modeshape.jcr.api.query.q
      * @see javax.jcr.query.qom.QueryObjectModelFactory#comparison(javax.jcr.query.qom.DynamicOperand, java.lang.String,
      *      javax.jcr.query.qom.StaticOperand)
      */
-    @Override
     public Comparison comparison( DynamicOperand operand1,
                                   String operator,
                                   StaticOperand operand2 ) {
@@ -353,7 +339,6 @@ public class JcrQueryObjectModelFactory implements org.modeshape.jcr.api.query.q
      * 
      * @see javax.jcr.query.qom.QueryObjectModelFactory#descendantNode(java.lang.String, java.lang.String)
      */
-    @Override
     public DescendantNode descendantNode( String selectorName,
                                           String path ) {
         CheckArg.isNotNull(selectorName, "selectorName");
@@ -366,7 +351,6 @@ public class JcrQueryObjectModelFactory implements org.modeshape.jcr.api.query.q
      * 
      * @see javax.jcr.query.qom.QueryObjectModelFactory#descendantNodeJoinCondition(java.lang.String, java.lang.String)
      */
-    @Override
     public DescendantNodeJoinCondition descendantNodeJoinCondition( String descendantSelectorName,
                                                                     String ancestorSelectorName ) {
         CheckArg.isNotNull(descendantSelectorName, "descendantSelectorName");
@@ -380,7 +364,6 @@ public class JcrQueryObjectModelFactory implements org.modeshape.jcr.api.query.q
      * @see javax.jcr.query.qom.QueryObjectModelFactory#equiJoinCondition(java.lang.String, java.lang.String, java.lang.String,
      *      java.lang.String)
      */
-    @Override
     public EquiJoinCondition equiJoinCondition( String selector1Name,
                                                 String property1Name,
                                                 String selector2Name,
@@ -398,7 +381,6 @@ public class JcrQueryObjectModelFactory implements org.modeshape.jcr.api.query.q
      * @see javax.jcr.query.qom.QueryObjectModelFactory#fullTextSearch(java.lang.String, java.lang.String,
      *      javax.jcr.query.qom.StaticOperand)
      */
-    @Override
     public FullTextSearch fullTextSearch( String selectorName,
                                           String propertyName,
                                           StaticOperand fullTextSearchExpression ) throws RepositoryException {
@@ -412,7 +394,6 @@ public class JcrQueryObjectModelFactory implements org.modeshape.jcr.api.query.q
      * 
      * @see javax.jcr.query.qom.QueryObjectModelFactory#fullTextSearchScore(java.lang.String)
      */
-    @Override
     public FullTextSearchScore fullTextSearchScore( String selectorName ) {
         CheckArg.isNotNull(selectorName, "selectorName");
         return new JcrFullTextSearchScore(selectorName(selectorName));
@@ -424,7 +405,6 @@ public class JcrQueryObjectModelFactory implements org.modeshape.jcr.api.query.q
      * @see javax.jcr.query.qom.QueryObjectModelFactory#join(javax.jcr.query.qom.Source, javax.jcr.query.qom.Source,
      *      java.lang.String, javax.jcr.query.qom.JoinCondition)
      */
-    @Override
     public Join join( Source left,
                       Source right,
                       String joinType,
@@ -451,7 +431,6 @@ public class JcrQueryObjectModelFactory implements org.modeshape.jcr.api.query.q
      * 
      * @see javax.jcr.query.qom.QueryObjectModelFactory#length(javax.jcr.query.qom.PropertyValue)
      */
-    @Override
     public Length length( PropertyValue propertyValue ) {
         JcrPropertyValue jcrPropValue = CheckArg.getInstanceOf(propertyValue, JcrPropertyValue.class, "propertyValue");
         return new JcrLength(jcrPropValue);
@@ -462,7 +441,6 @@ public class JcrQueryObjectModelFactory implements org.modeshape.jcr.api.query.q
      * 
      * @see javax.jcr.query.qom.QueryObjectModelFactory#literal(javax.jcr.Value)
      */
-    @Override
     public Literal literal( Value literalValue ) throws RepositoryException {
         CheckArg.isNotNull(literalValue, "literalValue");
         return new JcrLiteral(literalValue);
@@ -473,7 +451,6 @@ public class JcrQueryObjectModelFactory implements org.modeshape.jcr.api.query.q
      * 
      * @see javax.jcr.query.qom.QueryObjectModelFactory#lowerCase(javax.jcr.query.qom.DynamicOperand)
      */
-    @Override
     public LowerCase lowerCase( DynamicOperand operand ) {
         JcrDynamicOperand jcrOperand = CheckArg.getInstanceOf(operand, JcrDynamicOperand.class, "operand");
         return new JcrLowerCase(jcrOperand);
@@ -484,7 +461,6 @@ public class JcrQueryObjectModelFactory implements org.modeshape.jcr.api.query.q
      * 
      * @see javax.jcr.query.qom.QueryObjectModelFactory#nodeLocalName(java.lang.String)
      */
-    @Override
     public NodeLocalName nodeLocalName( String selectorName ) {
         CheckArg.isNotNull(selectorName, "selectorName");
         return new JcrNodeLocalName(selectorName(selectorName));
@@ -495,7 +471,6 @@ public class JcrQueryObjectModelFactory implements org.modeshape.jcr.api.query.q
      * 
      * @see javax.jcr.query.qom.QueryObjectModelFactory#nodeName(java.lang.String)
      */
-    @Override
     public NodeName nodeName( String selectorName ) {
         CheckArg.isNotNull(selectorName, "selectorName");
         return new JcrNodeName(selectorName(selectorName));
@@ -506,7 +481,6 @@ public class JcrQueryObjectModelFactory implements org.modeshape.jcr.api.query.q
      * 
      * @see javax.jcr.query.qom.QueryObjectModelFactory#not(javax.jcr.query.qom.Constraint)
      */
-    @Override
     public Not not( Constraint constraint ) {
         JcrConstraint jcrConstraint = CheckArg.getInstanceOf(constraint, JcrConstraint.class, "constraint");
         return new JcrNot(jcrConstraint);
@@ -517,7 +491,6 @@ public class JcrQueryObjectModelFactory implements org.modeshape.jcr.api.query.q
      * 
      * @see javax.jcr.query.qom.QueryObjectModelFactory#or(javax.jcr.query.qom.Constraint, javax.jcr.query.qom.Constraint)
      */
-    @Override
     public Or or( Constraint constraint1,
                   Constraint constraint2 ) {
         JcrConstraint jcrConstraint1 = CheckArg.getInstanceOf(constraint1, JcrConstraint.class, "constraint1");
@@ -530,7 +503,6 @@ public class JcrQueryObjectModelFactory implements org.modeshape.jcr.api.query.q
      * 
      * @see javax.jcr.query.qom.QueryObjectModelFactory#propertyExistence(java.lang.String, java.lang.String)
      */
-    @Override
     public PropertyExistence propertyExistence( String selectorName,
                                                 String propertyName ) {
         CheckArg.isNotNull(selectorName, "selectorName");
@@ -543,7 +515,6 @@ public class JcrQueryObjectModelFactory implements org.modeshape.jcr.api.query.q
      * 
      * @see javax.jcr.query.qom.QueryObjectModelFactory#propertyValue(java.lang.String, java.lang.String)
      */
-    @Override
     public PropertyValue propertyValue( String selectorName,
                                         String propertyName ) {
         CheckArg.isNotNull(selectorName, "selectorName");
@@ -556,7 +527,6 @@ public class JcrQueryObjectModelFactory implements org.modeshape.jcr.api.query.q
      * 
      * @see javax.jcr.query.qom.QueryObjectModelFactory#sameNode(java.lang.String, java.lang.String)
      */
-    @Override
     public SameNode sameNode( String selectorName,
                               String path ) {
         CheckArg.isNotNull(selectorName, "selectorName");
@@ -570,7 +540,6 @@ public class JcrQueryObjectModelFactory implements org.modeshape.jcr.api.query.q
      * @see javax.jcr.query.qom.QueryObjectModelFactory#sameNodeJoinCondition(java.lang.String, java.lang.String,
      *      java.lang.String)
      */
-    @Override
     public SameNodeJoinCondition sameNodeJoinCondition( String selector1Name,
                                                         String selector2Name,
                                                         String selector2Path ) {
@@ -584,7 +553,6 @@ public class JcrQueryObjectModelFactory implements org.modeshape.jcr.api.query.q
      * 
      * @see javax.jcr.query.qom.QueryObjectModelFactory#upperCase(javax.jcr.query.qom.DynamicOperand)
      */
-    @Override
     public UpperCase upperCase( DynamicOperand operand ) {
         JcrDynamicOperand jcrOperand = CheckArg.getInstanceOf(operand, JcrDynamicOperand.class, "operand");
         return new JcrUpperCase(jcrOperand);
@@ -595,7 +563,6 @@ public class JcrQueryObjectModelFactory implements org.modeshape.jcr.api.query.q
      * 
      * @see org.modeshape.jcr.api.query.qom.QueryObjectModelFactory#nodePath(java.lang.String)
      */
-    @Override
     public NodePath nodePath( String selectorName ) {
         CheckArg.isNotNull(selectorName, "selectorName");
         return new JcrNodePath(selectorName(selectorName));
@@ -606,7 +573,6 @@ public class JcrQueryObjectModelFactory implements org.modeshape.jcr.api.query.q
      * 
      * @see org.modeshape.jcr.api.query.qom.QueryObjectModelFactory#nodeDepth(java.lang.String)
      */
-    @Override
     public NodeDepth nodeDepth( String selectorName ) {
         CheckArg.isNotNull(selectorName, "selectorName");
         return new JcrNodeDepth(selectorName(selectorName));
@@ -617,7 +583,6 @@ public class JcrQueryObjectModelFactory implements org.modeshape.jcr.api.query.q
      * 
      * @see org.modeshape.jcr.api.query.qom.QueryObjectModelFactory#limit(int, int)
      */
-    @Override
     public Limit limit( int rowLimit,
                         int offset ) {
         CheckArg.isPositive(rowLimit, "rowLimit");
@@ -631,7 +596,6 @@ public class JcrQueryObjectModelFactory implements org.modeshape.jcr.api.query.q
      * @see org.modeshape.jcr.api.query.qom.QueryObjectModelFactory#between(javax.jcr.query.qom.DynamicOperand,
      *      javax.jcr.query.qom.StaticOperand, javax.jcr.query.qom.StaticOperand, boolean, boolean)
      */
-    @Override
     public Between between( DynamicOperand operand,
                             StaticOperand lowerBound,
                             StaticOperand upperBound,
@@ -649,7 +613,6 @@ public class JcrQueryObjectModelFactory implements org.modeshape.jcr.api.query.q
      * @see org.modeshape.jcr.api.query.qom.QueryObjectModelFactory#in(javax.jcr.query.qom.DynamicOperand,
      *      javax.jcr.query.qom.StaticOperand[])
      */
-    @Override
     public SetCriteria in( DynamicOperand operand,
                            StaticOperand... values ) {
         JcrDynamicOperand jcrOperand = CheckArg.getInstanceOf(operand, JcrDynamicOperand.class, "operand");
@@ -666,7 +629,6 @@ public class JcrQueryObjectModelFactory implements org.modeshape.jcr.api.query.q
      * 
      * @see org.modeshape.jcr.api.query.qom.QueryObjectModelFactory#subquery(org.modeshape.jcr.api.query.qom.QueryCommand)
      */
-    @Override
     public Subquery subquery( QueryCommand subqueryCommand ) {
         JcrQueryCommand jcrCommand = CheckArg.getInstanceOf(subqueryCommand, JcrQueryCommand.class, "subqueryCommand");
         return new JcrSubquery(jcrCommand);
@@ -678,7 +640,6 @@ public class JcrQueryObjectModelFactory implements org.modeshape.jcr.api.query.q
      * @see org.modeshape.jcr.api.query.qom.QueryObjectModelFactory#add(javax.jcr.query.qom.DynamicOperand,
      *      javax.jcr.query.qom.DynamicOperand)
      */
-    @Override
     public ArithmeticOperand add( DynamicOperand left,
                                   DynamicOperand right ) {
         return arithmeticOperand(left, ArithmeticOperator.ADD, right);
@@ -690,7 +651,6 @@ public class JcrQueryObjectModelFactory implements org.modeshape.jcr.api.query.q
      * @see org.modeshape.jcr.api.query.qom.QueryObjectModelFactory#subtract(javax.jcr.query.qom.DynamicOperand,
      *      javax.jcr.query.qom.DynamicOperand)
      */
-    @Override
     public ArithmeticOperand subtract( DynamicOperand left,
                                        DynamicOperand right ) {
         return arithmeticOperand(left, ArithmeticOperator.SUBTRACT, right);
@@ -702,7 +662,6 @@ public class JcrQueryObjectModelFactory implements org.modeshape.jcr.api.query.q
      * @see org.modeshape.jcr.api.query.qom.QueryObjectModelFactory#multiply(javax.jcr.query.qom.DynamicOperand,
      *      javax.jcr.query.qom.DynamicOperand)
      */
-    @Override
     public ArithmeticOperand multiply( DynamicOperand left,
                                        DynamicOperand right ) {
         return arithmeticOperand(left, ArithmeticOperator.MULTIPLY, right);
@@ -714,7 +673,6 @@ public class JcrQueryObjectModelFactory implements org.modeshape.jcr.api.query.q
      * @see org.modeshape.jcr.api.query.qom.QueryObjectModelFactory#divide(javax.jcr.query.qom.DynamicOperand,
      *      javax.jcr.query.qom.DynamicOperand)
      */
-    @Override
     public ArithmeticOperand divide( DynamicOperand left,
                                      DynamicOperand right ) {
         return arithmeticOperand(left, ArithmeticOperator.DIVIDE, right);
@@ -733,7 +691,6 @@ public class JcrQueryObjectModelFactory implements org.modeshape.jcr.api.query.q
      * 
      * @see org.modeshape.jcr.api.query.qom.QueryObjectModelFactory#referenceValue(java.lang.String)
      */
-    @Override
     public JcrReferenceValue referenceValue( String selectorName ) {
         return new JcrReferenceValue(selectorName(selectorName), null);
     }
@@ -743,7 +700,6 @@ public class JcrQueryObjectModelFactory implements org.modeshape.jcr.api.query.q
      * 
      * @see org.modeshape.jcr.api.query.qom.QueryObjectModelFactory#referenceValue(java.lang.String, java.lang.String)
      */
-    @Override
     public JcrReferenceValue referenceValue( String selectorName,
                                              String propertyName ) {
         return new JcrReferenceValue(selectorName(selectorName), propertyName);

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/query/qom/JcrReferenceValue.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/query/qom/JcrReferenceValue.java
@@ -52,7 +52,6 @@ public class JcrReferenceValue extends ReferenceValue
      * 
      * @see javax.jcr.query.qom.PropertyValue#getPropertyName()
      */
-    @Override
     public String getPropertyName() {
         return propertyName();
     }
@@ -62,7 +61,6 @@ public class JcrReferenceValue extends ReferenceValue
      * 
      * @see javax.jcr.query.qom.PropertyValue#getSelectorName()
      */
-    @Override
     public String getSelectorName() {
         return selectorName().name();
     }

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/query/qom/JcrSameNode.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/query/qom/JcrSameNode.java
@@ -47,7 +47,6 @@ public class JcrSameNode extends SameNode implements javax.jcr.query.qom.SameNod
      * 
      * @see javax.jcr.query.qom.SameNode#getPath()
      */
-    @Override
     public String getPath() {
         return path();
     }
@@ -57,7 +56,6 @@ public class JcrSameNode extends SameNode implements javax.jcr.query.qom.SameNod
      * 
      * @see javax.jcr.query.qom.PropertyValue#getSelectorName()
      */
-    @Override
     public String getSelectorName() {
         return selectorName().name();
     }

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/query/qom/JcrSameNodeJoinCondition.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/query/qom/JcrSameNodeJoinCondition.java
@@ -66,7 +66,6 @@ public class JcrSameNodeJoinCondition extends SameNodeJoinCondition
      * 
      * @see javax.jcr.query.qom.SameNodeJoinCondition#getSelector2Path()
      */
-    @Override
     public String getSelector2Path() {
         return selector2Path();
     }
@@ -76,7 +75,6 @@ public class JcrSameNodeJoinCondition extends SameNodeJoinCondition
      * 
      * @see javax.jcr.query.qom.SameNodeJoinCondition#getSelector1Name()
      */
-    @Override
     public String getSelector1Name() {
         return selector1Name().name();
     }
@@ -86,7 +84,6 @@ public class JcrSameNodeJoinCondition extends SameNodeJoinCondition
      * 
      * @see javax.jcr.query.qom.SameNodeJoinCondition#getSelector2Name()
      */
-    @Override
     public String getSelector2Name() {
         return selector2Name().name();
     }

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/query/qom/JcrSelectQuery.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/query/qom/JcrSelectQuery.java
@@ -116,7 +116,6 @@ public class JcrSelectQuery extends Query implements org.modeshape.jcr.api.query
      * 
      * @see org.modeshape.jcr.api.query.qom.SelectQuery#getConstraint()
      */
-    @Override
     public Constraint getConstraint() {
         return constraint();
     }
@@ -126,7 +125,6 @@ public class JcrSelectQuery extends Query implements org.modeshape.jcr.api.query
      * 
      * @see org.modeshape.jcr.api.query.qom.SelectQuery#getSource()
      */
-    @Override
     public Source getSource() {
         return source();
     }
@@ -136,7 +134,6 @@ public class JcrSelectQuery extends Query implements org.modeshape.jcr.api.query
      * 
      * @see org.modeshape.jcr.api.query.qom.QueryCommand#getLimits()
      */
-    @Override
     public Limit getLimits() {
         return limits();
     }
@@ -146,7 +143,6 @@ public class JcrSelectQuery extends Query implements org.modeshape.jcr.api.query
      * 
      * @see org.modeshape.jcr.api.query.qom.QueryCommand#getColumns()
      */
-    @Override
     public Column[] getColumns() {
         List<? extends JcrColumn> columns = columns();
         return columns.toArray(new Column[columns.size()]);
@@ -157,7 +153,6 @@ public class JcrSelectQuery extends Query implements org.modeshape.jcr.api.query
      * 
      * @see org.modeshape.jcr.api.query.qom.QueryCommand#getOrderings()
      */
-    @Override
     public Ordering[] getOrderings() {
         List<? extends JcrOrdering> orderings = orderings();
         return orderings.toArray(new Ordering[orderings.size()]);

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/query/qom/JcrSetCriteria.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/query/qom/JcrSetCriteria.java
@@ -56,7 +56,6 @@ public class JcrSetCriteria extends SetCriteria implements JcrConstraint, org.mo
      * 
      * @see org.modeshape.jcr.api.query.qom.SetCriteria#getOperand()
      */
-    @Override
     public javax.jcr.query.qom.DynamicOperand getOperand() {
         return (JcrDynamicOperand)super.leftOperand();
     }
@@ -67,7 +66,6 @@ public class JcrSetCriteria extends SetCriteria implements JcrConstraint, org.mo
      * @see org.modeshape.jcr.api.query.qom.SetCriteria#getValues()
      */
     @SuppressWarnings( "unchecked" )
-    @Override
     public Collection<? extends javax.jcr.query.qom.StaticOperand> getValues() {
         return (Collection<JcrStaticOperand>)super.rightOperands();
     }

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/query/qom/JcrSetQuery.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/query/qom/JcrSetQuery.java
@@ -130,7 +130,6 @@ public class JcrSetQuery extends SetQuery implements org.modeshape.jcr.api.query
      * 
      * @see org.modeshape.jcr.api.query.qom.QueryCommand#getLimits()
      */
-    @Override
     public Limit getLimits() {
         return limits();
     }
@@ -140,7 +139,6 @@ public class JcrSetQuery extends SetQuery implements org.modeshape.jcr.api.query
      * 
      * @see org.modeshape.jcr.api.query.qom.SetQuery#getLeft()
      */
-    @Override
     public JcrQueryCommand getLeft() {
         return left();
     }
@@ -150,7 +148,6 @@ public class JcrSetQuery extends SetQuery implements org.modeshape.jcr.api.query
      * 
      * @see org.modeshape.jcr.api.query.qom.SetQuery#getRight()
      */
-    @Override
     public JcrQueryCommand getRight() {
         return right();
     }
@@ -160,7 +157,6 @@ public class JcrSetQuery extends SetQuery implements org.modeshape.jcr.api.query
      * 
      * @see org.modeshape.jcr.api.query.qom.SetQuery#getOperation()
      */
-    @Override
     public String getOperation() {
         switch (operation()) {
             case UNION:
@@ -179,7 +175,6 @@ public class JcrSetQuery extends SetQuery implements org.modeshape.jcr.api.query
      * 
      * @see org.modeshape.jcr.api.query.qom.QueryCommand#getColumns()
      */
-    @Override
     public Column[] getColumns() {
         List<? extends JcrColumn> columns = columns();
         return columns.toArray(new Column[columns.size()]);
@@ -190,7 +185,6 @@ public class JcrSetQuery extends SetQuery implements org.modeshape.jcr.api.query
      * 
      * @see org.modeshape.jcr.api.query.qom.QueryCommand#getOrderings()
      */
-    @Override
     public Ordering[] getOrderings() {
         List<? extends JcrOrdering> orderings = orderings();
         return orderings.toArray(new Ordering[orderings.size()]);

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/query/qom/JcrSetQueryObjectModel.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/query/qom/JcrSetQueryObjectModel.java
@@ -73,7 +73,6 @@ public class JcrSetQueryObjectModel extends JcrQuery implements SetQueryObjectMo
      * 
      * @see org.modeshape.jcr.api.query.qom.SetQuery#getLeft()
      */
-    @Override
     public org.modeshape.jcr.api.query.qom.QueryCommand getLeft() {
         return query().getLeft();
     }
@@ -83,7 +82,6 @@ public class JcrSetQueryObjectModel extends JcrQuery implements SetQueryObjectMo
      * 
      * @see org.modeshape.jcr.api.query.qom.SetQuery#getRight()
      */
-    @Override
     public org.modeshape.jcr.api.query.qom.QueryCommand getRight() {
         return query().getRight();
     }
@@ -93,7 +91,6 @@ public class JcrSetQueryObjectModel extends JcrQuery implements SetQueryObjectMo
      * 
      * @see org.modeshape.jcr.api.query.qom.SetQuery#isAll()
      */
-    @Override
     public boolean isAll() {
         return query().isAll();
     }
@@ -103,7 +100,6 @@ public class JcrSetQueryObjectModel extends JcrQuery implements SetQueryObjectMo
      * 
      * @see org.modeshape.jcr.api.query.qom.QueryCommand#getLimits()
      */
-    @Override
     public Limit getLimits() {
         return query().getLimits();
     }
@@ -113,7 +109,6 @@ public class JcrSetQueryObjectModel extends JcrQuery implements SetQueryObjectMo
      * 
      * @see org.modeshape.jcr.api.query.qom.SetQuery#getOperation()
      */
-    @Override
     public String getOperation() {
         return query().getOperation();
     }
@@ -123,7 +118,6 @@ public class JcrSetQueryObjectModel extends JcrQuery implements SetQueryObjectMo
      * 
      * @see javax.jcr.query.qom.QueryObjectModel#getColumns()
      */
-    @Override
     public Column[] getColumns() {
         return query().getColumns();
     }
@@ -133,7 +127,6 @@ public class JcrSetQueryObjectModel extends JcrQuery implements SetQueryObjectMo
      * 
      * @see javax.jcr.query.qom.QueryObjectModel#getOrderings()
      */
-    @Override
     public Ordering[] getOrderings() {
         return query().getOrderings();
     }

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/query/qom/JcrSubquery.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/query/qom/JcrSubquery.java
@@ -45,7 +45,6 @@ public class JcrSubquery extends Subquery implements JcrStaticOperand, org.modes
      * 
      * @see org.modeshape.jcr.api.query.qom.Subquery#getQuery()
      */
-    @Override
     public QueryCommand getQuery() {
         return (JcrQueryCommand)query();
     }

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/query/qom/JcrUpperCase.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/query/qom/JcrUpperCase.java
@@ -44,7 +44,6 @@ public class JcrUpperCase extends UpperCase implements javax.jcr.query.qom.Upper
      * 
      * @see javax.jcr.query.qom.LowerCase#getOperand()
      */
-    @Override
     public JcrDynamicOperand getOperand() {
         return (JcrDynamicOperand)operand();
     }

--- a/modeshape-jcr/src/test/java/org/modeshape/jcr/AbstractJcrTest.java
+++ b/modeshape-jcr/src/test/java/org/modeshape/jcr/AbstractJcrTest.java
@@ -151,7 +151,6 @@ public abstract class AbstractJcrTest {
         cache = new SessionCache(jcrSession, store.getCurrentWorkspaceName(), context, nodeTypes, store);
 
         when(jcrSession.getNodeByIdentifier(anyString())).thenAnswer(new Answer<AbstractJcrNode>() {
-            @Override
             public AbstractJcrNode answer( InvocationOnMock invocation ) throws Throwable {
                 String uuidStr = invocation.getArguments()[0].toString();
                 Location location = Location.create(UUID.fromString(uuidStr));

--- a/modeshape-jcr/src/test/java/org/modeshape/jcr/query/JcrSql2QueryParserTest.java
+++ b/modeshape-jcr/src/test/java/org/modeshape/jcr/query/JcrSql2QueryParserTest.java
@@ -544,88 +544,71 @@ public class JcrSql2QueryParserTest {
             this.delegate = this.executionContext.getValueFactories().getTypeSystem();
         }
 
-        @Override
         public Set<String> getTypeNames() {
             return delegate.getTypeNames();
         }
 
-        @Override
         public TypeFactory<?> getTypeFactory( Object prototype ) {
             return delegate.getTypeFactory(prototype);
         }
 
-        @Override
         public TypeFactory<?> getTypeFactory( String typeName ) {
             return delegate.getTypeFactory(typeName);
         }
 
-        @Override
         public TypeFactory<String> getStringFactory() {
             return delegate.getStringFactory();
         }
 
-        @Override
         public TypeFactory<?> getReferenceFactory() {
             return delegate.getReferenceFactory();
         }
 
-        @Override
         public TypeFactory<?> getPathFactory() {
             return delegate.getPathFactory();
         }
 
-        @Override
         public TypeFactory<Long> getLongFactory() {
             return delegate.getLongFactory();
         }
 
-        @Override
         public TypeFactory<Double> getDoubleFactory() {
             return delegate.getDoubleFactory();
         }
 
-        @Override
         public String getDefaultType() {
             return delegate.getDefaultType();
         }
 
-        @Override
         public Comparator<Object> getDefaultComparator() {
             return delegate.getDefaultComparator();
         }
 
-        @Override
         public TypeFactory<BigDecimal> getDecimalFactory() {
             return delegate.getDecimalFactory();
         }
 
-        @Override
         public TypeFactory<?> getDateTimeFactory() {
             return delegate.getDateTimeFactory();
         }
 
-        @Override
         public String getCompatibleType( String type1,
                                          String type2 ) {
             return delegate.getCompatibleType(type1, type2);
         }
 
-        @Override
         public TypeFactory<Boolean> getBooleanFactory() {
             return delegate.getBooleanFactory();
         }
 
-        @Override
         public TypeFactory<?> getBinaryFactory() {
             return delegate.getBinaryFactory();
         }
 
-        @Override
         public String asString( Object value ) {
             return delegate.asString(value);
         }
 
-        @Override
         public ValueFactory getValueFactory() {
             return valueFactory;
         }

--- a/modeshape-repository/src/main/java/org/modeshape/repository/ModeShapeConfiguration.java
+++ b/modeshape-repository/src/main/java/org/modeshape/repository/ModeShapeConfiguration.java
@@ -1238,6 +1238,7 @@ public class ModeShapeConfiguration {
          * 
          * @see org.modeshape.repository.ModeShapeConfiguration.Returnable#and()
          */
+        @Override
         public ReturnType and() {
             return returnObject;
         }
@@ -1340,10 +1341,12 @@ public class ModeShapeConfiguration {
             return path.getLastSegment().getName().getString(context.getNamespaceRegistry());
         }
 
+        @Override
         public ThisType setDescription( String description ) {
             return setProperty(ModeShapeLexicon.DESCRIPTION, description);
         }
 
+        @Override
         public String getDescription() {
             Property property = getProperty(ModeShapeLexicon.DESCRIPTION);
             if (property != null && !property.isEmpty()) {
@@ -1361,6 +1364,7 @@ public class ModeShapeConfiguration {
             return thisType();
         }
 
+        @Override
         public ThisType setProperty( String propertyName,
                                      Object value ) {
             return setProperty(context.getValueFactories().getNameFactory().create(propertyName), value);
@@ -1375,46 +1379,55 @@ public class ModeShapeConfiguration {
             return thisType();
         }
 
+        @Override
         public ThisType setProperty( String propertyName,
                                      Object[] values ) {
             return setProperty(context.getValueFactories().getNameFactory().create(propertyName), values);
         }
 
+        @Override
         public ThisType setProperty( String beanPropertyName,
                                      boolean value ) {
             return setProperty(beanPropertyName, (Object)value);
         }
 
+        @Override
         public ThisType setProperty( String beanPropertyName,
                                      int value ) {
             return setProperty(beanPropertyName, (Object)value);
         }
 
+        @Override
         public ThisType setProperty( String beanPropertyName,
                                      short value ) {
             return setProperty(beanPropertyName, (Object)value);
         }
 
+        @Override
         public ThisType setProperty( String beanPropertyName,
                                      long value ) {
             return setProperty(beanPropertyName, (Object)value);
         }
 
+        @Override
         public ThisType setProperty( String beanPropertyName,
                                      double value ) {
             return setProperty(beanPropertyName, (Object)value);
         }
 
+        @Override
         public ThisType setProperty( String beanPropertyName,
                                      float value ) {
             return setProperty(beanPropertyName, (Object)value);
         }
 
+        @Override
         public ThisType setProperty( String beanPropertyName,
                                      String value ) {
             return setProperty(beanPropertyName, (Object)value);
         }
 
+        @Override
         public ThisType setProperty( String beanPropertyName,
                                      String firstValue,
                                      String... additionalValues ) {
@@ -1424,6 +1437,7 @@ public class ModeShapeConfiguration {
             return setProperty(beanPropertyName, values);
         }
 
+        @Override
         public Property getProperty( String beanPropertyName ) {
             return properties.get(context.getValueFactories().getNameFactory().create(beanPropertyName));
         }
@@ -1432,6 +1446,7 @@ public class ModeShapeConfiguration {
             return properties.get(beanPropertyName);
         }
 
+        @Override
         public ReturnType remove() {
             batch.delete(path);
             properties.clear();
@@ -1455,12 +1470,15 @@ public class ModeShapeConfiguration {
             super(returnObject, batch, path, names);
         }
 
+        @Override
         public LoadedFrom<ThisType> usingClass( final String classname ) {
             return new LoadedFrom<ThisType>() {
+                @Override
                 public ThisType loadedFromClasspath() {
                     return setProperty(ModeShapeLexicon.CLASSNAME, classname);
                 }
 
+                @Override
                 public ThisType loadedFrom( String... classpath ) {
                     List<String> classpaths = new ArrayList<String>();
                     // Ignore any null, zero-length, or duplicate elements ...
@@ -1479,6 +1497,7 @@ public class ModeShapeConfiguration {
             };
         }
 
+        @Override
         public ThisType usingClass( Class<? extends ComponentType> componentClass ) {
             return setProperty(ModeShapeLexicon.CLASSNAME, componentClass.getCanonicalName());
         }
@@ -1533,6 +1552,7 @@ public class ModeShapeConfiguration {
             return this;
         }
 
+        @Override
         public RepositorySourceDefinition<ReturnType> setRetryLimit( int retryLimit ) {
             return setProperty(ModeShapeLexicon.RETRY_LIMIT, retryLimit);
         }
@@ -1572,6 +1592,7 @@ public class ModeShapeConfiguration {
             return this;
         }
 
+        @Override
         public Set<PathExpression> getPathExpressions() {
             Set<PathExpression> expressions = new HashSet<PathExpression>();
             try {
@@ -1588,6 +1609,7 @@ public class ModeShapeConfiguration {
             return expressions;
         }
 
+        @Override
         public SequencerDefinition<ReturnType> sequencingFrom( PathExpression expression ) {
             CheckArg.isNotNull(expression, "expression");
             Set<PathExpression> compiledExpressions = getPathExpressions();
@@ -1601,9 +1623,11 @@ public class ModeShapeConfiguration {
             return this;
         }
 
+        @Override
         public PathExpressionOutput<ReturnType> sequencingFrom( final String fromPathExpression ) {
             CheckArg.isNotEmpty(fromPathExpression, "fromPathExpression");
             return new PathExpressionOutput<ReturnType>() {
+                @Override
                 public SequencerDefinition<ReturnType> andOutputtingTo( String into ) {
                     CheckArg.isNotEmpty(into, "into");
                     return sequencingFrom(PathExpression.compile(fromPathExpression + " => " + into));

--- a/modeshape-repository/src/main/java/org/modeshape/repository/ModeShapeEngine.java
+++ b/modeshape-repository/src/main/java/org/modeshape/repository/ModeShapeEngine.java
@@ -401,6 +401,7 @@ public class ModeShapeEngine {
         }
 
         final Runnable gcTask = new Runnable() {
+            @Override
             public void run() {
                 getRepositoryService().runGarbageCollection(null); // log problems as errors
             }

--- a/modeshape-repository/src/main/java/org/modeshape/repository/RepositoryLibrary.java
+++ b/modeshape-repository/src/main/java/org/modeshape/repository/RepositoryLibrary.java
@@ -89,6 +89,7 @@ public class RepositoryLibrary implements RepositoryConnectionFactory, Observabl
         /**
          * {@inheritDoc}
          */
+        @Override
         public boolean awaitTermination( long timeout,
                                          TimeUnit unit ) throws InterruptedException {
             return RepositoryLibrary.this.awaitTermination(timeout, unit);
@@ -176,6 +177,7 @@ public class RepositoryLibrary implements RepositoryConnectionFactory, Observabl
      * 
      * @see org.modeshape.graph.observe.Observable#register(org.modeshape.graph.observe.Observer)
      */
+    @Override
     public boolean register( Observer observer ) {
         if (observer == null) return false;
         return observationBus.register(observer);
@@ -189,6 +191,7 @@ public class RepositoryLibrary implements RepositoryConnectionFactory, Observabl
      * 
      * @see org.modeshape.graph.observe.Observable#unregister(org.modeshape.graph.observe.Observer)
      */
+    @Override
     public boolean unregister( Observer observer ) {
         return observationBus.unregister(observer);
     }
@@ -405,6 +408,7 @@ public class RepositoryLibrary implements RepositoryConnectionFactory, Observabl
              * 
              * @see org.modeshape.graph.connector.RepositoryContext#getExecutionContext()
              */
+            @Override
             public ExecutionContext getExecutionContext() {
                 return RepositoryLibrary.this.getExecutionContext();
             }
@@ -414,6 +418,7 @@ public class RepositoryLibrary implements RepositoryConnectionFactory, Observabl
              * 
              * @see org.modeshape.graph.connector.RepositoryContext#getRepositoryConnectionFactory()
              */
+            @Override
             public RepositoryConnectionFactory getRepositoryConnectionFactory() {
                 return RepositoryLibrary.this;
             }
@@ -423,6 +428,7 @@ public class RepositoryLibrary implements RepositoryConnectionFactory, Observabl
              * 
              * @see org.modeshape.graph.connector.RepositoryContext#getObserver()
              */
+            @Override
             public Observer getObserver() {
                 return observationBus.hasObservers() ? observationBus : null;
             }
@@ -432,6 +438,7 @@ public class RepositoryLibrary implements RepositoryConnectionFactory, Observabl
              * 
              * @see org.modeshape.graph.connector.RepositoryContext#getConfiguration(int)
              */
+            @Override
             public Subgraph getConfiguration( int depth ) {
                 Subgraph result = null;
                 RepositorySource configSource = getConfigurationSource();
@@ -551,6 +558,7 @@ public class RepositoryLibrary implements RepositoryConnectionFactory, Observabl
      * 
      * @see org.modeshape.graph.connector.RepositoryConnectionFactory#createConnection(java.lang.String)
      */
+    @Override
     public RepositoryConnection createConnection( String sourceName ) {
         try {
             this.sourcesLock.readLock().lock();

--- a/modeshape-repository/src/main/java/org/modeshape/repository/RepositoryService.java
+++ b/modeshape-repository/src/main/java/org/modeshape/repository/RepositoryService.java
@@ -114,6 +114,7 @@ public class RepositoryService implements AdministeredService, Observer {
          * 
          * @see org.modeshape.repository.service.ServiceAdministrator#awaitTermination(long, java.util.concurrent.TimeUnit)
          */
+        @Override
         public boolean awaitTermination( long timeout,
                                          TimeUnit unit ) {
             return true;
@@ -174,6 +175,7 @@ public class RepositoryService implements AdministeredService, Observer {
     /**
      * {@inheritDoc}
      */
+    @Override
     public final ServiceAdministrator getAdministrator() {
         return this.administrator;
     }
@@ -540,6 +542,7 @@ public class RepositoryService implements AdministeredService, Observer {
      * 
      * @see org.modeshape.graph.observe.Observer#notify(org.modeshape.graph.observe.Changes)
      */
+    @Override
     public void notify( Changes changes ) {
         // Forward the changes to the net change observer ...
         this.configurationChangeObserver.notify(changes);

--- a/modeshape-repository/src/main/java/org/modeshape/repository/SimpleRepositoryContext.java
+++ b/modeshape-repository/src/main/java/org/modeshape/repository/SimpleRepositoryContext.java
@@ -54,6 +54,7 @@ public class SimpleRepositoryContext implements RepositoryContext {
      * 
      * @see org.modeshape.graph.connector.RepositoryContext#getConfiguration(int)
      */
+    @Override
     public Subgraph getConfiguration( int depth ) {
         return null;
     }
@@ -63,6 +64,7 @@ public class SimpleRepositoryContext implements RepositoryContext {
      * 
      * @see org.modeshape.graph.connector.RepositoryContext#getExecutionContext()
      */
+    @Override
     public ExecutionContext getExecutionContext() {
         return context;
     }
@@ -72,6 +74,7 @@ public class SimpleRepositoryContext implements RepositoryContext {
      * 
      * @see org.modeshape.graph.connector.RepositoryContext#getObserver()
      */
+    @Override
     public Observer getObserver() {
         return observer;
     }
@@ -81,6 +84,7 @@ public class SimpleRepositoryContext implements RepositoryContext {
      * 
      * @see org.modeshape.graph.connector.RepositoryContext#getRepositoryConnectionFactory()
      */
+    @Override
     public RepositoryConnectionFactory getRepositoryConnectionFactory() {
         return connectionFactory;
     }

--- a/modeshape-repository/src/main/java/org/modeshape/repository/cluster/ClusteringService.java
+++ b/modeshape-repository/src/main/java/org/modeshape/repository/cluster/ClusteringService.java
@@ -80,6 +80,7 @@ public class ClusteringService implements AdministeredService, ObservationBus {
         /**
          * {@inheritDoc}
          */
+        @Override
         public boolean awaitTermination( long timeout,
                                          TimeUnit unit ) {
             return true; // nothing to wait for

--- a/modeshape-repository/src/main/java/org/modeshape/repository/sequencer/SequencerOutputMap.java
+++ b/modeshape-repository/src/main/java/org/modeshape/repository/sequencer/SequencerOutputMap.java
@@ -64,6 +64,7 @@ public class SequencerOutputMap implements SequencerOutput, Iterable<SequencerOu
     /**
      * {@inheritDoc}
      */
+    @Override
     public void setProperty( Path nodePath,
                              Name propertyName,
                              Object... values ) {
@@ -95,6 +96,7 @@ public class SequencerOutputMap implements SequencerOutput, Iterable<SequencerOu
      *             mappings for the given URIs in the name components of the nodePath and propertyName to be mapped in the
      *             NamespaceRegistry of the ModeShapeEngine's (or JcrEngine's) ExecutionContext.
      */
+    @Override
     @Deprecated
     public void setProperty( String nodePath,
                              String property,
@@ -114,6 +116,7 @@ public class SequencerOutputMap implements SequencerOutput, Iterable<SequencerOu
      *             mappings for the given URIs in the name components of the nodePath and propertyName to be mapped in the
      *             NamespaceRegistry of the ModeShapeEngine's (or JcrEngine's) ExecutionContext.
      */
+    @Override
     @Deprecated
     public void setReference( String nodePath,
                               String propertyName,
@@ -169,6 +172,7 @@ public class SequencerOutputMap implements SequencerOutput, Iterable<SequencerOu
      * <p>
      * {@inheritDoc}
      */
+    @Override
     public Iterator<Entry> iterator() {
         // LinkedList<Path> paths = new LinkedList<Path>(data.keySet());
         // Collections.sort(paths);
@@ -252,6 +256,7 @@ public class SequencerOutputMap implements SequencerOutput, Iterable<SequencerOu
         /**
          * {@inheritDoc}
          */
+        @Override
         public int compareTo( PropertyValue that ) {
             if (this == that) return 0;
             if (this.name.equals(JcrLexicon.PRIMARY_TYPE)) return -1;
@@ -355,6 +360,7 @@ public class SequencerOutputMap implements SequencerOutput, Iterable<SequencerOu
         /**
          * {@inheritDoc}
          */
+        @Override
         public boolean hasNext() {
             return iter.hasNext();
         }
@@ -362,6 +368,7 @@ public class SequencerOutputMap implements SequencerOutput, Iterable<SequencerOu
         /**
          * {@inheritDoc}
          */
+        @Override
         public Entry next() {
             this.last = iter.next();
             return new Entry(last, getProperties(last));
@@ -370,6 +377,7 @@ public class SequencerOutputMap implements SequencerOutput, Iterable<SequencerOu
         /**
          * {@inheritDoc}
          */
+        @Override
         public void remove() {
             if (last == null) throw new IllegalStateException();
             try {

--- a/modeshape-repository/src/main/java/org/modeshape/repository/sequencer/SequencingService.java
+++ b/modeshape-repository/src/main/java/org/modeshape/repository/sequencer/SequencingService.java
@@ -99,6 +99,7 @@ public class SequencingService implements AdministeredService {
      */
     protected static class DefaultSelector implements Selector {
 
+        @Override
         public List<Sequencer> selectSequencers( List<Sequencer> sequencers,
                                                  Node node,
                                                  NetChange nodeChange ) {
@@ -160,6 +161,7 @@ public class SequencingService implements AdministeredService {
         /**
          * {@inheritDoc}
          */
+        @Override
         public boolean awaitTermination( long timeout,
                                          TimeUnit unit ) throws InterruptedException {
             return doAwaitTermination(timeout, unit);
@@ -191,6 +193,7 @@ public class SequencingService implements AdministeredService {
      * 
      * @return the administrative component; never null
      */
+    @Override
     public ServiceAdministrator getAdministrator() {
         return this.administrator;
     }
@@ -653,6 +656,7 @@ public class SequencingService implements AdministeredService {
             try {
                 getExecutorService().execute(new Runnable() {
 
+                    @Override
                     public void run() {
                         processChange(netChanges);
                     }

--- a/modeshape-repository/src/main/java/org/modeshape/repository/sequencer/StreamSequencerAdapter.java
+++ b/modeshape-repository/src/main/java/org/modeshape/repository/sequencer/StreamSequencerAdapter.java
@@ -89,6 +89,7 @@ public class StreamSequencerAdapter implements Sequencer {
     /**
      * {@inheritDoc}
      */
+    @Override
     public SequencerConfig getConfiguration() {
         return this.configuration;
     }
@@ -96,6 +97,7 @@ public class StreamSequencerAdapter implements Sequencer {
     /**
      * {@inheritDoc}
      */
+    @Override
     public void setConfiguration( SequencerConfig configuration ) {
         this.configuration = configuration;
 
@@ -141,6 +143,7 @@ public class StreamSequencerAdapter implements Sequencer {
     /**
      * {@inheritDoc}
      */
+    @Override
     public void execute( Node input,
                          String sequencedPropertyName,
                          NetChange changes,

--- a/modeshape-repository/src/main/java/org/modeshape/repository/service/AbstractServiceAdministrator.java
+++ b/modeshape-repository/src/main/java/org/modeshape/repository/service/AbstractServiceAdministrator.java
@@ -55,6 +55,7 @@ public abstract class AbstractServiceAdministrator implements ServiceAdministrat
      * 
      * @return the current state
      */
+    @Override
     public State getState() {
         return this.state;
     }
@@ -69,6 +70,7 @@ public abstract class AbstractServiceAdministrator implements ServiceAdministrat
      * @see #pause()
      * @see #shutdown()
      */
+    @Override
     @GuardedBy( "this" )
     public synchronized ServiceAdministrator setState( State state ) {
         switch (state) {
@@ -98,6 +100,7 @@ public abstract class AbstractServiceAdministrator implements ServiceAdministrat
      * @see #pause()
      * @see #shutdown()
      */
+    @Override
     public ServiceAdministrator setState( String state ) {
         State newState = state == null ? null : State.valueOf(state.toUpperCase());
         if (newState == null) {
@@ -116,6 +119,7 @@ public abstract class AbstractServiceAdministrator implements ServiceAdministrat
      * @see #shutdown()
      * @see #isStarted()
      */
+    @Override
     public synchronized ServiceAdministrator start() {
         switch (this.state) {
             case STARTED:
@@ -155,6 +159,7 @@ public abstract class AbstractServiceAdministrator implements ServiceAdministrat
      * @see #shutdown()
      * @see #isPaused()
      */
+    @Override
     public synchronized ServiceAdministrator pause() {
         switch (this.state) {
             case STARTED:
@@ -193,6 +198,7 @@ public abstract class AbstractServiceAdministrator implements ServiceAdministrat
      * @see #pause()
      * @see #isShutdown()
      */
+    @Override
     public synchronized ServiceAdministrator shutdown() {
         switch (this.state) {
             case STARTED:
@@ -232,6 +238,7 @@ public abstract class AbstractServiceAdministrator implements ServiceAdministrat
      * @see #isPaused()
      * @see #isShutdown()
      */
+    @Override
     public boolean isStarted() {
         return this.state == State.STARTED;
     }
@@ -245,6 +252,7 @@ public abstract class AbstractServiceAdministrator implements ServiceAdministrat
      * @see #isStarted()
      * @see #isShutdown()
      */
+    @Override
     public boolean isPaused() {
         return this.state == State.PAUSED;
     }
@@ -257,6 +265,7 @@ public abstract class AbstractServiceAdministrator implements ServiceAdministrat
      * @see #isPaused()
      * @see #isStarted()
      */
+    @Override
     public boolean isShutdown() {
         return this.state == State.SHUTDOWN || this.state == State.TERMINATED;
     }
@@ -264,6 +273,7 @@ public abstract class AbstractServiceAdministrator implements ServiceAdministrat
     /**
      * {@inheritDoc}
      */
+    @Override
     public boolean isTerminated() {
         switch (this.state) {
             case PAUSED:

--- a/modeshape-repository/src/test/java/org/modeshape/repository/FakeRepositorySource.java
+++ b/modeshape-repository/src/test/java/org/modeshape/repository/FakeRepositorySource.java
@@ -67,6 +67,7 @@ public class FakeRepositorySource implements PathRepositorySource {
      * 
      * @see org.modeshape.graph.connector.RepositorySource#getCapabilities()
      */
+    @Override
     public RepositorySourceCapabilities getCapabilities() {
         return new RepositorySourceCapabilities();
     }
@@ -76,6 +77,7 @@ public class FakeRepositorySource implements PathRepositorySource {
      * 
      * @see org.modeshape.graph.connector.RepositorySource#getConnection()
      */
+    @Override
     public RepositoryConnection getConnection() throws RepositorySourceException {
         throw new UnsupportedOperationException();
     }
@@ -85,6 +87,7 @@ public class FakeRepositorySource implements PathRepositorySource {
      * 
      * @see org.modeshape.graph.connector.RepositorySource#close()
      */
+    @Override
     public void close() {
         // do nothing
     }
@@ -94,6 +97,7 @@ public class FakeRepositorySource implements PathRepositorySource {
      * 
      * @see org.modeshape.graph.connector.RepositorySource#getName()
      */
+    @Override
     public String getName() {
         return name;
     }
@@ -110,6 +114,7 @@ public class FakeRepositorySource implements PathRepositorySource {
      * 
      * @see org.modeshape.graph.connector.RepositorySource#getRetryLimit()
      */
+    @Override
     public int getRetryLimit() {
         return retryLimit;
     }
@@ -119,6 +124,7 @@ public class FakeRepositorySource implements PathRepositorySource {
      * 
      * @see org.modeshape.graph.connector.RepositorySource#setRetryLimit(int)
      */
+    @Override
     public void setRetryLimit( int limit ) {
         this.retryLimit = limit;
     }
@@ -128,6 +134,7 @@ public class FakeRepositorySource implements PathRepositorySource {
      * 
      * @see org.modeshape.graph.connector.RepositorySource#initialize(org.modeshape.graph.connector.RepositoryContext)
      */
+    @Override
     public void initialize( RepositoryContext context ) throws RepositorySourceException {
         // do nothing
     }
@@ -137,6 +144,7 @@ public class FakeRepositorySource implements PathRepositorySource {
      * 
      * @see javax.naming.Referenceable#getReference()
      */
+    @Override
     public Reference getReference() {
         throw new UnsupportedOperationException();
     }
@@ -213,6 +221,7 @@ public class FakeRepositorySource implements PathRepositorySource {
         this.stringArrayParam = stringArrayParam;
     }
 
+    @Override
     public boolean areUpdatesAllowed() {
         return false;
     }
@@ -221,22 +230,27 @@ public class FakeRepositorySource implements PathRepositorySource {
         this.cachePolicy = cachePolicy;
     }
 
+    @Override
     public PathCachePolicy getCachePolicy() {
         return this.cachePolicy;
     }
 
+    @Override
     public String getDefaultWorkspaceName() {
         return null;
     }
 
+    @Override
     public RepositoryContext getRepositoryContext() {
         return null;
     }
 
+    @Override
     public UUID getRootNodeUuid() {
         return null;
     }
 
+    @Override
     public void setUpdatesAllowed( boolean updatesAllowed ) {
         // NOP
     }

--- a/modeshape-repository/src/test/java/org/modeshape/repository/ModeShapeEngineTest.java
+++ b/modeshape-repository/src/test/java/org/modeshape/repository/ModeShapeEngineTest.java
@@ -219,6 +219,7 @@ public class ModeShapeEngineTest {
             this.mimeType = mimeType;
         }
 
+        @Override
         public String mimeTypeOf( String name,
                                   InputStream is ) {
             return mimeType;

--- a/modeshape-repository/src/test/java/org/modeshape/repository/sequencer/MockSequencerA.java
+++ b/modeshape-repository/src/test/java/org/modeshape/repository/sequencer/MockSequencerA.java
@@ -59,6 +59,7 @@ public class MockSequencerA implements Sequencer {
     /**
      * {@inheritDoc}
      */
+    @Override
     public void setConfiguration( SequencerConfig sequencerConfiguration ) {
         this.config = sequencerConfiguration;
     }
@@ -66,6 +67,7 @@ public class MockSequencerA implements Sequencer {
     /**
      * {@inheritDoc}
      */
+    @Override
     public void execute( Node input,
                          String sequencedPropertyName,
                          NetChange changes,
@@ -88,6 +90,7 @@ public class MockSequencerA implements Sequencer {
     /**
      * @return config
      */
+    @Override
     public SequencerConfig getConfiguration() {
         return this.config;
     }

--- a/modeshape-repository/src/test/java/org/modeshape/repository/sequencer/MockSequencerB.java
+++ b/modeshape-repository/src/test/java/org/modeshape/repository/sequencer/MockSequencerB.java
@@ -59,6 +59,7 @@ public class MockSequencerB implements Sequencer {
     /**
      * {@inheritDoc}
      */
+    @Override
     public void setConfiguration( SequencerConfig sequencerConfiguration ) {
         this.config = sequencerConfiguration;
     }
@@ -66,6 +67,7 @@ public class MockSequencerB implements Sequencer {
     /**
      * {@inheritDoc}
      */
+    @Override
     public void execute( Node input,
                          String sequencedPropertyName,
                          NetChange changes,
@@ -88,6 +90,7 @@ public class MockSequencerB implements Sequencer {
     /**
      * @return config
      */
+    @Override
     public SequencerConfig getConfiguration() {
         return this.config;
     }

--- a/modeshape-repository/src/test/java/org/modeshape/repository/sequencer/MockStreamSequencerA.java
+++ b/modeshape-repository/src/test/java/org/modeshape/repository/sequencer/MockStreamSequencerA.java
@@ -57,6 +57,7 @@ public class MockStreamSequencerA implements StreamSequencer {
      * @see org.modeshape.graph.sequencer.StreamSequencer#sequence(java.io.InputStream,
      *      org.modeshape.graph.sequencer.SequencerOutput, org.modeshape.graph.sequencer.StreamSequencerContext)
      */
+    @Override
     public void sequence( InputStream stream,
                           SequencerOutput output,
                           StreamSequencerContext context ) {

--- a/modeshape-repository/src/test/java/org/modeshape/repository/sequencer/MockStreamSequencerB.java
+++ b/modeshape-repository/src/test/java/org/modeshape/repository/sequencer/MockStreamSequencerB.java
@@ -57,6 +57,7 @@ public class MockStreamSequencerB implements StreamSequencer {
      * @see org.modeshape.graph.sequencer.StreamSequencer#sequence(java.io.InputStream,
      *      org.modeshape.graph.sequencer.SequencerOutput, org.modeshape.graph.sequencer.StreamSequencerContext)
      */
+    @Override
     public void sequence( InputStream stream,
                           SequencerOutput output,
                           StreamSequencerContext context ) {

--- a/modeshape-repository/src/test/java/org/modeshape/repository/sequencer/StreamSequencerAdapterTest.java
+++ b/modeshape-repository/src/test/java/org/modeshape/repository/sequencer/StreamSequencerAdapterTest.java
@@ -102,6 +102,7 @@ public class StreamSequencerAdapterTest {
              * This method always copies the {@link StreamSequencerAdapterTest#sequencerOutput} data into the output {@inheritDoc}
              * , and does nothing else with any of the other parameters.
              */
+            @Override
             public void sequence( InputStream stream,
                                   SequencerOutput output,
                                   StreamSequencerContext context ) {
@@ -145,6 +146,7 @@ public class StreamSequencerAdapterTest {
     protected void testSequencer( final StreamSequencer sequencer ) throws Throwable {
         StreamSequencer streamSequencer = new StreamSequencer() {
 
+            @Override
             public void sequence( InputStream stream,
                                   SequencerOutput output,
                                   StreamSequencerContext context ) {
@@ -397,6 +399,7 @@ public class StreamSequencerAdapterTest {
     public void shouldPassNonNullInputStreamToSequencer() throws Throwable {
         testSequencer(new StreamSequencer() {
 
+            @Override
             public void sequence( InputStream stream,
                                   SequencerOutput output,
                                   StreamSequencerContext context ) {
@@ -409,6 +412,7 @@ public class StreamSequencerAdapterTest {
     public void shouldPassNonNullSequencerOutputToSequencer() throws Throwable {
         testSequencer(new StreamSequencer() {
 
+            @Override
             public void sequence( InputStream stream,
                                   SequencerOutput output,
                                   StreamSequencerContext context ) {
@@ -421,6 +425,7 @@ public class StreamSequencerAdapterTest {
     public void shouldPassNonNullSequencerContextToSequencer() throws Throwable {
         testSequencer(new StreamSequencer() {
 
+            @Override
             public void sequence( InputStream stream,
                                   SequencerOutput output,
                                   StreamSequencerContext context ) {

--- a/utils/modeshape-jdbc-local/src/main/java/org/modeshape/jdbc/JcrMetaData.java
+++ b/utils/modeshape-jdbc-local/src/main/java/org/modeshape/jdbc/JcrMetaData.java
@@ -2695,6 +2695,7 @@ public class JcrMetaData implements DatabaseMetaData {
 
         if (nodetypes.size() > 1) {
             final Comparator<NodeType> name_order = new Comparator<NodeType>() {
+                @Override
                 public int compare( NodeType e1,
                                     NodeType e2 ) {
                     return e1.getName().compareTo(e2.getName());
@@ -2767,6 +2768,7 @@ public class JcrMetaData implements DatabaseMetaData {
 
         if (resultDefns.size() > 1) {
             final Comparator<PropertyDefinition> name_order = new Comparator<PropertyDefinition>() {
+                @Override
                 public int compare( PropertyDefinition e1,
                                     PropertyDefinition e2 ) {
                     return e1.getName().compareTo(e2.getName());

--- a/utils/modeshape-jdbc-local/src/main/java/org/modeshape/jdbc/delegate/AbstractRepositoryDelegate.java
+++ b/utils/modeshape-jdbc-local/src/main/java/org/modeshape/jdbc/delegate/AbstractRepositoryDelegate.java
@@ -143,6 +143,7 @@ public abstract class AbstractRepositoryDelegate implements RepositoryDelegate {
         this.getConnectionInfo().setRepositoryName(repositoryName);
     }
 
+    @Override
     public Set<String> getRepositoryNames() {
         return this.repositoryNames;
     }

--- a/utils/modeshape-jdbc-local/src/main/java/org/modeshape/jdbc/delegate/LocalRepositoryDelegate.java
+++ b/utils/modeshape-jdbc-local/src/main/java/org/modeshape/jdbc/delegate/LocalRepositoryDelegate.java
@@ -68,6 +68,7 @@ public class LocalRepositoryDelegate extends AbstractRepositoryDelegate {
 
         if (contextFactory == null) {
             jcrContext = new JcrContextFactory() {
+                @Override
                 public Context createContext( Properties properties ) throws NamingException {
                     InitialContext initContext = ((properties == null || properties.isEmpty()) ? new InitialContext() : new InitialContext(
                                                                                                                                            properties));

--- a/utils/modeshape-jdbc-local/src/main/java/org/modeshape/jdbc/metadata/MetaDataQueryResult.java
+++ b/utils/modeshape-jdbc-local/src/main/java/org/modeshape/jdbc/metadata/MetaDataQueryResult.java
@@ -143,6 +143,7 @@ class QueryResultNodeIterator implements NodeIterator {
      * 
      * @see javax.jcr.NodeIterator#nextNode()
      */
+    @Override
     public Node nextNode() {
         Node node = nodes[(int)(position)];
         ++position;
@@ -154,6 +155,7 @@ class QueryResultNodeIterator implements NodeIterator {
      * 
      * @see javax.jcr.RangeIterator#getPosition()
      */
+    @Override
     public long getPosition() {
         return position;
     }
@@ -163,6 +165,7 @@ class QueryResultNodeIterator implements NodeIterator {
      * 
      * @see javax.jcr.RangeIterator#getSize()
      */
+    @Override
     public long getSize() {
         return size;
     }
@@ -172,6 +175,7 @@ class QueryResultNodeIterator implements NodeIterator {
      * 
      * @see javax.jcr.RangeIterator#skip(long)
      */
+    @Override
     public void skip( long skipNum ) {
         for (long i = 0L; i != skipNum; ++i)
             nextNode();
@@ -182,6 +186,7 @@ class QueryResultNodeIterator implements NodeIterator {
      * 
      * @see java.util.Iterator#hasNext()
      */
+    @Override
     public boolean hasNext() {
         return (nodes.length > position);
     }
@@ -191,6 +196,7 @@ class QueryResultNodeIterator implements NodeIterator {
      * 
      * @see java.util.Iterator#next()
      */
+    @Override
     public Object next() {
         return nextNode();
     }
@@ -200,6 +206,7 @@ class QueryResultNodeIterator implements NodeIterator {
      * 
      * @see java.util.Iterator#remove()
      */
+    @Override
     public void remove() {
         throw new UnsupportedOperationException();
     }
@@ -228,6 +235,7 @@ class QueryResultRowIterator implements RowIterator {
      * 
      * @see javax.jcr.query.RowIterator#nextRow()
      */
+    @Override
     public Row nextRow() {
         if (nextRow == null) {
             // Didn't call 'hasNext()' ...
@@ -247,6 +255,7 @@ class QueryResultRowIterator implements RowIterator {
      * 
      * @see javax.jcr.RangeIterator#getPosition()
      */
+    @Override
     public long getPosition() {
         return position;
     }
@@ -256,6 +265,7 @@ class QueryResultRowIterator implements RowIterator {
      * 
      * @see javax.jcr.RangeIterator#getSize()
      */
+    @Override
     public long getSize() {
         return numRows;
     }
@@ -265,6 +275,7 @@ class QueryResultRowIterator implements RowIterator {
      * 
      * @see javax.jcr.RangeIterator#skip(long)
      */
+    @Override
     public void skip( long skipNum ) {
         for (long i = 0L; i != skipNum; ++i) {
             tuples.next();
@@ -277,6 +288,7 @@ class QueryResultRowIterator implements RowIterator {
      * 
      * @see java.util.Iterator#hasNext()
      */
+    @Override
     public boolean hasNext() {
         if (nextRow != null) {
             return true;
@@ -310,6 +322,7 @@ class QueryResultRowIterator implements RowIterator {
      * 
      * @see java.util.Iterator#next()
      */
+    @Override
     public Object next() {
         return nextRow();
     }
@@ -319,6 +332,7 @@ class QueryResultRowIterator implements RowIterator {
      * 
      * @see java.util.Iterator#remove()
      */
+    @Override
     public void remove() {
         throw new UnsupportedOperationException();
     }

--- a/utils/modeshape-jdbc-local/src/main/java/org/modeshape/jdbc/metadata/ResultSetMetaDataImpl.java
+++ b/utils/modeshape-jdbc-local/src/main/java/org/modeshape/jdbc/metadata/ResultSetMetaDataImpl.java
@@ -50,27 +50,33 @@ public class ResultSetMetaDataImpl implements ResultSetMetaData {
         return index - 1;
     }
 
+    @Override
     public int getColumnCount() {
         return provider.getColumnCount();
     }
 
+    @Override
     public boolean isAutoIncrement( int index ) {
         return provider.getBooleanValue(adjustColumn(index), ResultsMetadataConstants.AUTO_INCREMENTING);
     }
 
+    @Override
     public boolean isCaseSensitive( int index ) {
         return provider.getBooleanValue(adjustColumn(index), ResultsMetadataConstants.CASE_SENSITIVE);
     }
 
+    @Override
     public boolean isSearchable( int index ) {
         Integer searchable = (Integer)provider.getValue(adjustColumn(index), ResultsMetadataConstants.SEARCHABLE);
         return !(ResultsMetadataConstants.SEARCH_TYPES.UNSEARCHABLE.equals(searchable));
     }
 
+    @Override
     public boolean isCurrency( int index ) {
         return provider.getBooleanValue(adjustColumn(index), ResultsMetadataConstants.CURRENCY);
     }
 
+    @Override
     public int isNullable( int index ) {
         Object nullable = provider.getValue(adjustColumn(index), ResultsMetadataConstants.NULLABLE);
         if (nullable.equals(ResultsMetadataConstants.NULL_TYPES.NULLABLE)) {
@@ -82,22 +88,27 @@ public class ResultSetMetaDataImpl implements ResultSetMetaData {
         }
     }
 
+    @Override
     public boolean isSigned( int index ) {
         return provider.getBooleanValue(adjustColumn(index), ResultsMetadataConstants.SIGNED);
     }
 
+    @Override
     public int getColumnDisplaySize( int index ) {
         return provider.getIntValue(adjustColumn(index), ResultsMetadataConstants.DISPLAY_SIZE);
     }
 
+    @Override
     public String getColumnLabel( int index ) {
         return provider.getStringValue(adjustColumn(index), ResultsMetadataConstants.COLUMN_LABEL);
     }
 
+    @Override
     public String getColumnName( int index ) {
         return provider.getStringValue(adjustColumn(index), ResultsMetadataConstants.COLUMN);
     }
 
+    @Override
     public String getSchemaName( int index ) {
         String name = provider.getStringValue(adjustColumn(index), ResultsMetadataConstants.SCHEMA);
         if (name != null) {
@@ -109,14 +120,17 @@ public class ResultSetMetaDataImpl implements ResultSetMetaData {
         return null;
     }
 
+    @Override
     public int getPrecision( int index ) {
         return provider.getIntValue(adjustColumn(index), ResultsMetadataConstants.PRECISION);
     }
 
+    @Override
     public int getScale( int index ) {
         return provider.getIntValue(adjustColumn(index), ResultsMetadataConstants.SCALE);
     }
 
+    @Override
     public String getTableName( int index ) {
         String name = provider.getStringValue(adjustColumn(index), ResultsMetadataConstants.TABLE);
         if (name != null) {
@@ -128,10 +142,12 @@ public class ResultSetMetaDataImpl implements ResultSetMetaData {
         return name;
     }
 
+    @Override
     public String getCatalogName( int index ) {
         return provider.getStringValue(adjustColumn(index), ResultsMetadataConstants.CATALOG);
     }
 
+    @Override
     public int getColumnType( int index ) {
         String runtimeTypeName = provider.getStringValue(adjustColumn(index), ResultsMetadataConstants.DATA_TYPE);
 
@@ -139,22 +155,27 @@ public class ResultSetMetaDataImpl implements ResultSetMetaData {
         return typeInfo != null ? typeInfo.getJdbcType() : Types.VARCHAR;
     }
 
+    @Override
     public String getColumnTypeName( int index ) {
         return provider.getStringValue(adjustColumn(index), ResultsMetadataConstants.DATA_TYPE);
     }
 
+    @Override
     public boolean isReadOnly( int index ) {
         return !provider.getBooleanValue(adjustColumn(index), ResultsMetadataConstants.WRITABLE);
     }
 
+    @Override
     public boolean isWritable( int index ) {
         return provider.getBooleanValue(adjustColumn(index), ResultsMetadataConstants.WRITABLE);
     }
 
+    @Override
     public boolean isDefinitelyWritable( int index ) {
         return provider.getBooleanValue(adjustColumn(index), ResultsMetadataConstants.WRITABLE);
     }
 
+    @Override
     public String getColumnClassName( int index ) {
         JcrType typeInfo = JcrType.typeInfo(getColumnTypeName(index));
         return typeInfo != null ? typeInfo.getRepresentationClass().getName() : String.class.getName();

--- a/utils/modeshape-jdbc-local/src/main/java/org/modeshape/jdbc/util/ClassUtil.java
+++ b/utils/modeshape-jdbc-local/src/main/java/org/modeshape/jdbc/util/ClassUtil.java
@@ -107,6 +107,7 @@ public final class ClassUtil {
             } else {
                 AccessController.doPrivileged(new PrivilegedAction<Object>() {
 
+                    @Override
                     public Object run() {
                         object.setAccessible(true);
                         return null;

--- a/utils/modeshape-jdbc-local/src/main/java/org/modeshape/jdbc/util/ClasspathLocalizationRepository.java
+++ b/utils/modeshape-jdbc-local/src/main/java/org/modeshape/jdbc/util/ClasspathLocalizationRepository.java
@@ -64,6 +64,7 @@ public class ClasspathLocalizationRepository implements LocalizationRepository {
     /**
      * {@inheritDoc}
      */
+    @Override
     public URL getLocalizationBundle( String bundleName,
                                       Locale locale ) {
         URL url = null;

--- a/utils/modeshape-jdbc-local/src/main/java/org/modeshape/jdbc/util/UrlEncoder.java
+++ b/utils/modeshape-jdbc-local/src/main/java/org/modeshape/jdbc/util/UrlEncoder.java
@@ -78,6 +78,7 @@ public class UrlEncoder implements TextEncoder, TextDecoder {
     /**
      * {@inheritDoc}
      */
+    @Override
     public String encode( String text ) {
         if (text == null) return null;
         if (text.length() == 0) return text;
@@ -105,6 +106,7 @@ public class UrlEncoder implements TextEncoder, TextDecoder {
     /**
      * {@inheritDoc}
      */
+    @Override
     public String decode( String encodedText ) {
         if (encodedText == null) return null;
         if (encodedText.length() == 0) return encodedText;

--- a/utils/modeshape-jdbc-local/src/test/java/org/modeshape/jdbc/TestUtil.java
+++ b/utils/modeshape-jdbc-local/src/test/java/org/modeshape/jdbc/TestUtil.java
@@ -258,6 +258,7 @@ class QueryResultNodeIterator implements NodeIterator {
      * 
      * @see javax.jcr.NodeIterator#nextNode()
      */
+    @Override
     public Node nextNode() {
         Node node = nodes.next();
         ++position;
@@ -269,6 +270,7 @@ class QueryResultNodeIterator implements NodeIterator {
      * 
      * @see javax.jcr.RangeIterator#getPosition()
      */
+    @Override
     public long getPosition() {
         return position;
     }
@@ -278,6 +280,7 @@ class QueryResultNodeIterator implements NodeIterator {
      * 
      * @see javax.jcr.RangeIterator#getSize()
      */
+    @Override
     public long getSize() {
         return size;
     }
@@ -287,6 +290,7 @@ class QueryResultNodeIterator implements NodeIterator {
      * 
      * @see javax.jcr.RangeIterator#skip(long)
      */
+    @Override
     public void skip( long skipNum ) {
         for (long i = 0L; i != skipNum; ++i)
             nextNode();
@@ -297,6 +301,7 @@ class QueryResultNodeIterator implements NodeIterator {
      * 
      * @see java.util.Iterator#hasNext()
      */
+    @Override
     public boolean hasNext() {
         return nodes.hasNext();
     }
@@ -306,6 +311,7 @@ class QueryResultNodeIterator implements NodeIterator {
      * 
      * @see java.util.Iterator#next()
      */
+    @Override
     public Object next() {
         return nextNode();
     }
@@ -315,6 +321,7 @@ class QueryResultNodeIterator implements NodeIterator {
      * 
      * @see java.util.Iterator#remove()
      */
+    @Override
     public void remove() {
         throw new UnsupportedOperationException();
     }
@@ -348,6 +355,7 @@ class QueryResultRowIterator implements RowIterator {
      * 
      * @see javax.jcr.query.RowIterator#nextRow()
      */
+    @Override
     public Row nextRow() {
         if (nextRow == null) {
             // Didn't call 'hasNext()' ...
@@ -367,6 +375,7 @@ class QueryResultRowIterator implements RowIterator {
      * 
      * @see javax.jcr.RangeIterator#getPosition()
      */
+    @Override
     public long getPosition() {
         return position;
     }
@@ -376,6 +385,7 @@ class QueryResultRowIterator implements RowIterator {
      * 
      * @see javax.jcr.RangeIterator#getSize()
      */
+    @Override
     public long getSize() {
         return numRows;
     }
@@ -385,6 +395,7 @@ class QueryResultRowIterator implements RowIterator {
      * 
      * @see javax.jcr.RangeIterator#skip(long)
      */
+    @Override
     public void skip( long skipNum ) {
         for (long i = 0L; i != skipNum; ++i) {
             tuples.next();
@@ -397,6 +408,7 @@ class QueryResultRowIterator implements RowIterator {
      * 
      * @see java.util.Iterator#hasNext()
      */
+    @Override
     public boolean hasNext() {
         if (nextRow != null) {
             return true;
@@ -430,6 +442,7 @@ class QueryResultRowIterator implements RowIterator {
      * 
      * @see java.util.Iterator#next()
      */
+    @Override
     public Object next() {
         return nextRow();
     }
@@ -439,6 +452,7 @@ class QueryResultRowIterator implements RowIterator {
      * 
      * @see java.util.Iterator#remove()
      */
+    @Override
     public void remove() {
         throw new UnsupportedOperationException();
     }

--- a/utils/modeshape-unit-test/src/main/java/org/modeshape/test/ModeShapeUnitTest.java
+++ b/utils/modeshape-unit-test/src/main/java/org/modeshape/test/ModeShapeUnitTest.java
@@ -1237,6 +1237,7 @@ public abstract class ModeShapeUnitTest {
             this.path = path;
         }
 
+        @Override
         public void run( Session s ) throws RepositoryException {
             // Verify the file was imported ...
             Node node = s.getNode(path);
@@ -1246,6 +1247,7 @@ public abstract class ModeShapeUnitTest {
     }
 
     protected class CountNodes extends BasicOperation {
+        @Override
         public void run( Session s ) throws RepositoryException {
             // Count the nodes below the root, excluding the '/jcr:system' branch ...
             String queryStr = "SELECT [jcr:primaryType] FROM [nt:base]";
@@ -1256,6 +1258,7 @@ public abstract class ModeShapeUnitTest {
     }
 
     protected class PrintNodes extends BasicOperation {
+        @Override
         public void run( Session s ) throws RepositoryException {
             // Count the nodes below the root, excluding the '/jcr:system' branch ...
             String queryStr = "SELECT [jcr:path] FROM [nt:base] ORDER BY [jcr:path]";

--- a/web/modeshape-web-jcr-rest-client/src/main/java/org/modeshape/web/jcr/rest/client/domain/NodeType.java
+++ b/web/modeshape-web-jcr-rest-client/src/main/java/org/modeshape/web/jcr/rest/client/domain/NodeType.java
@@ -126,6 +126,7 @@ public class NodeType implements IModeShapeObject, javax.jcr.nodetype.NodeType {
      * 
      * @see org.modeshape.web.jcr.rest.client.domain.IModeShapeObject#getName()
      */
+    @Override
     public String getName() {
         return this.name;
     }
@@ -379,6 +380,7 @@ public class NodeType implements IModeShapeObject, javax.jcr.nodetype.NodeType {
      * 
      * @see org.modeshape.web.jcr.rest.client.domain.IModeShapeObject#getShortDescription()
      */
+    @Override
     public String getShortDescription() {
         return RestClientI18n.nodeTypeShortDescription.text(this.name);
     }

--- a/web/modeshape-web-jcr-rest-client/src/main/java/org/modeshape/web/jcr/rest/client/domain/Repository.java
+++ b/web/modeshape-web-jcr-rest-client/src/main/java/org/modeshape/web/jcr/rest/client/domain/Repository.java
@@ -90,6 +90,7 @@ public class Repository implements IModeShapeObject {
      * 
      * @see org.modeshape.web.jcr.rest.client.domain.IModeShapeObject#getName()
      */
+    @Override
     public String getName() {
         return this.name;
     }
@@ -106,6 +107,7 @@ public class Repository implements IModeShapeObject {
      * 
      * @see org.modeshape.web.jcr.rest.client.domain.IModeShapeObject#getShortDescription()
      */
+    @Override
     public String getShortDescription() {
         return RestClientI18n.repositoryShortDescription.text(this.name, this.server.getName());
     }

--- a/web/modeshape-web-jcr-rest-client/src/main/java/org/modeshape/web/jcr/rest/client/domain/Server.java
+++ b/web/modeshape-web-jcr-rest-client/src/main/java/org/modeshape/web/jcr/rest/client/domain/Server.java
@@ -114,6 +114,7 @@ public class Server implements IModeShapeObject {
      * 
      * @see org.modeshape.web.jcr.rest.client.domain.IModeShapeObject#getName()
      */
+    @Override
     public String getName() {
         return getUrl();
     }
@@ -130,6 +131,7 @@ public class Server implements IModeShapeObject {
      * 
      * @see org.modeshape.web.jcr.rest.client.domain.IModeShapeObject#getShortDescription()
      */
+    @Override
     public String getShortDescription() {
         return RestClientI18n.serverShortDescription.text(this.url, this.user);
     }

--- a/web/modeshape-web-jcr-rest-client/src/main/java/org/modeshape/web/jcr/rest/client/domain/Workspace.java
+++ b/web/modeshape-web-jcr-rest-client/src/main/java/org/modeshape/web/jcr/rest/client/domain/Workspace.java
@@ -90,6 +90,7 @@ public class Workspace implements IModeShapeObject {
      * 
      * @see org.modeshape.web.jcr.rest.client.domain.IModeShapeObject#getName()
      */
+    @Override
     public String getName() {
         return this.name;
     }
@@ -113,6 +114,7 @@ public class Workspace implements IModeShapeObject {
      * 
      * @see org.modeshape.web.jcr.rest.client.domain.IModeShapeObject#getShortDescription()
      */
+    @Override
     public String getShortDescription() {
         return RestClientI18n.workspaceShortDescription.text(this.name, this.repository.getName());
     }

--- a/web/modeshape-web-jcr-rest-client/src/main/java/org/modeshape/web/jcr/rest/client/json/JsonRestClient.java
+++ b/web/modeshape-web-jcr-rest-client/src/main/java/org/modeshape/web/jcr/rest/client/json/JsonRestClient.java
@@ -244,6 +244,7 @@ public final class JsonRestClient implements IRestClient {
      * 
      * @see org.modeshape.web.jcr.rest.client.IRestClient#getRepositories(org.modeshape.web.jcr.rest.client.domain.Server)
      */
+    @Override
     public Collection<Repository> getRepositories( Server server ) throws Exception {
         assert server != null;
         LOGGER.trace("getRepositories: server={0}", server);
@@ -330,6 +331,7 @@ public final class JsonRestClient implements IRestClient {
      * @see org.modeshape.web.jcr.rest.client.IRestClient#getUrl(java.io.File, java.lang.String,
      *      org.modeshape.web.jcr.rest.client.domain.Workspace)
      */
+    @Override
     public URL getUrl( File file,
                        String path,
                        Workspace workspace ) throws Exception {
@@ -350,6 +352,7 @@ public final class JsonRestClient implements IRestClient {
      * 
      * @see org.modeshape.web.jcr.rest.client.IRestClient#getWorkspaces(org.modeshape.web.jcr.rest.client.domain.Repository)
      */
+    @Override
     public Collection<Workspace> getWorkspaces( Repository repository ) throws Exception {
         assert repository != null;
         LOGGER.trace("getWorkspaces: repository={0}", repository);
@@ -445,6 +448,7 @@ public final class JsonRestClient implements IRestClient {
      * @see org.modeshape.web.jcr.rest.client.IRestClient#publish(org.modeshape.web.jcr.rest.client.domain.Workspace,
      *      java.lang.String, java.io.File)
      */
+    @Override
     public Status publish( Workspace workspace,
                            String path,
                            File file ) {
@@ -457,6 +461,7 @@ public final class JsonRestClient implements IRestClient {
      * @see org.modeshape.web.jcr.rest.client.IRestClient#publish(org.modeshape.web.jcr.rest.client.domain.Workspace,
      *      java.lang.String, java.io.File, boolean)
      */
+    @Override
     public Status publish( Workspace workspace,
                            String path,
                            File file,
@@ -491,6 +496,7 @@ public final class JsonRestClient implements IRestClient {
      * @see org.modeshape.web.jcr.rest.client.IRestClient#unpublish(org.modeshape.web.jcr.rest.client.domain.Workspace,
      *      java.lang.String, java.io.File)
      */
+    @Override
     public Status unpublish( Workspace workspace,
                              String path,
                              File file ) {
@@ -856,6 +862,7 @@ public final class JsonRestClient implements IRestClient {
         File modelsDirFile = new File(dir);
         FileFilter fileFilter = new FileFilter() {
 
+            @Override
             public boolean accept( File file ) {
                 if (file.isDirectory()) {
                     return false;

--- a/web/modeshape-web-jcr-rest-client/src/test/java/org/modeshape/web/jcr/rest/client/MockRestClient.java
+++ b/web/modeshape-web-jcr-rest-client/src/test/java/org/modeshape/web/jcr/rest/client/MockRestClient.java
@@ -48,6 +48,7 @@ public final class MockRestClient implements IRestClient {
      * 
      * @see org.modeshape.web.jcr.rest.client.IRestClient#getRepositories(org.modeshape.web.jcr.rest.client.domain.Server)
      */
+    @Override
     public Collection<Repository> getRepositories( Server server ) throws Exception {
         return null;
     }
@@ -58,6 +59,7 @@ public final class MockRestClient implements IRestClient {
      * @see org.modeshape.web.jcr.rest.client.IRestClient#getUrl(java.io.File, java.lang.String,
      *      org.modeshape.web.jcr.rest.client.domain.Workspace)
      */
+    @Override
     public URL getUrl( File file,
                        String path,
                        Workspace workspace ) throws Exception {
@@ -69,6 +71,7 @@ public final class MockRestClient implements IRestClient {
      * 
      * @see org.modeshape.web.jcr.rest.client.IRestClient#getWorkspaces(org.modeshape.web.jcr.rest.client.domain.Repository)
      */
+    @Override
     public Collection<Workspace> getWorkspaces( Repository repository ) throws Exception {
         return null;
     }
@@ -79,6 +82,7 @@ public final class MockRestClient implements IRestClient {
      * @see org.modeshape.web.jcr.rest.client.IRestClient#publish(org.modeshape.web.jcr.rest.client.domain.Workspace,
      *      java.lang.String, java.io.File)
      */
+    @Override
     public Status publish( Workspace workspace,
                            String path,
                            File file ) {
@@ -105,6 +109,7 @@ public final class MockRestClient implements IRestClient {
      * @see org.modeshape.web.jcr.rest.client.IRestClient#unpublish(org.modeshape.web.jcr.rest.client.domain.Workspace,
      *      java.lang.String, java.io.File)
      */
+    @Override
     public Status unpublish( Workspace workspace,
                              String path,
                              File file ) {

--- a/web/modeshape-web-jcr-rest/src/main/java/org/modeshape/web/jcr/rest/JcrResources.java
+++ b/web/modeshape-web-jcr-rest/src/main/java/org/modeshape/web/jcr/rest/JcrResources.java
@@ -492,6 +492,7 @@ public class JcrResources extends AbstractHandler {
     @Provider
     public static class NotFoundExceptionMapper implements ExceptionMapper<NotFoundException> {
 
+        @Override
         public Response toResponse( NotFoundException exception ) {
             return Response.status(Status.NOT_FOUND).entity(exception.getMessage()).build();
         }
@@ -501,6 +502,7 @@ public class JcrResources extends AbstractHandler {
     @Provider
     public static class NoSuchRepositoryExceptionMapper implements ExceptionMapper<NoSuchRepositoryException> {
 
+        @Override
         public Response toResponse( NoSuchRepositoryException exception ) {
             return Response.status(Status.NOT_FOUND).entity(exception.getMessage()).build();
         }
@@ -510,6 +512,7 @@ public class JcrResources extends AbstractHandler {
     @Provider
     public static class JSONExceptionMapper implements ExceptionMapper<JSONException> {
 
+        @Override
         public Response toResponse( JSONException exception ) {
             return Response.status(Status.BAD_REQUEST).entity(exception.getMessage()).build();
         }
@@ -519,6 +522,7 @@ public class JcrResources extends AbstractHandler {
     @Provider
     public static class InvalidQueryExceptionMapper implements ExceptionMapper<InvalidQueryException> {
 
+        @Override
         public Response toResponse( InvalidQueryException exception ) {
             return Response.status(Status.BAD_REQUEST).entity(exception.getMessage()).build();
         }
@@ -528,6 +532,7 @@ public class JcrResources extends AbstractHandler {
     @Provider
     public static class RepositoryExceptionMapper implements ExceptionMapper<RepositoryException> {
 
+        @Override
         public Response toResponse( RepositoryException exception ) {
             /*
              * This error code is murky - the request must have been syntactically valid to get to

--- a/web/modeshape-web-jcr/src/main/java/org/modeshape/web/jcr/ModeShapeJcrDeployer.java
+++ b/web/modeshape-web-jcr/src/main/java/org/modeshape/web/jcr/ModeShapeJcrDeployer.java
@@ -49,6 +49,7 @@ public class ModeShapeJcrDeployer implements ServletContextListener {
      * @see RepositoryFactory#shutdown()
      * @see RepositoryProvider#shutdown()
      */
+    @Override
     public void contextDestroyed( ServletContextEvent event ) {
         RepositoryFactory.shutdown();
     }
@@ -59,6 +60,7 @@ public class ModeShapeJcrDeployer implements ServletContextListener {
      * @param event the servlet context event
      * @see RepositoryFactory#initialize(javax.servlet.ServletContext)
      */
+    @Override
     public void contextInitialized( ServletContextEvent event ) {
         RepositoryFactory.initialize(event.getServletContext());
     }

--- a/web/modeshape-web-jcr/src/main/java/org/modeshape/web/jcr/ServletSecurityContext.java
+++ b/web/modeshape-web-jcr/src/main/java/org/modeshape/web/jcr/ServletSecurityContext.java
@@ -56,6 +56,7 @@ public class ServletSecurityContext implements SecurityContext {
      * 
      * @see SecurityContext#getUserName()
      */
+    @Override
     public final String getUserName() {
         return userName;
     }
@@ -65,6 +66,7 @@ public class ServletSecurityContext implements SecurityContext {
      * 
      * @see SecurityContext#hasRole(String)
      */
+    @Override
     public final boolean hasRole( String roleName ) {
         return request.isUserInRole(roleName);
     }
@@ -74,6 +76,7 @@ public class ServletSecurityContext implements SecurityContext {
      * 
      * @see SecurityContext#logout()
      */
+    @Override
     public void logout() {
     }
 

--- a/web/modeshape-web-jcr/src/main/java/org/modeshape/web/jcr/spi/FactoryRepositoryProvider.java
+++ b/web/modeshape-web-jcr/src/main/java/org/modeshape/web/jcr/spi/FactoryRepositoryProvider.java
@@ -57,6 +57,7 @@ public class FactoryRepositoryProvider implements RepositoryProvider {
     public FactoryRepositoryProvider() {
     }
 
+    @Override
     public Set<String> getJcrRepositoryNames() {
         RepositoryFactory factory = factory();
         if (factory == null) return null;
@@ -71,10 +72,12 @@ public class FactoryRepositoryProvider implements RepositoryProvider {
         return factory.getRepositories(jcrUrl).getRepository(repositoryName);
     }
 
+    @Override
     public void startup( ServletContext context ) {
         this.jcrUrl = context.getInitParameter(JCR_URL);
     }
 
+    @Override
     public void shutdown() {
         factory().shutdown();
     }
@@ -97,6 +100,7 @@ public class FactoryRepositoryProvider implements RepositoryProvider {
      * @return an active session with the given workspace in the named repository
      * @throws RepositoryException if any other error occurs
      */
+    @Override
     public Session getSession( HttpServletRequest request,
                                String repositoryName,
                                String workspaceName ) throws RepositoryException {


### PR DESCRIPTION
The 'modeshape-jcr', 'modeshape-jcr-api' and 'modeshape-graph' modules are now compiled with JDK 1.5 (see MODE-1108), so the @Override annotations need to be removed from that code. All of the remaining modules use JDK 6, and thus need to use @Override in all places (including interfaces).
