### PR TITLE
MODE-1156 Client JAR is now included in distribution

### DIFF
--- a/bin/release.py
+++ b/bin/release.py
@@ -173,8 +173,8 @@ def copy_artifacts_to_archive_location(archive_path,version):
     pass
     
   # Copy the 'modeshape-distribution' artifacts ...
-  from_files = ['dist.zip','gettingstarted-examples.zip','jars-with-dependencies.jar','javadoc-public-api.zip','javadoc.zip','source-archive.zip']
-  to_files = ['dist.zip','gettingstarted-examples.zip','all-with-dependencies.jar','javadoc-public-api.zip','javadoc.zip','src.zip']
+  from_files = ['dist.zip','gettingstarted-examples.zip','jars-with-dependencies.jar','javadoc-public-api.zip','javadoc.zip','source-archive.zip','client.jar']
+  to_files = ['dist.zip','gettingstarted-examples.zip','all-with-dependencies.jar','javadoc-public-api.zip','javadoc.zip','src.zip','client.jar']
   for fsuffix,tsuffix in zip(from_files,to_files):
     shutil.copy("modeshape-distribution/target/modeshape-%s-%s" % (version,fsuffix), "%s/modeshape-%s-%s" % (archive_path,version,tsuffix))
 
@@ -254,8 +254,8 @@ def upload_artifacts(base_dir, version):
   os.makedirs("downloads/%s" % version)
 
   # Copy the 'modeshape-distribution' artifacts ...
-  from_files = ['dist.zip','gettingstarted-examples.zip','jars-with-dependencies.jar','javadoc-public-api.zip','javadoc.zip','source-archive.zip']
-  to_files = ['dist.zip','gettingstarted-examples.zip','all-with-dependencies.jar','javadoc-public-api.zip','javadoc.zip','src.zip']
+  from_files = ['dist.zip','gettingstarted-examples.zip','jars-with-dependencies.jar','javadoc-public-api.zip','javadoc.zip','source-archive.zip','client.jar']
+  to_files = ['dist.zip','gettingstarted-examples.zip','all-with-dependencies.jar','javadoc-public-api.zip','javadoc.zip','src.zip','client.jar']
   for fsuffix,tsuffix in zip(from_files,to_files):
     shutil.copy("%s/modeshape-distribution/target/modeshape-%s-%s" % (base_dir,version,fsuffix), "downloads/%s/modeshape-%s-%s" % (version,version,tsuffix))
 

--- a/modeshape-assembly-descriptors/src/main/resources/assemblies/binary-distribution.xml
+++ b/modeshape-assembly-descriptors/src/main/resources/assemblies/binary-distribution.xml
@@ -34,6 +34,16 @@
 		  <outputDirectory>lib/test</outputDirectory>
 		</dependencySet>
 	</dependencySets>
+	<files>
+	  <file>
+		  <!--
+			Gather into the distribution the client JAR (renamed)
+		  -->
+		  <source>../utils/modeshape-jdbc/target/modeshape-jdbc-${project.version}-jar-with-dependencies.jar</source>
+		  <outputDirectory>lib</outputDirectory>
+		  <destName>modeshape-client-${project.version}.jar</destName>
+	  </file>
+	</files>
   <fileSets>
 		<fileSet>
 		  <!--

--- a/modeshape-distribution/pom.xml
+++ b/modeshape-distribution/pom.xml
@@ -1132,6 +1132,24 @@
 							<attach>false</attach>
 		        </configuration>
 		      </plugin>
+          <plugin>
+            <!-- Copy the JDBC driver (with dependencies) JAR file into the distribution's target directory and rename ... -->
+            <artifactId>maven-antrun-plugin</artifactId>
+            <executions>
+              <execution>
+                <phase>package</phase>
+                <configuration>
+                  <tasks>
+                    <copy file="../utils/modeshape-jdbc/target/modeshape-jdbc-${project.version}-jar-with-dependencies.jar"
+                          tofile="${project.build.directory}/modeshape-${project.version}-client.jar" />
+                  </tasks>
+                </configuration>
+                <goals>
+                  <goal>run</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
 		    </plugins>
 		  </build>
     </profile>
@@ -1344,7 +1362,25 @@
 							<attach>false</attach>
 		        </configuration>
 		      </plugin>
-				</plugins>
+          <plugin>
+            <!-- Copy the JDBC driver (with dependencies) JAR file into the distribution's target directory and rename ... -->
+            <artifactId>maven-antrun-plugin</artifactId>
+            <executions>
+              <execution>
+                <phase>package</phase>
+                <configuration>
+                  <tasks>
+                    <copy file="../utils/modeshape-jdbc/target/modeshape-jdbc-${project.version}-jar-with-dependencies.jar"
+                          tofile="${project.build.directory}/modeshape-${project.version}-client.jar" />
+                  </tasks>
+                </configuration>
+                <goals>
+                  <goal>run</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
 			</build>
 		</profile>
   </profiles>

--- a/utils/modeshape-jdbc/pom.xml
+++ b/utils/modeshape-jdbc/pom.xml
@@ -274,7 +274,7 @@
                     <phase>package</phase>
                     <configuration>
                         <tasks>
-                            <unzip src="target/modeshape-jdbc-${project.version}-http-jar-with-dependencies.jar" dest="target/tempjars" />
+                            <unzip src="target/modeshape-jdbc-${project.version}-jar-with-dependencies.jar" dest="target/tempjars" />
                             
                             <unzip src="target/tempjars/jaxrs-api-1.2.1.GA.jar" dest="target/temploc" />                                   
                             <unzip src="target/tempjars/jcr-2.0.jar" dest="target/temploc" />                                   
@@ -329,13 +329,13 @@
                              </copy>
                                                                                                      
                             
-                            <delete file="target/modeshape-jdbc-${project.version}-http-jar-with-dependencies.jar" />
-                            <jar destfile="target/modeshape-jdbc-${project.version}-http-jar-with-dependencies.jar" basedir="target/temploc" />
+                            <delete file="target/modeshape-jdbc-${project.version}-jar-with-dependencies.jar" />
+                            <jar destfile="target/modeshape-jdbc-${project.version}-jar-with-dependencies.jar" basedir="target/temploc" />
                             
                              <delete dir="target/tempjars" />
                              <delete dir="target/temploc" />
                              <delete dir="target/tempproviders" />
-                             <delete file="target/modeshape-jdbc-${project.version}-http-jar-with-dependencies.zip" />
+                             <delete file="target/modeshape-jdbc-${project.version}-jar-with-dependencies.zip" />
                         </tasks>
                     </configuration>
                     <goals>

--- a/utils/modeshape-jdbc/src/assembly/kit.xml
+++ b/utils/modeshape-jdbc/src/assembly/kit.xml
@@ -3,7 +3,7 @@
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.0 http://maven.apache.org/xsd/assembly-1.1.0.xsd">
 
-  <id>http-jar-with-dependencies</id>
+  <id>jar-with-dependencies</id>
       
   <formats>
     <format>jar</format>


### PR DESCRIPTION
The client JAR (which is actually the 'modeshape-jdbc-<version>-jar-with-dependencies.jar' file) is now copied into the 'modeshape-distribution/target' directory and renamed to 'modeshape-<version>-client.jar', and is also placed into the 'modeshape-<version>-dist.zip' file. The release script was also changed to copy the information into the archive directory.
