### PR TITLE
MODE-1147 Added support for vendor extensions in the CND importer

### DIFF
--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrEngine.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrEngine.java
@@ -40,8 +40,8 @@ import java.util.concurrent.locks.ReentrantLock;
 import javax.jcr.PropertyType;
 import javax.jcr.Repository;
 import javax.jcr.RepositoryException;
-import org.modeshape.common.annotation.ThreadSafe;
 import org.modeshape.cnd.CndImporter;
+import org.modeshape.common.annotation.ThreadSafe;
 import org.modeshape.common.collection.Problem;
 import org.modeshape.common.collection.Problem.Status;
 import org.modeshape.common.collection.Problems;
@@ -504,7 +504,7 @@ public class JcrEngine extends ModeShapeEngine implements Repositories {
                         GraphBatchDestination destination = new GraphBatchDestination(batch);
 
                         Path nodeTypesAbsPath = pathFactory.create(repositoryPath, JcrLexicon.NODE_TYPES);
-                        CndImporter importer = new CndImporter(destination, nodeTypesAbsPath, true);
+                        CndImporter importer = new CndImporter(destination, nodeTypesAbsPath, true, false);
                         InputStream is = IoUtil.getResourceAsStream(resource, classLoader, getClass());
                         Problems cndProblems = new SimpleProblems();
                         if (is == null) {


### PR DESCRIPTION
The CND tokenizer already supported capturing vendor extensions as a separate kind of token, but it was not used in the CndImporter. We should enable this functionality in the importer.

However, we don't need to use it in the 'modeshape-jcr' module, as we have no extensions that will be required. First of all, the 'nt:nodeTypeDefinition', 'nt:propertyDefinition', and 'nt:childNodeDefinition' node type definitions do not allow extra properties (we'd have to use a mixin for this). Secondly, we wouldn't use them at all anyway.

All unit and integration tests pass with these changes.
