### PR TITLE
MODE-1139 Added tests to verify behavior when XML contains values that violate constraints

### DIFF
--- a/modeshape-jcr/src/test/java/org/modeshape/jcr/JcrImportExportTest.java
+++ b/modeshape-jcr/src/test/java/org/modeshape/jcr/JcrImportExportTest.java
@@ -44,6 +44,7 @@ import javax.jcr.NodeIterator;
 import javax.jcr.PathNotFoundException;
 import javax.jcr.RepositoryException;
 import javax.jcr.Session;
+import javax.jcr.nodetype.ConstraintViolationException;
 import javax.jcr.nodetype.NodeType;
 import org.junit.After;
 import org.junit.AfterClass;
@@ -503,11 +504,29 @@ public class JcrImportExportTest {
     }
 
     // ----------------------------------------------------------------------------------------------------------------
-    // Import System View WITH 'jcr:root' node and WITH uuids
+    // Import Document and System View containing constraint violations
+    // ----------------------------------------------------------------------------------------------------------------
+
+    @FixFor( "MODE-1139" )
+    @Test( expected = ConstraintViolationException.class )
+    public void shouldThrowCorrectExceptionWhenImportingDocumentViewContainingPropertiesThatViolateConstraints() throws Exception {
+        // Set up the repository ...
+        assertImport("io/full-workspace-document-view-with-constraint-violation.xml", "/", ImportBehavior.THROW);
+    }
+
+    @FixFor( "MODE-1139" )
+    @Test( expected = ConstraintViolationException.class )
+    public void shouldThrowCorrectExceptionWhenImportingSystemViewContainingPropertiesThatViolateConstraints() throws Exception {
+        // Set up the repository ...
+        assertImport("io/full-workspace-system-view-with-constraint-violation.xml", "/", ImportBehavior.THROW);
+    }
+
+    // ----------------------------------------------------------------------------------------------------------------
+    // Import Document View WITH 'jcr:root' node and WITH uuids
     // ----------------------------------------------------------------------------------------------------------------
 
     @Test
