### PR TITLE
MODE-1197 Removed JBoss Maven repository settings from our POM

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,16 +37,17 @@ The general idea is to keep your 'master' branch in-sync with the 'upstream/mast
 
 ## Building ModeShape
 
-Then, we use Maven 2.2 to build our software. The following command compiles all the code, installs the JARs into your local Maven repository, and run all of the unit tests:
+Then, we use Maven 3.x to build our software. The following command compiles all the code, installs the JARs into your local Maven repository, and run all of the unit tests:
 
-	$ mvn clean install
+	$ mvn clean install -s settings.xml
 
-That takes a while -- we do have over 12K unit tests. So if need be, your builds can skip the tests:
+BTW, that '-s settings.xml' argument uses the 'settings.xml' file in our codebase, which is set up to use the JBoss Maven repository. 
 
-	$ mvn clean install -DskipTests
+That command takes a while -- we do have over 12K unit tests. So if need be, your builds can skip the tests:
+
+	$ mvn clean install -s settings.xml -DskipTests
 	
-If you have *any* trouble building, check the [detailed build instructions and tips](http://docs.jboss.org/modeshape/latest/manuals/reference/html_single/reference-guide-en.html#maven) in our 
-[Reference Guide](http://docs.jboss.org/modeshape/latest/manuals/reference/html_single/reference-guide-en.html).
+If you have *any* trouble building (or don't like the '-s settings.xml' usage), check the [detailed build instructions and tips](http://community.jboss.org/wiki/ModeShapeAndMaven).
 
 ## Contribute fixes and features
 

--- a/modeshape-parent/pom.xml
+++ b/modeshape-parent/pom.xml
@@ -1222,44 +1222,6 @@
 		</plugins>
 	</reporting>
 
-	<repositories>
-		<repository>
-			<id>jboss-public-repository-group</id>
-			<name>JBoss Public Repository Group</name>
-			<url>http://repository.jboss.org/nexus/content/groups/developer/</url>
-			<layout>default</layout>
-			<releases>
-				<enabled>true</enabled>
-				<updatePolicy>never</updatePolicy>
-			</releases>
-			<snapshots>
-				<enabled>true</enabled>
-				<updatePolicy>never</updatePolicy>
-			</snapshots>
-		</repository>
-        <repository>
-          <id>qa.jboss.com</id>
-          <url>http://www.qa.jboss.com/jdbc-drivers/maven2</url>
-          <!--url>10.16.89.17/jdbc-drivers/maven2</url-->
-          <snapshots>
-            <enabled>false</enabled>
-          </snapshots>
-        </repository>
-		
-	</repositories>
-	<pluginRepositories>
-		<pluginRepository>
-			<id>jboss-public-repository-group</id>
-			<name>JBoss Public Repository Group</name>
-			<url>http://repository.jboss.org/nexus/content/groups/developer/</url>
-			<releases>
-				<enabled>true</enabled>
-			</releases>
-			<snapshots>
-				<enabled>true</enabled>
-			</snapshots>
-		</pluginRepository>
-	</pluginRepositories>
 	<distributionManagement>
 		<repository>
 			<id>jboss-releases-repository</id>

--- a/settings.xml
+++ b/settings.xml
@@ -1,0 +1,48 @@
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0
+                      http://maven.apache.org/xsd/settings-1.0.0.xsd">
+
+  <profiles>
+    <profile>
+      <id>jboss-public-repository</id>
+      <repositories>
+        <repository>
+          <id>jboss-public-repository-group</id>
+          <name>JBoss Public Maven Repository Group</name>
+          <url>http://repository.jboss.org/nexus/content/groups/public/</url>
+          <layout>default</layout>
+          <releases>
+            <enabled>true</enabled>
+            <updatePolicy>never</updatePolicy>
+          </releases>
+          <snapshots>
+            <enabled>true</enabled>
+            <updatePolicy>never</updatePolicy>
+          </snapshots>
+        </repository>
+      </repositories>
+      <pluginRepositories>
+        <pluginRepository>
+          <id>jboss-public-repository-group</id>
+          <name>JBoss Public Maven Repository Group</name>
+          <url>http://repository.jboss.org/nexus/content/groups/public/</url>
+          <layout>default</layout>
+          <releases>
+            <enabled>true</enabled>
+            <updatePolicy>never</updatePolicy>
+          </releases>
+          <snapshots>
+            <enabled>true</enabled>
+            <updatePolicy>never</updatePolicy>
+          </snapshots>
+        </pluginRepository>
+      </pluginRepositories>
+    </profile>
+  </profiles>
+
+  <activeProfiles>
+    <activeProfile>jboss-public-repository</activeProfile>
+  </activeProfiles>
+
+</settings>


### PR DESCRIPTION
Having a `repositories` and `pluginRepositories` sections in our parent POM makes it very difficult (if not impossible) to host the ModeShape artifacts in any other repository, including the Maven central repository.

This change removes those sections from the parent POM and places them in a new `settings.xml` file in our codebase. This means that developers that don't want to change their `~/.m2/settings.xml` file can simply add the "`-s settings.xml`" argument to all Maven commands. For details on how to configure Maven, see the [ModeShape and Maven](http://community.jboss.org/docs/DOC-16545) wiki page.

The following procedure was used to test these changes:
1. removed the `repositories` and `pluginRepositories` sections from our parent POM;
2. temporarily renamed my `~/.m2/settings.xml` file and `~/.m2/repositories` directory so they wouldn't be used;
3. added to the root of our codebase a `settings.xml` file that specified the JBoss Maven repository in the `repositories` and `pluginRepositories` sections; and
4. ran "`mvn -Passembly clean install -s settings.xml`" build command to successfully build all artifacts (except JavaDoc and assemblies), downloading everything Maven needed (i.e., the whole internet)

The build worked fine.
