### PR TITLE
MODE-1146 REST Servlet Ignores Servlet Mappings Other Than /*

### DIFF
--- a/web/modeshape-web-jcr-rest-client/src/test/java/org/modeshape/web/jcr/rest/client/json/JsonRestClientTest.java
+++ b/web/modeshape-web-jcr-rest-client/src/test/java/org/modeshape/web/jcr/rest/client/json/JsonRestClientTest.java
@@ -64,7 +64,7 @@ public final class JsonRestClientTest {
     private static final String PSWD = "password";
     private static final String USER = "dnauser";
 
-    private static final Server SERVER = new Server("http://localhost:8090/resources", USER, PSWD);
+    private static final Server SERVER = new Server("http://localhost:8090/resources/test", USER, PSWD);
     private static final String REPOSITORY_NAME = "mode:repository";
     private static final Repository REPOSITORY1 = new Repository(REPOSITORY_NAME, SERVER);
     private static final String WORKSPACE_NAME = "default";

--- a/web/modeshape-web-jcr-rest-war/src/main/webapp/WEB-INF/web.xml
+++ b/web/modeshape-web-jcr-rest-war/src/main/webapp/WEB-INF/web.xml
@@ -55,6 +55,13 @@
 		<param-name>javax.ws.rs.Application</param-name>
 		<param-value>org.modeshape.web.jcr.rest.JcrApplication</param-value>
 	</context-param>
+	
+	<!--  Optional parameter If the url-pattern for the Resteasy servlet-mapping is not /* -->
+
+	<context-param>
+		<param-name>resteasy.servlet.mapping.prefix</param-name>
+		<param-value>/test</param-value>
+	</context-param>
 
 	<!-- Required parameter for RESTEasy - should not be modified -->
 	<listener>
@@ -89,7 +96,7 @@
 		<display-name>ModeShape REST</display-name>
 		<web-resource-collection>
 			<web-resource-name>RestEasy</web-resource-name>
-			<url-pattern>/*</url-pattern>
+			<url-pattern>/test/*</url-pattern>
 		</web-resource-collection>
 		<auth-constraint>
 			<!--  

--- a/web/modeshape-web-jcr-rest-war/src/test/java/org/modeshape/web/jcr/rest/JcrResourcesTest.java
+++ b/web/modeshape-web-jcr-rest-war/src/test/java/org/modeshape/web/jcr/rest/JcrResourcesTest.java
@@ -51,7 +51,7 @@ import org.modeshape.common.util.Base64;
  */
 public class JcrResourcesTest {
 
-    private static final String SERVER_CONTEXT = "/resources";
+    private static final String SERVER_CONTEXT = "/resources/test";
     private static final String SERVER_URL = "http://localhost:8090" + SERVER_CONTEXT;
 
     @Before
@@ -145,7 +145,8 @@ public class JcrResourcesTest {
 
         JSONObject objFromResponse = new JSONObject(body);
         JSONObject expected = new JSONObject(
-                                             "{\"mode%3arepository\":{\"repository\":{\"name\":\"mode%3arepository\",\"resources\":{\"workspaces\":\"/resources/mode%3arepository\"}}}}");
+                                             "{\"mode%3arepository\":{\"repository\":{\"name\":\"mode%3arepository\",\"resources\":{\"workspaces\":\""
+                                             + SERVER_CONTEXT + "/mode%3arepository\"}}}}");
 
         assertThat(connection.getResponseCode(), is(HttpURLConnection.HTTP_OK));
         assertThat(objFromResponse.toString(), is(expected.toString()));
@@ -164,7 +165,10 @@ public class JcrResourcesTest {
 
         JSONObject objFromResponse = new JSONObject(body);
         JSONObject expected = new JSONObject(
-                                             "{\"default\":{\"workspace\":{\"name\":\"default\",\"resources\":{\"query\":\"/resources/mode%3arepository/default/query\",\"items\":\"/resources/mode%3arepository/default/items\"}}}}");
+                                             "{\"default\":{\"workspace\":{\"name\":\"default\",\"resources\":{\"query\":\""
+                                             + SERVER_CONTEXT
+                                             + "/mode%3arepository/default/query\",\"items\":\""
+                                             + SERVER_CONTEXT + "/mode%3arepository/default/items\"}}}}");
 
         assertThat(connection.getResponseCode(), is(HttpURLConnection.HTTP_OK));
         assertThat(objFromResponse.toString(), is(expected.toString()));

--- a/web/modeshape-web-jcr-rest/src/main/java/org/modeshape/web/jcr/rest/RepositoryHandler.java
+++ b/web/modeshape-web-jcr-rest/src/main/java/org/modeshape/web/jcr/rest/RepositoryHandler.java
@@ -36,12 +36,15 @@ class RepositoryHandler extends AbstractHandler {
         Session session = getSession(request, rawRepositoryName, null);
         rawRepositoryName = URL_ENCODER.encode(rawRepositoryName);
 
+        String uri = request.getRequestURI();
+        uri = uri.substring(0, uri.length() - rawRepositoryName.length() - 1);
+
         for (String name : session.getWorkspace().getAccessibleWorkspaceNames()) {
             if (name.trim().length() == 0) {
                 name = EMPTY_WORKSPACE_NAME;
             }
             name = URL_ENCODER.encode(name);
-            workspaces.put(name, new WorkspaceEntry(request.getContextPath(), rawRepositoryName, name));
+            workspaces.put(name, new WorkspaceEntry(uri, rawRepositoryName, name));
         }
 
         return workspaces;

--- a/web/modeshape-web-jcr-rest/src/main/java/org/modeshape/web/jcr/rest/ServerHandler.java
+++ b/web/modeshape-web-jcr-rest/src/main/java/org/modeshape/web/jcr/rest/ServerHandler.java
@@ -23,13 +23,18 @@ class ServerHandler extends AbstractHandler {
         assert request != null;
 
         Map<String, RepositoryEntry> repositories = new HashMap<String, RepositoryEntry>();
+        String uri = request.getRequestURI();
+
+        if (uri.endsWith("/")) {
+            uri = uri.substring(0, uri.length() - 1);
+        }
 
         for (String name : RepositoryFactory.getJcrRepositoryNames()) {
             if (name.trim().length() == 0) {
                 name = EMPTY_REPOSITORY_NAME;
             }
             name = URL_ENCODER.encode(name);
-            repositories.put(name, new RepositoryEntry(request.getContextPath(), name));
+            repositories.put(name, new RepositoryEntry(uri, name));
         }
 
         return repositories;


### PR DESCRIPTION
Attached patch that corrects the way that the REST server produces URIs when querying the server-level resource and the repository-level resource.  Higher-level resources are not affected by this issue, because we use relative URIs for node children.  The patch remaps the servlet in the tests from /\* to /test/\* and slightly modifies some test scripts accordingly.
