### PR TITLE
MODE-1150 Upgrade to SLF4J 1.6.1 (or the latest available version)

### DIFF
--- a/modeshape-parent/pom.xml
+++ b/modeshape-parent/pom.xml
@@ -197,8 +197,8 @@
 		<junit.version>4.8.2</junit.version>
 		<hamcrest.version>1.1</hamcrest.version>
 		<mockito.all.version>1.8.4</mockito.all.version>
-		<slf4j.api.version>1.5.11</slf4j.api.version>
-		<slf4j.log4j.version>1.5.11</slf4j.log4j.version>
+		<slf4j.api.version>1.6.1</slf4j.api.version>
+		<slf4j.log4j.version>1.6.1</slf4j.log4j.version>
 		<log4j.version>1.2.16</log4j.version>
 		<jcip.version>1.0</jcip.version>
 		<jcr.version>2.0</jcr.version>


### PR DESCRIPTION
SL4FJ has made a major release, and at this time 1.6.1 is the current version. We should upgrade ModeShape to use the latest release.
