### PR TITLE
MODE-1122 in case JAAS fails go for anonymous

### DIFF
--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrI18n.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrI18n.java
@@ -44,6 +44,7 @@ public final class JcrI18n {
     public static I18n mustBeInPrivilegedAction;
     public static I18n loginConfigNotFound;
     public static I18n credentialsMustReturnLoginContext;
+    public static I18n usingAnonymousUser;
     public static I18n unknownCredentialsImplementation;
     public static I18n defaultWorkspaceName;
     public static I18n pathNotFound;

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrRepository.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrRepository.java
@@ -69,13 +69,13 @@ import org.modeshape.common.util.CheckArg;
 import org.modeshape.common.util.Logger;
 import org.modeshape.graph.ExecutionContext;
 import org.modeshape.graph.Graph;
-import org.modeshape.graph.Graph.Batch;
 import org.modeshape.graph.GraphI18n;
 import org.modeshape.graph.JaasSecurityContext;
 import org.modeshape.graph.Location;
 import org.modeshape.graph.SecurityContext;
 import org.modeshape.graph.Subgraph;
 import org.modeshape.graph.Workspace;
+import org.modeshape.graph.Graph.Batch;
 import org.modeshape.graph.connector.RepositoryConnection;
 import org.modeshape.graph.connector.RepositoryConnectionFactory;
 import org.modeshape.graph.connector.RepositoryContext;
@@ -102,8 +102,8 @@ import org.modeshape.graph.property.ValueFactories;
 import org.modeshape.graph.property.ValueFactory;
 import org.modeshape.graph.property.basic.GraphNamespaceRegistry;
 import org.modeshape.graph.query.QueryBuilder;
-import org.modeshape.graph.query.QueryBuilder.ConstraintBuilder;
 import org.modeshape.graph.query.QueryResults;
+import org.modeshape.graph.query.QueryBuilder.ConstraintBuilder;
 import org.modeshape.graph.query.model.QueryCommand;
 import org.modeshape.graph.query.model.Visitors;
 import org.modeshape.graph.query.parse.QueryParsers;
@@ -354,7 +354,16 @@ public class JcrRepository implements Repository {
          * leave the derived content. The default value is 'true'.
          * </p>
          */
-        REMOVE_DERIVED_CONTENT_WITH_ORIGINAL, ;
+        REMOVE_DERIVED_CONTENT_WITH_ORIGINAL,
+
+        /**
+         * Indicates whether a failed attempt to {@link #login} should automatically attempt to use anonymous access instead. If
+         * anonymous access is not enabled, then failed login attempts will still cause an {@link LoginException} to be thrown.
+         * The default value is 'true'.
+         * 
+         * @see #ANONYMOUS_USER_ROLES
+         */
+        USE_ANONYMOUS_ACCESS_ON_FAILED_LOGIN, ;
 
         /**
          * Determine the option given the option name. This does more than {@link Option#valueOf(String)}, since this method first
@@ -481,6 +490,11 @@ public class JcrRepository implements Repository {
          * The default value for the {@link Option#REMOVE_DERIVED_CONTENT_WITH_ORIGINAL} option is {@value} .
          */
         public static final String REMOVE_DERIVED_CONTENT_WITH_ORIGINAL = Boolean.TRUE.toString();
+
+        /**
+         * The default value for the {@link Option#USE_ANONYMOUS_ACCESS_ON_FAILED_LOGIN} option is {@value} .
+         */
+        public static final String USE_ANONYMOUS_ACCESS_ON_FAILED_LOGIN = Boolean.TRUE.toString();
     }
 
     /**
@@ -543,6 +557,7 @@ public class JcrRepository implements Repository {
         defaults.put(Option.VERSION_HISTORY_STRUCTURE, DefaultOption.VERSION_HISTORY_STRUCTURE);
         defaults.put(Option.REPOSITORY_JNDI_LOCATION, DefaultOption.REPOSITORY_JNDI_LOCATION);
         defaults.put(Option.REMOVE_DERIVED_CONTENT_WITH_ORIGINAL, DefaultOption.REMOVE_DERIVED_CONTENT_WITH_ORIGINAL);
+        defaults.put(Option.USE_ANONYMOUS_ACCESS_ON_FAILED_LOGIN, DefaultOption.USE_ANONYMOUS_ACCESS_ON_FAILED_LOGIN);
         DEFAULT_OPTIONS = Collections.<Option, String>unmodifiableMap(defaults);
     }
 
@@ -1305,6 +1320,7 @@ public class JcrRepository implements Repository {
         // Ensure credentials are either null or provide a JAAS method
         Map<String, Object> sessionAttributes = new HashMap<String, Object>();
         ExecutionContext execContext = null;
+
         if (credentials == null || credentials instanceof AnonymousCredentials) {
             Subject subject = Subject.getSubject(AccessController.getContext());
             if (subject != null) {
@@ -1366,7 +1382,16 @@ public class JcrRepository implements Repository {
             } catch (RuntimeException error) {
                 throw error; // pass along
             } catch (javax.jcr.LoginException error) {
-                throw error; // pass along
+                boolean tryAnonAccess = Boolean.valueOf(options.get(Option.USE_ANONYMOUS_ACCESS_ON_FAILED_LOGIN));
+
+                if (tryAnonAccess && anonymousUserContext != null) {
+                    if (LOGGER.isDebugEnabled()) {
+                        LOGGER.debug(JcrI18n.usingAnonymousUser.text());
+                    }
+                    execContext = executionContext.with(this.anonymousUserContext);
+                } else {
+                    throw error; // pass along
+                }
             } catch (Exception error) {
                 throw new javax.jcr.LoginException(error); // wrap
             }

--- a/modeshape-jcr/src/main/resources/org/modeshape/jcr/JcrI18n.properties
+++ b/modeshape-jcr/src/main/resources/org/modeshape/jcr/JcrI18n.properties
@@ -34,6 +34,7 @@ credentialsMustProvideJaasMethod = The Credentials class "{0}" must implement "p
 mustBeInPrivilegedAction=login() can only be called successfully from within a java.security.PrivilegedAction or when the ANONYMOUS_USER_ROLES repository option is set
 loginConfigNotFound = The JAAS policy named '{0}' (nor the policy named 'other') could not be found; check the value of the '{1}' repository option in the configuration for the '{2}' repository
 credentialsMustReturnLoginContext = The "getLoginContext()" method in Credentials class "{0}" may not return null
+usingAnonymousUser = Invalid credentials provided.  Using anonymous user context.
 unknownCredentialsImplementation = ModeShape does not know how to use the "{0}" implementation of javax.jcr.Credentials.
 defaultWorkspaceName=
 pathNotFound = No item exists at path {0} in workspace "{1}"

--- a/modeshape-jcr/src/test/java/org/modeshape/jcr/JcrConfigurationTest.java
+++ b/modeshape-jcr/src/test/java/org/modeshape/jcr/JcrConfigurationTest.java
@@ -54,8 +54,8 @@ import org.modeshape.graph.property.Path;
 import org.modeshape.jcr.JcrRepository.DefaultOption;
 import org.modeshape.jcr.JcrRepository.Option;
 import org.modeshape.repository.ModeShapeConfiguration;
-import org.modeshape.repository.ModeShapeConfiguration.ConfigurationDefinition;
 import org.modeshape.repository.ModeShapeLexicon;
+import org.modeshape.repository.ModeShapeConfiguration.ConfigurationDefinition;
 
 public class JcrConfigurationTest {
 
@@ -260,6 +260,7 @@ public class JcrConfigurationTest {
         options.put(Option.EXPOSE_WORKSPACE_NAMES_IN_DESCRIPTOR, DefaultOption.EXPOSE_WORKSPACE_NAMES_IN_DESCRIPTOR);
         options.put(Option.VERSION_HISTORY_STRUCTURE, DefaultOption.VERSION_HISTORY_STRUCTURE);
         options.put(Option.REPOSITORY_JNDI_LOCATION, DefaultOption.REPOSITORY_JNDI_LOCATION);
+        options.put(Option.USE_ANONYMOUS_ACCESS_ON_FAILED_LOGIN, DefaultOption.USE_ANONYMOUS_ACCESS_ON_FAILED_LOGIN);
         String defaultRemoveDerivedValue = DefaultOption.REMOVE_DERIVED_CONTENT_WITH_ORIGINAL;
         if (engine.getSequencingService().getSequencers().isEmpty()) {
             defaultRemoveDerivedValue = Boolean.FALSE.toString();

--- a/modeshape-jcr/src/test/java/org/modeshape/jcr/JcrRepositoryTest.java
+++ b/modeshape-jcr/src/test/java/org/modeshape/jcr/JcrRepositoryTest.java
@@ -56,9 +56,9 @@ import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 import org.modeshape.graph.ExecutionContext;
 import org.modeshape.graph.Graph;
-import org.modeshape.graph.JaasSecurityContext.UserPasswordCallbackHandler;
 import org.modeshape.graph.MockSecurityContext;
 import org.modeshape.graph.Node;
+import org.modeshape.graph.JaasSecurityContext.UserPasswordCallbackHandler;
 import org.modeshape.graph.connector.RepositoryConnection;
 import org.modeshape.graph.connector.RepositoryConnectionFactory;
 import org.modeshape.graph.connector.RepositorySource;
@@ -270,9 +270,36 @@ public class JcrRepositoryTest {
         repository.login();
     }
 
+    @Test( expected = javax.jcr.LoginException.class )
+    public void shouldNotAllowLoginWithCredentialsWhenAnonymousAuthenticationIsEnabledButTryAnonymousAuthenticationIsNotEnabled()
+        throws Exception {
+        // This would work iff this code was executing in a privileged block, but it's not
+        Map<Option, String> options = new HashMap<Option, String>();
+        options.put(Option.USE_ANONYMOUS_ACCESS_ON_FAILED_LOGIN, "false"); // disable anonymous authentication
+        repository = new JcrRepository(context, connectionFactory, sourceName, new MockObservable(), null, descriptors, options,
+                                       null);
+
+        repository.login(new SimpleCredentials("InvalidUserID", "InvalidPassword".toCharArray()));
+    }
+
     @Test
     public void shouldAllowLoginWithNoCredentialsWhenAnonymousAuthenticationIsEnabled() throws Exception {
         repository.login();
+    }
+
+    @Test( expected = javax.jcr.LoginException.class )
+    public void shouldNotAllowLoginWithInvalidCredentialsWhenAnonymousAuthenticationIsNotEnabled() throws Exception {
+        Map<Option, String> options = new HashMap<Option, String>();
+        options.put(Option.ANONYMOUS_USER_ROLES, ""); // disable anonymous authentication
+        repository = new JcrRepository(context, connectionFactory, sourceName, new MockObservable(), null, descriptors, options,
+                                       null);
+        repository.login(new SimpleCredentials("InvalidUserID", "InvalidPassword".toCharArray()));
+    }
+
+    @Test
+    public void shouldAllowLoginWithInvalidCredentialsWhenAnonymousAuthenticationIsEnabled() throws Exception {
+        Session session = repository.login(new SimpleCredentials("InvalidUserID", "InvalidPassword".toCharArray()));
+        assertThat(session.getUserID(), is(JcrRepository.ANONYMOUS_USER_NAME));
     }
 
     @SuppressWarnings( "cast" )


### PR DESCRIPTION
Attached patch that falls back to using an anonymous user context if one is configured and the attempt to login with simple credentials fails.  If this patch looks good, I can modify the documentation to reflect the new behavior.
