### PR TITLE
Changing the datasource to use the local jdbc driver

### DIFF
--- a/deploy/jbossas/modeshape-jbossas-service/src/kit/modeshape-jdbc-ds.xml
+++ b/deploy/jbossas/modeshape-jbossas-service/src/kit/modeshape-jdbc-ds.xml
@@ -17,7 +17,7 @@
     <jndi-name>ModeShapeDS</jndi-name>
     <connection-url>jdbc:jcr:jndi:jcr/local?repositoryName=repository</connection-url>
 
-    <driver-class>org.modeshape.jdbc.JcrDriver</driver-class>
+    <driver-class>org.modeshape.jdbc.LocalJcrDriver</driver-class>
     <user>admin</user>
     <password>admin</password>
 


### PR DESCRIPTION
MODE-1194 - changing the jboss deployment datasource to use the modeshape local jdbc driver.