-    public void shouldImportDocumentView() throws Exception {
+    public void shouldImportDocumentViewWithUuids() throws Exception {
         // Set up the repository ...
         assertImport("io/full-workspace-document-view-with-uuids.xml", "/", ImportBehavior.THROW); // no matching UUIDs expected
         assertNode("/a/b/Cars");
@@ -522,11 +541,11 @@ public class JcrImportExportTest {
     }
 
     // ----------------------------------------------------------------------------------------------------------------
-    // Import System View WITH constraints
+    // Import Document View WITH constraints
     // ----------------------------------------------------------------------------------------------------------------
 
     @Test
-    public void shouldImportSystemViewWithReferenceConstraints() throws Exception {
+    public void shouldImportDocumentViewWithReferenceConstraints() throws Exception {
         // Set up the repository ...
         assertImport("io/full-workspace-document-view-with-uuids.xml", "/", ImportBehavior.THROW); // no matching UUIDs expected
         assertNode("/a/b/Cars");

--- a/modeshape-jcr/src/test/resources/io/full-workspace-document-view-with-constraint-violation.xml
+++ b/modeshape-jcr/src/test/resources/io/full-workspace-document-view-with-constraint-violation.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:car="http://www.modeshape.org/examples/cars/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:sv="http://www.jcp.org/jcr/sv/1.0" xmlns:mix="http://www.jcp.org/jcr/mix/1.0" xmlns:modeint="http://www.modeshape.org/internal/1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:mode="http://www.modeshape.org/1.0" jcr:primaryType="mode:root" jcr:uuid="0d0566db-1b07-499b-85cb-f21426b32a6f">
+	<a jcr:primaryType="nt:unstructured" jcr:uuid="fba275bf-a822-4fce-bb2a-2da96a833b21" jcr:mixinTypes="mix:referenceable">
+		<b jcr:primaryType="nt:unstructured" jcr:uuid="446561b5-fc94-475c-bb29-0ad1ebdeeccf" jcr:mixinTypes="mix:referenceable">
+			<Cars jcr:primaryType="nt:unstructured" jcr:uuid="e41075cb-a09a-4910-87b1-90ce8b4ca9dd" jcr:mixinTypes="mix:referenceable">
+				<Hybrid jcr:primaryType="nt:unstructured" jcr:uuid="7e999653-e558-4131-8889-af1e16872f4d" jcr:mixinTypes="mix:referenceable">
+					<Toyota_x0020_Prius jcr:primaryType="car:Car" car:year="2008" car:msrp="$21,500" car:mpgHighway="45" jcr:uuid="e92eddc1-d33a-4bd4-ae36-fe0a761b8d89" car:model="Prius" car:valueRating="5" car:maker="Toyota" car:mpgCity="48" jcr:mixinTypes="mix:referenceable" car:userRating="4"/>
+                    <!-- Next item contains an invalid user rating!! -->     
+					<Toyota_x0020_Highlander jcr:primaryType="car:Car" car:year="2008" car:msrp="$34,200" car:mpgHighway="25" jcr:uuid="f6348fbe-a0ba-43c4-9ae5-3faff5c0f6ec" car:model="Highlander" car:valueRating="5" car:maker="Toyota" car:mpgCity="27" jcr:mixinTypes="mix:referenceable" car:userRating="400"/>
+					<Nissan_x0020_Altima jcr:primaryType="car:Car" car:maker="Nissan" car:mpgCity="23" car:year="2008" car:msrp="$18,260" car:mpgHighway="32" jcr:uuid="b79bd26a-3556-4c40-9c6a-bdcbecae7677" jcr:mixinTypes="mix:referenceable" car:model="Altima"/>
+				</Hybrid>
+				<Sports jcr:primaryType="nt:unstructured" jcr:uuid="9145c396-e6d2-46d7-a5c3-654b4094f762" jcr:mixinTypes="mix:referenceable">
+					<Aston_x0020_Martin_x0020_DB9 jcr:primaryType="car:Car" car:engine="5,935_x0020_cc_x0020_5.9_x0020_liters_x0020_V_x0020_12" car:year="2008" car:wheelbaseInInches="108.0" car:msrp="$171,600" car:mpgHighway="19" jcr:uuid="6b595b19-7e89-4df5-954e-b2440b242403" car:model="DB9" car:maker="Aston_x0020_Martin" car:mpgCity="12" jcr:mixinTypes="mix:referenceable" car:userRating="5" car:lengthInInches="185.5"/>
+					<Infiniti_x0020_G37 jcr:primaryType="car:Car" car:year="2008" car:msrp="$34,900" car:mpgHighway="24" jcr:uuid="24807d85-6789-48f4-9e67-41c59d7d3fae" car:model="G37" car:valueRating="4" car:maker="Infiniti" car:mpgCity="18" jcr:mixinTypes="mix:referenceable" car:userRating="3"/>
+				</Sports>
+				<Luxury jcr:primaryType="nt:unstructured" jcr:uuid="f96fe720-49a9-4bf2-9bc4-39a0dd90e374" jcr:mixinTypes="mix:referenceable">
+					<Cadillac_x0020_DTS jcr:primaryType="car:Car" car:maker="Cadillac" car:engine="3.6_x0020_liter_x0020_V6" car:year="2008" jcr:uuid="c91ed7ba-39c5-4fcd-854c-8efbb1567b95" jcr:mixinTypes="mix:referenceable" car:userRating="1" car:model="DTS"/>
+					<Bentley_x0020_Continental jcr:primaryType="car:Car" car:maker="Bentley" car:mpgCity="10" car:year="2008" car:msrp="$170,990" car:mpgHighway="17" jcr:uuid="baa8ad28-6707-4342-9314-bb82dd9067a9" jcr:mixinTypes="mix:referenceable" car:model="Continental"/>
+					<Lexus_x0020_IS350 jcr:primaryType="car:Car" car:year="2008" car:msrp="$36,305" car:mpgHighway="25" jcr:uuid="7c513b8e-e77e-40f2-bf4d-147419037a75" car:model="IS350" car:valueRating="5" car:maker="Lexus" car:mpgCity="18" jcr:mixinTypes="mix:referenceable" car:userRating="4"/>
+				</Luxury>
+				<Utility jcr:primaryType="nt:unstructured" jcr:uuid="30568ebe-6351-4e74-9502-71b136387142" jcr:mixinTypes="mix:referenceable">
+					<Land_x0020_Rover_x0020_LR2 jcr:primaryType="car:Car" car:year="2008" car:msrp="$33,985" car:mpgHighway="23" jcr:uuid="df508fe2-439b-481c-9d29-4d7463471683" car:model="LR2" car:valueRating="5" car:maker="Land_x0020_Rover" car:mpgCity="16" jcr:mixinTypes="mix:referenceable" car:userRating="4"/>
+					<Land_x0020_Rover_x0020_LR3 jcr:primaryType="car:Car" car:year="2008" car:msrp="$48,525" car:mpgHighway="17" jcr:uuid="745a0fa0-c8fb-4920-813f-7f677cb0149e" car:model="LR3" car:valueRating="2" car:maker="Land_x0020_Rover" car:mpgCity="12" jcr:mixinTypes="mix:referenceable" car:userRating="5"/>
+					<Hummer_x0020_H3 jcr:primaryType="car:Car" car:year="2008" car:msrp="$30,595" car:mpgHighway="16" jcr:uuid="b7b00901-abbf-4fab-8487-34f3d85f8d61" car:model="H3" car:valueRating="4" car:maker="Hummer" car:mpgCity="13" jcr:mixinTypes="mix:referenceable" car:userRating="3"/>
+					<Ford_x0020_F-150 jcr:primaryType="car:Car" car:year="2008" car:msrp="$23,910" car:mpgHighway="20" jcr:uuid="aea99057-3454-435b-aea5-1253cee1efd4" car:model="F-150" car:valueRating="1" car:maker="Ford" car:mpgCity="14" jcr:mixinTypes="mix:referenceable" car:userRating="5"/>
+				</Utility>
+			</Cars>
+		</b>
+	</a>
+	<jcr:system jcr:primaryType="mode:system">
+		<jcr:versionStorage jcr:primaryType="mode:versionStorage"/>
+		<mode:namespaces jcr:primaryType="mode:namespaces">
+			<modeint jcr:primaryType="mode:namespace" mode:uri="http://www.modeshape.org/internal/1.0"/>
+			<mode jcr:primaryType="mode:namespace" mode:uri="http://www.modeshape.org/1.0"/>
+			<jcr jcr:primaryType="mode:namespace" mode:uri="http://www.jcp.org/jcr/1.0"/>
+			<mix jcr:primaryType="mode:namespace" mode:uri="http://www.jcp.org/jcr/mix/1.0"/>
+			<car jcr:primaryType="mode:namespace" mode:uri="http://www.modeshape.org/examples/cars/1.0"/>
+			<nt jcr:primaryType="mode:namespace" mode:uri="http://www.jcp.org/jcr/nt/1.0"/>
+			<xsd jcr:primaryType="mode:namespace" mode:uri="http://www.w3.org/2001/XMLSchema"/>
+			<sv jcr:primaryType="mode:namespace" mode:uri="http://www.jcp.org/jcr/sv/1.0"/>
+			<xml jcr:primaryType="mode:namespace" mode:uri="http://www.w3.org/XML/1998/namespace"/>
+			<xmlns jcr:primaryType="mode:namespace" mode:uri="http://www.w3.org/2000/xmlns/"/>
+			<xsi jcr:primaryType="mode:namespace" mode:uri="http://www.w3.org/2001/XMLSchema-instance"/>
+		</mode:namespaces>
+		<mode:locks jcr:primaryType="mode:locks"/>
+	</jcr:system>
+</jcr:root>

--- a/modeshape-jcr/src/test/resources/io/full-workspace-system-view-with-constraint-violation.xml
+++ b/modeshape-jcr/src/test/resources/io/full-workspace-system-view-with-constraint-violation.xml
@@ -1,0 +1,609 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<sv:node xmlns:car="http://www.modeshape.org/examples/cars/1.0"
+         xmlns:jcr="http://www.jcp.org/jcr/1.0"
+         xmlns:nt="http://www.jcp.org/jcr/nt/1.0"
+         xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+         xmlns:sv="http://www.jcp.org/jcr/sv/1.0"
+         xmlns:mix="http://www.jcp.org/jcr/mix/1.0"
+         xmlns:modeint="http://www.modeshape.org/internal/1.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns:mode="http://www.modeshape.org/1.0"
+         sv:name="jcr:root">
+	<sv:property sv:name="jcr:primaryType" sv:type="Name">
+		<sv:value>mode:root</sv:value>
+	</sv:property>
+	<sv:property sv:name="jcr:uuid" sv:type="String">
+		<sv:value>7e1bba85-30ee-40a1-8815-f186672df882</sv:value>
+	</sv:property>
+	<sv:node sv:name="a">
+		<sv:property sv:name="jcr:primaryType" sv:type="Name">
+			<sv:value>nt:unstructured</sv:value>
+		</sv:property>
+		<sv:property sv:name="jcr:mixinTypes" sv:type="Name">
+			<sv:value>mix:referenceable</sv:value>
+		</sv:property>
+		<sv:property sv:name="jcr:uuid" sv:type="String">
+			<sv:value>fba275bf-a822-4fce-bb2a-2da96a833b21</sv:value>
+		</sv:property>
+		<sv:node sv:name="b">
+			<sv:property sv:name="jcr:primaryType" sv:type="Name">
+				<sv:value>nt:unstructured</sv:value>
+			</sv:property>
+			<sv:property sv:name="jcr:mixinTypes" sv:type="Name">
+				<sv:value>mix:referenceable</sv:value>
+			</sv:property>
+			<sv:property sv:name="jcr:uuid" sv:type="String">
+				<sv:value>446561b5-fc94-475c-bb29-0ad1ebdeeccf</sv:value>
+			</sv:property>
+			<sv:node sv:name="Cars">
+				<sv:property sv:name="jcr:primaryType" sv:type="Name">
+					<sv:value>nt:unstructured</sv:value>
+				</sv:property>
+				<sv:property sv:name="jcr:mixinTypes" sv:type="Name">
+					<sv:value>mix:referenceable</sv:value>
+				</sv:property>
+				<sv:property sv:name="jcr:uuid" sv:type="String">
+					<sv:value>e41075cb-a09a-4910-87b1-90ce8b4ca9dd</sv:value>
+				</sv:property>
+				<sv:node sv:name="Hybrid">
+					<sv:property sv:name="jcr:primaryType" sv:type="Name">
+						<sv:value>nt:unstructured</sv:value>
+					</sv:property>
+					<sv:property sv:name="jcr:mixinTypes" sv:type="Name">
+						<sv:value>mix:referenceable</sv:value>
+					</sv:property>
+					<sv:property sv:name="jcr:uuid" sv:type="String">
+						<sv:value>7e999653-e558-4131-8889-af1e16872f4d</sv:value>
+					</sv:property>
+					<sv:node sv:name="Toyota Prius">
+						<sv:property sv:name="jcr:primaryType" sv:type="Name">
+							<sv:value>car:Car</sv:value>
+						</sv:property>
+						<sv:property sv:name="jcr:mixinTypes" sv:type="Name">
+							<sv:value>mix:referenceable</sv:value>
+						</sv:property>
+						<sv:property sv:name="jcr:uuid" sv:type="String">
+							<sv:value>e92eddc1-d33a-4bd4-ae36-fe0a761b8d89</sv:value>
+						</sv:property>
+						<sv:property sv:name="car:year" sv:type="String">
+							<sv:value>2008</sv:value>
+						</sv:property>
+						<sv:property sv:name="car:msrp" sv:type="String">
+							<sv:value>$21,500</sv:value>
+						</sv:property>
+						<sv:property sv:name="car:mpgHighway" sv:type="Long">
+							<sv:value>45</sv:value>
+						</sv:property>
+						<sv:property sv:name="car:model" sv:type="String">
+							<sv:value>Prius</sv:value>
+						</sv:property>
+						<sv:property sv:name="car:maker" sv:type="String">
+							<sv:value>Toyota</sv:value>
+						</sv:property>
+						<sv:property sv:name="car:valueRating" sv:type="Long">
+							<sv:value>5</sv:value>
+						</sv:property>
+						<sv:property sv:name="car:mpgCity" sv:type="Long">
+							<sv:value>48</sv:value>
+						</sv:property>
+						<sv:property sv:name="car:userRating" sv:type="Long">
+							<sv:value>4</sv:value>
+						</sv:property>
+					</sv:node>
+					<sv:node sv:name="Toyota Highlander">
+						<sv:property sv:name="jcr:primaryType" sv:type="Name">
+							<sv:value>car:Car</sv:value>
+						</sv:property>
+						<sv:property sv:name="jcr:mixinTypes" sv:type="Name">
+							<sv:value>mix:referenceable</sv:value>
+						</sv:property>
+						<sv:property sv:name="jcr:uuid" sv:type="String">
+							<sv:value>f6348fbe-a0ba-43c4-9ae5-3faff5c0f6ec</sv:value>
+						</sv:property>
+						<sv:property sv:name="car:year" sv:type="String">
+							<sv:value>2008</sv:value>
+						</sv:property>
+						<sv:property sv:name="car:msrp" sv:type="String">
+							<sv:value>$34,200</sv:value>
+						</sv:property>
+						<sv:property sv:name="car:mpgHighway" sv:type="Long">
+							<sv:value>25</sv:value>
+						</sv:property>
+						<sv:property sv:name="car:model" sv:type="String">
+							<sv:value>Highlander</sv:value>
+						</sv:property>
+						<sv:property sv:name="car:maker" sv:type="String">
+							<sv:value>Toyota</sv:value>
+						</sv:property>
+						<sv:property sv:name="car:valueRating" sv:type="Long">
+							<sv:value>5</sv:value>
+						</sv:property>
+						<sv:property sv:name="car:mpgCity" sv:type="Long">
+							<sv:value>27</sv:value>
+						</sv:property>
+                        <!-- This value violates the constraint!! -->
+                        <sv:property sv:name="car:userRating" sv:type="Long">
+                            <sv:value>4000</sv:value>
+                        </sv:property>
+					</sv:node>
+					<sv:node sv:name="Nissan Altima">
+						<sv:property sv:name="jcr:primaryType" sv:type="Name">
+							<sv:value>car:Car</sv:value>
+						</sv:property>
+						<sv:property sv:name="jcr:mixinTypes" sv:type="Name">
+							<sv:value>mix:referenceable</sv:value>
+						</sv:property>
+						<sv:property sv:name="jcr:uuid" sv:type="String">
+							<sv:value>b79bd26a-3556-4c40-9c6a-bdcbecae7677</sv:value>
+						</sv:property>
+						<sv:property sv:name="car:maker" sv:type="String">
+							<sv:value>Nissan</sv:value>
+						</sv:property>
+						<sv:property sv:name="car:mpgCity" sv:type="Long">
+							<sv:value>23</sv:value>
+						</sv:property>
+						<sv:property sv:name="car:year" sv:type="String">
+							<sv:value>2008</sv:value>
+						</sv:property>
+						<sv:property sv:name="car:msrp" sv:type="String">
+							<sv:value>$18,260</sv:value>
+						</sv:property>
+						<sv:property sv:name="car:mpgHighway" sv:type="Long">
+							<sv:value>32</sv:value>
+						</sv:property>
+						<sv:property sv:name="car:model" sv:type="String">
+							<sv:value>Altima</sv:value>
+						</sv:property>
+					</sv:node>
+				</sv:node>
+				<sv:node sv:name="Sports">
+					<sv:property sv:name="jcr:primaryType" sv:type="Name">
+						<sv:value>nt:unstructured</sv:value>
+					</sv:property>
+					<sv:property sv:name="jcr:mixinTypes" sv:type="Name">
+						<sv:value>mix:referenceable</sv:value>
+					</sv:property>
+					<sv:property sv:name="jcr:uuid" sv:type="String">
+						<sv:value>9145c396-e6d2-46d7-a5c3-654b4094f762</sv:value>
+					</sv:property>
+					<sv:node sv:name="Aston Martin DB9">
+						<sv:property sv:name="jcr:primaryType" sv:type="Name">
+							<sv:value>car:Car</sv:value>
+						</sv:property>
+						<sv:property sv:name="jcr:mixinTypes" sv:type="Name">
+							<sv:value>mix:referenceable</sv:value>
+						</sv:property>
+						<sv:property sv:name="jcr:uuid" sv:type="String">
+							<sv:value>6b595b19-7e89-4df5-954e-b2440b242403</sv:value>
+						</sv:property>
+						<sv:property sv:name="car:engine" sv:type="String">
+							<sv:value>5,935 cc 5.9 liters V 12</sv:value>
+						</sv:property>
+						<sv:property sv:name="car:year" sv:type="String">
+							<sv:value>2008</sv:value>
+						</sv:property>
+						<sv:property sv:name="car:wheelbaseInInches" sv:type="Double">
+							<sv:value>108.0</sv:value>
+						</sv:property>
+						<sv:property sv:name="car:msrp" sv:type="String">
+							<sv:value>$171,600</sv:value>
+						</sv:property>
+						<sv:property sv:name="car:mpgHighway" sv:type="Long">
+							<sv:value>19</sv:value>
+						</sv:property>
+						<sv:property sv:name="car:model" sv:type="String">
+							<sv:value>DB9</sv:value>
+						</sv:property>
+						<sv:property sv:name="car:maker" sv:type="String">
+							<sv:value>Aston Martin</sv:value>
+						</sv:property>
+						<sv:property sv:name="car:mpgCity" sv:type="Long">
+							<sv:value>12</sv:value>
+						</sv:property>
+						<sv:property sv:name="car:userRating" sv:type="Long">
+							<sv:value>5</sv:value>
+						</sv:property>
+						<sv:property sv:name="car:lengthInInches" sv:type="Double">
+							<sv:value>185.5</sv:value>
+						</sv:property>
+					</sv:node>
+					<sv:node sv:name="Infiniti G37">
+						<sv:property sv:name="jcr:primaryType" sv:type="Name">
+							<sv:value>car:Car</sv:value>
+						</sv:property>
+						<sv:property sv:name="jcr:mixinTypes" sv:type="Name">
+							<sv:value>mix:referenceable</sv:value>
+						</sv:property>
+						<sv:property sv:name="jcr:uuid" sv:type="String">
+							<sv:value>24807d85-6789-48f4-9e67-41c59d7d3fae</sv:value>
+						</sv:property>
+						<sv:property sv:name="car:year" sv:type="String">
+							<sv:value>2008</sv:value>
+						</sv:property>
+						<sv:property sv:name="car:msrp" sv:type="String">
+							<sv:value>$34,900</sv:value>
+						</sv:property>
+						<sv:property sv:name="car:mpgHighway" sv:type="Long">
+							<sv:value>24</sv:value>
+						</sv:property>
+						<sv:property sv:name="car:model" sv:type="String">
+							<sv:value>G37</sv:value>
+						</sv:property>
+						<sv:property sv:name="car:maker" sv:type="String">
+							<sv:value>Infiniti</sv:value>
+						</sv:property>
+						<sv:property sv:name="car:valueRating" sv:type="Long">
+							<sv:value>4</sv:value>
+						</sv:property>
+						<sv:property sv:name="car:mpgCity" sv:type="Long">
+							<sv:value>18</sv:value>
+						</sv:property>
+						<sv:property sv:name="car:userRating" sv:type="Long">
+							<sv:value>3</sv:value>
+						</sv:property>
+					</sv:node>
+				</sv:node>
+				<sv:node sv:name="Luxury">
+					<sv:property sv:name="jcr:primaryType" sv:type="Name">
+						<sv:value>nt:unstructured</sv:value>
+					</sv:property>
+					<sv:property sv:name="jcr:mixinTypes" sv:type="Name">
+						<sv:value>mix:referenceable</sv:value>
+					</sv:property>
+					<sv:property sv:name="jcr:uuid" sv:type="String">
+						<sv:value>f96fe720-49a9-4bf2-9bc4-39a0dd90e374</sv:value>
+					</sv:property>
+					<sv:node sv:name="Cadillac DTS">
+						<sv:property sv:name="jcr:primaryType" sv:type="Name">
+							<sv:value>car:Car</sv:value>
+						</sv:property>
+						<sv:property sv:name="jcr:mixinTypes" sv:type="Name">
+							<sv:value>mix:referenceable</sv:value>
+						</sv:property>
+						<sv:property sv:name="jcr:uuid" sv:type="String">
+							<sv:value>c91ed7ba-39c5-4fcd-854c-8efbb1567b95</sv:value>
+						</sv:property>
+						<sv:property sv:name="car:maker" sv:type="String">
+							<sv:value>Cadillac</sv:value>
+						</sv:property>
+						<sv:property sv:name="car:engine" sv:type="String">
+							<sv:value>3.6 liter V6</sv:value>
+						</sv:property>
+						<sv:property sv:name="car:year" sv:type="String">
+							<sv:value>2008</sv:value>
+						</sv:property>
+						<sv:property sv:name="car:userRating" sv:type="Long">
+							<sv:value>1</sv:value>
+						</sv:property>
+						<sv:property sv:name="car:model" sv:type="String">
+							<sv:value>DTS</sv:value>
+						</sv:property>
+					</sv:node>
+					<sv:node sv:name="Bentley Continental">
+						<sv:property sv:name="jcr:primaryType" sv:type="Name">
+							<sv:value>car:Car</sv:value>
+						</sv:property>
+						<sv:property sv:name="jcr:mixinTypes" sv:type="Name">
+							<sv:value>mix:referenceable</sv:value>
+						</sv:property>
+						<sv:property sv:name="jcr:uuid" sv:type="String">
+							<sv:value>baa8ad28-6707-4342-9314-bb82dd9067a9</sv:value>
+						</sv:property>
+						<sv:property sv:name="car:maker" sv:type="String">
+							<sv:value>Bentley</sv:value>
+						</sv:property>
+						<sv:property sv:name="car:mpgCity" sv:type="Long">
+							<sv:value>10</sv:value>
+						</sv:property>
+						<sv:property sv:name="car:year" sv:type="String">
+							<sv:value>2008</sv:value>
+						</sv:property>
+						<sv:property sv:name="car:msrp" sv:type="String">
+							<sv:value>$170,990</sv:value>
+						</sv:property>
+						<sv:property sv:name="car:mpgHighway" sv:type="Long">
+							<sv:value>17</sv:value>
+						</sv:property>
+						<sv:property sv:name="car:model" sv:type="String">
+							<sv:value>Continental</sv:value>
+						</sv:property>
+					</sv:node>
+					<sv:node sv:name="Lexus IS350">
+						<sv:property sv:name="jcr:primaryType" sv:type="Name">
+							<sv:value>car:Car</sv:value>
+						</sv:property>
+						<sv:property sv:name="jcr:mixinTypes" sv:type="Name">
+							<sv:value>mix:referenceable</sv:value>
+						</sv:property>
+						<sv:property sv:name="jcr:uuid" sv:type="String">
+							<sv:value>7c513b8e-e77e-40f2-bf4d-147419037a75</sv:value>
+						</sv:property>
+						<sv:property sv:name="car:year" sv:type="String">
+							<sv:value>2008</sv:value>
+						</sv:property>
+						<sv:property sv:name="car:msrp" sv:type="String">
+							<sv:value>$36,305</sv:value>
+						</sv:property>
+						<sv:property sv:name="car:mpgHighway" sv:type="Long">
+							<sv:value>25</sv:value>
+						</sv:property>
+						<sv:property sv:name="car:model" sv:type="String">
+							<sv:value>IS350</sv:value>
+						</sv:property>
+						<sv:property sv:name="car:maker" sv:type="String">
+							<sv:value>Lexus</sv:value>
+						</sv:property>
+						<sv:property sv:name="car:valueRating" sv:type="Long">
+							<sv:value>5</sv:value>
+						</sv:property>
+						<sv:property sv:name="car:mpgCity" sv:type="Long">
+							<sv:value>18</sv:value>
+						</sv:property>
+						<sv:property sv:name="car:userRating" sv:type="Long">
+							<sv:value>4</sv:value>
+						</sv:property>
+					</sv:node>
+				</sv:node>
+				<sv:node sv:name="Utility">
+					<sv:property sv:name="jcr:primaryType" sv:type="Name">
+						<sv:value>nt:unstructured</sv:value>
+					</sv:property>
+					<sv:property sv:name="jcr:mixinTypes" sv:type="Name">
+						<sv:value>mix:referenceable</sv:value>
+					</sv:property>
+					<sv:property sv:name="jcr:uuid" sv:type="String">
+						<sv:value>30568ebe-6351-4e74-9502-71b136387142</sv:value>
+					</sv:property>
+					<sv:node sv:name="Land Rover LR2">
+						<sv:property sv:name="jcr:primaryType" sv:type="Name">
+							<sv:value>car:Car</sv:value>
+						</sv:property>
+						<sv:property sv:name="jcr:mixinTypes" sv:type="Name">
+							<sv:value>mix:referenceable</sv:value>
+						</sv:property>
+						<sv:property sv:name="jcr:uuid" sv:type="String">
+							<sv:value>df508fe2-439b-481c-9d29-4d7463471683</sv:value>
+						</sv:property>
+						<sv:property sv:name="car:year" sv:type="String">
+							<sv:value>2008</sv:value>
+						</sv:property>
+						<sv:property sv:name="car:msrp" sv:type="String">
+							<sv:value>$33,985</sv:value>
+						</sv:property>
+						<sv:property sv:name="car:mpgHighway" sv:type="Long">
+							<sv:value>23</sv:value>
+						</sv:property>
+						<sv:property sv:name="car:model" sv:type="String">
+							<sv:value>LR2</sv:value>
+						</sv:property>
+						<sv:property sv:name="car:maker" sv:type="String">
+							<sv:value>Land Rover</sv:value>
+						</sv:property>
+						<sv:property sv:name="car:valueRating" sv:type="Long">
+							<sv:value>5</sv:value>
+						</sv:property>
+						<sv:property sv:name="car:mpgCity" sv:type="Long">
+							<sv:value>16</sv:value>
+						</sv:property>
+						<sv:property sv:name="car:userRating" sv:type="Long">
+							<sv:value>4</sv:value>
+						</sv:property>
+					</sv:node>
+					<sv:node sv:name="Land Rover LR3">
+						<sv:property sv:name="jcr:primaryType" sv:type="Name">
+							<sv:value>car:Car</sv:value>
+						</sv:property>
+						<sv:property sv:name="jcr:mixinTypes" sv:type="Name">
+							<sv:value>mix:referenceable</sv:value>
+						</sv:property>
+						<sv:property sv:name="jcr:uuid" sv:type="String">
+							<sv:value>745a0fa0-c8fb-4920-813f-7f677cb0149e</sv:value>
+						</sv:property>
+						<sv:property sv:name="car:year" sv:type="String">
+							<sv:value>2008</sv:value>
+						</sv:property>
+						<sv:property sv:name="car:msrp" sv:type="String">
+							<sv:value>$48,525</sv:value>
+						</sv:property>
+						<sv:property sv:name="car:mpgHighway" sv:type="Long">
+							<sv:value>17</sv:value>
+						</sv:property>
+						<sv:property sv:name="car:model" sv:type="String">
+							<sv:value>LR3</sv:value>
+						</sv:property>
+						<sv:property sv:name="car:maker" sv:type="String">
+							<sv:value>Land Rover</sv:value>
+						</sv:property>
+						<sv:property sv:name="car:valueRating" sv:type="Long">
+							<sv:value>2</sv:value>
+						</sv:property>
+						<sv:property sv:name="car:mpgCity" sv:type="Long">
+							<sv:value>12</sv:value>
+						</sv:property>
+						<sv:property sv:name="car:userRating" sv:type="Long">
+							<sv:value>5</sv:value>
+						</sv:property>
+					</sv:node>
+					<sv:node sv:name="Hummer H3">
+						<sv:property sv:name="jcr:primaryType" sv:type="Name">
+							<sv:value>car:Car</sv:value>
+						</sv:property>
+						<sv:property sv:name="jcr:mixinTypes" sv:type="Name">
+							<sv:value>mix:referenceable</sv:value>
+						</sv:property>
+						<sv:property sv:name="jcr:uuid" sv:type="String">
+							<sv:value>b7b00901-abbf-4fab-8487-34f3d85f8d61</sv:value>
+						</sv:property>
+						<sv:property sv:name="car:year" sv:type="String">
+							<sv:value>2008</sv:value>
+						</sv:property>
+						<sv:property sv:name="car:msrp" sv:type="String">
+							<sv:value>$30,595</sv:value>
+						</sv:property>
+						<sv:property sv:name="car:mpgHighway" sv:type="Long">
+							<sv:value>16</sv:value>
+						</sv:property>
+						<sv:property sv:name="car:model" sv:type="String">
+							<sv:value>H3</sv:value>
+						</sv:property>
+						<sv:property sv:name="car:maker" sv:type="String">
+							<sv:value>Hummer</sv:value>
+						</sv:property>
+						<sv:property sv:name="car:valueRating" sv:type="Long">
+							<sv:value>4</sv:value>
+						</sv:property>
+						<sv:property sv:name="car:mpgCity" sv:type="Long">
+							<sv:value>13</sv:value>
+						</sv:property>
+						<sv:property sv:name="car:userRating" sv:type="Long">
+							<sv:value>3</sv:value>
+						</sv:property>
+					</sv:node>
+					<sv:node sv:name="Ford F-150">
+						<sv:property sv:name="jcr:primaryType" sv:type="Name">
+							<sv:value>car:Car</sv:value>
+						</sv:property>
+						<sv:property sv:name="jcr:mixinTypes" sv:type="Name">
+							<sv:value>mix:referenceable</sv:value>
+						</sv:property>
+						<sv:property sv:name="jcr:uuid" sv:type="String">
+							<sv:value>aea99057-3454-435b-aea5-1253cee1efd4</sv:value>
+						</sv:property>
+						<sv:property sv:name="car:year" sv:type="String">
+							<sv:value>2008</sv:value>
+						</sv:property>
+						<sv:property sv:name="car:msrp" sv:type="String">
+							<sv:value>$23,910</sv:value>
+						</sv:property>
+						<sv:property sv:name="car:mpgHighway" sv:type="Long">
+							<sv:value>20</sv:value>
+						</sv:property>
+						<sv:property sv:name="car:model" sv:type="String">
+							<sv:value>F-150</sv:value>
+						</sv:property>
+						<sv:property sv:name="car:maker" sv:type="String">
+							<sv:value>Ford</sv:value>
+						</sv:property>
+						<sv:property sv:name="car:valueRating" sv:type="Long">
+							<sv:value>1</sv:value>
+						</sv:property>
+						<sv:property sv:name="car:mpgCity" sv:type="Long">
+							<sv:value>14</sv:value>
+						</sv:property>
+						<sv:property sv:name="car:userRating" sv:type="Long">
+							<sv:value>5</sv:value>
+						</sv:property>
+					</sv:node>
+				</sv:node>
+			</sv:node>
+		</sv:node>
+	</sv:node>
+	<sv:node sv:name="jcr:system">
+		<sv:property sv:name="jcr:primaryType" sv:type="Name">
+			<sv:value>mode:system</sv:value>
+		</sv:property>
+		<sv:node sv:name="jcr:versionStorage">
+			<sv:property sv:name="jcr:primaryType" sv:type="Name">
+				<sv:value>mode:versionStorage</sv:value>
+			</sv:property>
+		</sv:node>
+		<sv:node sv:name="mode:namespaces">
+			<sv:property sv:name="jcr:primaryType" sv:type="Name">
+				<sv:value>mode:namespaces</sv:value>
+			</sv:property>
+			<sv:node sv:name="modeint">
+				<sv:property sv:name="jcr:primaryType" sv:type="Name">
+					<sv:value>mode:namespace</sv:value>
+				</sv:property>
+				<sv:property sv:name="mode:uri" sv:type="String">
+					<sv:value>http://www.modeshape.org/internal/1.0</sv:value>
+				</sv:property>
+			</sv:node>
+			<sv:node sv:name="mode">
+				<sv:property sv:name="jcr:primaryType" sv:type="Name">
+					<sv:value>mode:namespace</sv:value>
+				</sv:property>
+				<sv:property sv:name="mode:uri" sv:type="String">
+					<sv:value>http://www.modeshape.org/1.0</sv:value>
+				</sv:property>
+			</sv:node>
+			<sv:node sv:name="jcr">
+				<sv:property sv:name="jcr:primaryType" sv:type="Name">
+					<sv:value>mode:namespace</sv:value>
+				</sv:property>
+				<sv:property sv:name="mode:uri" sv:type="String">
+					<sv:value>http://www.jcp.org/jcr/1.0</sv:value>
+				</sv:property>
+			</sv:node>
+			<sv:node sv:name="mix">
+				<sv:property sv:name="jcr:primaryType" sv:type="Name">
+					<sv:value>mode:namespace</sv:value>
+				</sv:property>
+				<sv:property sv:name="mode:uri" sv:type="String">
+					<sv:value>http://www.jcp.org/jcr/mix/1.0</sv:value>
+				</sv:property>
+			</sv:node>
+			<sv:node sv:name="car">
+				<sv:property sv:name="jcr:primaryType" sv:type="Name">
+					<sv:value>mode:namespace</sv:value>
+				</sv:property>
+				<sv:property sv:name="mode:uri" sv:type="String">
+					<sv:value>http://www.modeshape.org/examples/cars/1.0</sv:value>
+				</sv:property>
+			</sv:node>
+			<sv:node sv:name="nt">
+				<sv:property sv:name="jcr:primaryType" sv:type="Name">
+					<sv:value>mode:namespace</sv:value>
+				</sv:property>
+				<sv:property sv:name="mode:uri" sv:type="String">
+					<sv:value>http://www.jcp.org/jcr/nt/1.0</sv:value>
+				</sv:property>
+			</sv:node>
+			<sv:node sv:name="xsd">
+				<sv:property sv:name="jcr:primaryType" sv:type="Name">
+					<sv:value>mode:namespace</sv:value>
+				</sv:property>
+				<sv:property sv:name="mode:uri" sv:type="String">
+					<sv:value>http://www.w3.org/2001/XMLSchema</sv:value>
+				</sv:property>
+			</sv:node>
+			<sv:node sv:name="sv">
+				<sv:property sv:name="jcr:primaryType" sv:type="Name">
+					<sv:value>mode:namespace</sv:value>
+				</sv:property>
+				<sv:property sv:name="mode:uri" sv:type="String">
+					<sv:value>http://www.jcp.org/jcr/sv/1.0</sv:value>
+				</sv:property>
+			</sv:node>
+			<sv:node sv:name="xml">
+				<sv:property sv:name="jcr:primaryType" sv:type="Name">
+					<sv:value>mode:namespace</sv:value>
+				</sv:property>
+				<sv:property sv:name="mode:uri" sv:type="String">
+					<sv:value>http://www.w3.org/XML/1998/namespace</sv:value>
+				</sv:property>
+			</sv:node>
+			<sv:node sv:name="xmlns">
+				<sv:property sv:name="jcr:primaryType" sv:type="Name">
+					<sv:value>mode:namespace</sv:value>
+				</sv:property>
+				<sv:property sv:name="mode:uri" sv:type="String">
+					<sv:value>http://www.w3.org/2000/xmlns/</sv:value>
+				</sv:property>
+			</sv:node>
+			<sv:node sv:name="xsi">
+				<sv:property sv:name="jcr:primaryType" sv:type="Name">
+					<sv:value>mode:namespace</sv:value>
+				</sv:property>
+				<sv:property sv:name="mode:uri" sv:type="String">
+					<sv:value>http://www.w3.org/2001/XMLSchema-instance</sv:value>
+				</sv:property>
+			</sv:node>
+		</sv:node>
+		<sv:node sv:name="mode:locks">
+			<sv:property sv:name="jcr:primaryType" sv:type="Name">
+				<sv:value>mode:locks</sv:value>
+			</sv:property>
+		</sv:node>
+	</sv:node>
+</sv:node>


### PR DESCRIPTION
Added two tests that import XML (both system and document views) that contains values that violate constraints of a property definition. The tests show that in both cases, Session.importXML(...) does indeed throw a ConstraintViolationException (rather than the EnclosingSAXException as reported).
