### PR TITLE
MODE-1171 Exported workspace.xml not correctly imported in case of sv:mul

### DIFF
--- a/modeshape-integration-tests/src/test/java/org/modeshape/test/integration/sequencer/XmlSequencerIntegrationTest.java
+++ b/modeshape-integration-tests/src/test/java/org/modeshape/test/integration/sequencer/XmlSequencerIntegrationTest.java
@@ -58,8 +58,8 @@ public class XmlSequencerIntegrationTest extends AbstractSequencerTest {
 
     @Test
     public void generateSequencerOutputForXmlSequencerChapterOfReferenceGuide() throws Exception {
-        // Uncomment next line to get the output graph showin the XML Sequencer chapter of the Ref Guide
-        print = true;
+        // Uncomment next line to get the output graph showing the XML Sequencer chapter of the Ref Guide
+        // print = true;
         uploadFile("docForReferenceGuide.xml", "/files/");
 
         // Find the sequenced node ...

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrSvLexicon.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrSvLexicon.java
@@ -39,6 +39,7 @@ public class JcrSvLexicon {
     }
 
     public static final Name NODE = new BasicName(Namespace.URI, "node");
+    public static final Name MULTIPLE = new BasicName(Namespace.URI, "multiple");
     public static final Name PROPERTY = new BasicName(Namespace.URI, "property");
     public static final Name NAME = new BasicName(Namespace.URI, "name");
     public static final Name TYPE = new BasicName(Namespace.URI, "type");

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrSystemViewExporter.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrSystemViewExporter.java
@@ -218,6 +218,15 @@ class JcrSystemViewExporter extends AbstractJcrExporter {
                               PropertyType.nameFromValue(PropertyType.STRING),
                               PropertyType.nameFromValue(prop.getType()));
 
+        // and it's sv:multiple attribute
+        if (prop.isMultiple()) {
+            propAtts.addAttribute(JcrSvLexicon.TYPE.getNamespaceUri(),
+                                  JcrSvLexicon.TYPE.getLocalName(),
+                                  getPrefixedName(JcrSvLexicon.MULTIPLE),
+                                  PropertyType.nameFromValue(PropertyType.BOOLEAN),
+                                  Boolean.TRUE.toString());
+        }
+
         // output the sv:property element
         startElement(contentHandler, JcrSvLexicon.PROPERTY, propAtts);
 


### PR DESCRIPTION
Attached patch that adds support for the sv:multiple attribute in system view imports and exports as well as a test case to verify that this is working.

Thanks to K. Bachl for isolating and reporting this bug!
