### PR TITLE
MODE-1176 Changed ModeShapeUnitTest to correctly find config files on classpath

### DIFF
--- a/extensions/modeshape-connector-store-jpa/src/main/java/org/modeshape/connector/store/jpa/JpaSource.java
+++ b/extensions/modeshape-connector-store-jpa/src/main/java/org/modeshape/connector/store/jpa/JpaSource.java
@@ -480,9 +480,9 @@ public class JpaSource implements RepositorySource, ObjectFactory {
      *        be treated as "disable".
      */
     public synchronized void setAutoGenerateSchema( String autoGenerateSchema ) {
-        if (autoGenerateSchema == null) autoGenerateSchema = DEFAULT_AUTO_GENERATE_SCHEMA;
+        if (autoGenerateSchema == null || autoGenerateSchema.length() == 0) autoGenerateSchema = DEFAULT_AUTO_GENERATE_SCHEMA;
         autoGenerateSchema = autoGenerateSchema.trim();
-        if (autoGenerateSchema.length() == 0 || autoGenerateSchema.equalsIgnoreCase(AUTO_GENERATE_SCHEMA_DISABLE)) autoGenerateSchema = AUTO_GENERATE_SCHEMA_DISABLE;
+        if (AUTO_GENERATE_SCHEMA_DISABLE.equalsIgnoreCase(autoGenerateSchema)) autoGenerateSchema = AUTO_GENERATE_SCHEMA_DISABLE;
         this.autoGenerateSchema = autoGenerateSchema;
         assert this.autoGenerateSchema != null;
         assert this.autoGenerateSchema.length() != 0;

--- a/extensions/modeshape-connector-store-jpa/src/test/java/org/modeshape/connector/store/jpa/JpaSourceTest.java
+++ b/extensions/modeshape-connector-store-jpa/src/test/java/org/modeshape/connector/store/jpa/JpaSourceTest.java
@@ -149,16 +149,16 @@ public class JpaSourceTest {
 
     @FixFor( "MODE-1102" )
     @Test
-    public void shouldTreatEmptyStringValueForAutoGenerateSchemaAsDisable() {
+    public void shouldTreatEmptyStringValueForAutoGenerateSchemaAsDefault() {
         source = new JpaSource();
         source.setName("Some name");
         source.setAutoGenerateSchema("");
-        assertThat(source.getAutoGenerateSchema(), is(JpaSource.AUTO_GENERATE_SCHEMA_DISABLE));
+        assertThat(source.getAutoGenerateSchema(), is(JpaSource.DEFAULT_AUTO_GENERATE_SCHEMA));
 
         // Verify it is set correctly on the Hibernate configuration ...
         Ejb3Configuration config = new Ejb3Configuration();
         source.configure(config);
-        assertThat(config.getProperties().get("hibernate.hbm2ddl.auto"), is(nullValue()));
+        assertThat(config.getProperties().get("hibernate.hbm2ddl.auto").toString(), is(JpaSource.DEFAULT_AUTO_GENERATE_SCHEMA));
     }
 
     @FixFor( "MODE-1102" )

--- a/modeshape-integration-tests/src/test/java/org/modeshape/test/integration/jdbc/JcrDriverIntegrationTest.java
+++ b/modeshape-integration-tests/src/test/java/org/modeshape/test/integration/jdbc/JcrDriverIntegrationTest.java
@@ -104,7 +104,7 @@ public class JcrDriverIntegrationTest extends ModeShapeMultiUseTest {
         // } catch (Exception ex) {
         // throw new IllegalStateException(ex);
         // }
-        JcrEngine engine = startEngineUsing("config/configRepositoryForJdbc.xml");
+        JcrEngine engine = startEngineUsing("config/configRepositoryForJdbc.xml", JcrDriverIntegrationTest.class);
         importContent(JcrDriverIntegrationTest.class, "jdbc/cars-system-view-with-uuids.xml", "Repo", null);
 
         // Use a session to load the contents ...

--- a/utils/modeshape-unit-test/src/main/java/org/modeshape/test/ModeShapeMultiUseTest.java
+++ b/utils/modeshape-unit-test/src/main/java/org/modeshape/test/ModeShapeMultiUseTest.java
@@ -30,7 +30,7 @@ package org.modeshape.test;
  * <pre>
  * @BeforeClass
  * public static void beforeAll() throws Exception {
- *     startEngineUsing("path/to/configuration.xml");
+ *     startEngineUsing("path/to/configuration.xml",ClassUnderTest.class);
  * }
  * @AfterClass
  * public static void afterAll() throws Exception {

--- a/utils/modeshape-unit-test/src/test/java/org/modeshape/test/UnitTestsForModeShapeMultiUseTest.java
+++ b/utils/modeshape-unit-test/src/test/java/org/modeshape/test/UnitTestsForModeShapeMultiUseTest.java
@@ -35,7 +35,7 @@ public class UnitTestsForModeShapeMultiUseTest extends ModeShapeMultiUseTest {
 
     @BeforeClass
     public static void beforeAll() throws Exception {
-        startEngineUsing("modeshape_configuration_inmemory.xml");
+        startEngineUsing("modeshape_configuration_inmemory.xml", UnitTestsForModeShapeMultiUseTest.class);
     }
 
     @AfterClass


### PR DESCRIPTION
When the 'startEngineUsing' method was called by a static method, it could not determine the classloader and thus could not find the configuration file that was on the classpath. The solution was to add another form of the method that took the class under test as a second parameter, and to make the 'startEngineUsing(String)' method non-static so that can only be called when the class under test can be determined.
