### PR TITLE
MODE-1177 Unit tests within a module are not run in alphabetical order

### DIFF
--- a/modeshape-parent/pom.xml
+++ b/modeshape-parent/pom.xml
@@ -812,6 +812,7 @@
 						</property>
 					</systemProperties>
 					<argLine>-Xmx256M ${debug.argline} -XX:MaxPermSize=512m</argLine>
+					<runOrder>alphabetical</runOrder>
 				</configuration>
 			</plugin>
 


### PR DESCRIPTION
This change should make all builds on all machines much more consistent.
