### PR TITLE
MODE-1141 Corrected VersionManager.checkin(...) logic to not duplicate ve

### DIFF
--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrVersionManager.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrVersionManager.java
@@ -416,7 +416,7 @@ final class JcrVersionManager implements VersionManager {
                          .with(JcrLexicon.CHILD_VERSION_HISTORY, historyUuid)
                          .and();
 
-                    break;
+                    return;
                 }
 
                 // Otherwise, treat it as a copy, as per 8.2.11.2 in the 1.0.1 Spec


### PR DESCRIPTION
MODE-1141 Corrected VersionManager.checkin(...) logic to not duplicate versionable nodes in history

As noted in the JIRA issue, the JcrVersionManager.checkin(...) method calls the versionNodeAt(...) recursive method, which copies the versionable state into the new version in version history. This method should _not_ be walking children when the child is 'mix:versionable' and has an OPV on the child node definition of VERSION.

This change simply implements this behavior by returning from the method rather than breaking (the children are walked after the break).

All unit and integration tests pass with this minor change.
