### PR TITLE
MODE-1201 Using InMemoryBinary when writing to a repository can cause hea

### DIFF
--- a/modeshape-graph/src/main/java/org/modeshape/graph/GraphI18n.java
+++ b/modeshape-graph/src/main/java/org/modeshape/graph/GraphI18n.java
@@ -98,6 +98,7 @@ public final class GraphI18n {
     public static I18n aliasesMappedToRealNamespacesButWereNotRegisteredInAliasNamespace;
     public static I18n noPropertiesToUpdate;
     public static I18n noPropertiesToRemove;
+    public static I18n streamTooLarge;
 
     public static I18n errorImportingContent;
     public static I18n unableToFindRepositorySourceWithName;

--- a/modeshape-graph/src/main/java/org/modeshape/graph/property/basic/FileInputStreamBinary.java
+++ b/modeshape-graph/src/main/java/org/modeshape/graph/property/basic/FileInputStreamBinary.java
@@ -1,0 +1,151 @@
+/*
+ * ModeShape (http://www.modeshape.org)
+ * See the COPYRIGHT.txt file distributed with this work for information
+ * regarding copyright ownership.  Some portions may be licensed
+ * to Red Hat, Inc. under one or more contributor license agreements.
+ * See the AUTHORS.txt file in the distribution for a full listing of 
+ * individual contributors. 
+ *
+ * ModeShape is free software. Unless otherwise indicated, all code in ModeShape
+ * is licensed to you under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * ModeShape is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.modeshape.graph.property.basic;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+import java.nio.channels.Channels;
+import java.nio.channels.FileChannel;
+import java.nio.channels.FileChannel.MapMode;
+import org.modeshape.common.annotation.NotThreadSafe;
+import org.modeshape.common.util.CheckArg;
+import org.modeshape.graph.GraphI18n;
+import org.modeshape.graph.property.Binary;
+
+/**
+ * An implementation of {@link Binary} that wraps a data stream.
+ * <p/>
+ * <b>NOTE: This is not a fully valid implementation of {@link Binary} as it is not Immutable.</b>
+ */
+@NotThreadSafe
+public class FileInputStreamBinary extends AbstractBinary {
+
+    /**
+     * Version {@value} .
+     */
+    private static final long serialVersionUID = 2L;
+
+    private final FileChannel channel;
+    private byte[] sha1hash;
+    private int hc;
+
+    public FileInputStreamBinary( FileInputStream stream ) {
+        super();
+        CheckArg.isNotNull(stream, "stream");
+        this.channel = stream.getChannel();
+    }
+
+    /**
+     * {@inheritDoc}
+     * 
+     * @see java.lang.Object#hashCode()
+     */
+    @Override
+    public int hashCode() {
+        if (sha1hash == null) {
+            // Idempotent, so doesn't matter if we recompute in concurrent threads ...
+            sha1hash = computeHash(getBytes());
+            hc = sha1hash.hashCode();
+        }
+        return hc;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public long getSize() {
+        try {
+            return channel.size();
+        } catch (IOException ioe) {
+            throw new IllegalStateException(ioe);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     * 
+     * @see org.modeshape.graph.property.Binary#getHash()
+     */
+    public byte[] getHash() {
+        if (sha1hash == null) {
+            // Idempotent, so doesn't matter if we recompute in concurrent threads ...
+            sha1hash = computeHash(getBytes());
+            hc = sha1hash.hashCode();
+        }
+        return sha1hash;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public byte[] getBytes() {
+        try {
+            if (channel.size() > Integer.MAX_VALUE) {
+                throw new IllegalStateException(GraphI18n.streamTooLarge.text(channel.size()));
+            }
+
+            ByteBuffer bytes = channel.map(MapMode.READ_ONLY, 0, channel.size());
+
+            byte[] buff = new byte[(int)channel.size()];
+            bytes.get(buff);
+
+            return buff;
+        } catch (IOException ioe) {
+            throw new IllegalStateException(ioe);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public InputStream getStream() {
+        try {
+            channel.position(0);
+        } catch (IOException ioe) {
+            throw new IllegalStateException(ioe);
+        }
+        return Channels.newInputStream(channel);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public void acquire() {
+        // do nothing
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public void release() {
+        // try {
+        // channel.close();
+        // } catch (IOException ioe) {
+        // throw new IllegalStateException(ioe);
+        // }
+
+    }
+}

--- a/modeshape-graph/src/main/resources/org/modeshape/graph/GraphI18n.properties
+++ b/modeshape-graph/src/main/resources/org/modeshape/graph/GraphI18n.properties
@@ -86,6 +86,7 @@ namespaceAliasWasNotMappedToRealNamespace = The aliased namespace "{0}" was not 
 aliasesMappedToRealNamespacesButWereNotRegisteredInAliasNamespace = One or more alias namespaces were mapped to original namespaces but not registered with a prefix in the alias namespace registry: {0}
 noPropertiesToUpdate = No properties are to be updated on "{0}"
 noPropertiesToRemove = No properties are to be removed on "{0}"
+streamTooLarge = The binary could not be converted to a byte array because its size ({0}) exceeds Integer.MAX_VALUE.
 
 errorImportingContent = Error importing {0} content from {1}
 unableToFindRepositorySourceWithName = Unable to find a repository source named "{0}"

--- a/modeshape-graph/src/test/java/org/modeshape/graph/property/basic/FileInputStreamBinaryTest.java
+++ b/modeshape-graph/src/test/java/org/modeshape/graph/property/basic/FileInputStreamBinaryTest.java
@@ -1,0 +1,146 @@
+/*
+ * ModeShape (http://www.modeshape.org)
+ * See the COPYRIGHT.txt file distributed with this work for information
+ * regarding copyright ownership.  Some portions may be licensed
+ * to Red Hat, Inc. under one or more contributor license agreements.
+ * See the AUTHORS.txt file in the distribution for a full listing of 
+ * individual contributors. 
+ *
+ * ModeShape is free software. Unless otherwise indicated, all code in ModeShape
+ * is licensed to you under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * ModeShape is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.modeshape.graph.property.basic;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+import static org.modeshape.graph.property.basic.BinaryContains.hasContent;
+import static org.modeshape.graph.property.basic.BinaryContains.hasNoContent;
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import org.junit.Before;
+import org.junit.Test;
+import org.modeshape.common.util.IoUtil;
+import org.modeshape.common.util.StringUtil;
+import org.modeshape.graph.property.Binary;
+
+/**
+ * @author Randall Hauch
+ */
+public class FileInputStreamBinaryTest {
+
+    private byte[] validByteArrayContent;
+    private String validStringContent;
+    private Binary binary;
+
+    /**
+     * @throws java.lang.Exception
+     */
+    @Before
+    public void setUp() throws Exception {
+        validStringContent = "This is a valid string content";
+        validByteArrayContent = this.validStringContent.getBytes("UTF-8");
+        binary = new FileInputStreamBinary(createFileInputStream(validByteArrayContent));
+    }
+
+    private FileInputStream createFileInputStream( byte[] bytes ) throws IOException {
+        File tmp = File.createTempFile("modeshape", "bin");
+        FileOutputStream fos = new FileOutputStream(tmp);
+        IoUtil.write(new ByteArrayInputStream(bytes), fos);
+        fos.close();
+
+        return new FileInputStream(tmp);
+    }
+
+    @Test
+    public void shouldConstructFromByteArray() {
+        assertThat(binary.getSize(), is((long)validByteArrayContent.length));
+        assertThat(binary, hasContent(validByteArrayContent));
+    }
+
+    @Test
+    public void shouldConstructFromEmptyByteArray() throws Exception {
+        validByteArrayContent = new byte[0];
+        binary = new FileInputStreamBinary(createFileInputStream(validByteArrayContent));
+        assertThat(binary.getSize(), is(0l));
+        assertThat(binary, hasNoContent());
+    }
+
+    @Test( expected = IllegalArgumentException.class )
+    public void shouldNotConstructFromNullByteArray() {
+        new FileInputStreamBinary(null);
+    }
+
+    @Test
+    public void shouldHaveSizeThatMatchesContentLength() {
+        assertThat(binary.getSize(), is((long)validByteArrayContent.length));
+    }
+
+    @Test
+    public void shouldProvideInputStreamToContent() throws IOException {
+        InputStream stream = binary.getStream();
+        byte[] actual = IoUtil.readBytes(stream); // closes the stream
+        assertThat(actual.length, is(validByteArrayContent.length));
+        for (int i = 0, len = actual.length; i != len; ++i) {
+            assertThat(actual[i], is(validByteArrayContent[i]));
+        }
+    }
+
+    @Test
+    public void shouldConsiderEquivalentThoseInstancesWithSameContent() throws Exception {
+        Binary another = new FileInputStreamBinary(createFileInputStream(validByteArrayContent));
+        assertThat(binary.equals(another), is(true));
+        assertThat(binary.compareTo(another), is(0));
+        assertThat(binary, is(another));
+        assertThat(binary, hasContent(validByteArrayContent));
+        assertThat(another, hasContent(validByteArrayContent));
+    }
+
+    @Test
+    public void shouldUseSizeWhenComparing() throws Exception {
+        byte[] shorterContent = new byte[validByteArrayContent.length - 2];
+        for (int i = 0; i != shorterContent.length; ++i) {
+            shorterContent[i] = validByteArrayContent[i];
+        }
+        Binary another = new FileInputStreamBinary(createFileInputStream(shorterContent));
+        assertThat(binary.equals(another), is(false));
+        assertThat(binary.compareTo(another), is(1));
+        assertThat(another.compareTo(binary), is(-1));
+        assertThat(another, hasContent(shorterContent));
+    }
+
+    @Test
+    public void shouldComputeSha1HashOfEmptyContent() throws Exception {
+        validByteArrayContent = new byte[0];
+        binary = new FileInputStreamBinary(createFileInputStream(validByteArrayContent));
+        assertThat(binary.getSize(), is(0l));
+        assertThat(binary, hasNoContent());
+        byte[] hash = binary.getHash();
+        assertThat(hash.length, is(20));
+        assertThat(StringUtil.getHexString(hash), is("da39a3ee5e6b4b0d3255bfef95601890afd80709"));
+    }
+
+    @Test
+    public void shouldComputeSha1HashOfNonEmptyContent() throws Exception {
+        assertThat(binary.getSize(), is((long)validByteArrayContent.length));
+        byte[] hash = binary.getHash();
+        assertThat(hash.length, is(20));
+        assertThat(StringUtil.getHexString(hash), is("14abe696257e85ba18b7c784d6c7855f46ce50ea"));
+    }
+
+}

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrValueFactory.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrValueFactory.java
@@ -23,6 +23,7 @@
  */
 package org.modeshape.jcr;
 
+import java.io.FileInputStream;
 import java.io.InputStream;
 import java.math.BigDecimal;
 import java.util.Calendar;
@@ -38,6 +39,7 @@ import org.modeshape.graph.property.NamespaceRegistry;
 import org.modeshape.graph.property.Reference;
 import org.modeshape.graph.property.ReferenceFactory;
 import org.modeshape.graph.property.ValueFactories;
+import org.modeshape.graph.property.basic.FileInputStreamBinary;
 
 /**
  * The {@link ValueFactory} implementation for ModeShape.
@@ -108,7 +110,12 @@ class JcrValueFactory implements ValueFactory {
     }
 
     public JcrBinary createBinary( InputStream value ) {
-        Binary binary = valueFactories.getBinaryFactory().create(value);
+        Binary binary;
+        if (value instanceof FileInputStream) {
+            binary = new FileInputStreamBinary((FileInputStream)value);
+        } else {
+            binary = valueFactories.getBinaryFactory().create(value);
+        }
         return new JcrBinary(binary);
     }
 


### PR DESCRIPTION
MODE-1201 Using InMemoryBinary when writing to a repository can cause heap/memory problems writing large files

Attached a very crude patch that creates a new kind of Binary implementation that will lazily wrap a FileInputStream to avoid trying to load it into memory and a test case that duplicates the issue.  The patch has some problems.  It is hacked into JcrValueFactory, it violates the immutability contract that Binary implementations are supposed to implement, and it only works for FileInputStreams.  The last issue may not be a real problem, as I can't think of another InputStream at this moment that wouldn't also be subject to heapsize limitations.

Nonetheless, it works around this issue, and this issue is going to pretty important for ModeShape when it's used as an enterprise repository's backing store.
