### PR TITLE
MODE-1050 NPE in NodeTypeManager when validating a recursive node definit

### DIFF
--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/RepositoryNodeTypeManager.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/RepositoryNodeTypeManager.java
@@ -1750,9 +1750,13 @@ class RepositoryNodeTypeManager implements JcrSystemObserver {
 
                 List<JcrNodeType> supertypes = supertypesFor(nodeTypeDefn, typesPendingRegistration);
                 JcrNodeType nodeType = nodeTypeFrom(nodeTypeDefn, supertypes);
-                validate(nodeType, supertypes, typesPendingRegistration);
 
+                /*
+                 * Add this new node type to the pending registration list first in case it has a child node
+                 * definition that references itself (q.v., MODE-1050).
+                 */
                 typesPendingRegistration.add(nodeType);
+                validate(nodeType, supertypes, typesPendingRegistration);
             }
 
             // Make sure the nodes have primary types that are either already registered, or pending registration ...

--- a/modeshape-jcr/src/test/java/org/modeshape/jcr/ModeShapeTckTest.java
+++ b/modeshape-jcr/src/test/java/org/modeshape/jcr/ModeShapeTckTest.java
@@ -26,6 +26,8 @@ import javax.jcr.ValueFactory;
 import javax.jcr.lock.LockException;
 import javax.jcr.lock.LockManager;
 import javax.jcr.nodetype.ConstraintViolationException;
+import javax.jcr.nodetype.NodeDefinitionTemplate;
+import javax.jcr.nodetype.NodeTypeManager;
 import javax.jcr.nodetype.NodeTypeTemplate;
 import javax.jcr.nodetype.PropertyDefinitionTemplate;
 import javax.jcr.version.Version;
@@ -1919,5 +1921,24 @@ public class ModeShapeTckTest extends AbstractJCRTest {
         } catch (UnsupportedRepositoryOperationException e) {
             return false;
         }
+    }
+
+    @SuppressWarnings( "unchecked" )
+    @FixFor( "MODE-1050" )
+    public void testShouldSuccessfullyRegisterChildAndParentSameTypes() throws RepositoryException {
+        Session session = getHelper().getSuperuserSession();
+
+        session.getWorkspace().getNamespaceRegistry().registerNamespace("mx", "urn:test");
+        final NodeTypeManager nodeTypeMgr = session.getWorkspace().getNodeTypeManager();
+
+        final NodeTypeTemplate nodeType = nodeTypeMgr.createNodeTypeTemplate();
+        nodeType.setName("mx:type");
+        nodeType.setDeclaredSuperTypeNames(new String[] {"nt:folder"});
+
+        final NodeDefinitionTemplate subTypes = nodeTypeMgr.createNodeDefinitionTemplate();
+        subTypes.setRequiredPrimaryTypeNames(new String[] {"mx:type"});
+        nodeType.getNodeDefinitionTemplates().add(subTypes);
+
+        nodeTypeMgr.registerNodeType(nodeType, false);
     }
 }


### PR DESCRIPTION
MODE-1050 NPE in NodeTypeManager when validating a recursive node definition

RTNM.registerNodeTypes iterates over the list of node types to be registered, adding each to a list of pending node types after it has been validated.  However, validating a node type that uses itself as a required primary type for a child node definition fails.  This is because validating the required primary types for child nodes checks the list of currently registered node types and the list of pending node types to ensure that the required primary type is in one list or the other, but the node type being validated hasn't been added to the list of pending node types yet because it hasn't been validated.

The fix is to add the node type being validated to the list of pending node types _before_ it gets validated.  If the validation fails, the method throws an exception anyway, so it doesn't matter than an invalid node type definition got into the local list of pending node types.

All tests pass, including the new one that Edouard was kind enough to donate in the MODE-1050 description.
