### PR TITLE
MODE-1144 Corrected logic to convert XPath queries to JCR-SQL2

### DIFF
--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/xpath/XPathToQueryTranslator.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/xpath/XPathToQueryTranslator.java
@@ -376,11 +376,12 @@ public class XPathToQueryTranslator {
         if (tableName != null) {
             // This is after some element(...) steps, so we need to join ...
             builder.joinAllNodesAs(alias);
+            alias = tableName;
         } else {
             // This is the only part of the query ...
             builder.fromAllNodesAs(alias);
+            tableName = alias;
         }
-        tableName = alias;
         if (path.size() == 1 && path.get(0).collapse() instanceof NameTest) {
             // Node immediately below root ...
             NameTest nodeName = (NameTest)path.get(0).collapse();

--- a/modeshape-jcr/src/test/java/org/modeshape/jcr/xpath/XPathToQueryTranslatorTest.java
+++ b/modeshape-jcr/src/test/java/org/modeshape/jcr/xpath/XPathToQueryTranslatorTest.java
@@ -391,6 +391,13 @@ public class XPathToQueryTranslatorTest {
         xpath("//element(*, employee)[@secretary and @assistant]");
     }
 
+    @FixFor( "MODE-1144" )
+    @Test
+    public void shouldTranslateFromXPathContainingContainsCriteria() {
+        assertThat(xpath("//*[@jcr:primaryType='mgnl:content']//*[jcr:contains(., 'paragraph')]"),
+                   isSql("SELECT nodeSet1.[jcr:primaryType] FROM __ALLNODES__ AS nodeSet1 WHERE (nodeSet1.[jcr:primaryType] = 'mgnl:content' AND CONTAINS(nodeSet1.*,'paragraph'))"));
+    }
+
     // ----------------------------------------------------------------------------------------------------------------
     // utility methods
     // ----------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
First added a unit test in JcrQueryManagerTest to execute the same XPath query, and replicated the error. After a bit of searching, the problem turned out to be the generated JCR-SQL2 query was incorrect (used a different alias in the second criteria). Thus the problem was likely in the XPathToQueryTranslator, so another unit test was added to XPathToQueryTranslatorTest, which also failed.

After a bit of investigation, discovered that the processing of the criteria was incorrectly switching table names. Simply correcting this appears to have fixed this issue.

All unit and integration tests pass with these changes.
