### PR TITLE
MODE-1179 Add Connector for Disk-Based Storage

### DIFF
--- a/docs/reference/src/main/docbook/en-US/content/connectors/disk.xml
+++ b/docs/reference/src/main/docbook/en-US/content/connectors/disk.xml
@@ -1,0 +1,175 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ ModeShape (http://www.modeshape.org)
+  ~
+  ~ See the COPYRIGHT.txt file distributed with this work for information
+  ~ regarding copyright ownership.  Some portions may be licensed
+  ~ to Red Hat, Inc. under one or more contributor license agreements.
+  ~ See the AUTHORS.txt file in the distribution for a full listing of 
+  ~ individual contributors.
+  ~
+  ~ ModeShape is free software. Unless otherwise indicated, all code in ModeShape
+  ~ is licensed to you under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ ModeShape is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+  ~ or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+  ~ for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public License
+  ~ along with this distribution; if not, write to:
+  ~ Free Software Foundation, Inc.
+  ~ 51 Franklin Street, Fifth Floor
+  ~ Boston, MA  02110-1301  USA
+  -->
+<!DOCTYPE preface PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN" "http://www.oasis-open.org/docbook/xml/4.5/docbookx.dtd"	[
+<!ENTITY % CustomDTD SYSTEM "../../custom.dtd">
+%CustomDTD;
+]>
+<chapter id="disk-connector">
+  <title>Disk Connector</title>
+  <para>
+		This connector stores content in a ModeShape-specific file format on disk.  Although this may seem similar in concept to the <link linkend="file-system-connector">File System Connector</link>,
+		this connector actually serves a much different purpose.  While the File System Connector is designed to expose existing files and folders on the 
+		disk and allow ModeShape users to create content that can be read directly by other applications, the Disk Connector is designed for efficiency and
+		stores content in a serialized representation that is not readily accessible to other applications.  Conversely, the Disk Connector supports referenceable
+		nodes and can efficiently access nodes by UUID, unlike the File System Connector.    
+ 	</para>
+	<para>
+		The &DiskSource; class provides a number of JavaBean properties that control its behavior:
+	</para>
+	<table frame='all'>
+		<title>&DiskSource; properties</title>
+		<tgroup cols='2' align='left' colsep='1' rowsep='1'>
+      <colspec colname='c1' colwidth="1*"/>
+      <colspec colname='c2' colwidth="1*"/>
+			<thead>
+				<row>
+		  		<entry>Property</entry>
+		  		<entry>Description</entry>
+				</row>
+			</thead>
+			<tbody>
+				<row>
+					<entry>cachePolicy</entry>
+					<entry>Optional property that, if used, defines the cache policy for this repository source.  When not used, this source will not define a specific
+						duration for caching information.</entry>
+				</row>
+				<row>
+					<entry>creatingWorkspaceAllowed</entry>
+					<entry>Optional property that defines whether clients can create additional workspaces.  The default value is "true".
+					</entry>
+				</row>
+				<row>
+					<entry>defaultWorkspaceName</entry>
+					<entry>Optional property that is initialized to <code>"default"</code> and which defines the name for the workspace that will be used by default
+						if none is specified.</entry>
+				</row>
+				<row>
+					<entry>name</entry>
+					<entry>The name of the repository source, which is used by the &RepositoryService; when obtaining a &RepositoryConnection; by name.</entry>
+				</row>
+				<row>
+					<entry>predefinedWorkspaceNames</entry>
+					<entry>Optional property that, if used, defines names of the workspaces that are predefined and need not be created before being used.
+						This can be coupled with a "false" value for the "creatingWorkspaceAllowed" property to allow only the use of only predefined workspaces.
+					</entry>
+				</row>
+				<row>
+					<entry>rootNodeUuid</entry>
+					<entry>Optional property that, if used, specifies the UUID that should be used for the root node of each workspace.  If no value is
+					specified, a default UUID is used.</entry>
+				</row>	
+				<row>
+					<entry>retryLimit</entry>
+					<entry>Optional property that, if used, defines the number of times that any single operation on a &RepositoryConnection; to this source should be retried
+						following a communication failure. The default value is '0'.</entry>
+				</row>
+				<row>
+					<entry>updatesAllowed</entry>
+					<entry>Determines whether the content in the file system can be updated ("true"), or if the content may only be read ("false").
+						The default value is "true".</entry>
+				</row>
+				<row>
+					<entry>repositoryRootPath</entry>
+					<entry>
+					<para>Optional property that specifies a path on the local file system to the root of all workspaces.  The connector will use this as the root
+					for a file and folder structure for storing content.  The default value is "/tmp", so setting this property to a more logical value is strongly 
+					recommended.
+					</para>
+					</entry>
+				</row>	
+				
+			</tbody>
+		</tgroup>
+	</table>
+	<para>
+		One way to configure the file system connector is to create &JcrConfiguration; instance with a repository source that uses the &DiskSource; class.
+		For example:
+	</para>
+  <programlisting language="JAVA" role="JAVA"><![CDATA[
+JcrConfiguration config = ...
+config.repositorySource("Disk Store")
+      .usingClass(DiskSource.class)
+      .setDescription("The repository for our content")
+      .setProperty("repositoryRootPath", "/home/content/someApp")
+      .setProperty("defaultWorkspaceName", "prod")
+      .setProperty("predefinedWorkspaceNames", new String[] { "staging", "dev"})
+      .setProperty("rootNodeUuid", UUID.fromString("fd129c12-81a8-42ed-aa4b-820dba49e6f0")
+      .setProperty("updatesAllowed", "true")
+      .setProperty("creatingWorkspaceAllowed", "false");
+ ]]></programlisting>
+	<para>
+		Another way to configure the file system connector is to create &JcrConfiguration; instance and load an XML configuration file that contains a repository source that 
+		uses the &DiskSource; class.
+		For example a file named configRepository.xml can be created with these contents:
+	</para>
+	
+  <programlisting language="XML" role="XML"><![CDATA[
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration xmlns:mode="http://www.modeshape.org/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0">
+    <!-- 
+    Define the sources for the content.  These sources are directly accessible using the 
+    ModeShape-specific Graph API. In fact, this is how the ModeShape JCR implementation works.  You can 
+    think of these as being similar to JDBC DataSource objects, except that they expose graph 
+    content via the Graph API instead of records via SQL or JDBC. 
+    -->
+    <mode:sources jcr:primaryType="nt:unstructured">
+        <!-- 
+        The 'Disk Store' repository is a file system source with a three predefined workspaces 
+        ("prod", "staging", and "dev").
+        -->
+        <mode:source jcr:name="Disk Store" 
+        	mode:classname="org.modeshape.connector.disk.DiskSource"
+        	mode:description="The repository for our content"
+        	mode:repositoryRootPath="/home/content/someApp"
+        	mode:defaultWorkspaceName="prod"
+        	mode:creatingWorkspacesAllowed="false"
+        	mode:rootNodeUuid="fd129c12-81a8-42ed-aa4b-820dba49e6f0"
+        	mode:updatesAllowed="true" >
+            <mode:predefinedWorkspaceNames>staging</mode:predefinedWorkspaceNames>
+            <mode:predefinedWorkspaceNames>dev</mode:predefinedWorkspaceNames>
+      	    <!-- 
+      	    If desired, specify a cache policy that caches items in memory for 5 minutes (300000 ms).
+      	    This fragment can be left out if the connector should not cache any content.
+      	    -->
+      	    <mode:cachePolicy jcr:name="cachePolicy" 
+      	      mode:classname="org.modeshape.graph.connector.path.cache.InMemoryWorkspaceCache$InMemoryCachePolicy"
+      	      mode:timeToLiveInMilliseconds="300000" />
+        </mode:source>    
+    </mode:sources>
+
+	<!-- MIME type detectors and JCR repositories would be defined below --> 
+</configuration>
+ ]]></programlisting>
+	<para>
+		The configuration can then be loaded from Java like this:
+	</para>
+	
+	<programlisting language="JAVA" role="JAVA"><![CDATA[
+JcrConfiguration config = new JcrConfiguration().loadFrom("/configRepository.xml");
+ ]]></programlisting>
+ </chapter>
+

--- a/docs/reference/src/main/docbook/en-US/custom.dtd
+++ b/docs/reference/src/main/docbook/en-US/custom.dtd
@@ -259,6 +259,7 @@
 <!-- Types in extensions/ -->
 
 <!ENTITY JcrRepositorySource  				"<ulink url='&API;connector/jcr/JcrRepositorySource.html'><classname>JcrRepositorySource</classname></ulink>">
+<!ENTITY DiskSource  						"<ulink url='&API;connector/disk/DiskSource.html'><classname>DiskSource</classname></ulink>">
 <!ENTITY FileSystemSource  						"<ulink url='&API;connector/filesystem/FileSystemSource.html'><classname>FileSystemSource</classname></ulink>">
 <!ENTITY CustomPropertiesFactory  		"<ulink url='&API;connector/filesystem/CustomPropertiesFactory'><classname>CustomPropertiesFactory</classname></ulink>">
 <!ENTITY JpaSource  									"<ulink url='&API;connector/store/jpa/JpaSource.html'><classname>JpaSource</classname></ulink>">

--- a/docs/reference/src/main/docbook/en-US/master.xml
+++ b/docs/reference/src/main/docbook/en-US/master.xml
@@ -101,6 +101,7 @@
   	<xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="content/connectors/subversion.xml"/>
   	<xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="content/connectors/jboss_cache.xml"/>
   	<xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="content/connectors/infinispan.xml"/>
+  	<xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="content/connectors/disk.xml"/>
   	<xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="content/connectors/jdbc_metadata.xml"/>
 	</part>
 	<part id="provided-sequencers-part">

--- a/extensions/modeshape-connector-disk/pom.xml
+++ b/extensions/modeshape-connector-disk/pom.xml
@@ -1,0 +1,149 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.modeshape</groupId>
+    <artifactId>modeshape-parent</artifactId>
+    <version>2.5-SNAPSHOT</version>
+    <relativePath>../../modeshape-parent</relativePath>
+  </parent>
+  <!-- The groupId and version values are inherited from parent -->
+  <artifactId>modeshape-connector-disk</artifactId>
+  <packaging>jar</packaging>
+  <name>ModeShape Connector to Disk-Based Storage</name>
+  <description>ModeShape Connector that stores arbitrary content on a disk</description>
+  <url>http://www.modeshape.org</url>
+  <!--
+  Define the dependencies.  Note that all version and scopes default to those 
+  defined in the dependencyManagement section of the parent pom.
+  -->
+  <dependencies>
+    <!-- 
+    Common
+    -->
+    <dependency>
+      <groupId>org.modeshape</groupId>
+      <artifactId>modeshape-common</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.modeshape</groupId>
+      <artifactId>modeshape-graph</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.modeshape</groupId>
+      <artifactId>modeshape-common</artifactId>
+      <version>${project.version}</version>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.modeshape</groupId>
+      <artifactId>modeshape-graph</artifactId>
+      <version>${project.version}</version>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+
+    <!-- 
+    Testing (note the scope)
+    -->
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-all</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-library</artifactId>
+    </dependency>
+
+    <!-- 
+    Logging (require SLF4J API for compiling, but use Log4J and its SLF4J binding for testing) 
+    -->
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-log4j12</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>log4j</groupId>
+      <artifactId>log4j</artifactId>
+    </dependency>
+  </dependencies>
+  <reporting>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-report-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </reporting>
+
+  <build>
+    <plugins>
+			<!--
+				Adding OSGI metadata to the JAR without changing the packaging type.
+			-->
+			<plugin>
+				<artifactId>maven-jar-plugin</artifactId>
+				<configuration>
+					<archive>
+						<manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+					</archive>
+				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.felix</groupId>
+				<artifactId>maven-bundle-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>bundle-manifest</id>
+						<phase>process-classes</phase>
+						<goals>
+							<goal>manifest</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+  </build>
+	<profiles>
+		<profile>
+			<id>assembly</id>
+			<build>
+	    	<plugins>
+		      <plugin>
+		        <artifactId>maven-assembly-plugin</artifactId>
+					  <dependencies>
+					    <dependency>
+					      <groupId>${project.groupId}</groupId>
+					      <artifactId>modeshape-assembly-descriptors</artifactId>
+					      <version>${project.version}</version>
+					    </dependency>
+					  </dependencies>
+		        <configuration>
+		          <descriptorRefs>
+		            <descriptorRef>connector-with-dependencies</descriptorRef>
+		          </descriptorRefs>
+							<finalName>${project.artifactId}-${project.version}</finalName>
+		        </configuration>
+		        <executions>
+		          <execution>
+		            <phase>package</phase>
+		            <goals>
+		              <goal>single</goal>
+		            </goals>
+		          </execution>
+		        </executions>
+		      </plugin>
+				</plugins>
+			</build>
+		</profile>
+	</profiles>
+</project>

--- a/extensions/modeshape-connector-disk/src/main/java/org/modeshape/connector/disk/DiskConnectorI18n.java
+++ b/extensions/modeshape-connector-disk/src/main/java/org/modeshape/connector/disk/DiskConnectorI18n.java
@@ -1,0 +1,59 @@
+package org.modeshape.connector.disk;
+
+import java.util.Locale;
+import java.util.Set;
+import org.modeshape.common.i18n.I18n;
+
+/**
+ * The internationalized string constants for the <code>org.modeshape.connector.infinispan*</code> packages.
+ */
+public final class DiskConnectorI18n {
+
+    public static I18n connectorName;
+    public static I18n propertyIsRequired;
+    public static I18n errorSerializingCachePolicyInSource;
+    public static I18n unableToCreateWorkspace;
+
+    public static I18n namePropertyDescription;
+    public static I18n namePropertyLabel;
+    public static I18n namePropertyCategory;
+    public static I18n defaultWorkspaceNamePropertyDescription;
+    public static I18n defaultWorkspaceNamePropertyLabel;
+    public static I18n defaultWorkspaceNamePropertyCategory;
+    public static I18n rootNodeUuidPropertyDescription;
+    public static I18n rootNodeUuidPropertyLabel;
+    public static I18n rootNodeUuidPropertyCategory;
+    public static I18n predefinedWorkspaceNamesPropertyDescription;
+    public static I18n predefinedWorkspaceNamesPropertyLabel;
+    public static I18n predefinedWorkspaceNamesPropertyCategory;
+    public static I18n retryLimitPropertyDescription;
+    public static I18n retryLimitPropertyLabel;
+    public static I18n retryLimitPropertyCategory;
+    public static I18n updatesAllowedPropertyDescription;
+    public static I18n updatesAllowedPropertyLabel;
+    public static I18n updatesAllowedPropertyCategory;
+    public static I18n repositoryRootPathPropertyDescription;
+    public static I18n repositoryRootPathPropertyLabel;
+    public static I18n repositoryRootPathPropertyCategory;
+
+    static {
+        try {
+            I18n.initialize(DiskConnectorI18n.class);
+        } catch (final Exception err) {
+            System.err.println(err);
+        }
+    }
+
+    public static Set<Locale> getLocalizationProblemLocales() {
+        return I18n.getLocalizationProblemLocales(DiskConnectorI18n.class);
+    }
+
+    public static Set<String> getLocalizationProblems() {
+        return I18n.getLocalizationProblems(DiskConnectorI18n.class);
+    }
+
+    public static Set<String> getLocalizationProblems( Locale locale ) {
+        return I18n.getLocalizationProblems(DiskConnectorI18n.class, locale);
+    }
+
+}

--- a/extensions/modeshape-connector-disk/src/main/java/org/modeshape/connector/disk/DiskNode.java
+++ b/extensions/modeshape-connector-disk/src/main/java/org/modeshape/connector/disk/DiskNode.java
@@ -1,0 +1,108 @@
+/*
+ * ModeShape (http://www.modeshape.org)
+ * See the COPYRIGHT.txt file distributed with this work for information
+ * regarding copyright ownership.  Some portions may be licensed
+ * to Red Hat, Inc. under one or more contributor license agreements.
+ * See the AUTHORS.txt file in the distribution for a full listing of 
+ * individual contributors.
+ *
+ * ModeShape is free software. Unless otherwise indicated, all code in ModeShape
+ * is licensed to you under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ * 
+ * ModeShape is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.modeshape.connector.disk;
+
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.modeshape.graph.connector.base.MapNode;
+import org.modeshape.graph.property.Name;
+import org.modeshape.graph.property.Property;
+import org.modeshape.graph.property.Path.Segment;
+
+/**
+ * A specialization of the {@link MapNode}.
+ */
+public class DiskNode extends MapNode {
+
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * Create a new node for storage on a disk.
+     * 
+     * @param uuid the desired UUID; never null
+     * @param name the name of the new node; may be null if the name is not known and there is no parent
+     * @param parent the UUID of the parent node; may be null if this is the root node and there is no name
+     * @param properties the properties; may be null if there are no properties
+     * @param children the list of child nodes; may be null
+     */
+    public DiskNode( UUID uuid,
+                           Segment name,
+                           UUID parent,
+                           Map<Name, Property> properties,
+                           List<UUID> children ) {
+        super(uuid, name, parent, properties, children);
+    }
+
+    /**
+     * Create a new node for storage on a disk..
+     * 
+     * @param uuid the desired UUID; never null
+     * @param name the name of the new node; may be null if the name is not known and there is no parent
+     * @param parent the UUID of the parent node; may be null if this is the root node and there is no name
+     * @param properties the properties; may be null if there are no properties
+     * @param children the list of child nodes; may be null
+     */
+    public DiskNode( UUID uuid,
+                           Segment name,
+                           UUID parent,
+                           Iterable<Property> properties,
+                           List<UUID> children ) {
+        super(uuid, name, parent, properties, children);
+    }
+
+    /**
+     * Create a new node for storage on a disk.
+     * 
+     * @param uuid the desired UUID; never null
+     */
+    public DiskNode( UUID uuid ) {
+        super(uuid);
+    }
+
+    /**
+     * {@inheritDoc}
+     * 
+     * @see org.modeshape.graph.connector.base.MapNode#freeze()
+     */
+    @Override
+    public DiskNode freeze() {
+        if (!hasChanges()) return this;
+        return new DiskNode(getUuid(), getName(), getParent(), changes.getUnmodifiableProperties(),
+                                  changes.getUnmodifiableChildren());
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * This method never clones the {@link #hasChanges() changes}.
+     * </p>
+     * 
+     * @see java.lang.Object#clone()
+     */
+    @Override
+    public DiskNode clone() {
+        return new DiskNode(getUuid(), getName(), getParent(), getProperties(), getChildren());
+    }
+}

--- a/extensions/modeshape-connector-disk/src/main/java/org/modeshape/connector/disk/DiskRepository.java
+++ b/extensions/modeshape-connector-disk/src/main/java/org/modeshape/connector/disk/DiskRepository.java
@@ -1,0 +1,93 @@
+/*
+ * ModeShape (http://www.modeshape.org)
+ * See the COPYRIGHT.txt file distributed with this work for information
+ * regarding copyright ownership.  Some portions may be licensed
+ * to Red Hat, Inc. under one or more contributor license agreements.
+ * See the AUTHORS.txt file in the distribution for a full listing of 
+ * individual contributors.
+ *
+ * ModeShape is free software. Unless otherwise indicated, all code in ModeShape
+ * is licensed to you under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ * 
+ * ModeShape is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.modeshape.connector.disk;
+
+import java.io.File;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+import org.modeshape.common.annotation.ThreadSafe;
+import org.modeshape.graph.ExecutionContext;
+import org.modeshape.graph.connector.base.Repository;
+
+/**
+ * The representation of a disk-based repository and its content.
+ */
+@ThreadSafe
+public class DiskRepository extends Repository<DiskNode, DiskWorkspace> {
+
+    private final File repositoryRoot;
+    private final ReadWriteLock lock = new ReentrantReadWriteLock();
+    private final Set<String> predefinedWorkspaceNames;
+
+    public DiskRepository( DiskSource source ) {
+        super(source);
+
+        repositoryRoot = new File(source.getRepositoryRootPath());
+        if (!repositoryRoot.exists()) repositoryRoot.mkdir();
+        Set<String> workspaceNames = new HashSet<String>();
+        for (String workspaceName : source.getPredefinedWorkspaceNames()) {
+            workspaceNames.add(workspaceName);
+        }
+        this.predefinedWorkspaceNames = Collections.unmodifiableSet(workspaceNames);
+        initialize();
+    }
+
+    /**
+     * {@inheritDoc}
+     * 
+     * @see org.modeshape.graph.connector.base.Repository#getWorkspaceNames()
+     */
+    @Override
+    public Set<String> getWorkspaceNames() {
+        Set<String> names = new HashSet<String>(super.getWorkspaceNames());
+        names.addAll(predefinedWorkspaceNames);
+        return Collections.unmodifiableSet(names);
+    }
+
+    /**
+     * Get the root of this repository
+     * 
+     * @return the root of this repository; never null
+     */
+    protected File getRepositoryRoot() {
+        return repositoryRoot;
+    }
+
+    /**
+     * {@inheritDoc}
+     * 
+     * @see org.modeshape.graph.connector.base.Repository#startTransaction(org.modeshape.graph.ExecutionContext, boolean)
+     */
+    @Override
+    public DiskTransaction startTransaction( ExecutionContext context,
+                                                   boolean readonly ) {
+        final Lock lock = readonly ? this.lock.readLock() : this.lock.writeLock();
+        lock.lock();
+        return new DiskTransaction(context, this, getRootNodeUuid(), lock);
+    }
+}

--- a/extensions/modeshape-connector-disk/src/main/java/org/modeshape/connector/disk/DiskSource.java
+++ b/extensions/modeshape-connector-disk/src/main/java/org/modeshape/connector/disk/DiskSource.java
@@ -1,0 +1,543 @@
+/*
+ * ModeShape (http://www.modeshape.org)
+ * See the COPYRIGHT.txt file distributed with this work for information
+ * regarding copyright ownership.  Some portions may be licensed
+ * to Red Hat, Inc. under one or more contributor license agreements.
+ * See the AUTHORS.txt file in the distribution for a full listing of
+ * individual contributors.
+ *
+ * ModeShape is free software. Unless otherwise indicated, all code in ModeShape
+ * is licensed to you under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * ModeShape is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.modeshape.connector.disk;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.Hashtable;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import javax.naming.BinaryRefAddr;
+import javax.naming.Context;
+import javax.naming.RefAddr;
+import javax.naming.Reference;
+import javax.naming.Referenceable;
+import javax.naming.StringRefAddr;
+import javax.naming.spi.ObjectFactory;
+import org.modeshape.common.annotation.Category;
+import org.modeshape.common.annotation.Description;
+import org.modeshape.common.annotation.Label;
+import org.modeshape.common.annotation.ThreadSafe;
+import org.modeshape.common.i18n.I18n;
+import org.modeshape.common.util.HashCode;
+import org.modeshape.common.util.StringUtil;
+import org.modeshape.graph.cache.CachePolicy;
+import org.modeshape.graph.connector.RepositoryConnection;
+import org.modeshape.graph.connector.RepositoryContext;
+import org.modeshape.graph.connector.RepositorySource;
+import org.modeshape.graph.connector.RepositorySourceCapabilities;
+import org.modeshape.graph.connector.RepositorySourceException;
+import org.modeshape.graph.connector.base.BaseRepositorySource;
+import org.modeshape.graph.connector.base.Connection;
+import org.modeshape.graph.observe.Observer;
+
+/**
+ * A repository source that uses a uses a disk to store arbitrary content. Unlike the {@code FileSystemSource}, this connector can
+ * store arbitrary content and is not limited to storing nodes of type {@code nt:folder, nt:file, and nt:resource}. However,
+ * content stored by this connector is not intended to be accessible to other applications unless they integrate with ModeShape to
+ * read the data.
+ * <p>
+ * Nodes created by this source are assigned a UUID and mapped to a system of folders and subfolders based on this UUID.
+ * </p>
+ * <p>
+ * Like other {@link RepositorySource} classes, instances of DiskSource can be placed into JNDI and do support the creation of
+ * {@link Referenceable JNDI referenceable} objects and resolution of references into DiskSource.
+ * </p>
+ */
+@ThreadSafe
+public class DiskSource implements BaseRepositorySource, ObjectFactory {
+
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * The default limit is {@value} for retrying {@link RepositoryConnection connection} calls to the underlying source.
+     */
+    public static final int DEFAULT_RETRY_LIMIT = 0;
+
+    /**
+     * The default limit is {@value} for the root node's UUID.
+     */
+    public static final String DEFAULT_ROOT_NODE_UUID = "cafebabe-cafe-babe-cafe-babecafebabe";
+
+    /**
+     * The initial {@link #getDefaultWorkspaceName() name of the default workspace} is "{@value} ", unless otherwise specified.
+     */
+    public static final String DEFAULT_NAME_OF_DEFAULT_WORKSPACE = "default";
+
+    /**
+     * The initial value for whether updates are allowed is "{@value} ", unless otherwise specified.
+     */
+    public static final boolean DEFAULT_UPDATES_ALLOWED = true;
+
+    /**
+     * The initial value for where content should be stored on disk is "{@value} ", unless otherwise specified.
+     */
+    public static final String DEFAULT_REPOSITORY_ROOT_PATH = "/tmp";
+
+    private static final String ROOT_NODE_UUID = "rootNodeUuid";
+    private static final String SOURCE_NAME = "sourceName";
+    private static final String DEFAULT_CACHE_POLICY = "defaultCachePolicy";
+    private static final String RETRY_LIMIT = "retryLimit";
+    private static final String DEFAULT_WORKSPACE = "defaultWorkspace";
+    private static final String PREDEFINED_WORKSPACE_NAMES = "predefinedWorkspaceNames";
+    private static final String ALLOW_CREATING_WORKSPACES = "allowCreatingWorkspaces";
+    private static final String UPDATES_ALLOWED = "updatesAllowed";
+    private static final String REPOSITORY_ROOT_PATH = "repositoryRootPath";
+
+    @Description( i18n = DiskConnectorI18n.class, value = "namePropertyDescription" )
+    @Label( i18n = DiskConnectorI18n.class, value = "namePropertyLabel" )
+    @Category( i18n = DiskConnectorI18n.class, value = "namePropertyCategory" )
+    private volatile String name;
+
+    @Description( i18n = DiskConnectorI18n.class, value = "rootNodeUuidPropertyDescription" )
+    @Label( i18n = DiskConnectorI18n.class, value = "rootNodeUuidPropertyLabel" )
+    @Category( i18n = DiskConnectorI18n.class, value = "rootNodeUuidPropertyCategory" )
+    private volatile UUID rootNodeUuid = UUID.fromString(DEFAULT_ROOT_NODE_UUID);
+
+    @Description( i18n = DiskConnectorI18n.class, value = "retryLimitPropertyDescription" )
+    @Label( i18n = DiskConnectorI18n.class, value = "retryLimitPropertyLabel" )
+    @Category( i18n = DiskConnectorI18n.class, value = "retryLimitPropertyCategory" )
+    private volatile int retryLimit = DEFAULT_RETRY_LIMIT;
+
+    @Description( i18n = DiskConnectorI18n.class, value = "defaultWorkspaceNamePropertyDescription" )
+    @Label( i18n = DiskConnectorI18n.class, value = "defaultWorkspaceNamePropertyLabel" )
+    @Category( i18n = DiskConnectorI18n.class, value = "defaultWorkspaceNamePropertyCategory" )
+    private volatile String defaultWorkspace;
+
+    @Description( i18n = DiskConnectorI18n.class, value = "predefinedWorkspaceNamesPropertyDescription" )
+    @Label( i18n = DiskConnectorI18n.class, value = "predefinedWorkspaceNamesPropertyLabel" )
+    @Category( i18n = DiskConnectorI18n.class, value = "predefinedWorkspaceNamesPropertyCategory" )
+    private volatile String[] predefinedWorkspaces = new String[] {};
+
+    @Description( i18n = DiskConnectorI18n.class, value = "updatesAllowedPropertyDescription" )
+    @Label( i18n = DiskConnectorI18n.class, value = "updatesAllowedPropertyLabel" )
+    @Category( i18n = DiskConnectorI18n.class, value = "updatesAllowedPropertyCategory" )
+    private volatile boolean updatesAllowed = DEFAULT_UPDATES_ALLOWED;
+
+    @Description( i18n = DiskConnectorI18n.class, value = "repositoryRootPathPropertyDescription" )
+    @Label( i18n = DiskConnectorI18n.class, value = "repositoryRootPathPropertyLabel" )
+    @Category( i18n = DiskConnectorI18n.class, value = "repositoryRootPathPropertyCategory" )
+    private volatile String repositoryRootPath = DEFAULT_REPOSITORY_ROOT_PATH;
+
+    private volatile CachePolicy defaultCachePolicy;
+    private volatile RepositorySourceCapabilities capabilities = new RepositorySourceCapabilities(true, true, false, true, true);
+    private transient DiskRepository repository;
+    private transient Context jndiContext;
+    private transient RepositoryContext repositoryContext;
+
+    /**
+     * Create a repository source instance.
+     */
+    public DiskSource() {
+    }
+
+    /**
+     * {@inheritDoc}
+     * 
+     * @see org.modeshape.graph.connector.RepositorySource#initialize(org.modeshape.graph.connector.RepositoryContext)
+     */
+    @Override
+    public void initialize( RepositoryContext context ) throws RepositorySourceException {
+        this.repositoryContext = context;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getName() {
+        return this.name;
+    }
+
+    /**
+     * @return the path to the root of the repository on disk. This path must be (at least) readable.
+     */
+    public String getRepositoryRootPath() {
+        return this.repositoryRootPath;
+    }
+
+    /**
+     * {@inheritDoc}
+     * 
+     * @see org.modeshape.graph.connector.RepositorySource#getCapabilities()
+     */
+    @Override
+    public RepositorySourceCapabilities getCapabilities() {
+        return capabilities;
+    }
+
+    /**
+     * Get the default cache policy for this source, or null if the global default cache policy should be used
+     * 
+     * @return the default cache policy, or null if this source has no explicit default cache policy
+     */
+    @Override
+    public CachePolicy getDefaultCachePolicy() {
+        return defaultCachePolicy;
+    }
+
+    /**
+     * @param defaultCachePolicy Sets defaultCachePolicy to the specified value.
+     */
+    public synchronized void setDefaultCachePolicy( CachePolicy defaultCachePolicy ) {
+        if (this.defaultCachePolicy == defaultCachePolicy || this.defaultCachePolicy != null
+            && this.defaultCachePolicy.equals(defaultCachePolicy)) return; // unchanged
+        this.defaultCachePolicy = defaultCachePolicy;
+    }
+
+    /**
+     * {@inheritDoc}
+     * 
+     * @see org.modeshape.graph.connector.RepositorySource#getRetryLimit()
+     */
+    @Override
+    public int getRetryLimit() {
+        return retryLimit;
+    }
+
+    /**
+     * {@inheritDoc}
+     * 
+     * @see org.modeshape.graph.connector.RepositorySource#setRetryLimit(int)
+     */
+    @Override
+    public synchronized void setRetryLimit( int limit ) {
+        retryLimit = limit < 0 ? 0 : limit;
+    }
+
+    /**
+     * Set the name of this source
+     * 
+     * @param name the name for this source
+     */
+    public synchronized void setName( String name ) {
+        if (this.name == name || this.name != null && this.name.equals(name)) return; // unchanged
+        this.name = name;
+    }
+
+    /**
+     * Set the the path to the root of the repository on disk. This path must be (at least) readable.
+     * 
+     * @param repositoryRootPath the path to the root of the repository on disk. This path must be (at least) readable.
+     */
+    public synchronized void setRepositoryRootPath( String repositoryRootPath ) {
+        if (repositoryRootPath == null) repositoryRootPath = DEFAULT_REPOSITORY_ROOT_PATH;
+        this.repositoryRootPath = repositoryRootPath;
+    }
+
+    /**
+     * Get the UUID of the root node for the cache. If the cache exists, this UUID is not used but is instead set to the UUID of
+     * the existing root node.
+     * 
+     * @return the UUID of the root node for the cache.
+     */
+    public String getRootNodeUuid() {
+        return this.rootNodeUuid.toString();
+    }
+
+    /**
+     * Get the UUID of the root node for the cache. If the cache exists, this UUID is not used but is instead set to the UUID of
+     * the existing root node.
+     * 
+     * @return the UUID of the root node for the cache.
+     */
+    @Override
+    public UUID getRootNodeUuidObject() {
+        return this.rootNodeUuid;
+    }
+
+    /**
+     * Set the UUID of the root node in this repository. If the cache exists, this UUID is not used but is instead set to the UUID
+     * of the existing root node.
+     * 
+     * @param rootNodeUuid the UUID of the root node for the cache, or null if the UUID should be randomly generated
+     */
+    public synchronized void setRootNodeUuid( String rootNodeUuid ) {
+        UUID uuid = null;
+        if (rootNodeUuid == null) uuid = UUID.randomUUID();
+        else uuid = UUID.fromString(rootNodeUuid);
+        if (this.rootNodeUuid.equals(uuid)) return; // unchanged
+        this.rootNodeUuid = uuid;
+    }
+
+    /**
+     * Get the name of the default workspace.
+     * 
+     * @return the name of the workspace that should be used by default; never null
+     */
+    @Override
+    public String getDefaultWorkspaceName() {
+        return defaultWorkspace;
+    }
+
+    /**
+     * Set the name of the workspace that should be used when clients don't specify a workspace.
+     * 
+     * @param nameOfDefaultWorkspace the name of the workspace that should be used by default, or null if the
+     *        {@link #DEFAULT_NAME_OF_DEFAULT_WORKSPACE default name} should be used
+     */
+    public synchronized void setDefaultWorkspaceName( String nameOfDefaultWorkspace ) {
+        this.defaultWorkspace = nameOfDefaultWorkspace != null ? nameOfDefaultWorkspace : DEFAULT_NAME_OF_DEFAULT_WORKSPACE;
+    }
+
+    /**
+     * Gets the names of the workspaces that are available when this source is created.
+     * 
+     * @return the names of the workspaces that this source starts with, or null if there are no such workspaces
+     * @see #setPredefinedWorkspaceNames(String[])
+     * @see #setCreatingWorkspacesAllowed(boolean)
+     */
+    public synchronized String[] getPredefinedWorkspaceNames() {
+        String[] copy = new String[predefinedWorkspaces.length];
+        System.arraycopy(predefinedWorkspaces, 0, copy, 0, predefinedWorkspaces.length);
+        return copy;
+    }
+
+    /**
+     * Sets the names of the workspaces that are available when this source is created.
+     * 
+     * @param predefinedWorkspaceNames the names of the workspaces that this source should start with, or null if there are no
+     *        such workspaces
+     * @see #setCreatingWorkspacesAllowed(boolean)
+     * @see #getPredefinedWorkspaceNames()
+     */
+    public synchronized void setPredefinedWorkspaceNames( String[] predefinedWorkspaceNames ) {
+        if (predefinedWorkspaceNames != null && predefinedWorkspaceNames.length == 1) {
+            predefinedWorkspaceNames = predefinedWorkspaceNames[0].split("\\s*,\\s*");
+        }
+        this.predefinedWorkspaces = predefinedWorkspaceNames;
+    }
+
+    /**
+     * Get whether this source allows workspaces to be created dynamically.
+     * 
+     * @return true if this source allows workspaces to be created by clients, or false if the
+     *         {@link #getPredefinedWorkspaceNames() set of workspaces} is fixed
+     * @see #setPredefinedWorkspaceNames(String[])
+     * @see #getPredefinedWorkspaceNames()
+     * @see #setCreatingWorkspacesAllowed(boolean)
+     */
+    public boolean isCreatingWorkspacesAllowed() {
+        return capabilities.supportsCreatingWorkspaces();
+    }
+
+    /**
+     * Set whether this source allows workspaces to be created dynamically.
+     * 
+     * @param allowWorkspaceCreation true if this source allows workspaces to be created by clients, or false if the
+     *        {@link #getPredefinedWorkspaceNames() set of workspaces} is fixed
+     * @see #setPredefinedWorkspaceNames(String[])
+     * @see #getPredefinedWorkspaceNames()
+     * @see #isCreatingWorkspacesAllowed()
+     */
+    public synchronized void setCreatingWorkspacesAllowed( boolean allowWorkspaceCreation ) {
+        capabilities = new RepositorySourceCapabilities(true, capabilities.supportsUpdates(), false, allowWorkspaceCreation,
+                                                        capabilities.supportsReferences());
+    }
+
+    /**
+     * {@inheritDoc}
+     * 
+     * @see org.modeshape.graph.connector.RepositorySource#close()
+     */
+    @Override
+    public synchronized void close() {
+    }
+
+    /**
+     * @return repositoryContext
+     */
+    @Override
+    public RepositoryContext getRepositoryContext() {
+        return repositoryContext;
+    }
+
+    protected Observer getObserver() {
+        return repositoryContext != null ? repositoryContext.getObserver() : null;
+    }
+
+    protected synchronized Context getContext() {
+        return this.jndiContext;
+    }
+
+    protected synchronized void setContext( Context context ) {
+        this.jndiContext = context;
+    }
+
+    @Override
+    public boolean areUpdatesAllowed() {
+        return this.updatesAllowed;
+    }
+
+    @Override
+    public void setUpdatesAllowed( boolean updatesAllowed ) {
+        this.updatesAllowed = updatesAllowed;
+    }
+
+    /**
+     * {@inheritDoc}
+     * 
+     * @see org.modeshape.graph.connector.RepositorySource#getConnection()
+     */
+    @Override
+    public synchronized RepositoryConnection getConnection() throws RepositorySourceException {
+        if (getName() == null) {
+            I18n msg = DiskConnectorI18n.propertyIsRequired;
+            throw new RepositorySourceException(getName(), msg.text("name"));
+        }
+
+        if (this.repository == null) {
+            this.repository = new DiskRepository(this);
+        }
+
+        return new Connection<DiskNode, DiskWorkspace>(this, this.repository);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public synchronized Reference getReference() {
+        String className = getClass().getName();
+        String managerClassName = this.getClass().getName();
+        Reference ref = new Reference(className, managerClassName, null);
+
+        ref.add(new StringRefAddr(SOURCE_NAME, getName()));
+        ref.add(new StringRefAddr(ROOT_NODE_UUID, getRootNodeUuid().toString()));
+        ref.add(new StringRefAddr(RETRY_LIMIT, Integer.toString(getRetryLimit())));
+        ref.add(new StringRefAddr(DEFAULT_WORKSPACE, getDefaultWorkspaceName()));
+        ref.add(new StringRefAddr(UPDATES_ALLOWED, String.valueOf(areUpdatesAllowed())));
+        ref.add(new StringRefAddr(REPOSITORY_ROOT_PATH, String.valueOf(getRepositoryRootPath())));
+        ref.add(new StringRefAddr(ALLOW_CREATING_WORKSPACES, Boolean.toString(isCreatingWorkspacesAllowed())));
+        String[] workspaceNames = getPredefinedWorkspaceNames();
+        if (workspaceNames != null && workspaceNames.length != 0) {
+            ref.add(new StringRefAddr(PREDEFINED_WORKSPACE_NAMES, StringUtil.combineLines(workspaceNames)));
+        }
+        if (getDefaultCachePolicy() != null) {
+            ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            CachePolicy policy = getDefaultCachePolicy();
+            try {
+                ObjectOutputStream oos = new ObjectOutputStream(baos);
+                oos.writeObject(policy);
+                ref.add(new BinaryRefAddr(DEFAULT_CACHE_POLICY, baos.toByteArray()));
+            } catch (IOException e) {
+                I18n msg = DiskConnectorI18n.errorSerializingCachePolicyInSource;
+                throw new RepositorySourceException(getName(), msg.text(policy.getClass().getName(), getName()), e);
+            }
+        }
+        return ref;
+    }
+
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean equals( Object obj ) {
+        if (obj == this) return true;
+        if (obj instanceof DiskSource) {
+            DiskSource that = (DiskSource)obj;
+            if (this.getName() == null) {
+                if (that.getName() != null) return false;
+            } else {
+                if (!this.getName().equals(that.getName())) return false;
+            }
+            return true;
+        }
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        return HashCode.compute(getName());
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Object getObjectInstance( Object obj,
+                                     javax.naming.Name name,
+                                     Context nameCtx,
+                                     Hashtable<?, ?> environment ) throws Exception {
+        if (obj instanceof Reference) {
+            Map<String, Object> values = new HashMap<String, Object>();
+            Reference ref = (Reference)obj;
+            Enumeration<?> en = ref.getAll();
+            while (en.hasMoreElements()) {
+                RefAddr subref = (RefAddr)en.nextElement();
+                if (subref instanceof StringRefAddr) {
+                    String key = subref.getType();
+                    Object value = subref.getContent();
+                    if (value != null) values.put(key, value.toString());
+                } else if (subref instanceof BinaryRefAddr) {
+                    String key = subref.getType();
+                    Object value = subref.getContent();
+                    if (value instanceof byte[]) {
+                        // Deserialize ...
+                        ByteArrayInputStream bais = new ByteArrayInputStream((byte[])value);
+                        ObjectInputStream ois = new ObjectInputStream(bais);
+                        value = ois.readObject();
+                        values.put(key, value);
+                    }
+                }
+            }
+            String sourceName = (String)values.get(SOURCE_NAME);
+            String rootNodeUuidString = (String)values.get(ROOT_NODE_UUID);
+            Object defaultCachePolicy = values.get(DEFAULT_CACHE_POLICY);
+            String retryLimit = (String)values.get(RETRY_LIMIT);
+            String defaultWorkspace = (String)values.get(DEFAULT_WORKSPACE);
+            String createWorkspaces = (String)values.get(ALLOW_CREATING_WORKSPACES);
+            String updatesAllowed = (String)values.get(UPDATES_ALLOWED);
+            String repositoryRootPath = (String)values.get(REPOSITORY_ROOT_PATH);
+
+            String combinedWorkspaceNames = (String)values.get(PREDEFINED_WORKSPACE_NAMES);
+            String[] workspaceNames = null;
+            if (combinedWorkspaceNames != null) {
+                List<String> paths = StringUtil.splitLines(combinedWorkspaceNames);
+                workspaceNames = paths.toArray(new String[paths.size()]);
+            }
+
+            // Create the source instance ...
+            DiskSource source = new DiskSource();
+            if (sourceName != null) source.setName(sourceName);
+            if (rootNodeUuidString != null) source.setRootNodeUuid(rootNodeUuidString);
+            if (defaultCachePolicy instanceof CachePolicy) source.setDefaultCachePolicy((CachePolicy)defaultCachePolicy);
+            if (retryLimit != null) source.setRetryLimit(Integer.parseInt(retryLimit));
+            if (defaultWorkspace != null) source.setDefaultWorkspaceName(defaultWorkspace);
+            if (createWorkspaces != null) source.setCreatingWorkspacesAllowed(Boolean.parseBoolean(createWorkspaces));
+            if (workspaceNames != null && workspaceNames.length != 0) source.setPredefinedWorkspaceNames(workspaceNames);
+            if (updatesAllowed != null) source.setUpdatesAllowed(Boolean.valueOf(updatesAllowed));
+            if (repositoryRootPath != null) source.setRepositoryRootPath(repositoryRootPath);
+            return source;
+        }
+        return null;
+    }
+}

--- a/extensions/modeshape-connector-disk/src/main/java/org/modeshape/connector/disk/DiskTransaction.java
+++ b/extensions/modeshape-connector-disk/src/main/java/org/modeshape/connector/disk/DiskTransaction.java
@@ -1,0 +1,151 @@
+/*
+ * ModeShape (http://www.modeshape.org)
+ * See the COPYRIGHT.txt file distributed with this work for information
+ * regarding copyright ownership.  Some portions may be licensed
+ * to Red Hat, Inc. under one or more contributor license agreements.
+ * See the AUTHORS.txt file in the distribution for a full listing of 
+ * individual contributors.
+ *
+ * ModeShape is free software. Unless otherwise indicated, all code in ModeShape
+ * is licensed to you under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ * 
+ * ModeShape is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.modeshape.connector.disk;
+
+import java.io.File;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.locks.Lock;
+import org.modeshape.common.annotation.NotThreadSafe;
+import org.modeshape.common.text.FilenameEncoder;
+import org.modeshape.common.text.TextEncoder;
+import org.modeshape.graph.ExecutionContext;
+import org.modeshape.graph.connector.base.MapTransaction;
+import org.modeshape.graph.property.Property;
+import org.modeshape.graph.property.Path.Segment;
+import org.modeshape.graph.request.InvalidWorkspaceException;
+
+/**
+ * 
+ */
+@NotThreadSafe
+public class DiskTransaction extends MapTransaction<DiskNode, DiskWorkspace> {
+
+    private static final TextEncoder FILE_ENCODER = new FilenameEncoder();
+
+    private final DiskRepository repository;
+    private final Lock lock;
+
+    protected DiskTransaction( ExecutionContext context,
+                                     DiskRepository repository,
+                                     UUID rootNodeUuid,
+                                     Lock lock ) {
+        super(context, repository, rootNodeUuid);
+        this.repository = repository;
+        this.lock = lock;
+    }
+
+    /**
+     * {@inheritDoc}
+     * 
+     * @see org.modeshape.graph.connector.base.Transaction#getWorkspaceNames()
+     */
+    @Override
+    public Set<String> getWorkspaceNames() {
+        return repository.getWorkspaceNames();
+    }
+
+    /**
+     * {@inheritDoc}
+     * 
+     * @see org.modeshape.graph.connector.base.Transaction#getWorkspace(java.lang.String,
+     *      org.modeshape.graph.connector.base.Workspace)
+     */
+    @Override
+    public DiskWorkspace getWorkspace( String name,
+                                             DiskWorkspace originalToClone ) {
+        File workspaceRoot = workspaceRootFor(name);
+
+        if (!workspaceRoot.exists()) {
+            if (!workspaceRoot.mkdir()) {
+                String msg = DiskConnectorI18n.unableToCreateWorkspace.text(name, repository.getSourceName());
+                throw new InvalidWorkspaceException(msg);
+            }
+        }
+        if (originalToClone != null) {
+            return new DiskWorkspace(name, workspaceRoot, originalToClone);
+        }
+        return new DiskWorkspace(name, workspaceRoot, new DiskNode(repository.getRootNodeUuid()));
+    }
+
+    /**
+     * {@inheritDoc}
+     * 
+     * @see org.modeshape.graph.connector.base.Transaction#destroyWorkspace(org.modeshape.graph.connector.base.Workspace)
+     */
+    @Override
+    public boolean destroyWorkspace( DiskWorkspace workspace ) {
+        workspace.destroy();
+        return true;
+    }
+
+    File workspaceRootFor( String workspaceName ) {
+        String encodedName = FILE_ENCODER.encode(workspaceName);
+        File repositoryRoot = repository.getRepositoryRoot();
+        return new File(repositoryRoot, encodedName);
+    }
+
+    /**
+     * {@inheritDoc}
+     * 
+     * @see org.modeshape.graph.connector.base.MapTransaction#createNode(java.util.UUID,
+     *      org.modeshape.graph.property.Path.Segment, java.util.UUID, java.lang.Iterable)
+     */
+    @Override
+    protected DiskNode createNode( UUID uuid,
+                                         Segment name,
+                                         UUID parentUuid,
+                                         Iterable<Property> properties ) {
+        return new DiskNode(uuid, name, parentUuid, properties, null);
+    }
+
+    /**
+     * {@inheritDoc}
+     * 
+     * @see org.modeshape.graph.connector.base.Transaction#commit()
+     */
+    @Override
+    public void commit() {
+        try {
+            super.commit();
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     * 
+     * @see org.modeshape.graph.connector.base.Transaction#rollback()
+     */
+    @Override
+    public void rollback() {
+        try {
+            super.rollback();
+        } finally {
+            lock.unlock();
+        }
+    }
+
+}

--- a/extensions/modeshape-connector-disk/src/main/java/org/modeshape/connector/disk/DiskWorkspace.java
+++ b/extensions/modeshape-connector-disk/src/main/java/org/modeshape/connector/disk/DiskWorkspace.java
@@ -1,0 +1,171 @@
+/*
+ * ModeShape (http://www.modeshape.org)
+ * See the COPYRIGHT.txt file distributed with this work for information
+ * regarding copyright ownership.  Some portions may be licensed
+ * to Red Hat, Inc. under one or more contributor license agreements.
+ * See the AUTHORS.txt file in the distribution for a full listing of 
+ * individual contributors.
+ *
+ * ModeShape is free software. Unless otherwise indicated, all code in ModeShape
+ * is licensed to you under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ * 
+ * ModeShape is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.modeshape.connector.disk;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.util.UUID;
+import org.modeshape.graph.connector.base.MapWorkspace;
+
+/**
+ * Workspace implementation for disk connector
+ */
+public class DiskWorkspace extends MapWorkspace<DiskNode> {
+
+    private File workspaceRoot;
+
+    /**
+     * Create a new workspace instance.
+     * 
+     * @param name the name of the workspace
+     * @param workspaceRoot a pointer to the root of the workspace on disk
+     * @param rootNode the root node for the workspace
+     */
+    public DiskWorkspace( String name,
+                          File workspaceRoot,
+                                DiskNode rootNode ) {
+        super(name, rootNode);
+        this.workspaceRoot = workspaceRoot;
+
+        File rootNodeFile = fileFor(rootNode.getUuid());
+        if (!rootNodeFile.exists()) {
+            putNode(rootNode);
+        }
+    }
+
+    /**
+     * Create a new workspace instance.
+     * 
+     * @param name the name of the workspace
+     * @param workspaceRoot a pointer to the root of the workspace on disk
+     * @param originalToClone the workspace that is to be cloned
+     */
+    public DiskWorkspace( String name,
+                          File workspaceRoot,
+                                DiskWorkspace originalToClone ) {
+        super(name, originalToClone);
+        this.workspaceRoot = workspaceRoot;
+    }
+
+    public void destroy() {
+        this.workspaceRoot.delete();
+    }
+
+    /**
+     * This method shuts down the workspace and makes it no longer usable. This method should also only be called once.
+     */
+    public void shutdown() {
+    }
+
+    static int getCount = 0;
+    @Override
+    public DiskNode getNode( UUID uuid ) {
+        File nodeFile = fileFor(uuid);
+        if (!nodeFile.exists()) return null;
+
+        return nodeFor(nodeFile);
+    }
+
+    @Override
+    public DiskNode putNode( DiskNode node ) {
+        writeNode(node);
+        return node;
+    }
+
+    @Override
+    public void removeAll() {
+        this.workspaceRoot.delete();
+        this.workspaceRoot.mkdir();
+    }
+
+    @Override
+    public DiskNode removeNode( UUID uuid ) {
+        File nodeFile = fileFor(uuid);
+        if (!nodeFile.exists()) return null;
+
+        DiskNode node = nodeFor(nodeFile);
+
+        nodeFile.delete();
+        return node;
+    }
+
+    private File fileFor( UUID uuid ) {
+        String uuidAsString = uuid.toString();
+
+        File firstLevel = new File(workspaceRoot, uuidAsString.substring(0, 2));
+        File secondLevel = new File(firstLevel, uuidAsString.substring(2, 4));
+        File file = new File(secondLevel, uuidAsString);
+
+        if (!file.exists()) {
+            if (!secondLevel.exists()) {
+                if (!firstLevel.exists()) firstLevel.mkdir();
+
+                secondLevel.mkdir();
+            }
+        }
+
+        return file;
+    }
+
+    private DiskNode nodeFor( File nodeFile ) {
+        ObjectInputStream ois = null;
+        try {
+            ois = new ObjectInputStream(new FileInputStream(nodeFile));
+            DiskNode newNode = (DiskNode)ois.readObject();
+
+            return newNode;
+        } catch (ClassNotFoundException cnfe) {
+            throw new IllegalStateException(cnfe);
+
+        } catch (IOException ioe) {
+            throw new IllegalStateException(ioe);
+        }
+        finally {
+            try { if (ois != null) ois.close(); } catch (Exception ignore) { }
+        }
+    }
+
+    private File writeNode( DiskNode node ) {
+        ObjectOutputStream oos = null;
+        try {
+            File nodeFile = fileFor(node.getUuid());
+            oos = new ObjectOutputStream(new FileOutputStream(nodeFile));
+
+            oos.writeObject(node);
+
+            return nodeFile;
+        } catch (IOException ioe) {
+            throw new IllegalStateException(ioe);
+        } finally {
+            try {
+                if (oos != null) oos.close();
+            } catch (Exception ignore) {
+            }
+        }
+    }
+}

--- a/extensions/modeshape-connector-disk/src/main/java/org/modeshape/connector/disk/package-info.java
+++ b/extensions/modeshape-connector-disk/src/main/java/org/modeshape/connector/disk/package-info.java
@@ -1,0 +1,30 @@
+/*
+ * ModeShape (http://www.modeshape.org)
+ * See the COPYRIGHT.txt file distributed with this work for information
+ * regarding copyright ownership.  Some portions may be licensed
+ * to Red Hat, Inc. under one or more contributor license agreements.
+ * See the AUTHORS.txt file in the distribution for a full listing of 
+ * individual contributors. 
+ *
+ * ModeShape is free software. Unless otherwise indicated, all code in ModeShape
+ * is licensed to you under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * ModeShape is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+/**
+ * The classes that make up the connector that stores content in a ModeShape-specific format on fixed disk.
+ * This implementation scales well for very large repository and node sizes. 
+ */
+
+package org.modeshape.connector.disk;
+

--- a/extensions/modeshape-connector-disk/src/main/resources/org/modeshape/connector/disk/DiskConnectorI18n.properties
+++ b/extensions/modeshape-connector-disk/src/main/resources/org/modeshape/connector/disk/DiskConnectorI18n.properties
@@ -1,0 +1,51 @@
+#
+# ModeShape (http://www.modeshape.org)
+# See the COPYRIGHT.txt file distributed with this work for information
+# regarding copyright ownership.  Some portions may be licensed
+# to Red Hat, Inc. under one or more contributor license agreements.
+# See the AUTHORS.txt file in the distribution for a full listing of 
+# individual contributors. 
+#
+# ModeShape is free software. Unless otherwise indicated, all code in ModeShape
+# is licensed to you under the terms of the GNU Lesser General Public License as
+# published by the Free Software Foundation; either version 2.1 of
+# the License, or (at your option) any later version.
+#
+# ModeShape is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this software; if not, write to the Free
+# Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+# 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+#
+
+connectorName = Disk Connector
+propertyIsRequired = The {0} property is required but has no value
+errorSerializingCachePolicyInSource = Error serializing a {0} instance owned by the {1} DiskSource
+unableToCreateWorkspace = Unable to create the directory for the "{0}" workspace in the {1} DiskSource
+
+namePropertyDescription = The name of the repository source, which must be unique within the ModeShape configuration.
+namePropertyLabel = Source Name
+namePropertyCategory =
+defaultWorkspaceNamePropertyDescription = Optional property that defines the name for the workspace that will be used by default if none is specified. The default value is an empty string.
+defaultWorkspaceNamePropertyLabel = Default Workspace Name
+defaultWorkspaceNamePropertyCategory = Workspaces
+rootNodeUuidPropertyDescription = Optional property that, if used, defines the UUID of the root node in this repository. If not used, then the 'cafebabe-cafe-babe-cafe-babecafebabe' UUID is used.
+rootNodeUuidPropertyLabel = UUID of Root Node
+rootNodeUuidPropertyCategory = Advanced
+predefinedWorkspaceNamesPropertyDescription = Optional property that specifies the names of the workspaces that are available at startup. The default value is an an empty array.
+predefinedWorkspaceNamesPropertyLabel = Predefined Workspace Names
+predefinedWorkspaceNamesPropertyCategory = Workspaces
+retryLimitPropertyDescription = Optional property that, if used, defines the number of times that any single operation on a connection to this source should be retried following a communication failure. The default value is '0'.
+retryLimitPropertyLabel = Retry Limit
+retryLimitPropertyCategory = Advanced
+updatesAllowedPropertyDescription = Specifies whether the source content can be updated or changed.
+updatesAllowedPropertyLabel = Allows Updates
+updatesAllowedPropertyCategory = Advanced
+repositoryRootPathPropertyDescription = The path to the location on the file system where repository content will be stored.  The repository will create folders and files under this location to organize the stored content.
+repositoryRootPathPropertyLabel = Repository Root Path
+repositoryRootPathPropertyCategory =
+

--- a/extensions/modeshape-connector-disk/src/test/java/org/modeshape/connector/disk/DiskConnectorCreateWorkspacesTest.java
+++ b/extensions/modeshape-connector-disk/src/test/java/org/modeshape/connector/disk/DiskConnectorCreateWorkspacesTest.java
@@ -1,0 +1,85 @@
+/*
+ * ModeShape (http://www.modeshape.org)
+ * See the COPYRIGHT.txt file distributed with this work for information
+ * regarding copyright ownership.  Some portions may be licensed
+ * to Red Hat, Inc. under one or more contributor license agreements.
+ * See the AUTHORS.txt file in the distribution for a full listing of 
+ * individual contributors.
+ *
+ * Unless otherwise indicated, all code in ModeShape is licensed
+ * to you under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ * 
+ * ModeShape is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.modeshape.connector.disk;
+
+import org.modeshape.graph.Graph;
+import org.modeshape.graph.connector.RepositorySource;
+import org.modeshape.graph.connector.test.WorkspaceConnectorTest;
+
+/**
+ * These tests verify that the file system connector behaves correctly when the source is configured to
+ * {@link DiskSource#setCreatingWorkspacesAllowed(boolean) allow the creation of workspaces}.
+ */
+public class DiskConnectorCreateWorkspacesTest extends WorkspaceConnectorTest {
+
+    /**
+     * {@inheritDoc}
+     * 
+     * @see org.modeshape.graph.connector.test.AbstractConnectorTest#setUpSource()
+     */
+    @Override
+    protected RepositorySource setUpSource() throws Exception {
+        String[] predefinedWorkspaceNames = new String[] {"airplanes", "cars"};
+        DiskSource source = new DiskSource();
+        source.setName("Test Repository");
+        source.setPredefinedWorkspaceNames(predefinedWorkspaceNames);
+        source.setDefaultWorkspaceName(predefinedWorkspaceNames[0]);
+        source.setCreatingWorkspacesAllowed(true);
+        source.setUpdatesAllowed(true);
+        source.setRepositoryRootPath("./target/diskRepoRoot");
+
+        return source;
+    }
+
+    /**
+     * {@inheritDoc}
+     * 
+     * @see org.modeshape.graph.connector.test.AbstractConnectorTest#initializeContent(org.modeshape.graph.Graph)
+     */
+    @Override
+    protected void initializeContent( Graph graph ) throws Exception {
+        // No need to initialize any content ...
+    }
+
+    /**
+     * {@inheritDoc}
+     * 
+     * @see org.modeshape.graph.connector.test.WorkspaceConnectorTest#generateInvalidNamesForNewWorkspaces()
+     */
+    @Override
+    protected String[] generateInvalidNamesForNewWorkspaces() {
+        return null; // nothing is considered invalid
+    }
+
+    /**
+     * {@inheritDoc}
+     * 
+     * @see org.modeshape.graph.connector.test.WorkspaceConnectorTest#generateValidNamesForNewWorkspaces()
+     */
+    @Override
+    protected String[] generateValidNamesForNewWorkspaces() {
+        return new String[] {"trains"};
+    }
+
+}

--- a/extensions/modeshape-connector-disk/src/test/java/org/modeshape/connector/disk/DiskConnectorI18nTest.java
+++ b/extensions/modeshape-connector-disk/src/test/java/org/modeshape/connector/disk/DiskConnectorI18nTest.java
@@ -1,0 +1,48 @@
+/*
+ * ModeShape (http://www.modeshape.org)
+ * See the COPYRIGHT.txt file distributed with this work for information
+ * regarding copyright ownership.  Some portions may be licensed
+ * to Red Hat, Inc. under one or more contributor license agreements.
+ * See the AUTHORS.txt file in the distribution for a full listing of 
+ * individual contributors. 
+ *
+ * ModeShape is free software. Unless otherwise indicated, all code in ModeShape
+ * is licensed to you under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * ModeShape is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.modeshape.connector.disk;
+
+import org.junit.Test;
+import org.modeshape.common.AbstractI18nTest;
+
+/**
+ * @author Randall Hauch
+ */
+public class DiskConnectorI18nTest extends AbstractI18nTest {
+
+    public DiskConnectorI18nTest() {
+        super(DiskConnectorI18n.class);
+    }
+
+    @Test
+    public void shouldHaveI18nConstantsAndPropertiesForDiskSource() throws Exception {
+        verifyI18nForAnnotationsOnObject(new DiskSource());
+    }
+
+    @Test
+    @Override
+    public void shouldNotHaveProblems() throws Exception {
+        super.shouldNotHaveProblems();
+    }
+}

--- a/extensions/modeshape-connector-disk/src/test/java/org/modeshape/connector/disk/DiskConnectorNoCreateWorkspacesTest.java
+++ b/extensions/modeshape-connector-disk/src/test/java/org/modeshape/connector/disk/DiskConnectorNoCreateWorkspacesTest.java
@@ -1,0 +1,83 @@
+/*
+ * ModeShape (http://www.modeshape.org)
+ * See the COPYRIGHT.txt file distributed with this work for information
+ * regarding copyright ownership.  Some portions may be licensed
+ * to Red Hat, Inc. under one or more contributor license agreements.
+ * See the AUTHORS.txt file in the distribution for a full listing of 
+ * individual contributors.
+ *
+ * Unless otherwise indicated, all code in ModeShape is licensed
+ * to you under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ * 
+ * ModeShape is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.modeshape.connector.disk;
+
+import org.modeshape.graph.Graph;
+import org.modeshape.graph.connector.RepositorySource;
+import org.modeshape.graph.connector.test.WorkspaceConnectorTest;
+
+/**
+ * These tests verify that the file system connector behaves correctly when the source is configured to
+ * {@link DiskSource#setCreatingWorkspacesAllowed(boolean) not allow creation of workspaces}.
+ */
+public class DiskConnectorNoCreateWorkspacesTest extends WorkspaceConnectorTest {
+
+    /**
+     * {@inheritDoc}
+     * 
+     * @see org.modeshape.graph.connector.test.AbstractConnectorTest#setUpSource()
+     */
+    @Override
+    protected RepositorySource setUpSource() throws Exception {
+        String[] predefinedWorkspaceNames = new String[] {"airplanes", "cars"};
+        DiskSource source = new DiskSource();
+        source.setName("Test Repository");
+        source.setPredefinedWorkspaceNames(predefinedWorkspaceNames);
+        source.setDefaultWorkspaceName(predefinedWorkspaceNames[0]);
+        source.setCreatingWorkspacesAllowed(false);
+        source.setRepositoryRootPath("./target/diskRepoRoot");
+
+        return source;
+    }
+
+    /**
+     * {@inheritDoc}
+     * 
+     * @see org.modeshape.graph.connector.test.AbstractConnectorTest#initializeContent(org.modeshape.graph.Graph)
+     */
+    @Override
+    protected void initializeContent( Graph graph ) throws Exception {
+        // No need to initialize any content ...
+    }
+
+    /**
+     * {@inheritDoc}
+     * 
+     * @see org.modeshape.graph.connector.test.WorkspaceConnectorTest#generateInvalidNamesForNewWorkspaces()
+     */
+    @Override
+    protected String[] generateInvalidNamesForNewWorkspaces() {
+        return null; // nothing is considered invalid
+    }
+
+    /**
+     * {@inheritDoc}
+     * 
+     * @see org.modeshape.graph.connector.test.WorkspaceConnectorTest#generateValidNamesForNewWorkspaces()
+     */
+    @Override
+    protected String[] generateValidNamesForNewWorkspaces() {
+        return new String[] {"trains"};
+    }
+}

--- a/extensions/modeshape-connector-disk/src/test/java/org/modeshape/connector/disk/DiskConnectorReadableTest.java
+++ b/extensions/modeshape-connector-disk/src/test/java/org/modeshape/connector/disk/DiskConnectorReadableTest.java
@@ -1,0 +1,78 @@
+package org.modeshape.connector.disk;
+
+import java.io.File;
+import java.io.IOException;
+import javax.naming.NamingException;
+import org.modeshape.common.statistic.Stopwatch;
+import org.modeshape.common.util.FileUtil;
+import org.modeshape.graph.Graph;
+import org.modeshape.graph.connector.RepositorySource;
+import org.modeshape.graph.connector.test.ReadableConnectorTest;
+import org.xml.sax.SAXException;
+
+public class DiskConnectorReadableTest extends ReadableConnectorTest {
+
+    private final String REPOSITORY_ROOT = "./target/repositoryRoot";
+
+    /**
+     * {@inheritDoc}
+     * 
+     * @see org.modeshape.graph.connector.test.AbstractConnectorTest#setUpSource()
+     */
+    @Override
+    protected RepositorySource setUpSource() throws NamingException {
+        String[] predefinedWorkspaceNames = new String[] {"aircraft", "cars"};
+        DiskSource source = new DiskSource();
+        source.setName("Test Repository");
+        source.setPredefinedWorkspaceNames(predefinedWorkspaceNames);
+        source.setDefaultWorkspaceName(predefinedWorkspaceNames[0]);
+        source.setCreatingWorkspacesAllowed(false);
+        source.setRepositoryRootPath(REPOSITORY_ROOT);
+
+        return source;
+    }
+
+    /**
+     * {@inheritDoc}
+     * 
+     * @throws SAXException
+     * @throws IOException
+     * @see org.modeshape.graph.connector.test.AbstractConnectorTest#initializeContent(org.modeshape.graph.Graph)
+     */
+    @Override
+    protected void initializeContent( Graph graph ) throws IOException, SAXException {
+        File repositoryRoot = new File(REPOSITORY_ROOT);
+
+        if (repositoryRoot.exists()) FileUtil.delete(repositoryRoot);
+        repositoryRoot.mkdir();
+
+        String initialPath = "";
+        int depth = 3;
+        int numChildrenPerNode = 4;
+        int numPropertiesPerNode = 7;
+        Stopwatch sw = new Stopwatch();
+        boolean batch = true;
+        output = null;
+
+        createSubgraph(graph, initialPath, depth, numChildrenPerNode, numPropertiesPerNode, batch, sw, output, null);
+    }
+
+    // @Test
+    // public void readEntireGraph() throws Exception {
+    // Stopwatch sw = new Stopwatch();
+    // sw.start();
+    // Subgraph sg = graph.getSubgraphOfDepth(Integer.MAX_VALUE).at("/");
+    //
+    // sw.stop();
+    //
+    // int count = 0;
+    //
+    // for (SubgraphNode sgn : sg) {
+    // count++;
+    // }
+    //
+    // System.out.println("Loaded " + count + " nodes in " + sw.getTotalDuration());
+    // System.out.println("avg = " + (sw.getTotalDuration().getDuratinInNanoseconds() / (count * 1000)) + " us");
+    // }
+
+}

--- a/extensions/modeshape-connector-disk/src/test/java/org/modeshape/connector/disk/DiskConnectorWritableTest.java
+++ b/extensions/modeshape-connector-disk/src/test/java/org/modeshape/connector/disk/DiskConnectorWritableTest.java
@@ -1,0 +1,48 @@
+package org.modeshape.connector.disk;
+
+import java.io.File;
+import java.io.IOException;
+import javax.naming.NamingException;
+import org.modeshape.common.util.FileUtil;
+import org.modeshape.graph.Graph;
+import org.modeshape.graph.connector.RepositorySource;
+import org.modeshape.graph.connector.test.WritableConnectorTest;
+import org.xml.sax.SAXException;
+
+public class DiskConnectorWritableTest extends WritableConnectorTest {
+
+    private final String REPOSITORY_ROOT = "./target/repositoryRoot";
+
+    /**
+     * {@inheritDoc}
+     * 
+     * @see org.modeshape.graph.connector.test.AbstractConnectorTest#setUpSource()
+     */
+    @Override
+    protected RepositorySource setUpSource() throws NamingException {
+        String[] predefinedWorkspaceNames = new String[] {"default"};
+        DiskSource source = new DiskSource();
+        source.setName("Test Repository");
+        source.setPredefinedWorkspaceNames(predefinedWorkspaceNames);
+        source.setDefaultWorkspaceName(predefinedWorkspaceNames[0]);
+        source.setCreatingWorkspacesAllowed(true);
+        source.setRepositoryRootPath(REPOSITORY_ROOT);
+
+        return source;
+    }
+
+    /**
+     * {@inheritDoc}
+     * 
+     * @throws SAXException
+     * @throws IOException
+     * @see org.modeshape.graph.connector.test.AbstractConnectorTest#initializeContent(org.modeshape.graph.Graph)
+     */
+    @Override
+    protected void initializeContent( Graph graph ) throws IOException, SAXException {
+        File repositoryRoot = new File(REPOSITORY_ROOT);
+
+        FileUtil.delete(repositoryRoot);
+        repositoryRoot.mkdir();
+    }
+}

--- a/extensions/modeshape-connector-disk/src/test/java/org/modeshape/connector/disk/DiskSourceTest.java
+++ b/extensions/modeshape-connector-disk/src/test/java/org/modeshape/connector/disk/DiskSourceTest.java
@@ -1,0 +1,213 @@
+/*
+ * ModeShape (http://www.modeshape.org)
+ * See the COPYRIGHT.txt file distributed with this work for information
+ * regarding copyright ownership.  Some portions may be licensed
+ * to Red Hat, Inc. under one or more contributor license agreements.
+ * See the AUTHORS.txt file in the distribution for a full listing of 
+ * individual contributors. 
+ *
+ * ModeShape is free software. Unless otherwise indicated, all code in ModeShape
+ * is licensed to you under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * ModeShape is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.modeshape.connector.disk;
+
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsNull.notNullValue;
+import static org.hamcrest.core.IsNull.nullValue;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.Hashtable;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import javax.naming.Context;
+import javax.naming.Name;
+import javax.naming.RefAddr;
+import javax.naming.Reference;
+import javax.naming.spi.ObjectFactory;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.modeshape.graph.ExecutionContext;
+import org.modeshape.graph.cache.BasicCachePolicy;
+import org.modeshape.graph.connector.RepositoryConnection;
+import org.modeshape.graph.connector.RepositoryContext;
+
+/**
+ */
+public class DiskSourceTest {
+
+    private ExecutionContext context;
+    private DiskSource source;
+    private RepositoryConnection connection;
+    private String validName;
+    private String repositoryRootPath;
+    private UUID validRootNodeUuid;
+    @Mock
+    private RepositoryContext repositoryContext;
+
+    @Before
+    public void beforeEach() throws Exception {
+        MockitoAnnotations.initMocks(this);
+        context = new ExecutionContext();
+        when(repositoryContext.getExecutionContext()).thenReturn(context);
+        validName = "disk source";
+        validRootNodeUuid = UUID.randomUUID();
+        repositoryRootPath = "target/root";
+        source = new DiskSource();
+
+        source.setRepositoryRootPath(repositoryRootPath);
+    }
+
+    @After
+    public void afterEach() throws Exception {
+        if (connection != null) {
+            connection.close();
+        }
+    }
+
+    @Test
+    public void shouldReturnNonNullCapabilities() {
+        assertThat(source.getCapabilities(), is(notNullValue()));
+    }
+
+    @Test
+    public void shouldSupportSameNameSiblings() {
+        assertThat(source.getCapabilities().supportsSameNameSiblings(), is(true));
+    }
+
+    @Test
+    public void shouldSupportUpdates() {
+        assertThat(source.getCapabilities().supportsUpdates(), is(true));
+    }
+
+    @Test
+    public void shouldHaveNullSourceNameUponConstruction() {
+        source = new DiskSource();
+        assertThat(source.getName(), is(nullValue()));
+    }
+
+    @Test
+    public void shouldAllowSettingName() {
+        source.setName("Something");
+        assertThat(source.getName(), is("Something"));
+        source.setName("another name");
+        assertThat(source.getName(), is("another name"));
+    }
+
+    @Test
+    public void shouldAllowSettingNameToNull() {
+        source.setName("some name");
+        source.setName(null);
+        assertThat(source.getName(), is(nullValue()));
+    }
+
+    @Test
+    public void shouldHaveDefaultRetryLimit() {
+        assertThat(source.getRetryLimit(), is(DiskSource.DEFAULT_RETRY_LIMIT));
+    }
+
+    @Test
+    public void shouldSetRetryLimitToZeroWhenSetWithNonPositiveValue() {
+        source.setRetryLimit(0);
+        assertThat(source.getRetryLimit(), is(0));
+        source.setRetryLimit(-1);
+        assertThat(source.getRetryLimit(), is(0));
+        source.setRetryLimit(-100);
+        assertThat(source.getRetryLimit(), is(0));
+    }
+
+    @Test
+    public void shouldAllowRetryLimitToBeSet() {
+        for (int i = 0; i != 100; ++i) {
+            source.setRetryLimit(i);
+            assertThat(source.getRetryLimit(), is(i));
+        }
+    }
+
+    @Test
+    public void shouldCreateJndiReferenceAndRecreatedObjectFromReference() throws Exception {
+        BasicCachePolicy cachePolicy = new BasicCachePolicy();
+        cachePolicy.setTimeToLive(1000L, TimeUnit.MILLISECONDS);
+        convertToAndFromJndiReference(validName,
+                                      validRootNodeUuid,
+ repositoryRootPath,
+                                      cachePolicy,
+                                      100);
+    }
+
+    @Test
+    public void shouldCreateJndiReferenceAndRecreatedObjectFromReferenceWithNullProperties() throws Exception {
+        BasicCachePolicy cachePolicy = new BasicCachePolicy();
+        cachePolicy.setTimeToLive(1000L, TimeUnit.MILLISECONDS);
+        convertToAndFromJndiReference("some source", null, null, null, 100);
+        convertToAndFromJndiReference(null, null, null, null, 100);
+    }
+
+    private void convertToAndFromJndiReference( String sourceName,
+                                                UUID rootNodeUuid,
+                                                String repositoryRootPath,
+                                                BasicCachePolicy cachePolicy,
+                                                int retryLimit ) throws Exception {
+        source.setRetryLimit(retryLimit);
+        source.setName(sourceName);
+        source.setDefaultCachePolicy(cachePolicy);
+        source.setRootNodeUuid(rootNodeUuid != null ? rootNodeUuid.toString() : null);
+        source.setRepositoryRootPath(repositoryRootPath);
+
+        Reference ref = source.getReference();
+        assertThat(ref.getClassName(), is(DiskSource.class.getName()));
+        assertThat(ref.getFactoryClassName(), is(DiskSource.class.getName()));
+
+        Map<String, Object> refAttributes = new HashMap<String, Object>();
+        Enumeration<RefAddr> enumeration = ref.getAll();
+        while (enumeration.hasMoreElements()) {
+            RefAddr addr = enumeration.nextElement();
+            refAttributes.put(addr.getType(), addr.getContent());
+        }
+
+        // Recreate the object, use a newly constructed source ...
+        ObjectFactory factory = new DiskSource();
+        Name name = mock(Name.class);
+        Context context = mock(Context.class);
+        Hashtable<?, ?> env = new Hashtable<Object, Object>();
+        DiskSource recoveredSource = (DiskSource)factory.getObjectInstance(ref, name, context, env);
+        assertThat(recoveredSource, is(notNullValue()));
+
+        assertThat(recoveredSource.getName(), is(source.getName()));
+        assertThat(recoveredSource.getRootNodeUuid(), is(source.getRootNodeUuid()));
+        assertThat(recoveredSource.getRetryLimit(), is(source.getRetryLimit()));
+        assertThat(recoveredSource.getRepositoryRootPath(), is(source.getRepositoryRootPath()));
+        assertThat(recoveredSource.getDefaultCachePolicy(), is(source.getDefaultCachePolicy()));
+
+        assertThat(recoveredSource.equals(source), is(true));
+        assertThat(source.equals(recoveredSource), is(true));
+    }
+
+    @Test
+    public void shouldCreateCacheUsingDefaultCacheManagerWhenNoCacheOrCacheManagerOrCacheConfigurationNameIsFound()
+        throws Exception {
+        source.setName(validName);
+        source.initialize(repositoryContext);
+        connection = source.getConnection();
+        assertThat(connection, is(notNullValue()));
+        // assertThat(connection.getCache(), is(notNullValue()));
+    }
+}

--- a/extensions/modeshape-connector-disk/src/test/resources/aircraft.xml
+++ b/extensions/modeshape-connector-disk/src/test/resources/aircraft.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- 
+  ~ ModeShape (http://www.modeshape.org)
+  ~
+  ~ See the COPYRIGHT.txt file distributed with this work for information
+  ~ regarding copyright ownership.  Some portions may be licensed
+  ~ to Red Hat, Inc. under one or more contributor license agreements.
+  ~ See the AUTHORS.txt file in the distribution for a full listing of 
+  ~ individual contributors.
+  ~
+  ~ ModeShape is free software. Unless otherwise indicated, all code in ModeShape
+  ~ is licensed to you under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ ModeShape is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+  ~ or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+  ~ for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public License
+  ~ along with this distribution; if not, write to:
+  ~ Free Software Foundation, Inc.
+  ~ 51 Franklin Street, Fifth Floor
+  ~ Boston, MA  02110-1301  USA
+  -->
+<Aircraft xmlns:jcr="http://www.jcp.org/jcr/1.0">
+    <Business>
+        <aircraft jcr:name="Gulfstream V" maker="Gulfstream" model="G-V" introduced="1995" range="5800nm" cruiseSpeed="488kt" crew="2" emptyWeight="46200lb" url="http://en.wikipedia.org/wiki/Gulfstream_V"/>
+        <aircraft jcr:name="Learjet 45" maker="Learjet" model="LJ45" introduced="1995" numberBuilt="264+" crew="2" emptyWeight="13695lb" range="2120nm" cruiseSpeed="457kt" url="http://en.wikipedia.org/wiki/Learjet_45"/>
+    </Business>
+    <Commercial>
+        <aircraft jcr:name="Boeing 777" maker="Boeing" model="777-200LR" introduced="1995" numberBuilt="731+" maxRange="7500nm" emptyWeight="326000lb" cruiseSpeed="560mph" url="http://en.wikipedia.org/wiki/Boeing_777"/>
+        <aircraft jcr:name="Boeing 767" maker="Boeing" model="767-200" introduced="1982" numberBuilt="966+" maxRange="3950nm" emptyWeight="176650lb" cruiseSpeed="530mph"  url="http://en.wikipedia.org/wiki/Boeing_767"/>
+        <aircraft jcr:name="Boeing 787" maker="Boeing" model="787-3" introduced="2009" range="3050nm" emptyWeight="223000lb" cruiseSpeed="561mph" url="http://en.wikipedia.org/wiki/Boeing_787"/>
+        <aircraft jcr:name="Boeing 757" maker="Boeing" model="757-200" introduced="1983" numberBuilt="1050" range="3900nm" maxWeight="255000lb" cruiseSpeed="530mph" url="http://en.wikipedia.org/wiki/Boeing_757"/>
+        <aircraft jcr:name="Airbus A380" maker="Airbus" model="A380-800" introduced="2007" numberBuilt="18" range="8200nm" maxWeight="1235000lb" cruiseSpeed="647mph" url="http://en.wikipedia.org/wiki/Airbus_a380"/>
+        <aircraft jcr:name="Airbus A340" maker="Airbus" model="A340-200" introduced="1993" numberBuilt="354" range="8000nm" maxWeight="606300lb" cruiseSpeed="557mph" url="http://en.wikipedia.org/wiki/Airbus_A-340"/>
+        <aircraft jcr:name="Airbus A310" maker="Airbus" model="A310-200" introduced="1983" numberBuilt="255" cruiseSpeed="850km/h" emptyWeight="176312lb" range="3670nm" url="http://en.wikipedia.org/wiki/Airbus_A-310"/>
+        <aircraft jcr:name="Embraer RJ-175" maker="Embraer" model="ERJ170-200" introduced="2004" range="3334km" cruiseSpeed="481kt" emptyWeight="21810kg" url="http://en.wikipedia.org/wiki/EMBRAER_170"/>
+    </Commercial>
+    <Vintage>
+        <aircraft jcr:name="Fokker Trimotor" maker="Fokker" model="F.VII" introduced="1925" cruiseSpeed="170km/h" emptyWeight="3050kg" crew="2" url="http://en.wikipedia.org/wiki/Fokker_trimotor"/>
+        <aircraft jcr:name="P-38 Lightning" maker="Lockheed" model="P-38" designedBy="Kelly Johnson" introduced="1941" numberBuilt="10037" rateOfClimb="4750ft/min" range="1300mi" emptyWeight="12780lb" crew="1" url="http://en.wikipedia.org/wiki/P-38_Lightning"/>
+        <aircraft jcr:name="A6M Zero" maker="Mitsubishi" model="A6M" designedBy="Jiro Horikoshi" introduced="1940" numberBuilt="11000" crew="1" emptyWeight="3704lb" serviceCeiling="33000ft" maxSpeed="331mph" range="1929mi" rateOfClimb="3100ft/min" url="http://en.wikipedia.org/wiki/A6M_Zero"/>
+        <aircraft jcr:name="Bf 109" maker="Messerschmitt" model="Bf 109" introduced="1937" url="http://en.wikipedia.org/wiki/BF_109"/>
+        <aircraft jcr:name="Wright Flyer" maker="Wright Brothers" introduced="1903" range="852ft" maxSpeed="30mph" emptyWeight="605lb" crew="1"/>
+    </Vintage>
+    <Homebuilt>
+        <aircraft jcr:name="Long-EZ" maker="Rutan Aircraft Factory" model="61" emptyWeight="760lb" fuelCapacity="200L" maxSpeed="185kt" since="1976" range="1200nm" url="http://en.wikipedia.org/wiki/Rutan_Long-EZ"/>
+        <aircraft jcr:name="Cirrus VK-30" maker="Cirrus Design" model="VK-30" emptyWeight="2400lb" maxLoad="1200lb" maxSpeed="250mph" rateOfClimb="1500ft/min" range="1300mi" url="http://en.wikipedia.org/wiki/Cirrus_VK-30"/>
+        <aircraft jcr:name="Van's RV-4" maker="Van's Aircraft" model="RV-4" introduced="1980" emptyWeight="905lb" maxLoad="500lb" maxSpeed="200mph" rateOfClimb="2450ft/min" range="725mi" url="http://en.wikipedia.org/wiki/Van%27s_Aircraft_RV-4"/>
+    </Homebuilt>
+</Aircraft>

--- a/extensions/modeshape-connector-disk/src/test/resources/cars.xml
+++ b/extensions/modeshape-connector-disk/src/test/resources/cars.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- 
+  ~ ModeShape (http://www.modeshape.org)
+  ~
+  ~ See the COPYRIGHT.txt file distributed with this work for information
+  ~ regarding copyright ownership.  Some portions may be licensed
+  ~ to Red Hat, Inc. under one or more contributor license agreements.
+  ~ See the AUTHORS.txt file in the distribution for a full listing of 
+  ~ individual contributors.
+  ~
+  ~ ModeShape is free software. Unless otherwise indicated, all code in ModeShape
+  ~ is licensed to you under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ ModeShape is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+  ~ or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+  ~ for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public License
+  ~ along with this distribution; if not, write to:
+  ~ Free Software Foundation, Inc.
+  ~ 51 Franklin Street, Fifth Floor
+  ~ Boston, MA  02110-1301  USA
+  -->
+<Cars xmlns:jcr="http://www.jcp.org/jcr/1.0">
+    <Hybrid>
+        <car jcr:name="Toyota Prius" maker="Toyota" model="Prius" year="2008" msrp="$21,500" userRating="4.2" valueRating="5" mpgCity="48" mpgHighway="45"/>
+        <car jcr:name="Toyota Highlander" maker="Toyota" model="Highlander" year="2008" msrp="$34,200" userRating="4" valueRating="5" mpgCity="27" mpgHighway="25"/>
+        <car jcr:name="Nissan Altima" maker="Nissan" model="Altima" year="2008" msrp="$18,260" mpgCity="23" mpgHighway="32"/>
+    </Hybrid>
+    <Sports>
+        <car jcr:name="Aston Martin DB9" maker="Aston Martin" model="DB9" year="2008" msrp="$171,600" userRating="5" mpgCity="12" mpgHighway="19" lengthInInches="185.5" wheelbaseInInches="108.0" engine="5,935 cc 5.9 liters V 12"/>
+        <car jcr:name="Infiniti G37" maker="Infiniti" model="G37" year="2008" msrp="$34,900" userRating="3.5" valueRating="4" mpgCity="18" mpgHighway="24" />
+    </Sports>
+    <Luxury>
+        <car jcr:name="Cadillac DTS" maker="Cadillac" model="DTS" year="2008" engine="3.6-liter V6" userRating="0"/>
+        <car jcr:name="Bentley Continental" maker="Bentley" model="Continental" year="2008" msrp="$170,990" mpgCity="10" mpgHighway="17" />
+        <car jcr:name="Lexus IS350" maker="Lexus" model="IS350" year="2008" msrp="$36,305" mpgCity="18" mpgHighway="25" userRating="4" valueRating="5" />
+    </Luxury>
+    <Utility>
+        <car jcr:name="Land Rover LR2" maker="Land Rover" model="LR2" year="2008" msrp="$33,985" userRating="4.5" valueRating="5" mpgCity="16" mpgHighway="23" />
+        <car jcr:name="Land Rover LR3" maker="Land Rover" model="LR3" year="2008" msrp="$48,525" userRating="5" valueRating="2" mpgCity="12" mpgHighway="17" />
+        <car jcr:name="Hummer H3" maker="Hummer" model="H3" year="2008" msrp="$30,595" userRating="3.5" valueRating="4" mpgCity="13" mpgHighway="16" />
+        <car jcr:name="Ford F-150" maker="Ford" model="F-150" year="2008" msrp="$23,910" userRating="4" valueRating="1" mpgCity="14" mpgHighway="20" />
+    </Utility>
+</Cars>

--- a/extensions/modeshape-connector-disk/src/test/resources/log4j.properties
+++ b/extensions/modeshape-connector-disk/src/test/resources/log4j.properties
@@ -1,0 +1,15 @@
+# Direct log messages to stdout
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.Target=System.out
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+log4j.appender.stdout.layout.ConversionPattern=%d{ABSOLUTE} %5p %m%n
+
+# Root logger option
+log4j.rootLogger=INFO, stdout
+
+# Set up the default logging to be INFO level, then override specific units
+log4j.logger.org.modeshape=INFO
+
+# JBoss Cache logging
+log4j.logger.org.infinispan=WARN, stdout
+

--- a/modeshape-integration-tests/pom.xml
+++ b/modeshape-integration-tests/pom.xml
@@ -138,6 +138,12 @@
 		</dependency>
 		<dependency>
 			<groupId>org.modeshape</groupId>
+			<artifactId>modeshape-connector-disk</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.modeshape</groupId>
 			<artifactId>modeshape-connector-filesystem</artifactId>
 			<version>${project.version}</version>
 			<scope>test</scope>

--- a/modeshape-integration-tests/src/test/java/org/modeshape/test/integration/DiskRepositoryTckTest.java
+++ b/modeshape-integration-tests/src/test/java/org/modeshape/test/integration/DiskRepositoryTckTest.java
@@ -1,0 +1,32 @@
+/*
+ * ModeShape (http://www.modeshape.org)
+ * See the COPYRIGHT.txt file distributed with this work for information
+ * regarding copyright ownership.  Some portions may be licensed
+ * to Red Hat, Inc. under one or more contributor license agreements.
+ * See the AUTHORS.txt file in the distribution for a full listing of 
+ * individual contributors.
+ *
+ * ModeShape is free software. Unless otherwise indicated, all code in ModeShape
+ * is licensed to you under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ * 
+ * ModeShape is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.modeshape.test.integration;
+
+import junit.framework.Test;
+
+public class DiskRepositoryTckTest {
+    public static Test suite() {
+        return AbstractRepositoryTckTest.readWriteRepositorySuite("disk");
+    }
+}

--- a/modeshape-integration-tests/src/test/resources/tck/disk/configRepository.xml
+++ b/modeshape-integration-tests/src/test/resources/tck/disk/configRepository.xml
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- 
+  ~ ModeShape (http://www.modeshape.org)
+  ~
+  ~ See the COPYRIGHT.txt file distributed with this work for information
+  ~ regarding copyright ownership.  Some portions may be licensed
+  ~ to Red Hat, Inc. under one or more contributor license agreements.
+  ~ See the AUTHORS.txt file in the distribution for a full listing of 
+  ~ individual contributors.
+  ~
+  ~ ModeShape is free software. Unless otherwise indicated, all code in ModeShape
+  ~ is licensed to you under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ ModeShape is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+  ~ or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+  ~ for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public License
+  ~ along with this distribution; if not, write to:
+  ~ Free Software Foundation, Inc.
+  ~ 51 Franklin Street, Fifth Floor
+  ~ Boston, MA  02110-1301  USA
+  -->
+<configuration xmlns:mode="http://www.modeshape.org/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0">
+    <!-- 
+    Define the sources for the content.  These sources are directly accessible using the ModeShape-specific Graph API.
+    In fact, this is how the ModeShape JCR implementation works.  You can think of these as being similar to
+    JDBC DataSource objects, except that they expose graph content via the Graph API instead of records via SQL or JDBC. 
+    -->
+    <mode:sources jcr:primaryType="nt:unstructured">
+        <!-- 
+        The 'JCR' repository is an Infinispan source with a single default workspace (though others could be created, too).
+        -->
+        <mode:source jcr:name="Store" mode:classname="org.modeshape.connector.disk.DiskSource" 
+                     mode:retryLimit="3" mode:defaultWorkspaceName="default" mode:repositoryRootPath="./target/diskRepoRoot">
+            <predefinedWorkspaceNames>default</predefinedWorkspaceNames>
+        </mode:source>    
+    </mode:sources>
+    <!-- 
+    Define the mime type detectors. This is an optional section.  By default, each engine will use the 
+    MIME type detector that uses filename extensions.  So we wouldn't need to define the same detector again,
+    but this is how you'd define another extension.
+    -->
+    <mode:mimeTypeDetectors>
+        <mode:mimeTypeDetector jcr:name="Detector">
+            <mode:description>Standard extension-based MIME type detector</mode:description>        
+            <!-- 
+            Specify the implementation class (required), as a child element or attribute on parent element.
+            -->
+            <mode:classname>org.modeshape.graph.mimetype.ExtensionBasedMimeTypeDetector</mode:classname>
+            <!-- 
+            Specify the classpath (optional) as an ordered list of 'names', where each name is significant to 
+            the classpath factory.  For example, a name could be an OSGI identifier or a Maven coordinate,
+            depending upon the classpath factory being used.  If there is only one 'name' in the classpath,
+            it may be specified as an attribute on the 'mimeTypeDetector' element.  If there is more than one
+            'name', then they must be specified as child 'classpath' elements. Blank or empty values are ignored. 
+             -->
+            <mode:classpath></mode:classpath>
+        </mode:mimeTypeDetector>
+    </mode:mimeTypeDetectors>
+    <!-- 
+    Define the JCR repositories 
+    -->
+    <mode:repositories>
+        <!-- 
+        Define a JCR repository that accesses the 'JCR' source directly.
+        This of course is optional, since we could access the same content through 'JCR'.
+        -->
+        <mode:repository jcr:name="Test Repository Source">
+            <!-- Specify the source that should be used for the repository -->
+            <mode:source>Store</mode:source>
+            <!-- Define the options for the JCR repository, using camelcase version of JcrRepository.Option names
+-->
+            <mode:options jcr:primaryType="mode:options">
+                <projectNodeTypes jcr:primaryType="mode:option" mode:value="false"/>
+            </mode:options>
+            <jcr:nodeTypes mode:resource="/tck/tck_test_types.cnd" />
+            <!-- Define any namespaces for this repository, other than those already defined by JCR or ModeShape
+-->
+            <namespaces jcr:primaryType="mode:namespaces">
+                <modetest jcr:primaryType="mode:namespace" mode:uri="http://www.modeshape.org/test/1.0"/>
+            </namespaces>
+        </mode:repository>
+    </mode:repositories>
+</configuration>

--- a/modeshape-integration-tests/src/test/resources/tck/disk/repositoryOverlay.properties
+++ b/modeshape-integration-tests/src/test/resources/tck/disk/repositoryOverlay.properties
@@ -1,0 +1,1 @@
+# Placeholder for any overlaid properties for this repo configuration

--- a/pom.xml
+++ b/pom.xml
@@ -45,6 +45,7 @@
 		<module>extensions/modeshape-sequencer-wsdl</module>
 		<module>extensions/modeshape-sequencer-zip</module>
 		<module>extensions/modeshape-sequencer-ddl</module>
+		<module>extensions/modeshape-connector-disk</module>
 		<module>extensions/modeshape-connector-filesystem</module>
 		<module>extensions/modeshape-connector-infinispan</module>
 		<module>extensions/modeshape-connector-jbosscache</module>


### PR DESCRIPTION
Added a patch that implements a connector that supports on-disk storage of arbitrary node content.  The connector currently creates different folder structures for each workspace and creates a file for each node.  Efficient access by UUID is supported.  This patch includes documentation in the Reference Guide and passes all TCK tests.
