### PR TITLE
MODE-986 FileSystemConnector should perform validation on filenamefilter

### DIFF
--- a/modeshape-repository/src/main/java/org/modeshape/repository/RepositoryI18n.java
+++ b/modeshape-repository/src/main/java/org/modeshape/repository/RepositoryI18n.java
@@ -93,6 +93,10 @@ public final class RepositoryI18n {
     public static I18n requiredNodeDoesNotExistRelativeToNode;
     public static I18n errorGettingNodeRelativeToNode;
     public static I18n unknownPropertyValueType;
+    public static I18n invalidArgumentExceptionWhileSettingProperty;
+    public static I18n illegalAccessExceptionWhileSettingProperty;
+    public static I18n invocationTargetExceptionWhileSettingProperty;
+    public static I18n securityExceptionWhileSettingProperty;
 
     // Path expressions
     public static I18n pathExpressionIsInvalid;

--- a/modeshape-repository/src/main/java/org/modeshape/repository/RepositoryService.java
+++ b/modeshape-repository/src/main/java/org/modeshape/repository/RepositoryService.java
@@ -425,29 +425,28 @@ public class RepositoryService implements AdministeredService, Observer {
                                                    configurationWorkspaceName);
                 setter.invoke(instance, value);
             } catch (SecurityException err) {
-                Logger.getLogger(getClass()).debug(err, "Error invoking {0}.{1}", instance.getClass(), setter);
+                problems.addWarning(err, RepositoryI18n.securityExceptionWhileSettingProperty, instance.getClass(), setter);
             } catch (IllegalArgumentException err) {
                 // Do nothing ... assume not a JavaBean property (but log)
-                String msg = "Invalid argument invoking {0} with parameter {1} on source at {2} in configuration repository {3} in workspace {4}";
-                Logger.getLogger(getClass()).debug(err,
-                                                   msg,
-                                                   setter,
-                                                   value,
-                                                   path,
-                                                   configurationSourceName,
-                                                   configurationWorkspaceName);
+                problems.addWarning(err,
+                                    RepositoryI18n.invalidArgumentExceptionWhileSettingProperty,
+                                    setter,
+                                    value,
+                                    path,
+                                    configurationSourceName,
+                                    configurationWorkspaceName);
             } catch (IllegalAccessException err) {
-                Logger.getLogger(getClass()).debug(err, "Error invoking {0}.{1}", instance.getClass(), setter);
+                problems.addWarning(err, RepositoryI18n.illegalAccessExceptionWhileSettingProperty,
+                                    instance.getClass(), setter);
             } catch (InvocationTargetException err) {
                 // Do nothing ... assume not a JavaBean property (but log)
-                String msg = "Error invoking {0} with parameter {1} on source at {2} in configuration repository {3} in workspace {4}";
-                Logger.getLogger(getClass()).debug(err.getTargetException(),
-                                                   msg,
-                                                   setter,
-                                                   value,
-                                                   path,
-                                                   configurationSourceName,
-                                                   configurationWorkspaceName);
+                problems.addWarning(err,
+                                    RepositoryI18n.invocationTargetExceptionWhileSettingProperty,
+                                    setter,
+                                    value,
+                                    path,
+                                    configurationSourceName,
+                                    configurationWorkspaceName);
             }
         }
 
@@ -467,7 +466,6 @@ public class RepositoryService implements AdministeredService, Observer {
             if (setter == null) continue;
 
             try {
-                setter.invoke(instance, value);
                 // Invoke the method ...
                 String msg = "Setting property {0} to {1} on object at {2} in configuration repository {3} in workspace {4}";
                 Logger.getLogger(getClass()).trace(msg,
@@ -478,29 +476,28 @@ public class RepositoryService implements AdministeredService, Observer {
                                                    configurationWorkspaceName);
                 setter.invoke(instance, value);
             } catch (SecurityException err) {
-                Logger.getLogger(getClass()).debug(err, "Error invoking {0}.{1}", instance.getClass(), setter);
+                problems.addWarning(err, RepositoryI18n.securityExceptionWhileSettingProperty, instance.getClass(), setter);
             } catch (IllegalArgumentException err) {
                 // Do nothing ... assume not a JavaBean property (but log)
-                String msg = "Invalid argument invoking {0} with parameter {1} on object at {2} in configuration repository {3} in workspace {4}";
-                Logger.getLogger(getClass()).debug(err,
-                                                   msg,
-                                                   setter,
-                                                   value,
-                                                   childPath,
-                                                   configurationSourceName,
-                                                   configurationWorkspaceName);
+                problems.addWarning(err,
+                                    RepositoryI18n.invalidArgumentExceptionWhileSettingProperty,
+                                    setter,
+                                    value,
+                                    childPath,
+                                    configurationSourceName,
+                                    configurationWorkspaceName);
             } catch (IllegalAccessException err) {
-                Logger.getLogger(getClass()).debug(err, "Error invoking {0}.{1}", instance.getClass(), setter);
+                problems.addWarning(err, RepositoryI18n.illegalAccessExceptionWhileSettingProperty,
+                                    instance.getClass(), setter);
             } catch (InvocationTargetException err) {
                 // Do nothing ... assume not a JavaBean property (but log)
-                String msg = "Error invoking {0} with parameter {1} on source at {2} in configuration repository {3} in workspace {4}";
-                Logger.getLogger(getClass()).debug(err.getTargetException(),
-                                                   msg,
-                                                   setter,
-                                                   value,
-                                                   childPath,
-                                                   configurationSourceName,
-                                                   configurationWorkspaceName);
+                problems.addWarning(err,
+                                    RepositoryI18n.invocationTargetExceptionWhileSettingProperty,
+                                    setter,
+                                    value,
+                                    childPath,
+                                    configurationSourceName,
+                                    configurationWorkspaceName);
             }
 
         }

--- a/modeshape-repository/src/main/resources/org/modeshape/repository/RepositoryI18n.properties
+++ b/modeshape-repository/src/main/resources/org/modeshape/repository/RepositoryI18n.properties
@@ -74,6 +74,10 @@ errorClosingBinaryStreamForPropertyFromNode = Error while closing the binary str
 requiredNodeDoesNotExistRelativeToNode = The required node {0} does not exist relative to {1}
 errorGettingNodeRelativeToNode = Error while getting the node {0} (relative to {1})
 unknownPropertyValueType = Property value {0} is of a type ({1}) that is unknown
+invalidArgumentExceptionWhileSettingProperty = Invalid argument invoking {0} with parameter {1} on object at {2} in configuration repository {3} in workspace {4}
+illegalAccessExceptionWhileSettingProperty = IllegalAccessException invoking {0}.{1}
+invocationTargetExceptionWhileSettingProperty = Error invoking {0} with parameter {1} on source at {2} in configuration repository {3} in workspace {4}
+securityExceptionWhileSettingProperty = SecurityException invoking {0}.{1}
 
 pathExpressionMayNotBeBlank = The path expression may not be blank
 pathExpressionIsInvalid = The path expression {0} is not valid


### PR DESCRIPTION
Per the discussion in the JIRA comments, the attached patch modifies RepositoryService so that exceptions encountered while setting properties on repository sources are stored in the problems instead of being logged.  The patch also adds a test case to verify the specific behavior described in the JIRA.
