### PR TITLE
MODE-1169 Reference Guide Documentation for Some Sequencers Doesn't Menti

### DIFF
--- a/docs/reference/src/main/docbook/en-US/content/sequencers/ddl.xml
+++ b/docs/reference/src/main/docbook/en-US/content/sequencers/ddl.xml
@@ -103,7 +103,12 @@ CREATE SCHEMA hollywood
 	      reference information and position of the statement in the text stream (e.g., line number, column number and character index)
 	      so the statement can be tied back to the original DDL:
 	    </para>
-	    <programlisting language="XML" role="XML"><![CDATA[<nt:unstructured jcr:name="statements" ddl:parserId="POSTGRES">
+	    <programlisting language="XML" role="XML"><![CDATA[
+<nt:unstructured jcr:name="statements" 
+                 jcr:mixinTypes = "mode:derived" 
+                 mode:derivedAt="2011-05-13T13:12:03.925Z" 
+                 mode:derivedFrom="/files/foo.sql"
+                 ddl:parserId="POSTGRES">
   <nt:unstructured jcr:name="hollywood" jcr:mixinTypes="ddl:createSchemaStatement" 
 	                 ddl:startLineNumber="1"
                    ddl:startColumnNumber="1"

--- a/docs/reference/src/main/docbook/en-US/content/sequencers/image.xml
+++ b/docs/reference/src/main/docbook/en-US/content/sequencers/image.xml
@@ -44,6 +44,15 @@
 			<listitem>
 				<itemizedlist>
 					<listitem>
+						<para><emphasis role="strong">jcr:mixinTypes</emphasis> - "mode:derived"</para>
+					</listitem>
+					<listitem>
+						<para><emphasis role="strong">mode:derivedAt</emphasis> - the date that at which content was sequenced to produce this record</para>
+					</listitem>
+					<listitem>
+						<para><emphasis role="strong">mode:derivedFrom</emphasis> - the repository path to the content that was sequenced</para>
+					</listitem>
+					<listitem>
 						<para><emphasis role="strong">jcr:mimeType</emphasis> - optional string property for the mime type of the image</para>
 					</listitem>
 					<listitem>

--- a/docs/reference/src/main/docbook/en-US/content/sequencers/java_class.xml
+++ b/docs/reference/src/main/docbook/en-US/content/sequencers/java_class.xml
@@ -76,7 +76,10 @@
 		The default class file recorder creates a subgraph rooted at the output location that takes the following form:  
 	</para>
 	<programlisting language="XML" role="XML"><![CDATA[
-<nt:unstructured jcr:name="packageName1">
+<nt:unstructured jcr:name="packageName1"
+                 jcr:mixinTypes = mode:derived 
+                 mode:derivedAt="2011-05-13T13:12:03.925Z" 
+                 mode:derivedFrom="/files/org/modeshape/Foo.class">
 	...
     <nt:unstructured jcr:name="packageNameN">
 	    <class:class jcr:name="ClassName">

--- a/docs/reference/src/main/docbook/en-US/content/sequencers/java_source.xml
+++ b/docs/reference/src/main/docbook/en-US/content/sequencers/java_source.xml
@@ -82,7 +82,10 @@
 		creates a subgraph rooted at the output location that takes the following form:  
 	</para>
 	<programlisting language="XML" role="XML"><![CDATA[
-<nt:unstructured jcr:name="packageName1">
+<nt:unstructured jcr:name="packageName1" 
+                 jcr:mixinTypes = "mode:derived" 
+                 mode:derivedAt="2011-05-13T13:12:03.925Z" 
+                 mode:derivedFrom="/files/org/modeshape/Foo.java">
 	...
     <nt:unstructured jcr:name="packageNameN">
 	    <class:class jcr:name="ClassName">

--- a/docs/reference/src/main/docbook/en-US/content/sequencers/teiid_model.xml
+++ b/docs/reference/src/main/docbook/en-US/content/sequencers/teiid_model.xml
@@ -621,7 +621,9 @@ config.sequencer("Teiid Model Sequencer")
     </para>
   	<programlisting><![CDATA[
 PartsVirtual jcr:primaryType="xmi:model" 
-   - jcr:mixinTypes=["mmcore:model","mix:referenceable","xmi:referenceable"]
+   - jcr:mixinTypes=["mmcore:model","mix:referenceable","xmi:referenceable", "mode:derived"]
+   - mode:derivedAt="2011-05-13T13:12:03.925Z" 
+   - mode:derivedFrom="/files/foo.xmi"
    - jcr:uuid="d1a1b82f-055b-4db2-a3e7-a9668f3a70b6"
    - mmcore:maxSetSize="100"
    - mmcore:modelType="VIRTUAL"

--- a/docs/reference/src/main/docbook/en-US/content/sequencers/teiid_vdb.xml
+++ b/docs/reference/src/main/docbook/en-US/content/sequencers/teiid_vdb.xml
@@ -166,7 +166,11 @@ config.sequencer("Teiid VDB Sequencer")
        Here is a representation of the nodes output by the sequencing of an example "<code>qe.2.vdb</code>" virtual database:
     </para>
   	<programlisting><![CDATA[
-qe jcr:primaryType="vdb:virtualDatabase" jcr:mixinTypes="mix:referenceable" jcr:uuid="1d110326-f8e9-4f5e-becd-2f3e4d63296e"
+qe jcr:primaryType="vdb:virtualDatabase" 
+  - jcr:mixinTypes=["mix:referenceable", "mode:derived"] 
+  - jcr:uuid="1d110326-f8e9-4f5e-becd-2f3e4d63296e"
+  - mode:derivedAt="2011-05-13T13:12:03.925Z" 
+  - mode:derivedFrom="/files/foo.vdb"
   - vdb:description="This VDB is for testing Recursive XML documents and Text Sources"
   - vdb:originalFile="/vdb/qe.vdb"
   - vdb:preview="false"

--- a/docs/reference/src/main/docbook/en-US/content/sequencers/text.xml
+++ b/docs/reference/src/main/docbook/en-US/content/sequencers/text.xml
@@ -84,7 +84,9 @@
 		child node of the row node.  The output graph takes the following form (all nodes have primary type <code>nt:unstructured</code>:  
 	</para>
 	<programlisting>
- &lt;graph root&gt;
+ &lt;graph root jcr:mixinTypes = mode:derived, 
+                mode:derivedAt="2011-05-13T13:12:03.925Z", 
+                mode:derivedFrom="/files/foo.dat"&gt;
      + text:row[1]
      |   + text:column[1] (jcr:mixinTypes = text:column, text:data = &lt;column1 data&gt;)
      |   + ...


### PR DESCRIPTION
MODE-1169 Reference Guide Documentation for Some Sequencers Doesn't Mention mode:derived

Added mode:derived mixin type and its two properties to the sample output for each of the sequencers above.
