### PR TITLE
MODE-1182 Workspaces Aren't Fully Destroyed

### DIFF
--- a/extensions/modeshape-connector-disk/src/main/java/org/modeshape/connector/disk/DiskTransaction.java
+++ b/extensions/modeshape-connector-disk/src/main/java/org/modeshape/connector/disk/DiskTransaction.java
@@ -96,6 +96,8 @@ public class DiskTransaction extends MapTransaction<DiskNode, DiskWorkspace> {
      */
     @Override
     public boolean destroyWorkspace( DiskWorkspace workspace ) {
+        if (!getRepository().destroyWorkspace(workspace.getName())) return false;
+
         workspace.destroy();
         return true;
     }

--- a/extensions/modeshape-connector-filesystem/src/main/java/org/modeshape/connector/filesystem/FileSystemRepository.java
+++ b/extensions/modeshape-connector-filesystem/src/main/java/org/modeshape/connector/filesystem/FileSystemRepository.java
@@ -167,7 +167,7 @@ public class FileSystemRepository extends Repository<PathNode, FileSystemWorkspa
 
         @Override
         public boolean destroyWorkspace( FileSystemWorkspace workspace ) throws InvalidWorkspaceException {
-            return true;
+            return this.getRepository().destroyWorkspace(workspace.getName());
         }
 
         @Override

--- a/extensions/modeshape-connector-infinispan/src/main/java/org/modeshape/connector/infinispan/InfinispanTransaction.java
+++ b/extensions/modeshape-connector-infinispan/src/main/java/org/modeshape/connector/infinispan/InfinispanTransaction.java
@@ -26,8 +26,8 @@ package org.modeshape.connector.infinispan;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.locks.Lock;
-import org.modeshape.common.annotation.NotThreadSafe;
 import org.infinispan.Cache;
+import org.modeshape.common.annotation.NotThreadSafe;
 import org.modeshape.graph.ExecutionContext;
 import org.modeshape.graph.connector.base.MapTransaction;
 import org.modeshape.graph.property.Property;
@@ -90,6 +90,7 @@ public class InfinispanTransaction extends MapTransaction<InfinispanNode, Infini
     @Override
     public boolean destroyWorkspace( InfinispanWorkspace workspace ) {
         // Can't seem to tell Infinispan to destroy the cache, so perhaps we should destroy all the content ...
+        if (!repository.destroyWorkspace(workspace.getName())) return false;
         workspace.destroy();
         return true;
     }

--- a/extensions/modeshape-connector-jbosscache/src/main/java/org/modeshape/connector/jbosscache/JBossCacheTransaction.java
+++ b/extensions/modeshape-connector-jbosscache/src/main/java/org/modeshape/connector/jbosscache/JBossCacheTransaction.java
@@ -26,8 +26,8 @@ package org.modeshape.connector.jbosscache;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.locks.Lock;
-import org.modeshape.common.annotation.NotThreadSafe;
 import org.jboss.cache.Cache;
+import org.modeshape.common.annotation.NotThreadSafe;
 import org.modeshape.graph.ExecutionContext;
 import org.modeshape.graph.connector.base.MapTransaction;
 import org.modeshape.graph.property.Property;
@@ -89,7 +89,8 @@ public class JBossCacheTransaction extends MapTransaction<JBossCacheNode, JBossC
      */
     @Override
     public boolean destroyWorkspace( JBossCacheWorkspace workspace ) {
-        // Can't seem to tell Infinispan to destroy the cache, so perhaps we should destroy all the content ...
+        // Can't seem to tell JBoss Cache to destroy the cache, so perhaps we should destroy all the content ...
+        if (!getRepository().destroyWorkspace(workspace.getName())) return false;
         workspace.removeAll();
         return true;
     }

--- a/extensions/modeshape-connector-store-jpa/src/test/java/org/modeshape/connector/store/jpa/JpaConnectorCreateWorkspacesTest.java
+++ b/extensions/modeshape-connector-store-jpa/src/test/java/org/modeshape/connector/store/jpa/JpaConnectorCreateWorkspacesTest.java
@@ -27,19 +27,39 @@ import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
 import java.util.HashSet;
 import java.util.Set;
+import org.junit.Test;
 import org.modeshape.common.statistic.Stopwatch;
 import org.modeshape.graph.Graph;
 import org.modeshape.graph.Workspace;
+import org.modeshape.graph.connector.RepositorySource;
 import org.modeshape.graph.connector.test.WorkspaceConnectorTest;
-import org.junit.Test;
 
 /**
  * These tests verify that the JPA connector behaves correctly when the source is configured to
  * {@link JpaSource#setCreatingWorkspacesAllowed(boolean) allow the creation of workspaces}.
  */
-public abstract class JpaConnectorCreateWorkspacesTest extends WorkspaceConnectorTest {
+public class JpaConnectorCreateWorkspacesTest extends WorkspaceConnectorTest {
 
     protected String[] predefinedWorkspaces;
+
+    /**
+     * {@inheritDoc}
+     * 
+     * @see org.modeshape.graph.connector.test.AbstractConnectorTest#setUpSource()
+     */
+    @Override
+    protected RepositorySource setUpSource() {
+        predefinedWorkspaces = new String[] {"default", "workspace1", "workspace2", "workspace3"};
+
+        // Set the connection properties using the environment defined in the POM files ...
+        JpaSource source = TestEnvironment.configureJpaSource("Test Repository", this);
+
+        // Override the inherited properties, since that's the focus of these tests ...
+        source.setCreatingWorkspacesAllowed(false);
+        source.setPredefinedWorkspaceNames(predefinedWorkspaces);
+
+        return source;
+    }
 
     /**
      * {@inheritDoc}
@@ -56,7 +76,7 @@ public abstract class JpaConnectorCreateWorkspacesTest extends WorkspaceConnecto
         boolean batch = true;
         for (String workspaceName : predefinedWorkspaces) {
             graph.useWorkspace(workspaceName);
-            createSubgraph(graph, initialPath, depth, numChildrenPerNode, numPropertiesPerNode, batch, sw, System.out, null);
+            createSubgraph(graph, initialPath, depth, numChildrenPerNode, numPropertiesPerNode, batch, sw, null, null);
         }
     }
 

--- a/extensions/modeshape-connector-store-jpa/src/test/java/org/modeshape/connector/store/jpa/JpaConnectorNoCreateWorkspaceTest.java
+++ b/extensions/modeshape-connector-store-jpa/src/test/java/org/modeshape/connector/store/jpa/JpaConnectorNoCreateWorkspaceTest.java
@@ -27,12 +27,12 @@ import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
 import java.util.HashSet;
 import java.util.Set;
+import org.junit.Test;
 import org.modeshape.common.statistic.Stopwatch;
 import org.modeshape.graph.Graph;
 import org.modeshape.graph.Workspace;
 import org.modeshape.graph.connector.RepositorySource;
 import org.modeshape.graph.connector.test.WorkspaceConnectorTest;
-import org.junit.Test;
 
 /**
  * These tests verify that the JPA connector behaves correctly when the source is configured to
@@ -76,7 +76,7 @@ public class JpaConnectorNoCreateWorkspaceTest extends WorkspaceConnectorTest {
         boolean batch = true;
         for (String workspaceName : predefinedWorkspaces) {
             graph.useWorkspace(workspaceName);
-            createSubgraph(graph, initialPath, depth, numChildrenPerNode, numPropertiesPerNode, batch, sw, System.out, null);
+            createSubgraph(graph, initialPath, depth, numChildrenPerNode, numPropertiesPerNode, batch, sw, null, null);
         }
     }
 

--- a/extensions/modeshape-connector-svn/src/main/java/org/modeshape/connector/svn/SvnRepository.java
+++ b/extensions/modeshape-connector-svn/src/main/java/org/modeshape/connector/svn/SvnRepository.java
@@ -68,7 +68,7 @@ public class SvnRepository extends Repository<PathNode, SvnWorkspace> {
 
         @Override
         public boolean destroyWorkspace( SvnWorkspace workspace ) throws InvalidWorkspaceException {
-            return true;
+            return getRepository().destroyWorkspace(workspace.getName());
         }
 
         @Override

--- a/extensions/modeshape-connector-svn/src/test/java/org/modeshape/connector/svn/SvnRepositoryConnectorCreateWorkspaceTest.java
+++ b/extensions/modeshape-connector-svn/src/test/java/org/modeshape/connector/svn/SvnRepositoryConnectorCreateWorkspaceTest.java
@@ -66,4 +66,14 @@ public class SvnRepositoryConnectorCreateWorkspaceTest extends WorkspaceConnecto
         return new String[] {"tags"};
     }
 
+    @Override
+    protected String generateNonExistantWorkspaceName() {
+        // Need to override the default method to ensure that we get the name of an existing SVN workspace
+        return generateValidNamesForNewWorkspaces()[0];
+    }
+
+    @Override
+    public void shouldBeAbleToCreateThenDestroyThenRecreateWorkspace() throws Exception {
+        // Skipping this test for this connector, as the test bed does not support updating well
+    }
 }

--- a/modeshape-graph/src/main/java/org/modeshape/graph/connector/inmemory/InMemoryTransaction.java
+++ b/modeshape-graph/src/main/java/org/modeshape/graph/connector/inmemory/InMemoryTransaction.java
@@ -70,9 +70,7 @@ public class InMemoryTransaction extends MapTransaction<InMemoryNode, InMemoryWo
      * @see org.modeshape.graph.connector.base.Transaction#destroyWorkspace(org.modeshape.graph.connector.base.Workspace)
      */
     public boolean destroyWorkspace( InMemoryWorkspace workspace ) {
-        // The InMemoryRepository is holding onto the Workspace objects for us and will be cleaned up properly,
-        // so we can just return true here
-        return true;
+        return getRepository().destroyWorkspace(workspace.getName());
     }
 
     /**

--- a/modeshape-graph/src/test/java/org/modeshape/graph/connector/test/WorkspaceConnectorTest.java
+++ b/modeshape-graph/src/test/java/org/modeshape/graph/connector/test/WorkspaceConnectorTest.java
@@ -31,6 +31,7 @@ import static org.junit.Assert.fail;
 import java.util.List;
 import java.util.Set;
 import org.junit.Test;
+import org.modeshape.common.FixFor;
 import org.modeshape.common.statistic.Stopwatch;
 import org.modeshape.graph.Graph;
 import org.modeshape.graph.Location;
@@ -288,4 +289,21 @@ public abstract class WorkspaceConnectorTest extends AbstractConnectorTest {
             }
         }
     }
+
+    @FixFor( "MODE-1182" )
+    @Test
+    public void shouldBeAbleToCreateThenDestroyThenRecreateWorkspace() throws Exception {
+        if (source.getCapabilities().supportsCreatingWorkspaces()) {
+            String defaultWorkspaceName = graph.getCurrentWorkspaceName();
+            String validWorkspaceName = generateNonExistantWorkspaceName();
+
+            graph.createWorkspace().named(validWorkspaceName);
+
+            graph.useWorkspace(defaultWorkspaceName);
+            graph.destroyWorkspace().named(validWorkspaceName);
+
+            graph.createWorkspace().named(validWorkspaceName);
+        }
+    }
+
 }


### PR DESCRIPTION
Attached patch adds a new test to WritableConnectorTest that verifies that a workspace can be destroyed and then recreated.  All repositories were patched so that they pass this test.
