### PR TITLE
MODE-1155 Added test to verify I18n messages exist for related annotations

### DIFF
--- a/extensions/modeshape-connector-filesystem/src/main/java/org/modeshape/connector/filesystem/FileSystemI18n.java
+++ b/extensions/modeshape-connector-filesystem/src/main/java/org/modeshape/connector/filesystem/FileSystemI18n.java
@@ -64,6 +64,9 @@ public final class FileSystemI18n {
     public static I18n exclusionPatternPropertyDescription;
     public static I18n exclusionPatternPropertyLabel;
     public static I18n exclusionPatternPropertyCategory;
+    public static I18n inclusionPatternPropertyDescription;
+    public static I18n inclusionPatternPropertyLabel;
+    public static I18n inclusionPatternPropertyCategory;
     public static I18n maxPathLengthPropertyDescription;
     public static I18n maxPathLengthPropertyLabel;
     public static I18n maxPathLengthPropertyCategory;

--- a/extensions/modeshape-connector-filesystem/src/main/java/org/modeshape/connector/filesystem/FileSystemSource.java
+++ b/extensions/modeshape-connector-filesystem/src/main/java/org/modeshape/connector/filesystem/FileSystemSource.java
@@ -36,10 +36,10 @@ import javax.naming.Context;
 import javax.naming.Reference;
 import javax.naming.StringRefAddr;
 import javax.naming.spi.ObjectFactory;
-import org.modeshape.common.annotation.ThreadSafe;
 import org.modeshape.common.annotation.Category;
 import org.modeshape.common.annotation.Description;
 import org.modeshape.common.annotation.Label;
+import org.modeshape.common.annotation.ThreadSafe;
 import org.modeshape.common.i18n.I18n;
 import org.modeshape.common.util.CheckArg;
 import org.modeshape.common.util.Logger;
@@ -152,9 +152,9 @@ public class FileSystemSource extends AbstractRepositorySource implements Object
     @Category( i18n = FileSystemI18n.class, value = "workspaceRootPathPropertyCategory" )
     private volatile String workspaceRootPath;
 
-    @Description( i18n = FileSystemI18n.class, value = "predefinedWorkspacesPropertyDescription" )
-    @Label( i18n = FileSystemI18n.class, value = "predefinedWorkspacesPropertyLabel" )
-    @Category( i18n = FileSystemI18n.class, value = "predefinedWorkspacesPropertyCategory" )
+    @Description( i18n = FileSystemI18n.class, value = "predefinedWorkspaceNamesPropertyDescription" )
+    @Label( i18n = FileSystemI18n.class, value = "predefinedWorkspaceNamesPropertyLabel" )
+    @Category( i18n = FileSystemI18n.class, value = "predefinedWorkspaceNamesPropertyCategory" )
     private volatile String[] predefinedWorkspaces = new String[] {};
 
     @Description( i18n = FileSystemI18n.class, value = "maxPathLengthPropertyDescription" )
@@ -326,8 +326,8 @@ public class FileSystemSource extends AbstractRepositorySource implements Object
      * @throws InstantiationException if the filename filter represents an abstract class, an interface, an array class, a
      *         primitive type, or void; or if the class has no nullary constructor; or if the instantiation fails for some other
      *         reason.
-     * @throws ClassCastException if the class named by {@code filenameFilterClassName} does not implement the {@code
-     *         FilenameFilter} interface
+     * @throws ClassCastException if the class named by {@code filenameFilterClassName} does not implement the
+     *         {@code FilenameFilter} interface
      */
     public synchronized void setFilenameFilter( String filenameFilterClassName )
         throws ClassCastException, ClassNotFoundException, IllegalAccessException, InstantiationException {
@@ -388,8 +388,8 @@ public class FileSystemSource extends AbstractRepositorySource implements Object
      * <p>
      * The length of any path is calculated relative to the file system root, NOT the repository root. That is, if a workspace
      * {@code foo} is mapped to the {@code /tmp/foo/bar} directory on the file system, then the path {@code /node1/node2} in the
-     * {@code foo} workspace has an effective length of 23 for the purposes of the {@code maxPathLength} calculation ({@code
-     * /tmp/foo/bar} has length 11, {@code /node1/node2} has length 12, 11 + 12 = 23).
+     * {@code foo} workspace has an effective length of 23 for the purposes of the {@code maxPathLength} calculation (
+     * {@code /tmp/foo/bar} has length 11, {@code /node1/node2} has length 12, 11 + 12 = 23).
      * </p>
      * 
      * @param maxPathLength the maximum absolute path length supported by this source; must be non-negative
@@ -587,8 +587,8 @@ public class FileSystemSource extends AbstractRepositorySource implements Object
      * @throws InstantiationException if the custom properties factory represents an abstract class, an interface, an array class,
      *         a primitive type, or void; or if the class has no nullary constructor; or if the instantiation fails for some other
      *         reason.
-     * @throws ClassCastException if the class named by {@code customPropertiesFactoryClassName} does not implement the {@code
-     *         CustomPropertiesFactory} interface
+     * @throws ClassCastException if the class named by {@code customPropertiesFactoryClassName} does not implement the
+     *         {@code CustomPropertiesFactory} interface
      * @see #setExtraPropertiesBehavior(String)
      */
     public synchronized void setCustomPropertiesFactory( String customPropertiesFactoryClassName )

--- a/extensions/modeshape-connector-filesystem/src/main/resources/org/modeshape/connector/filesystem/FileSystemI18n.properties
+++ b/extensions/modeshape-connector-filesystem/src/main/resources/org/modeshape/connector/filesystem/FileSystemI18n.properties
@@ -52,6 +52,9 @@ updatesAllowedPropertyCategory = Advanced
 exclusionPatternPropertyDescription = Specifies a regular expression that is used to determine which files and folders in the underlying file system should be exposed through this connector. Files and folders with a name that matches the provided regular expression will not be exposed by this source. Setting this property to null has the effect of removing the exclusion pattern.
 exclusionPatternPropertyLabel = Exclusion Pattern
 exclusionPatternPropertyCategory = Advanced
+inclusionPatternPropertyDescription = Specifies a regular expression that is used to determine which files and folders in the underlying file system should be exposed through this connector. Files and folders with a name that matches the provided regular expression will be exposed by this source. Setting this property to null has the effect of removing the inclusion pattern.
+inclusionPatternPropertyLabel = Inclusion Pattern
+inclusionPatternPropertyCategory = Advanced
 maxPathLengthPropertyDescription = The maximum absolute path length supported by this source and the operating system. The length of any path is calculated relative to the file system root, NOT the repository root. That is, if a workspace "bar" is mapped to the "/tmp/foo/bar" directory on the file system, then the path "/node1/node2" in the "bar" workspace has an effective length of 23 ("/tmp/foo/bar" has length 11, "/node1/node2" has length 12, so 11 + 12 = 23)./nThe default value is '255', which is the maximum path length on Microsoft Windows.
 maxPathLengthPropertyLabel = Maximum Path Length
 maxPathLengthPropertyCategory = Advanced

--- a/extensions/modeshape-connector-filesystem/src/test/java/org/modeshape/connector/filesystem/FileSystemI18nTest.java
+++ b/extensions/modeshape-connector-filesystem/src/test/java/org/modeshape/connector/filesystem/FileSystemI18nTest.java
@@ -23,6 +23,7 @@
  */
 package org.modeshape.connector.filesystem;
 
+import org.junit.Test;
 import org.modeshape.common.AbstractI18nTest;
 
 /**
@@ -32,5 +33,10 @@ public class FileSystemI18nTest extends AbstractI18nTest {
 
     public FileSystemI18nTest() {
         super(FileSystemI18n.class);
+    }
+
+    @Test
+    public void shouldHaveI18nConstantsAndPropertiesForFileSystemSource() throws Exception {
+        verifyI18nForAnnotationsOnObject(new FileSystemSource());
     }
 }

--- a/extensions/modeshape-connector-infinispan/src/test/java/org/modeshape/connector/infinispan/InfinispanConnectorI18nTest.java
+++ b/extensions/modeshape-connector-infinispan/src/test/java/org/modeshape/connector/infinispan/InfinispanConnectorI18nTest.java
@@ -23,6 +23,7 @@
  */
 package org.modeshape.connector.infinispan;
 
+import org.junit.Test;
 import org.modeshape.common.AbstractI18nTest;
 
 /**
@@ -32,5 +33,15 @@ public class InfinispanConnectorI18nTest extends AbstractI18nTest {
 
     public InfinispanConnectorI18nTest() {
         super(InfinispanConnectorI18n.class);
+    }
+
+    @Test
+    public void shouldHaveI18nConstantsAndPropertiesForInfinispanSource() throws Exception {
+        verifyI18nForAnnotationsOnObject(new InfinispanSource());
+    }
+
+    @Test
+    public void shouldHaveI18nConstantsAndPropertiesForRemoteInfinispanSource() throws Exception {
+        verifyI18nForAnnotationsOnObject(new RemoteInfinispanSource());
     }
 }

--- a/extensions/modeshape-connector-jbosscache/src/main/java/org/modeshape/connector/jbosscache/JBossCacheSource.java
+++ b/extensions/modeshape-connector-jbosscache/src/main/java/org/modeshape/connector/jbosscache/JBossCacheSource.java
@@ -45,15 +45,15 @@ import javax.naming.Reference;
 import javax.naming.Referenceable;
 import javax.naming.StringRefAddr;
 import javax.naming.spi.ObjectFactory;
-import org.modeshape.common.annotation.GuardedBy;
-import org.modeshape.common.annotation.ThreadSafe;
 import org.jboss.cache.Cache;
 import org.jboss.cache.CacheFactory;
 import org.jboss.cache.DefaultCacheFactory;
 import org.jboss.cache.config.ConfigurationException;
 import org.modeshape.common.annotation.Category;
 import org.modeshape.common.annotation.Description;
+import org.modeshape.common.annotation.GuardedBy;
 import org.modeshape.common.annotation.Label;
+import org.modeshape.common.annotation.ThreadSafe;
 import org.modeshape.common.i18n.I18n;
 import org.modeshape.common.util.HashCode;
 import org.modeshape.common.util.Logger;
@@ -133,7 +133,7 @@ public class JBossCacheSource implements BaseRepositorySource, ObjectFactory {
 
     @Description( i18n = JBossCacheConnectorI18n.class, value = "cacheFactoryJndiNamePropertyDescription" )
     @Label( i18n = JBossCacheConnectorI18n.class, value = "cacheFactoryJndiNamePropertyLabel" )
-    @Category( i18n = JBossCacheConnectorI18n.class, value = "cacheFactoryrJndiNamePropertyCategory" )
+    @Category( i18n = JBossCacheConnectorI18n.class, value = "cacheFactoryJndiNamePropertyCategory" )
     private volatile String cacheFactoryJndiName;
 
     @Description( i18n = JBossCacheConnectorI18n.class, value = "cacheJndiNamePropertyDescription" )
@@ -151,9 +151,9 @@ public class JBossCacheSource implements BaseRepositorySource, ObjectFactory {
     @Category( i18n = JBossCacheConnectorI18n.class, value = "defaultWorkspaceNamePropertyCategory" )
     private volatile String defaultWorkspace;
 
-    @Description( i18n = JBossCacheConnectorI18n.class, value = "predefinedWorkspacesPropertyDescription" )
-    @Label( i18n = JBossCacheConnectorI18n.class, value = "predefinedWorkspacesPropertyLabel" )
-    @Category( i18n = JBossCacheConnectorI18n.class, value = "predefinedWorkspacesPropertyCategory" )
+    @Description( i18n = JBossCacheConnectorI18n.class, value = "predefinedWorkspaceNamesPropertyDescription" )
+    @Label( i18n = JBossCacheConnectorI18n.class, value = "predefinedWorkspaceNamesPropertyLabel" )
+    @Category( i18n = JBossCacheConnectorI18n.class, value = "predefinedWorkspaceNamesPropertyCategory" )
     private volatile String[] predefinedWorkspaces = new String[] {};
 
     @Description( i18n = JBossCacheConnectorI18n.class, value = "updatesAllowedPropertyDescription" )

--- a/extensions/modeshape-connector-jbosscache/src/test/java/org/modeshape/connector/jbosscache/JBossCacheConnectorI18nTest.java
+++ b/extensions/modeshape-connector-jbosscache/src/test/java/org/modeshape/connector/jbosscache/JBossCacheConnectorI18nTest.java
@@ -23,6 +23,7 @@
  */
 package org.modeshape.connector.jbosscache;
 
+import org.junit.Test;
 import org.modeshape.common.AbstractI18nTest;
 
 /**
@@ -32,5 +33,10 @@ public class JBossCacheConnectorI18nTest extends AbstractI18nTest {
 
     public JBossCacheConnectorI18nTest() {
         super(JBossCacheConnectorI18n.class);
+    }
+
+    @Test
+    public void shouldHaveI18nConstantsAndPropertiesForJBossCacheSource() throws Exception {
+        verifyI18nForAnnotationsOnObject(new JBossCacheSource());
     }
 }

--- a/extensions/modeshape-connector-jcr/src/test/java/org/modeshape/connector/jcr/JcrConnectorI18nTest.java
+++ b/extensions/modeshape-connector-jcr/src/test/java/org/modeshape/connector/jcr/JcrConnectorI18nTest.java
@@ -23,11 +23,17 @@
  */
 package org.modeshape.connector.jcr;
 
+import org.junit.Test;
 import org.modeshape.common.AbstractI18nTest;
 
 public class JcrConnectorI18nTest extends AbstractI18nTest {
 
     public JcrConnectorI18nTest() {
         super(JcrConnectorI18n.class);
+    }
+
+    @Test
+    public void shouldHaveI18nConstantsAndPropertiesForJcrRepositorySource() throws Exception {
+        verifyI18nForAnnotationsOnObject(new JcrRepositorySource());
     }
 }

--- a/extensions/modeshape-connector-jdbc-metadata/src/test/java/org/modeshape/connector/meta/jdbc/JdbcMetadataI18nTest.java
+++ b/extensions/modeshape-connector-jdbc-metadata/src/test/java/org/modeshape/connector/meta/jdbc/JdbcMetadataI18nTest.java
@@ -23,12 +23,17 @@
  */
 package org.modeshape.connector.meta.jdbc;
 
-
+import org.junit.Test;
 import org.modeshape.common.AbstractI18nTest;
 
 public class JdbcMetadataI18nTest extends AbstractI18nTest {
 
     public JdbcMetadataI18nTest() {
         super(JdbcMetadataI18nTest.class);
+    }
+
+    @Test
+    public void shouldHaveI18nConstantsAndPropertiesForJdbcMetadataSource() throws Exception {
+        verifyI18nForAnnotationsOnObject(new JdbcMetadataSource());
     }
 }

--- a/extensions/modeshape-connector-store-jpa/src/main/java/org/modeshape/connector/store/jpa/JpaSource.java
+++ b/extensions/modeshape-connector-store-jpa/src/main/java/org/modeshape/connector/store/jpa/JpaSource.java
@@ -343,9 +343,9 @@ public class JpaSource implements RepositorySource, ObjectFactory {
     @Category( i18n = JpaConnectorI18n.class, value = "isolationLevelPropertyCategory" )
     private volatile Integer isolationLevel = DEFAULT_ISOLATION_LEVEL;
 
-    @Description( i18n = JpaConnectorI18n.class, value = "predefinedWorkspacesPropertyDescription" )
-    @Label( i18n = JpaConnectorI18n.class, value = "predefinedWorkspacesPropertyLabel" )
-    @Category( i18n = JpaConnectorI18n.class, value = "predefinedWorkspacesPropertyCategory" )
+    @Description( i18n = JpaConnectorI18n.class, value = "predefinedWorkspaceNamesPropertyDescription" )
+    @Label( i18n = JpaConnectorI18n.class, value = "predefinedWorkspaceNamesPropertyLabel" )
+    @Category( i18n = JpaConnectorI18n.class, value = "predefinedWorkspaceNamesPropertyCategory" )
     private volatile String[] predefinedWorkspaces = new String[] {};
 
     private volatile RepositorySourceCapabilities capabilities = new RepositorySourceCapabilities(
@@ -1234,9 +1234,7 @@ public class JpaSource implements RepositorySource, ObjectFactory {
                 setProperty(configurator, Environment.POOL_SIZE, 0); // don't use the built-in pool
                 if (this.maximumConnectionsInPool > 0) {
                     // Set the connection pooling properties (to use C3P0) ...
-                    setProperty(configurator,
-                                Environment.CONNECTION_PROVIDER,
-                                "org.hibernate.connection.C3P0ConnectionProvider");
+                    setProperty(configurator, Environment.CONNECTION_PROVIDER, "org.hibernate.connection.C3P0ConnectionProvider");
                     setProperty(configurator, Environment.C3P0_MAX_SIZE, this.maximumConnectionsInPool);
                     setProperty(configurator, Environment.C3P0_MIN_SIZE, this.minimumConnectionsInPool);
                     setProperty(configurator, Environment.C3P0_TIMEOUT, this.maximumConnectionIdleTimeInSeconds);

--- a/extensions/modeshape-connector-store-jpa/src/test/java/org/modeshape/connector/store/jpa/JpaConnectorI18nTest.java
+++ b/extensions/modeshape-connector-store-jpa/src/test/java/org/modeshape/connector/store/jpa/JpaConnectorI18nTest.java
@@ -23,6 +23,7 @@
  */
 package org.modeshape.connector.store.jpa;
 
+import org.junit.Test;
 import org.modeshape.common.AbstractI18nTest;
 
 /**
@@ -32,5 +33,10 @@ public class JpaConnectorI18nTest extends AbstractI18nTest {
 
     public JpaConnectorI18nTest() {
         super(JpaConnectorI18n.class);
+    }
+
+    @Test
+    public void shouldHaveI18nConstantsAndPropertiesForJpaSourceAnnotations() throws Exception {
+        verifyI18nForAnnotationsOnObject(new JpaSource());
     }
 }

--- a/extensions/modeshape-connector-svn/src/main/java/org/modeshape/connector/svn/SvnRepositorySource.java
+++ b/extensions/modeshape-connector-svn/src/main/java/org/modeshape/connector/svn/SvnRepositorySource.java
@@ -31,11 +31,11 @@ import javax.naming.Name;
 import javax.naming.Reference;
 import javax.naming.StringRefAddr;
 import javax.naming.spi.ObjectFactory;
-import org.modeshape.common.annotation.ThreadSafe;
 import org.modeshape.common.annotation.Category;
 import org.modeshape.common.annotation.Description;
 import org.modeshape.common.annotation.Label;
 import org.modeshape.common.annotation.ReadOnly;
+import org.modeshape.common.annotation.ThreadSafe;
 import org.modeshape.common.i18n.I18n;
 import org.modeshape.common.util.CheckArg;
 import org.modeshape.common.util.StringUtil;
@@ -120,9 +120,9 @@ public class SvnRepositorySource extends AbstractRepositorySource implements Obj
     @Category( i18n = SvnRepositoryConnectorI18n.class, value = "defaultWorkspaceNamePropertyCategory" )
     private volatile String defaultWorkspace = DEFAULT_WORKSPACE_NAME;
 
-    @Description( i18n = SvnRepositoryConnectorI18n.class, value = "predefinedWorkspacesPropertyDescription" )
-    @Label( i18n = SvnRepositoryConnectorI18n.class, value = "predefinedWorkspacesPropertyLabel" )
-    @Category( i18n = SvnRepositoryConnectorI18n.class, value = "predefinedWorkspacesPropertyCategory" )
+    @Description( i18n = SvnRepositoryConnectorI18n.class, value = "predefinedWorkspaceNamesPropertyDescription" )
+    @Label( i18n = SvnRepositoryConnectorI18n.class, value = "predefinedWorkspaceNamesPropertyLabel" )
+    @Category( i18n = SvnRepositoryConnectorI18n.class, value = "predefinedWorkspaceNamesPropertyCategory" )
     private volatile String[] predefinedWorkspaces = new String[] {};
 
     private volatile RepositorySourceCapabilities capabilities = new RepositorySourceCapabilities(

--- a/extensions/modeshape-connector-svn/src/test/java/org/modeshape/connector/svn/SvnRepositoryConnectorI18nTest.java
+++ b/extensions/modeshape-connector-svn/src/test/java/org/modeshape/connector/svn/SvnRepositoryConnectorI18nTest.java
@@ -23,8 +23,8 @@
  */
 package org.modeshape.connector.svn;
 
+import org.junit.Test;
 import org.modeshape.common.AbstractI18nTest;
-import org.modeshape.connector.svn.SvnRepositoryConnectorI18n;
 
 /**
  */
@@ -33,4 +33,10 @@ public class SvnRepositoryConnectorI18nTest extends AbstractI18nTest {
     public SvnRepositoryConnectorI18nTest() {
         super(SvnRepositoryConnectorI18n.class);
     }
+
+    @Test
+    public void shouldHaveI18nConstantsAndPropertiesForSvnRepositorySource() throws Exception {
+        verifyI18nForAnnotationsOnObject(new SvnRepositorySource());
+    }
+
 }

--- a/modeshape-common/src/test/java/org/modeshape/common/AbstractI18nTest.java
+++ b/modeshape-common/src/test/java/org/modeshape/common/AbstractI18nTest.java
@@ -24,14 +24,20 @@
 package org.modeshape.common;
 
 import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsNull.notNullValue;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
+import java.lang.annotation.Annotation;
 import java.lang.reflect.Field;
+import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.util.Locale;
 import java.util.Set;
-import org.modeshape.common.i18n.I18n;
 import org.junit.Test;
+import org.modeshape.common.annotation.Category;
+import org.modeshape.common.annotation.Description;
+import org.modeshape.common.annotation.Label;
+import org.modeshape.common.i18n.I18n;
 
 /**
  * @author John Verhaeg
@@ -67,6 +73,68 @@ public abstract class AbstractI18nTest {
                     fail(problems.iterator().next());
                 }
             }
+        }
+    }
+
+    protected static final String[] ANNOTATION_NAMES = {"Description", "Category", "Label"};
+
+    /**
+     * Utility method that can be used to verify that an I18n field exists for all of the I18n-related annotations on the supplied
+     * object. I18n-related annotations include {@link Description}, {@link Label}, and {@link Category}.
+     * 
+     * @param annotated the object that has field or method annotations
+     * @throws Exception if there is a problem
+     */
+    protected void verifyI18nForAnnotationsOnObject( Object annotated ) throws Exception {
+        // Check the known annotations that work with I18ns ...
+        Class<?> clazz = annotated.getClass();
+        for (Field field : clazz.getDeclaredFields()) {
+            for (Annotation annotation : field.getAnnotations()) {
+                verifyI18nForAnnotation(annotation, field);
+            }
+        }
+        for (Method method : clazz.getDeclaredMethods()) {
+            for (Annotation annotation : method.getAnnotations()) {
+                verifyI18nForAnnotation(annotation, method);
+            }
+        }
+    }
+
+    protected void verifyI18nForAnnotation( Annotation annotation,
+                                            Object annotatedObject ) throws Exception {
+        String i18nIdentifier;
+        Class<?> i18nClass;
+        if (annotation instanceof Category) {
+            Category cat = (Category)annotation;
+            i18nClass = cat.i18n();
+            i18nIdentifier = cat.value();
+        } else if (annotation instanceof Description) {
+            Description desc = (Description)annotation;
+            i18nClass = desc.i18n();
+            i18nIdentifier = desc.value();
+        } else if (annotation instanceof Label) {
+            Label label = (Label)annotation;
+            i18nClass = label.i18n();
+            i18nIdentifier = label.value();
+        } else {
+            return;
+        }
+        assertThat(i18nClass, is(notNullValue()));
+        assertThat(i18nIdentifier, is(notNullValue()));
+        try {
+            Field fld = i18nClass.getField(i18nIdentifier);
+            assertThat(fld, is(notNullValue()));
+            // Now check the I18n field ...
+            if (fld.getType() == I18n.class && (fld.getModifiers() & Modifier.PUBLIC) == Modifier.PUBLIC
+                && (fld.getModifiers() & Modifier.STATIC) == Modifier.STATIC
+                && (fld.getModifiers() & Modifier.FINAL) != Modifier.FINAL) {
+                I18n i18n = (I18n)fld.get(null);
+                if (i18n.hasProblem()) {
+                    fail(i18n.problem());
+                }
+            }
+        } catch (NoSuchFieldException e) {
+            fail("Missing I18n field on " + i18nClass.getName() + " for " + annotation + " on " + annotatedObject);
         }
     }
 }

--- a/modeshape-common/src/test/java/org/modeshape/common/CommonI18nTest.java
+++ b/modeshape-common/src/test/java/org/modeshape/common/CommonI18nTest.java
@@ -23,6 +23,9 @@
  */
 package org.modeshape.common;
 
+import org.junit.Test;
+import org.modeshape.common.component.ComponentConfig;
+
 /**
  * @author John Verhaeg
  */
@@ -30,5 +33,10 @@ public class CommonI18nTest extends AbstractI18nTest {
 
     public CommonI18nTest() {
         super(CommonI18n.class);
+    }
+
+    @Test
+    public void shouldHaveI18nConstantsAndPropertiesForComponentConfigs() throws Exception {
+        verifyI18nForAnnotationsOnObject(new ComponentConfig("name", "desc", "classname"));
     }
 }

--- a/modeshape-graph/src/main/java/org/modeshape/graph/connector/inmemory/InMemoryRepositorySource.java
+++ b/modeshape-graph/src/main/java/org/modeshape/graph/connector/inmemory/InMemoryRepositorySource.java
@@ -43,12 +43,12 @@ import javax.naming.RefAddr;
 import javax.naming.Reference;
 import javax.naming.StringRefAddr;
 import javax.naming.spi.ObjectFactory;
-import org.modeshape.common.annotation.GuardedBy;
-import org.modeshape.common.annotation.ThreadSafe;
 import org.modeshape.common.annotation.Category;
 import org.modeshape.common.annotation.Description;
+import org.modeshape.common.annotation.GuardedBy;
 import org.modeshape.common.annotation.Label;
 import org.modeshape.common.annotation.ReadOnly;
+import org.modeshape.common.annotation.ThreadSafe;
 import org.modeshape.common.i18n.I18n;
 import org.modeshape.common.util.CheckArg;
 import org.modeshape.common.util.StringUtil;
@@ -122,9 +122,9 @@ public class InMemoryRepositorySource implements BaseRepositorySource, ObjectFac
     @Category( i18n = GraphI18n.class, value = "rootNodeUuidPropertyCategory" )
     private UUID rootNodeUuid = UUID.randomUUID();
 
-    @Description( i18n = GraphI18n.class, value = "predefinedWorkspacesPropertyDescription" )
-    @Label( i18n = GraphI18n.class, value = "predefinedWorkspacesPropertyLabel" )
-    @Category( i18n = GraphI18n.class, value = "predefinedWorkspacesPropertyCategory" )
+    @Description( i18n = GraphI18n.class, value = "predefinedWorkspaceNamesPropertyDescription" )
+    @Label( i18n = GraphI18n.class, value = "predefinedWorkspaceNamesPropertyLabel" )
+    @Category( i18n = GraphI18n.class, value = "predefinedWorkspaceNamesPropertyCategory" )
     private volatile String[] predefinedWorkspaces = new String[] {};
 
     @Description( i18n = GraphI18n.class, value = "retryLimitPropertyDescription" )

--- a/modeshape-graph/src/test/java/org/modeshape/graph/GraphI18nTest.java
+++ b/modeshape-graph/src/test/java/org/modeshape/graph/GraphI18nTest.java
@@ -23,8 +23,14 @@
  */
 package org.modeshape.graph;
 
+import static org.mockito.Mockito.mock;
+import org.junit.Test;
 import org.modeshape.common.AbstractI18nTest;
-import org.modeshape.graph.GraphI18n;
+import org.modeshape.graph.connector.RepositoryConnectionPool;
+import org.modeshape.graph.connector.RepositorySource;
+import org.modeshape.graph.connector.federation.FederatedRepositorySource;
+import org.modeshape.graph.connector.inmemory.InMemoryRepositorySource;
+import org.modeshape.graph.connector.xmlfile.XmlFileRepositorySource;
 
 /**
  * @author Randall Hauch
@@ -33,5 +39,26 @@ public class GraphI18nTest extends AbstractI18nTest {
 
     public GraphI18nTest() {
         super(GraphI18n.class);
+    }
+
+    @Test
+    public void shouldHaveI18nConstantsAndPropertiesForInMemoryRepositorySource() throws Exception {
+        verifyI18nForAnnotationsOnObject(new InMemoryRepositorySource());
+    }
+
+    @Test
+    public void shouldHaveI18nConstantsAndPropertiesForFederatedRepositorySource() throws Exception {
+        verifyI18nForAnnotationsOnObject(new FederatedRepositorySource());
+    }
+
+    @Test
+    public void shouldHaveI18nConstantsAndPropertiesForXmlFileRepositorySource() throws Exception {
+        verifyI18nForAnnotationsOnObject(new XmlFileRepositorySource());
+    }
+
+    @Test
+    public void shouldHaveI18nConstantsAndPropertiesForRepositoryConnectionPool() throws Exception {
+        RepositorySource source = mock(RepositorySource.class);
+        verifyI18nForAnnotationsOnObject(new RepositoryConnectionPool(source));
     }
 }


### PR DESCRIPTION
Added several unit tests that check the existence and validity of I18n constants and messages for all annotations referencing them. These annotations, such as @Label, @Description, and @Category, reference the I18n messages by string value rather than I18n reference.

Note that a helper method was added to the AbstractI18nTest that is used in each module that uses I18n constants. This allows test methods to be easily added for any object that has such annotations.

Adding these tests pointed out quite a few mismatches between the string values and the I18n message keys. These were corrected, and all unit and integration tests now pass.
