### PR TITLE
MODE-1198 Copyright and License header still refers to JBoss DNA

### DIFF
--- a/extensions/modeshape-connector-jcr/src/main/java/org/modeshape/connector/jcr/JcrNamespaceRegistry.java
+++ b/extensions/modeshape-connector-jcr/src/main/java/org/modeshape/connector/jcr/JcrNamespaceRegistry.java
@@ -1,17 +1,17 @@
 /*
- * JBoss DNA (http://www.jboss.org/dna)
+ * ModeShape (http://www.modeshape.org)
  * See the COPYRIGHT.txt file distributed with this work for information
  * regarding copyright ownership.  Some portions may be licensed
  * to Red Hat, Inc. under one or more contributor license agreements.
- * See the AUTHORS.txt file in the distribution for a full listing of 
+ * See the AUTHORS.txt file in the distribution for a full listing of
  * individual contributors.
  *
- * JBoss DNA is free software. Unless otherwise indicated, all code in JBoss DNA
+ * ModeShape is free software. Unless otherwise indicated, all code in ModeShape
  * is licensed to you under the terms of the GNU Lesser General Public License as
  * published by the Free Software Foundation; either version 2.1 of
  * the License, or (at your option) any later version.
- * 
- * JBoss DNA is distributed in the hope that it will be useful,
+ *
+ * ModeShape is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * Lesser General Public License for more details.

--- a/extensions/modeshape-connector-jcr/src/main/java/org/modeshape/connector/jcr/JcrRepositoryConnection.java
+++ b/extensions/modeshape-connector-jcr/src/main/java/org/modeshape/connector/jcr/JcrRepositoryConnection.java
@@ -1,17 +1,17 @@
 /*
- * JBoss DNA (http://www.jboss.org/dna)
+ * ModeShape (http://www.modeshape.org)
  * See the COPYRIGHT.txt file distributed with this work for information
  * regarding copyright ownership.  Some portions may be licensed
  * to Red Hat, Inc. under one or more contributor license agreements.
- * See the AUTHORS.txt file in the distribution for a full listing of 
+ * See the AUTHORS.txt file in the distribution for a full listing of
  * individual contributors.
  *
- * JBoss DNA is free software. Unless otherwise indicated, all code in JBoss DNA
+ * ModeShape is free software. Unless otherwise indicated, all code in ModeShape
  * is licensed to you under the terms of the GNU Lesser General Public License as
  * published by the Free Software Foundation; either version 2.1 of
  * the License, or (at your option) any later version.
- * 
- * JBoss DNA is distributed in the hope that it will be useful,
+ *
+ * ModeShape is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * Lesser General Public License for more details.

--- a/extensions/modeshape-connector-jcr/src/main/java/org/modeshape/connector/jcr/JcrRequestProcessor.java
+++ b/extensions/modeshape-connector-jcr/src/main/java/org/modeshape/connector/jcr/JcrRequestProcessor.java
@@ -1,17 +1,17 @@
 /*
- * JBoss DNA (http://www.jboss.org/dna)
+ * ModeShape (http://www.modeshape.org)
  * See the COPYRIGHT.txt file distributed with this work for information
  * regarding copyright ownership.  Some portions may be licensed
  * to Red Hat, Inc. under one or more contributor license agreements.
- * See the AUTHORS.txt file in the distribution for a full listing of 
+ * See the AUTHORS.txt file in the distribution for a full listing of
  * individual contributors.
  *
- * JBoss DNA is free software. Unless otherwise indicated, all code in JBoss DNA
+ * ModeShape is free software. Unless otherwise indicated, all code in ModeShape
  * is licensed to you under the terms of the GNU Lesser General Public License as
  * published by the Free Software Foundation; either version 2.1 of
  * the License, or (at your option) any later version.
- * 
- * JBoss DNA is distributed in the hope that it will be useful,
+ *
+ * ModeShape is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * Lesser General Public License for more details.

--- a/extensions/modeshape-connector-jcr/src/test/java/org/modeshape/connector/jcr/JcrConnectorTestUtil.java
+++ b/extensions/modeshape-connector-jcr/src/test/java/org/modeshape/connector/jcr/JcrConnectorTestUtil.java
@@ -1,17 +1,17 @@
 /*
- * JBoss DNA (http://www.jboss.org/dna)
+ * ModeShape (http://www.modeshape.org)
  * See the COPYRIGHT.txt file distributed with this work for information
  * regarding copyright ownership.  Some portions may be licensed
  * to Red Hat, Inc. under one or more contributor license agreements.
- * See the AUTHORS.txt file in the distribution for a full listing of 
+ * See the AUTHORS.txt file in the distribution for a full listing of
  * individual contributors.
  *
- * JBoss DNA is free software. Unless otherwise indicated, all code in JBoss DNA
+ * ModeShape is free software. Unless otherwise indicated, all code in ModeShape
  * is licensed to you under the terms of the GNU Lesser General Public License as
  * published by the Free Software Foundation; either version 2.1 of
  * the License, or (at your option) any later version.
- * 
- * JBoss DNA is distributed in the hope that it will be useful,
+ *
+ * ModeShape is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * Lesser General Public License for more details.

--- a/extensions/modeshape-sequencer-ddl/src/main/java/org/modeshape/sequencer/ddl/DdlParserScorer.java
+++ b/extensions/modeshape-sequencer-ddl/src/main/java/org/modeshape/sequencer/ddl/DdlParserScorer.java
@@ -1,17 +1,17 @@
 /*
- * JBoss DNA (http://www.jboss.org/dna)
+ * ModeShape (http://www.modeshape.org)
  * See the COPYRIGHT.txt file distributed with this work for information
  * regarding copyright ownership.  Some portions may be licensed
  * to Red Hat, Inc. under one or more contributor license agreements.
- * See the AUTHORS.txt file in the distribution for a full listing of 
+ * See the AUTHORS.txt file in the distribution for a full listing of
  * individual contributors.
  *
- * JBoss DNA is free software. Unless otherwise indicated, all code in JBoss DNA
+ * ModeShape is free software. Unless otherwise indicated, all code in ModeShape
  * is licensed to you under the terms of the GNU Lesser General Public License as
  * published by the Free Software Foundation; either version 2.1 of
  * the License, or (at your option) any later version.
- * 
- * JBoss DNA is distributed in the hope that it will be useful,
+ *
+ * ModeShape is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * Lesser General Public License for more details.

--- a/modeshape-graph/src/main/java/org/modeshape/graph/property/basic/NamespaceRegistryWithAliases.java
+++ b/modeshape-graph/src/main/java/org/modeshape/graph/property/basic/NamespaceRegistryWithAliases.java
@@ -1,17 +1,17 @@
 /*
- * JBoss DNA (http://www.jboss.org/dna)
+ * ModeShape (http://www.modeshape.org)
  * See the COPYRIGHT.txt file distributed with this work for information
  * regarding copyright ownership.  Some portions may be licensed
  * to Red Hat, Inc. under one or more contributor license agreements.
- * See the AUTHORS.txt file in the distribution for a full listing of 
+ * See the AUTHORS.txt file in the distribution for a full listing of
  * individual contributors.
  *
- * JBoss DNA is free software. Unless otherwise indicated, all code in JBoss DNA
+ * ModeShape is free software. Unless otherwise indicated, all code in ModeShape
  * is licensed to you under the terms of the GNU Lesser General Public License as
  * published by the Free Software Foundation; either version 2.1 of
  * the License, or (at your option) any later version.
- * 
- * JBoss DNA is distributed in the hope that it will be useful,
+ *
+ * ModeShape is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * Lesser General Public License for more details.

--- a/modeshape-integration-tests/src/test/java/org/modeshape/test/integration/svn/JcrAndLocalSvnRepositoryTest.java
+++ b/modeshape-integration-tests/src/test/java/org/modeshape/test/integration/svn/JcrAndLocalSvnRepositoryTest.java
@@ -1,17 +1,17 @@
 /*
- * JBoss DNA (http://www.jboss.org/dna)
+ * ModeShape (http://www.modeshape.org)
  * See the COPYRIGHT.txt file distributed with this work for information
  * regarding copyright ownership.  Some portions may be licensed
  * to Red Hat, Inc. under one or more contributor license agreements.
- * See the AUTHORS.txt file in the distribution for a full listing of 
+ * See the AUTHORS.txt file in the distribution for a full listing of
  * individual contributors.
  *
- * JBoss DNA is free software. Unless otherwise indicated, all code in JBoss DNA
+ * ModeShape is free software. Unless otherwise indicated, all code in ModeShape
  * is licensed to you under the terms of the GNU Lesser General Public License as
  * published by the Free Software Foundation; either version 2.1 of
  * the License, or (at your option) any later version.
- * 
- * JBoss DNA is distributed in the hope that it will be useful,
+ *
+ * ModeShape is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * Lesser General Public License for more details.

--- a/modeshape-jcr-tck/src/test/java/org/modeshape/jcr/ResetRepositoryInstanceTest.java
+++ b/modeshape-jcr-tck/src/test/java/org/modeshape/jcr/ResetRepositoryInstanceTest.java
@@ -1,17 +1,17 @@
 /*
- * JBoss DNA (http://www.jboss.org/dna)
+ * ModeShape (http://www.modeshape.org)
  * See the COPYRIGHT.txt file distributed with this work for information
  * regarding copyright ownership.  Some portions may be licensed
  * to Red Hat, Inc. under one or more contributor license agreements.
- * See the AUTHORS.txt file in the distribution for a full listing of 
+ * See the AUTHORS.txt file in the distribution for a full listing of
  * individual contributors.
  *
- * JBoss DNA is free software. Unless otherwise indicated, all code in JBoss DNA
+ * ModeShape is free software. Unless otherwise indicated, all code in ModeShape
  * is licensed to you under the terms of the GNU Lesser General Public License as
  * published by the Free Software Foundation; either version 2.1 of
  * the License, or (at your option) any later version.
- * 
- * JBoss DNA is distributed in the hope that it will be useful,
+ *
+ * ModeShape is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * Lesser General Public License for more details.

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/ModeShapePermissions.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/ModeShapePermissions.java
@@ -1,17 +1,17 @@
 /*
- * JBoss DNA (http://www.jboss.org/dna)
+ * ModeShape (http://www.modeshape.org)
  * See the COPYRIGHT.txt file distributed with this work for information
  * regarding copyright ownership.  Some portions may be licensed
  * to Red Hat, Inc. under one or more contributor license agreements.
- * See the AUTHORS.txt file in the distribution for a full listing of 
+ * See the AUTHORS.txt file in the distribution for a full listing of
  * individual contributors.
  *
- * JBoss DNA is free software. Unless otherwise indicated, all code in JBoss DNA
+ * ModeShape is free software. Unless otherwise indicated, all code in ModeShape
  * is licensed to you under the terms of the GNU Lesser General Public License as
  * published by the Free Software Foundation; either version 2.1 of
  * the License, or (at your option) any later version.
- * 
- * JBoss DNA is distributed in the hope that it will be useful,
+ *
+ * ModeShape is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * Lesser General Public License for more details.

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/ModeShapeRoles.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/ModeShapeRoles.java
@@ -1,17 +1,17 @@
 /*
- * JBoss DNA (http://www.jboss.org/dna)
+ * ModeShape (http://www.modeshape.org)
  * See the COPYRIGHT.txt file distributed with this work for information
  * regarding copyright ownership.  Some portions may be licensed
  * to Red Hat, Inc. under one or more contributor license agreements.
- * See the AUTHORS.txt file in the distribution for a full listing of 
+ * See the AUTHORS.txt file in the distribution for a full listing of
  * individual contributors.
  *
- * JBoss DNA is free software. Unless otherwise indicated, all code in JBoss DNA
+ * ModeShape is free software. Unless otherwise indicated, all code in ModeShape
  * is licensed to you under the terms of the GNU Lesser General Public License as
  * published by the Free Software Foundation; either version 2.1 of
  * the License, or (at your option) any later version.
- * 
- * JBoss DNA is distributed in the hope that it will be useful,
+ *
+ * ModeShape is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * Lesser General Public License for more details.

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/query/JcrSql2QueryParser.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/query/JcrSql2QueryParser.java
@@ -1,17 +1,17 @@
 /*
- * JBoss DNA (http://www.jboss.org/dna)
+ * ModeShape (http://www.modeshape.org)
  * See the COPYRIGHT.txt file distributed with this work for information
  * regarding copyright ownership.  Some portions may be licensed
  * to Red Hat, Inc. under one or more contributor license agreements.
- * See the AUTHORS.txt file in the distribution for a full listing of 
+ * See the AUTHORS.txt file in the distribution for a full listing of
  * individual contributors.
  *
- * JBoss DNA is free software. Unless otherwise indicated, all code in JBoss DNA
+ * ModeShape is free software. Unless otherwise indicated, all code in ModeShape
  * is licensed to you under the terms of the GNU Lesser General Public License as
  * published by the Free Software Foundation; either version 2.1 of
  * the License, or (at your option) any later version.
- * 
- * JBoss DNA is distributed in the hope that it will be useful,
+ *
+ * ModeShape is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * Lesser General Public License for more details.


### PR DESCRIPTION
- Replaced the copyright headers to reflect the project name ModeShape

Contains no code changes, should be safe to merge.
