### PR TITLE
MODE-1175 REST client library should work with older servers

### DIFF
--- a/web/modeshape-web-jcr-rest-client/src/main/java/org/modeshape/web/jcr/rest/client/json/ServerNode.java
+++ b/web/modeshape-web-jcr-rest-client/src/main/java/org/modeshape/web/jcr/rest/client/json/ServerNode.java
@@ -118,10 +118,10 @@ public final class ServerNode extends JsonNode {
             // Get the metadata, if there ...
             Map<String, Object> meta = new HashMap<String, Object>();
             JSONObject named = (JSONObject)jsonObj.get(encodedName);
-            JSONObject repo = (JSONObject)named.get("repository");
-            if (repo != null) {
-                JSONObject metadata = (JSONObject)repo.get("metadata");
-                if (metadata != null) {
+            if (named.has("repository")) {
+                JSONObject repo = (JSONObject)named.get("repository");
+                if (repo.has("metadata")) {
+                    JSONObject metadata = (JSONObject)repo.get("metadata");
                     for (Iterator<String> keyIter = metadata.keys(); keyIter.hasNext();) {
                         String key = keyIter.next();
                         Object values = metadata.get(key);


### PR DESCRIPTION
The REST service was recently changed to expose metadata about the repository, and the REST client library was changed to support this new information. However, if the client connected to an older server, it expected this new metadata to be there, when in fact the client should handle the case when it is not.

The reason for this shortcoming is that the JSON library we're using throws an exception when code asks for the value of a key that is not in the JSON structure (instead of returning null nicely like Map does)! This can be fixed by simply checking for the key (and to get rid of the corresponding null checks).

All unit and integration tests pass with these changes.
