### PR TITLE
Mode 1011 - Incorrect datatypes in ModeShape JDBC driver

### DIFF
--- a/modeshape-integration-tests/src/test/java/org/modeshape/test/integration/jdbc/JcrDriverIntegrationTest.java
+++ b/modeshape-integration-tests/src/test/java/org/modeshape/test/integration/jdbc/JcrDriverIntegrationTest.java
@@ -27,7 +27,6 @@ import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsNull.notNullValue;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.when;
-import static org.modeshape.jdbc.ConnectionResultsComparator.executeTest;
 import java.sql.DatabaseMetaData;
 import java.sql.DriverManager;
 import java.sql.ResultSet;
@@ -72,10 +71,10 @@ import org.modeshape.test.ModeShapeMultiUseTest;
  * </p>
  * <p>
  * To create the expected results to be used to run a test, use the test and print method: example:
- * DriverTestUtil.executeTestAndPrint(this.connection, "SELECT * FROM [nt:base]"); This will print the expected results like this:
+ * ConnectionResultsComparator.executeTestAndPrint(this.connection, "SELECT * FROM [nt:base]"); This will print the expected results like this:
  * String[] expected = { "jcr:primaryType[STRING]", "mode:root", "car:Car", "car:Car", "nt:unstructured" } Now copy the expected
  * results to the test method. Then change the test to run the executeTest method passing in the <code>expected</code> results:
- * example: DriverTestUtil.executeTest(this.connection, "SELECT * FROM [nt:base]", expected);
+ * example: ConnectionResultsComparator.executeTest(this.connection, "SELECT * FROM [nt:base]", expected);
  * </p>
  */
 public class JcrDriverIntegrationTest extends ModeShapeMultiUseTest {
@@ -212,7 +211,7 @@ public class JcrDriverIntegrationTest extends ModeShapeMultiUseTest {
             "nt:unstructured    /Other/NodeA[3]    NodeA    1.0    NodeA    2",
             "nt:unstructured    /Other    Other    1.0    Other    1"};
 
-        executeTest(this.connection, "SELECT * FROM [nt:base]", expected, 23);
+        ConnectionResultsComparator.executeTest(this.connection, "SELECT * FROM [nt:base]", expected, 23);
     }
 
     @Test
@@ -751,27 +750,29 @@ public class JcrDriverIntegrationTest extends ModeShapeMultiUseTest {
     @Test
     public void shouldGetAllColumnsFor1Table() throws SQLException {
         results.compareColumns = false;
-
+       
         String[] expected = {
             "TABLE_CAT[String]    TABLE_SCHEM[String]    TABLE_NAME[String]    COLUMN_NAME[String]    DATA_TYPE[Long]    TYPE_NAME[String]    COLUMN_SIZE[Long]    BUFFER_LENGTH[Long]    DECIMAL_DIGITS[Long]    NUM_PREC_RADIX[Long]    NULLABLE[Long]    REMARKS[String]    COLUMN_DEF[String]    SQL_DATA_TYPE[Long]    SQL_DATETIME_SUB[Long]    CHAR_OCTET_LENGTH[Long]    ORDINAL_POSITION[Long]    IS_NULLABLE[String]    SCOPE_CATLOG[String]    SCOPE_SCHEMA[String]    SCOPE_TABLE[String]    SOURCE_DATA_TYPE[Long]",
-            "Repo    NULL    car:Car    car:engine    12    String    50    NULL    0    0    2        NULL    0    0    0    1    YES    NULL    NULL    NULL    0",
-            "Repo    NULL    car:Car    car:lengthInInches    8    Double    20    NULL    0    0    2        NULL    0    0    0    2    YES    NULL    NULL    NULL    0",
-            "Repo    NULL    car:Car    car:maker    12    String    50    NULL    0    0    2        NULL    0    0    0    3    YES    NULL    NULL    NULL    0",
-            "Repo    NULL    car:Car    car:model    12    String    50    NULL    0    0    2        NULL    0    0    0    4    YES    NULL    NULL    NULL    0",
-            "Repo    NULL    car:Car    car:mpgCity    -5    Long    20    NULL    0    0    2        NULL    0    0    0    5    YES    NULL    NULL    NULL    0",
-            "Repo    NULL    car:Car    car:mpgHighway    -5    Long    20    NULL    0    0    2        NULL    0    0    0    6    YES    NULL    NULL    NULL    0",
-            "Repo    NULL    car:Car    car:msrp    12    String    50    NULL    0    0    2        NULL    0    0    0    7    YES    NULL    NULL    NULL    0",
-            "Repo    NULL    car:Car    car:userRating    -5    Long    20    NULL    0    0    2        NULL    0    0    0    8    YES    NULL    NULL    NULL    0",
-            "Repo    NULL    car:Car    car:valueRating    -5    Long    20    NULL    0    0    2        NULL    0    0    0    9    YES    NULL    NULL    NULL    0",
-            "Repo    NULL    car:Car    car:wheelbaseInInches    8    Double    20    NULL    0    0    2        NULL    0    0    0    10    YES    NULL    NULL    NULL    0",
-            "Repo    NULL    car:Car    car:year    12    String    50    NULL    0    0    2        NULL    0    0    0    11    YES    NULL    NULL    NULL    0",
-            "Repo    NULL    car:Car    jcr:name    12    String    20    NULL    0    0    2        NULL    0    0    0    12    YES    NULL    NULL    NULL    0",
-            "Repo    NULL    car:Car    jcr:path    12    String    50    NULL    0    0    2        NULL    0    0    0    13    YES    NULL    NULL    NULL    0",
-            "Repo    NULL    car:Car    jcr:primaryType    12    String    20    NULL    0    0    1        NULL    0    0    0    14    NO    NULL    NULL    NULL    0",
-            "Repo    NULL    car:Car    jcr:score    8    Double    20    NULL    0    0    2        NULL    0    0    0    15    YES    NULL    NULL    NULL    0",
-            "Repo    NULL    car:Car    mode:depth    -5    Long    20    NULL    0    0    2        NULL    0    0    0    16    YES    NULL    NULL    NULL    0",
-            "Repo    NULL    car:Car    mode:localName    12    String    50    NULL    0    0    2        NULL    0    0    0    17    YES    NULL    NULL    NULL    0"};
-
+            "Repo    NULL    car:Car    car:engine    12    STRING    50    NULL    0    0    2        NULL    0    0    0    1    YES    NULL    NULL    NULL    0",
+            "Repo    NULL    car:Car    car:lengthInInches    8    DOUBLE    20    NULL    0    0    2        NULL    0    0    0    2    YES    NULL    NULL    NULL    0",
+            "Repo    NULL    car:Car    car:maker    12    STRING    50    NULL    0    0    2        NULL    0    0    0    3    YES    NULL    NULL    NULL    0",
+            "Repo    NULL    car:Car    car:model    12    STRING    50    NULL    0    0    2        NULL    0    0    0    4    YES    NULL    NULL    NULL    0",
+            "Repo    NULL    car:Car    car:mpgCity    -5    LONG    20    NULL    0    0    2        NULL    0    0    0    5    YES    NULL    NULL    NULL    0",
+            "Repo    NULL    car:Car    car:mpgHighway    -5    LONG    20    NULL    0    0    2        NULL    0    0    0    6    YES    NULL    NULL    NULL    0",
+            "Repo    NULL    car:Car    car:msrp    12    STRING    50    NULL    0    0    2        NULL    0    0    0    7    YES    NULL    NULL    NULL    0",
+            "Repo    NULL    car:Car    car:userRating    -5    LONG    20    NULL    0    0    2        NULL    0    0    0    8    YES    NULL    NULL    NULL    0",
+            "Repo    NULL    car:Car    car:valueRating    -5    LONG    20    NULL    0    0    2        NULL    0    0    0    9    YES    NULL    NULL    NULL    0",
+            "Repo    NULL    car:Car    car:wheelbaseInInches    8    DOUBLE    20    NULL    0    0    2        NULL    0    0    0    10    YES    NULL    NULL    NULL    0",
+            "Repo    NULL    car:Car    car:year    12    STRING    50    NULL    0    0    2        NULL    0    0    0    11    YES    NULL    NULL    NULL    0",
+            "Repo    NULL    car:Car    jcr:name    12    NAME    20    NULL    0    0    2        NULL    0    0    0    12    YES    NULL    NULL    NULL    0",
+            "Repo    NULL    car:Car    jcr:path    12    PATH    50    NULL    0    0    2        NULL    0    0    0    13    YES    NULL    NULL    NULL    0",
+            "Repo    NULL    car:Car    jcr:primaryType    12    NAME    20    NULL    0    0    1        NULL    0    0    0    14    NO    NULL    NULL    NULL    0",
+            "Repo    NULL    car:Car    jcr:score    8    DOUBLE    20    NULL    0    0    2        NULL    0    0    0    15    YES    NULL    NULL    NULL    0",
+            "Repo    NULL    car:Car    mode:depth    -5    LONG    20    NULL    0    0    2        NULL    0    0    0    16    YES    NULL    NULL    NULL    0",
+            "Repo    NULL    car:Car    mode:localName    12    STRING    50    NULL    0    0    2        NULL    0    0    0    17    YES    NULL    NULL    NULL    0"
+            };
+        
+        
         ResultSet rs = dbmd.getColumns("%", "%", "car:Car", "%");
 
         results.assertResultsSetEquals(rs, expected);
@@ -785,11 +786,11 @@ public class JcrDriverIntegrationTest extends ModeShapeMultiUseTest {
 
         String[] expected = {
             "TABLE_CAT[String]    TABLE_SCHEM[String]    TABLE_NAME[String]    COLUMN_NAME[String]    DATA_TYPE[Long]    TYPE_NAME[String]    COLUMN_SIZE[Long]    BUFFER_LENGTH[Long]    DECIMAL_DIGITS[Long]    NUM_PREC_RADIX[Long]    NULLABLE[Long]    REMARKS[String]    COLUMN_DEF[String]    SQL_DATA_TYPE[Long]    SQL_DATETIME_SUB[Long]    CHAR_OCTET_LENGTH[Long]    ORDINAL_POSITION[Long]    IS_NULLABLE[String]    SCOPE_CATLOG[String]    SCOPE_SCHEMA[String]    SCOPE_TABLE[String]    SOURCE_DATA_TYPE[Long]",
-            "Repo    NULL    mmcore:tags    jcr:name    12    String    20    NULL    0    0    2        NULL    0    0    0    1    YES    NULL    NULL    NULL    0",
-            "Repo    NULL    mmcore:tags    jcr:path    12    String    50    NULL    0    0    2        NULL    0    0    0    2    YES    NULL    NULL    NULL    0",
-            "Repo    NULL    mmcore:tags    jcr:score    8    Double    20    NULL    0    0    2        NULL    0    0    0    3    YES    NULL    NULL    NULL    0",
-            "Repo    NULL    mmcore:tags    mode:depth    -5    Long    20    NULL    0    0    2        NULL    0    0    0    4    YES    NULL    NULL    NULL    0",
-            "Repo    NULL    mmcore:tags    mode:localName    12    String    50    NULL    0    0    2        NULL    0    0    0    5    YES    NULL    NULL    NULL    0"};
+            "Repo    NULL    mmcore:tags    jcr:name    12    NAME    20    NULL    0    0    2        NULL    0    0    0    1    YES    NULL    NULL    NULL    0",
+            "Repo    NULL    mmcore:tags    jcr:path    12    PATH    50    NULL    0    0    2        NULL    0    0    0    2    YES    NULL    NULL    NULL    0",
+            "Repo    NULL    mmcore:tags    jcr:score    8    DOUBLE    20    NULL    0    0    2        NULL    0    0    0    3    YES    NULL    NULL    NULL    0",
+            "Repo    NULL    mmcore:tags    mode:depth    -5    LONG    20    NULL    0    0    2        NULL    0    0    0    4    YES    NULL    NULL    NULL    0",
+            "Repo    NULL    mmcore:tags    mode:localName    12    STRING    50    NULL    0    0    2        NULL    0    0    0    5    YES    NULL    NULL    NULL    0"};
 
         ResultSet rs = dbmd.getColumns("%", "%", "mmcore:tags", "%");
 
@@ -804,28 +805,30 @@ public class JcrDriverIntegrationTest extends ModeShapeMultiUseTest {
 
         String[] expected = {
             "TABLE_CAT[String]    TABLE_SCHEM[String]    TABLE_NAME[String]    COLUMN_NAME[String]    DATA_TYPE[Long]    TYPE_NAME[String]    COLUMN_SIZE[Long]    BUFFER_LENGTH[Long]    DECIMAL_DIGITS[Long]    NUM_PREC_RADIX[Long]    NULLABLE[Long]    REMARKS[String]    COLUMN_DEF[String]    SQL_DATA_TYPE[Long]    SQL_DATETIME_SUB[Long]    CHAR_OCTET_LENGTH[Long]    ORDINAL_POSITION[Long]    IS_NULLABLE[String]    SCOPE_CATLOG[String]    SCOPE_SCHEMA[String]    SCOPE_TABLE[String]    SOURCE_DATA_TYPE[Long]",
-            "Repo    NULL    car:Car    car:engine    12    String    50    NULL    0    0    2        NULL    0    0    0    1    YES    NULL    NULL    NULL    0",
-            "Repo    NULL    car:Car    car:lengthInInches    8    Double    20    NULL    0    0    2        NULL    0    0    0    2    YES    NULL    NULL    NULL    0",
-            "Repo    NULL    car:Car    car:maker    12    String    50    NULL    0    0    2        NULL    0    0    0    3    YES    NULL    NULL    NULL    0",
-            "Repo    NULL    car:Car    car:model    12    String    50    NULL    0    0    2        NULL    0    0    0    4    YES    NULL    NULL    NULL    0",
-            "Repo    NULL    car:Car    car:mpgCity    -5    Long    20    NULL    0    0    2        NULL    0    0    0    5    YES    NULL    NULL    NULL    0",
-            "Repo    NULL    car:Car    car:mpgHighway    -5    Long    20    NULL    0    0    2        NULL    0    0    0    6    YES    NULL    NULL    NULL    0",
-            "Repo    NULL    car:Car    car:msrp    12    String    50    NULL    0    0    2        NULL    0    0    0    7    YES    NULL    NULL    NULL    0",
-            "Repo    NULL    car:Car    car:userRating    -5    Long    20    NULL    0    0    2        NULL    0    0    0    8    YES    NULL    NULL    NULL    0",
-            "Repo    NULL    car:Car    car:valueRating    -5    Long    20    NULL    0    0    2        NULL    0    0    0    9    YES    NULL    NULL    NULL    0",
-            "Repo    NULL    car:Car    car:wheelbaseInInches    8    Double    20    NULL    0    0    2        NULL    0    0    0    10    YES    NULL    NULL    NULL    0",
-            "Repo    NULL    car:Car    car:year    12    String    50    NULL    0    0    2        NULL    0    0    0    11    YES    NULL    NULL    NULL    0",
-            "Repo    NULL    car:Car    jcr:name    12    String    20    NULL    0    0    2        NULL    0    0    0    12    YES    NULL    NULL    NULL    0",
-            "Repo    NULL    car:Car    jcr:path    12    String    50    NULL    0    0    2        NULL    0    0    0    13    YES    NULL    NULL    NULL    0",
-            "Repo    NULL    car:Car    jcr:primaryType    12    String    20    NULL    0    0    1        NULL    0    0    0    14    NO    NULL    NULL    NULL    0",
-            "Repo    NULL    car:Car    jcr:score    8    Double    20    NULL    0    0    2        NULL    0    0    0    15    YES    NULL    NULL    NULL    0",
-            "Repo    NULL    car:Car    mode:depth    -5    Long    20    NULL    0    0    2        NULL    0    0    0    16    YES    NULL    NULL    NULL    0",
-            "Repo    NULL    car:Car    mode:localName    12    String    50    NULL    0    0    2        NULL    0    0    0    17    YES    NULL    NULL    NULL    0"};
+            "Repo    NULL    car:Car    car:engine    12    STRING    50    NULL    0    0    2        NULL    0    0    0    1    YES    NULL    NULL    NULL    0",
+            "Repo    NULL    car:Car    car:lengthInInches    8    DOUBLE    20    NULL    0    0    2        NULL    0    0    0    2    YES    NULL    NULL    NULL    0",
+            "Repo    NULL    car:Car    car:maker    12    STRING    50    NULL    0    0    2        NULL    0    0    0    3    YES    NULL    NULL    NULL    0",
+            "Repo    NULL    car:Car    car:model    12    STRING    50    NULL    0    0    2        NULL    0    0    0    4    YES    NULL    NULL    NULL    0",
+            "Repo    NULL    car:Car    car:mpgCity    -5    LONG    20    NULL    0    0    2        NULL    0    0    0    5    YES    NULL    NULL    NULL    0",
+            "Repo    NULL    car:Car    car:mpgHighway    -5    LONG    20    NULL    0    0    2        NULL    0    0    0    6    YES    NULL    NULL    NULL    0",
+            "Repo    NULL    car:Car    car:msrp    12    STRING    50    NULL    0    0    2        NULL    0    0    0    7    YES    NULL    NULL    NULL    0",
+            "Repo    NULL    car:Car    car:userRating    -5    LONG    20    NULL    0    0    2        NULL    0    0    0    8    YES    NULL    NULL    NULL    0",
+            "Repo    NULL    car:Car    car:valueRating    -5    LONG    20    NULL    0    0    2        NULL    0    0    0    9    YES    NULL    NULL    NULL    0",
+            "Repo    NULL    car:Car    car:wheelbaseInInches    8    DOUBLE    20    NULL    0    0    2        NULL    0    0    0    10    YES    NULL    NULL    NULL    0",
+            "Repo    NULL    car:Car    car:year    12    STRING    50    NULL    0    0    2        NULL    0    0    0    11    YES    NULL    NULL    NULL    0",
+            "Repo    NULL    car:Car    jcr:name    12    NAME    20    NULL    0    0    2        NULL    0    0    0    12    YES    NULL    NULL    NULL    0",
+            "Repo    NULL    car:Car    jcr:path    12    PATH    50    NULL    0    0    2        NULL    0    0    0    13    YES    NULL    NULL    NULL    0",
+            "Repo    NULL    car:Car    jcr:primaryType    12    NAME    20    NULL    0    0    1        NULL    0    0    0    14    NO    NULL    NULL    NULL    0",
+            "Repo    NULL    car:Car    jcr:score    8    DOUBLE    20    NULL    0    0    2        NULL    0    0    0    15    YES    NULL    NULL    NULL    0",
+            "Repo    NULL    car:Car    mode:depth    -5    LONG    20    NULL    0    0    2        NULL    0    0    0    16    YES    NULL    NULL    NULL    0",
+            "Repo    NULL    car:Car    mode:localName    12    STRING    50    NULL    0    0    2        NULL    0    0    0    17    YES    NULL    NULL    NULL    0"
+            };
 
         ResultSet rs = dbmd.getColumns("%", "%", "car%", "%");
 
         results.assertResultsSetEquals(rs, expected);
         results.assertRowCount(11);
+
 
     }
 
@@ -835,12 +838,14 @@ public class JcrDriverIntegrationTest extends ModeShapeMultiUseTest {
 
         String[] expected = {
             "TABLE_CAT[String]    TABLE_SCHEM[String]    TABLE_NAME[String]    COLUMN_NAME[String]    DATA_TYPE[Long]    TYPE_NAME[String]    COLUMN_SIZE[Long]    BUFFER_LENGTH[Long]    DECIMAL_DIGITS[Long]    NUM_PREC_RADIX[Long]    NULLABLE[Long]    REMARKS[String]    COLUMN_DEF[String]    SQL_DATA_TYPE[Long]    SQL_DATETIME_SUB[Long]    CHAR_OCTET_LENGTH[Long]    ORDINAL_POSITION[Long]    IS_NULLABLE[String]    SCOPE_CATLOG[String]    SCOPE_SCHEMA[String]    SCOPE_TABLE[String]    SOURCE_DATA_TYPE[Long]",
-            "Repo    NULL    car:Car    car:msrp    12    String    50    NULL    0    0    2        NULL    0    0    0    1    YES    NULL    NULL    NULL    0"};
-
+            "Repo    NULL    car:Car    car:msrp    12    STRING    50    NULL    0    0    2        NULL    0    0    0    1    YES    NULL    NULL    NULL    0"
+            };
+        
         ResultSet rs = dbmd.getColumns("%", "%", "car:Car", "car:msrp");
+      
         results.assertResultsSetEquals(rs, expected);
         results.assertRowCount(1);
-
+        
     }
 
     @FixFor( "MODE-981" )
@@ -1200,5 +1205,4 @@ public class JcrDriverIntegrationTest extends ModeShapeMultiUseTest {
         }
 
     }
-
 }

--- a/utils/modeshape-jdbc-local/src/main/java/org/modeshape/jdbc/JcrResultSet.java
+++ b/utils/modeshape-jdbc-local/src/main/java/org/modeshape/jdbc/JcrResultSet.java
@@ -1274,9 +1274,18 @@ public class JcrResultSet implements ResultSet {
                 case PropertyType.DATE:       
                 	return value.getDate();
                 case PropertyType.DOUBLE:
+                    if (value.getType() != PropertyType.DOUBLE) {
+                        Object o = getValueObject(value, value.getType());
+                        return Double.parseDouble(o.toString());
+                    }                                     
                     return value.getDouble();
                 case PropertyType.LONG:
+                    if (value.getType() != PropertyType.LONG) {
+                        Object o = getValueObject(value, value.getType());
+                        return Long.parseLong(o.toString());
+                    } 
                     return value.getLong();
+
                 case PropertyType.BINARY:
                     return value.getBinary().getStream();
             }

--- a/utils/modeshape-jdbc-local/src/main/java/org/modeshape/jdbc/JcrType.java
+++ b/utils/modeshape-jdbc-local/src/main/java/org/modeshape/jdbc/JcrType.java
@@ -71,19 +71,19 @@ public final class JcrType {
 
     static {
         Map<String, JcrType> types = new HashMap<String, JcrType>();
-        register(types, PropertyType.BINARY, Types.BLOB, "Blob", JcrBlob.class, 30, Integer.MAX_VALUE, new BlobTransform()); // assumed
-        register(types, PropertyType.BOOLEAN, Types.BOOLEAN, "Boolean", Boolean.class, 5, 1, new BooleanTransform()); // 'true' or 'false'
-        register(types, PropertyType.DATE, Types.TIMESTAMP, "Timestamp", Timestamp.class, 30, 10, new DateTransform()); // yyyy-MM-dd'T'HH:mm:ss.SSS+HH:mm
-        register(types, PropertyType.DOUBLE, Types.DOUBLE, "Double" ,Double.class, 20, 20, new DoubleTransform()); // assumed
-        register(types, PropertyType.DECIMAL, Types.DECIMAL, "Bigdecimal", BigDecimal.class, 20, 20, new DecimalTransform()); // assumed
-        register(types, PropertyType.LONG, Types.BIGINT, "Long", Long.class, 20, 19, new LongTransform()); // assumed
-        register(types, PropertyType.NAME, Types.VARCHAR, "String", String.class, 20, Integer.MAX_VALUE, new StringTransform()); // assumed
-        register(types, PropertyType.PATH, Types.VARCHAR, "String", String.class, 50, Integer.MAX_VALUE, new StringTransform()); // assumed
-        register(types, PropertyType.REFERENCE, Types.VARCHAR, "String", UUID.class, UUID_LENGTH, UUID_LENGTH, new UUIDTransform());
-        register(types, PropertyType.WEAKREFERENCE, Types.VARCHAR, "String", UUID.class, UUID_LENGTH, UUID_LENGTH, new UUIDTransform());
-        register(types, PropertyType.URI, Types.VARCHAR, "String", String.class, 50, Integer.MAX_VALUE, new StringTransform()); // assumed
-        register(types, PropertyType.STRING, Types.VARCHAR, "String", String.class, 50, Integer.MAX_VALUE, new StringTransform()); // assumed
-        register(types, PropertyType.UNDEFINED, Types.VARCHAR, "String", String.class, 50, Integer.MAX_VALUE, new StringTransform()); // same
+        register(types, PropertyType.BINARY, Types.BLOB, "BLOB", JcrBlob.class, 30, Integer.MAX_VALUE, new BlobTransform()); // assumed
+        register(types, PropertyType.BOOLEAN, Types.BOOLEAN, "BOOLEAN", Boolean.class, 5, 1, new BooleanTransform()); // 'true' or 'false'
+        register(types, PropertyType.DATE, Types.TIMESTAMP, "TIMESTAMP", Timestamp.class, 30, 10, new DateTransform()); // yyyy-MM-dd'T'HH:mm:ss.SSS+HH:mm
+        register(types, PropertyType.DOUBLE, Types.DOUBLE, "DOUBLE" ,Double.class, 20, 20, new DoubleTransform()); // assumed
+        register(types, PropertyType.DECIMAL, Types.DECIMAL, "BIGDECIMAL", BigDecimal.class, 20, 20, new DecimalTransform()); // assumed
+        register(types, PropertyType.LONG, Types.BIGINT, "LONG", Long.class, 20, 19, new LongTransform()); // assumed
+        register(types, PropertyType.NAME, Types.VARCHAR, "NAME", String.class, 20, Integer.MAX_VALUE, new StringTransform()); // assumed
+        register(types, PropertyType.PATH, Types.VARCHAR, "PATH", String.class, 50, Integer.MAX_VALUE, new StringTransform()); // assumed
+        register(types, PropertyType.REFERENCE, Types.VARCHAR, "STRING", UUID.class, UUID_LENGTH, UUID_LENGTH, new UUIDTransform());
+        register(types, PropertyType.WEAKREFERENCE, Types.VARCHAR, "STRING", UUID.class, UUID_LENGTH, UUID_LENGTH, new UUIDTransform());
+        register(types, PropertyType.URI, Types.VARCHAR, "STRING", String.class, 50, Integer.MAX_VALUE, new StringTransform()); // assumed
+        register(types, PropertyType.STRING, Types.VARCHAR, "STRING", String.class, 50, Integer.MAX_VALUE, new StringTransform()); // assumed
+        register(types, PropertyType.UNDEFINED, Types.VARCHAR, "STRING", String.class, 50, Integer.MAX_VALUE, new StringTransform()); // same
         // as
         // string
         TYPE_INFO = Collections.unmodifiableMap(types);
@@ -118,7 +118,7 @@ public final class JcrType {
                        int precision,
                        Transform transform ) {
         this.jcrType = jcrType;
-        this.jcrName = PropertyType.nameFromValue(jcrType);
+        this.jcrName = PropertyType.nameFromValue(jcrType).toUpperCase();
         this.clazz = clazz;
         this.displaySize = displaySize;
         this.jdbcType = jdbcType;
@@ -259,21 +259,17 @@ public final class JcrType {
         return jcrtype.translateValue(value);
     }
 
-    /**
-     * Get the immutable built-in map from the type names to the Java representation class.
-     * 
-     * @return the built-in type map
-     */
-    public static Map<String, JcrType> builtInTypeMap() {
-        return TYPE_INFO;
-    }
-
-    public static JcrType typeInfo( String typeName ) {
-        return TYPE_INFO.get(typeName);
+    public static JcrType typeInfo( String jcrTypeName ) {
+        return TYPE_INFO.get(jcrTypeName.toUpperCase());
     }
 
     public static JcrType typeInfo( int jcrType ) {
         return typeInfo(PropertyType.nameFromValue(jcrType));
+    }
+    
+    public static String jdbcType( String jcrTypeName ) {
+        JcrType t = typeInfo(jcrTypeName);
+        return t.getJdbcTypeName();
     }
 
 }

--- a/utils/modeshape-jdbc-local/src/test/java/org/modeshape/jdbc/JcrDriverIntegrationTest.java
+++ b/utils/modeshape-jdbc-local/src/test/java/org/modeshape/jdbc/JcrDriverIntegrationTest.java
@@ -73,10 +73,10 @@ import org.modeshape.jcr.ModeShapeRoles;
  * </p>
  * <p>
  * To create the expected results to be used to run a test, use the test and print method: example:
- * DriverTestUtil.executeTestAndPrint(this.connection, "SELECT * FROM [nt:base]"); This will print the expected results like this:
+ * this.executeTestAndPrint(this.connection, "SELECT * FROM [nt:base]"); This will print the expected results like this:
  * String[] expected = { "jcr:primaryType[STRING]", "mode:root", "car:Car", "car:Car", "nt:unstructured" } Now copy the expected
  * results to the test method. Then change the test to run the executeTest method passing in the <code>expected</code> results:
- * example: DriverTestUtil.executeTest(this.connection, "SELECT * FROM [nt:base]", expected);
+ * example: this.executeTest(this.connection, "SELECT * FROM [nt:base]", expected);
  * </p>
  */
 public class JcrDriverIntegrationTest extends ConnectionResultsComparator {
@@ -566,26 +566,27 @@ public class JcrDriverIntegrationTest extends ConnectionResultsComparator {
 
         String[] expected = {
             "TABLE_CAT[String]    TABLE_SCHEM[String]    TABLE_NAME[String]    COLUMN_NAME[String]    DATA_TYPE[Long]    TYPE_NAME[String]    COLUMN_SIZE[Long]    BUFFER_LENGTH[Long]    DECIMAL_DIGITS[Long]    NUM_PREC_RADIX[Long]    NULLABLE[Long]    REMARKS[String]    COLUMN_DEF[String]    SQL_DATA_TYPE[Long]    SQL_DATETIME_SUB[Long]    CHAR_OCTET_LENGTH[Long]    ORDINAL_POSITION[Long]    IS_NULLABLE[String]    SCOPE_CATLOG[String]    SCOPE_SCHEMA[String]    SCOPE_TABLE[String]    SOURCE_DATA_TYPE[Long]",
-            "cars    NULL    car:Car    car:engine    12    String    50    NULL    0    0    2        NULL    0    0    0    1    YES    NULL    NULL    NULL    0",
-            "cars    NULL    car:Car    car:lengthInInches    8    Double    20    NULL    0    0    2        NULL    0    0    0    2    YES    NULL    NULL    NULL    0",
-            "cars    NULL    car:Car    car:maker    12    String    50    NULL    0    0    2        NULL    0    0    0    3    YES    NULL    NULL    NULL    0",
-            "cars    NULL    car:Car    car:model    12    String    50    NULL    0    0    2        NULL    0    0    0    4    YES    NULL    NULL    NULL    0",
-            "cars    NULL    car:Car    car:mpgCity    -5    Long    20    NULL    0    0    2        NULL    0    0    0    5    YES    NULL    NULL    NULL    0",
-            "cars    NULL    car:Car    car:mpgHighway    -5    Long    20    NULL    0    0    2        NULL    0    0    0    6    YES    NULL    NULL    NULL    0",
-            "cars    NULL    car:Car    car:msrp    12    String    50    NULL    0    0    2        NULL    0    0    0    7    YES    NULL    NULL    NULL    0",
-            "cars    NULL    car:Car    car:userRating    -5    Long    20    NULL    0    0    2        NULL    0    0    0    8    YES    NULL    NULL    NULL    0",
-            "cars    NULL    car:Car    car:valueRating    -5    Long    20    NULL    0    0    2        NULL    0    0    0    9    YES    NULL    NULL    NULL    0",
-            "cars    NULL    car:Car    car:wheelbaseInInches    8    Double    20    NULL    0    0    2        NULL    0    0    0    10    YES    NULL    NULL    NULL    0",
-            "cars    NULL    car:Car    car:year    12    String    50    NULL    0    0    2        NULL    0    0    0    11    YES    NULL    NULL    NULL    0",
-            "cars    NULL    car:Car    jcr:name    12    String    20    NULL    0    0    2        NULL    0    0    0    12    YES    NULL    NULL    NULL    0",
-            "cars    NULL    car:Car    jcr:path    12    String    50    NULL    0    0    2        NULL    0    0    0    13    YES    NULL    NULL    NULL    0",
-            "cars    NULL    car:Car    jcr:primaryType    12    String    20    NULL    0    0    1        NULL    0    0    0    14    NO    NULL    NULL    NULL    0",
-            "cars    NULL    car:Car    jcr:score    8    Double    20    NULL    0    0    2        NULL    0    0    0    15    YES    NULL    NULL    NULL    0",
-            "cars    NULL    car:Car    mode:depth    -5    Long    20    NULL    0    0    2        NULL    0    0    0    16    YES    NULL    NULL    NULL    0",
-            "cars    NULL    car:Car    mode:localName    12    String    50    NULL    0    0    2        NULL    0    0    0    17    YES    NULL    NULL    NULL    0"};
-
+            "cars    NULL    car:Car    car:engine    12    STRING    50    NULL    0    0    2        NULL    0    0    0    1    YES    NULL    NULL    NULL    0",
+            "cars    NULL    car:Car    car:lengthInInches    8    DOUBLE    20    NULL    0    0    2        NULL    0    0    0    2    YES    NULL    NULL    NULL    0",
+            "cars    NULL    car:Car    car:maker    12    STRING    50    NULL    0    0    2        NULL    0    0    0    3    YES    NULL    NULL    NULL    0",
+            "cars    NULL    car:Car    car:model    12    STRING    50    NULL    0    0    2        NULL    0    0    0    4    YES    NULL    NULL    NULL    0",
+            "cars    NULL    car:Car    car:mpgCity    -5    LONG    20    NULL    0    0    2        NULL    0    0    0    5    YES    NULL    NULL    NULL    0",
+            "cars    NULL    car:Car    car:mpgHighway    -5    LONG    20    NULL    0    0    2        NULL    0    0    0    6    YES    NULL    NULL    NULL    0",
+            "cars    NULL    car:Car    car:msrp    12    STRING    50    NULL    0    0    2        NULL    0    0    0    7    YES    NULL    NULL    NULL    0",
+            "cars    NULL    car:Car    car:userRating    -5    LONG    20    NULL    0    0    2        NULL    0    0    0    8    YES    NULL    NULL    NULL    0",
+            "cars    NULL    car:Car    car:valueRating    -5    LONG    20    NULL    0    0    2        NULL    0    0    0    9    YES    NULL    NULL    NULL    0",
+            "cars    NULL    car:Car    car:wheelbaseInInches    8    DOUBLE    20    NULL    0    0    2        NULL    0    0    0    10    YES    NULL    NULL    NULL    0",
+            "cars    NULL    car:Car    car:year    12    STRING    50    NULL    0    0    2        NULL    0    0    0    11    YES    NULL    NULL    NULL    0",
+            "cars    NULL    car:Car    jcr:name    12    NAME    20    NULL    0    0    2        NULL    0    0    0    12    YES    NULL    NULL    NULL    0",
+            "cars    NULL    car:Car    jcr:path    12    PATH    50    NULL    0    0    2        NULL    0    0    0    13    YES    NULL    NULL    NULL    0",
+            "cars    NULL    car:Car    jcr:primaryType    12    NAME    20    NULL    0    0    1        NULL    0    0    0    14    NO    NULL    NULL    NULL    0",
+            "cars    NULL    car:Car    jcr:score    8    DOUBLE    20    NULL    0    0    2        NULL    0    0    0    15    YES    NULL    NULL    NULL    0",
+            "cars    NULL    car:Car    mode:depth    -5    LONG    20    NULL    0    0    2        NULL    0    0    0    16    YES    NULL    NULL    NULL    0",
+            "cars    NULL    car:Car    mode:localName    12    STRING    50    NULL    0    0    2        NULL    0    0    0    17    YES    NULL    NULL    NULL    0"
+            };
+        
+        
         ResultSet rs = dbmd.getColumns("%", "%", "car:Car", "%");
-
         assertResultsSetEquals(rs, expected);
         assertRowCount(17);
 
@@ -597,24 +598,24 @@ public class JcrDriverIntegrationTest extends ConnectionResultsComparator {
 
         String[] expected = {
             "TABLE_CAT[String]    TABLE_SCHEM[String]    TABLE_NAME[String]    COLUMN_NAME[String]    DATA_TYPE[Long]    TYPE_NAME[String]    COLUMN_SIZE[Long]    BUFFER_LENGTH[Long]    DECIMAL_DIGITS[Long]    NUM_PREC_RADIX[Long]    NULLABLE[Long]    REMARKS[String]    COLUMN_DEF[String]    SQL_DATA_TYPE[Long]    SQL_DATETIME_SUB[Long]    CHAR_OCTET_LENGTH[Long]    ORDINAL_POSITION[Long]    IS_NULLABLE[String]    SCOPE_CATLOG[String]    SCOPE_SCHEMA[String]    SCOPE_TABLE[String]    SOURCE_DATA_TYPE[Long]",
-            "cars    NULL    car:Car    car:engine    12    String    50    NULL    0    0    2        NULL    0    0    0    1    YES    NULL    NULL    NULL    0",
-            "cars    NULL    car:Car    car:lengthInInches    8    Double    20    NULL    0    0    2        NULL    0    0    0    2    YES    NULL    NULL    NULL    0",
-            "cars    NULL    car:Car    car:maker    12    String    50    NULL    0    0    2        NULL    0    0    0    3    YES    NULL    NULL    NULL    0",
-            "cars    NULL    car:Car    car:model    12    String    50    NULL    0    0    2        NULL    0    0    0    4    YES    NULL    NULL    NULL    0",
-            "cars    NULL    car:Car    car:mpgCity    -5    Long    20    NULL    0    0    2        NULL    0    0    0    5    YES    NULL    NULL    NULL    0",
-            "cars    NULL    car:Car    car:mpgHighway    -5    Long    20    NULL    0    0    2        NULL    0    0    0    6    YES    NULL    NULL    NULL    0",
-            "cars    NULL    car:Car    car:msrp    12    String    50    NULL    0    0    2        NULL    0    0    0    7    YES    NULL    NULL    NULL    0",
-            "cars    NULL    car:Car    car:userRating    -5    Long    20    NULL    0    0    2        NULL    0    0    0    8    YES    NULL    NULL    NULL    0",
-            "cars    NULL    car:Car    car:valueRating    -5    Long    20    NULL    0    0    2        NULL    0    0    0    9    YES    NULL    NULL    NULL    0",
-            "cars    NULL    car:Car    car:wheelbaseInInches    8    Double    20    NULL    0    0    2        NULL    0    0    0    10    YES    NULL    NULL    NULL    0",
-            "cars    NULL    car:Car    car:year    12    String    50    NULL    0    0    2        NULL    0    0    0    11    YES    NULL    NULL    NULL    0",
-            "cars    NULL    car:Car    jcr:name    12    String    20    NULL    0    0    2        NULL    0    0    0    12    YES    NULL    NULL    NULL    0",
-            "cars    NULL    car:Car    jcr:path    12    String    50    NULL    0    0    2        NULL    0    0    0    13    YES    NULL    NULL    NULL    0",
-            "cars    NULL    car:Car    jcr:primaryType    12    String    20    NULL    0    0    1        NULL    0    0    0    14    NO    NULL    NULL    NULL    0",
-            "cars    NULL    car:Car    jcr:score    8    Double    20    NULL    0    0    2        NULL    0    0    0    15    YES    NULL    NULL    NULL    0",
-            "cars    NULL    car:Car    mode:depth    -5    Long    20    NULL    0    0    2        NULL    0    0    0    16    YES    NULL    NULL    NULL    0",
-            "cars    NULL    car:Car    mode:localName    12    String    50    NULL    0    0    2        NULL    0    0    0    17    YES    NULL    NULL    NULL    0"};
-
+            "cars    NULL    car:Car    car:engine    12    STRING    50    NULL    0    0    2        NULL    0    0    0    1    YES    NULL    NULL    NULL    0",
+            "cars    NULL    car:Car    car:lengthInInches    8    DOUBLE    20    NULL    0    0    2        NULL    0    0    0    2    YES    NULL    NULL    NULL    0",
+            "cars    NULL    car:Car    car:maker    12    STRING    50    NULL    0    0    2        NULL    0    0    0    3    YES    NULL    NULL    NULL    0",
+            "cars    NULL    car:Car    car:model    12    STRING    50    NULL    0    0    2        NULL    0    0    0    4    YES    NULL    NULL    NULL    0",
+            "cars    NULL    car:Car    car:mpgCity    -5    LONG    20    NULL    0    0    2        NULL    0    0    0    5    YES    NULL    NULL    NULL    0",
+            "cars    NULL    car:Car    car:mpgHighway    -5    LONG    20    NULL    0    0    2        NULL    0    0    0    6    YES    NULL    NULL    NULL    0",
+            "cars    NULL    car:Car    car:msrp    12    STRING    50    NULL    0    0    2        NULL    0    0    0    7    YES    NULL    NULL    NULL    0",
+            "cars    NULL    car:Car    car:userRating    -5    LONG    20    NULL    0    0    2        NULL    0    0    0    8    YES    NULL    NULL    NULL    0",
+            "cars    NULL    car:Car    car:valueRating    -5    LONG    20    NULL    0    0    2        NULL    0    0    0    9    YES    NULL    NULL    NULL    0",
+            "cars    NULL    car:Car    car:wheelbaseInInches    8    DOUBLE    20    NULL    0    0    2        NULL    0    0    0    10    YES    NULL    NULL    NULL    0",
+            "cars    NULL    car:Car    car:year    12    STRING    50    NULL    0    0    2        NULL    0    0    0    11    YES    NULL    NULL    NULL    0",
+            "cars    NULL    car:Car    jcr:name    12    NAME    20    NULL    0    0    2        NULL    0    0    0    12    YES    NULL    NULL    NULL    0",
+            "cars    NULL    car:Car    jcr:path    12    PATH    50    NULL    0    0    2        NULL    0    0    0    13    YES    NULL    NULL    NULL    0",
+            "cars    NULL    car:Car    jcr:primaryType    12    NAME    20    NULL    0    0    1        NULL    0    0    0    14    NO    NULL    NULL    NULL    0",
+            "cars    NULL    car:Car    jcr:score    8    DOUBLE    20    NULL    0    0    2        NULL    0    0    0    15    YES    NULL    NULL    NULL    0",
+            "cars    NULL    car:Car    mode:depth    -5    LONG    20    NULL    0    0    2        NULL    0    0    0    16    YES    NULL    NULL    NULL    0",
+            "cars    NULL    car:Car    mode:localName    12    STRING    50    NULL    0    0    2        NULL    0    0    0    17    YES    NULL    NULL    NULL    0"
+            };
         ResultSet rs = dbmd.getColumns("%", "%", "car%", "%");
 
         assertResultsSetEquals(rs, expected);
@@ -628,9 +629,10 @@ public class JcrDriverIntegrationTest extends ConnectionResultsComparator {
 
         String[] expected = {
             "TABLE_CAT[String]    TABLE_SCHEM[String]    TABLE_NAME[String]    COLUMN_NAME[String]    DATA_TYPE[Long]    TYPE_NAME[String]    COLUMN_SIZE[Long]    BUFFER_LENGTH[Long]    DECIMAL_DIGITS[Long]    NUM_PREC_RADIX[Long]    NULLABLE[Long]    REMARKS[String]    COLUMN_DEF[String]    SQL_DATA_TYPE[Long]    SQL_DATETIME_SUB[Long]    CHAR_OCTET_LENGTH[Long]    ORDINAL_POSITION[Long]    IS_NULLABLE[String]    SCOPE_CATLOG[String]    SCOPE_SCHEMA[String]    SCOPE_TABLE[String]    SOURCE_DATA_TYPE[Long]",
-            "cars    NULL    car:Car    car:msrp    12    String    50    NULL    0    0    2        NULL    0    0    0    1    YES    NULL    NULL    NULL    0"};
-
+            "cars    NULL    car:Car    car:msrp    12    STRING    50    NULL    0    0    2        NULL    0    0    0    1    YES    NULL    NULL    NULL    0"
+            };
         ResultSet rs = dbmd.getColumns("%", "%", "car:Car", "car:msrp");
+
         assertResultsSetEquals(rs, expected);
         assertRowCount(1);
 

--- a/utils/modeshape-jdbc-local/src/test/java/org/modeshape/jdbc/JcrResultSetMetaDataTest.java
+++ b/utils/modeshape-jdbc-local/src/test/java/org/modeshape/jdbc/JcrResultSetMetaDataTest.java
@@ -51,7 +51,7 @@ public class JcrResultSetMetaDataTest {
     public static final String PATH = TestUtil.PATH;
     public static final String REFERENCE = TestUtil.REFERENCE;
 
-    public static final Class<?> STRING_CLASS = JcrType.builtInTypeMap().get(STRING).getRepresentationClass();
+    public static final Class<?> STRING_CLASS = JcrType.typeInfo(STRING).getRepresentationClass();
 
     private JcrResultSetMetaData metadata;
     private JcrResultSetMetaData extMetadata;
@@ -145,8 +145,9 @@ public class JcrResultSetMetaDataTest {
     @Test
     public void shouldReturnActualTypeForColumnTypeWhenResultIsExtendedJcrQueryResult() {
         for (int i = 0; i != columnNames.length; ++i) {
-            assertThat(extMetadata.getColumnTypeName(i + 1), is(typeNames[i]));
             JcrType expectedType = JcrType.typeInfo(typeNames[i]);
+            
+            assertThat(extMetadata.getColumnTypeName(i + 1), is(expectedType.getJdbcTypeName()));
             assertThat(extMetadata.getColumnType(i + 1), is(expectedType.getJdbcType()));
             assertThat(extMetadata.getColumnClassName(i + 1), is(expectedType.getRepresentationClass().getName()));
         }

--- a/utils/modeshape-jdbc-local/src/test/java/org/modeshape/jdbc/TestUtil.java
+++ b/utils/modeshape-jdbc-local/src/test/java/org/modeshape/jdbc/TestUtil.java
@@ -56,15 +56,15 @@ import org.mockito.Mockito;
  */
 public class TestUtil {
 
-    public static final String STRING = PropertyType.nameFromValue(PropertyType.STRING);
-    public static final String DOUBLE = PropertyType.nameFromValue(PropertyType.DOUBLE);
-    public static final String LONG = PropertyType.nameFromValue(PropertyType.LONG);
-    public static final String BOOLEAN = PropertyType.nameFromValue(PropertyType.BOOLEAN);
-    public static final String DATE = PropertyType.nameFromValue(PropertyType.DATE);
-    public static final String PATH = PropertyType.nameFromValue(PropertyType.PATH);
-    public static final String BINARY = PropertyType.nameFromValue(PropertyType.BINARY);
+    public static final String STRING = PropertyType.nameFromValue(PropertyType.STRING).toUpperCase();
+    public static final String DOUBLE = PropertyType.nameFromValue(PropertyType.DOUBLE).toUpperCase();
+    public static final String LONG = PropertyType.nameFromValue(PropertyType.LONG).toUpperCase();
+    public static final String BOOLEAN = PropertyType.nameFromValue(PropertyType.BOOLEAN).toUpperCase();
+    public static final String DATE = PropertyType.nameFromValue(PropertyType.DATE).toUpperCase();
+    public static final String PATH = PropertyType.nameFromValue(PropertyType.PATH).toUpperCase();
+    public static final String BINARY = PropertyType.nameFromValue(PropertyType.BINARY).toUpperCase();
 
-    public static final String REFERENCE = PropertyType.nameFromValue(PropertyType.REFERENCE);
+    public static final String REFERENCE = PropertyType.nameFromValue(PropertyType.REFERENCE).toUpperCase();
 
     public static String[] COLUMN_NAMES;
 

--- a/utils/modeshape-jdbc-local/src/test/java/org/modeshape/jdbc/util/ResultSetReader.java
+++ b/utils/modeshape-jdbc-local/src/test/java/org/modeshape/jdbc/util/ResultSetReader.java
@@ -24,7 +24,6 @@ package org.modeshape.jdbc.util;
 
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
-
 import java.io.BufferedOutputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -33,191 +32,198 @@ import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import java.sql.SQLXML;
 import java.sql.Types;
-
-import javax.jcr.PropertyType;
 import javax.jcr.Value;
 import javax.xml.transform.OutputKeys;
 import javax.xml.transform.Transformer;
 import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.stream.StreamResult;
 import javax.xml.transform.stream.StreamSource;
-
 import org.hamcrest.core.IsInstanceOf;
 import org.modeshape.jdbc.JcrResultSet;
 import org.modeshape.jdbc.JcrType;
 
-
-/** 
- * This object wraps/extends a SQL ResultSet object as Reader object. Once the
- * ResultSet can read as reader then it can be persisted, printed or compared 
- * easily without lot of code hassle of walking it every time.
- * 
- * <p>PS: remember this is a Reader not InputStream, so all the fields read
- * going to be converted to strings before they returned.
- * 
+/**
+ * This object wraps/extends a SQL ResultSet object as Reader object. Once the ResultSet can read as reader then it can be
+ * persisted, printed or compared easily without lot of code hassle of walking it every time.
+ * <p>
+ * PS: remember this is a Reader not InputStream, so all the fields read going to be converted to strings before they returned.
  */
 public class ResultSetReader extends StringLineReader {
-	private static final String DEFAULT_DELIM =  "    "; //$NON-NLS-1$
-	
+    private static final String DEFAULT_DELIM = "    "; //$NON-NLS-1$
+
     JcrResultSet source = null;
     ResultSetMetaData metadata = null;
-    
+
     // Number of columns in the result set
     int columnCount = 0;
 
-    // delimiter between the fields while reading each row 
+    // delimiter between the fields while reading each row
     String delimiter = null;
- 
+
     boolean firstTime = true;
     int[] columnTypes = null;
-    
-    private int rowCount=0;
-    
+
+    private int rowCount = 0;
+
     private boolean compareColumns = true;
-    
-    
-    public ResultSetReader(JcrResultSet in, boolean compareCols) {
-    	this(in, DEFAULT_DELIM, compareCols);       
+
+    public ResultSetReader( JcrResultSet in,
+                            boolean compareCols ) {
+        this(in, DEFAULT_DELIM, compareCols);
     }
-    
-    public ResultSetReader(ResultSet in, String delimiter, boolean compareCols) {
-        this.source = (JcrResultSet)in;        
+
+    public ResultSetReader( ResultSet in,
+                            String delimiter,
+                            boolean compareCols ) {
+        this.source = (JcrResultSet)in;
         this.delimiter = delimiter;
         this.compareColumns = compareCols;
     }
-    
-    /** 
+
+    /**
      * @see java.io.Reader#close()
      */
     @Override
     public void close() throws IOException {
         source.close();
-	super.close();
+        super.close();
     }
 
     /**
-     * Get the next line of results from the ResultSet. The first line will be the 
-     * metadata of the resultset and then followed by the result rows. Each row will be 
-     * returned as one line.  
+     * Get the next line of results from the ResultSet. The first line will be the metadata of the resultset and then followed by
+     * the result rows. Each row will be returned as one line.
+     * 
      * @return next result line from result set.
-     * @throws IOException 
+     * @throws IOException
      */
     @Override
-    protected String nextLine() throws IOException, SQLException{        
- //       try {
-            if (firstTime) {
-                firstTime = false;
-                this.metadata = source.getMetaData();
-                columnCount = metadata.getColumnCount();
-                columnTypes  = new int[columnCount];
-                for (int i = 0; i < columnCount; i++) {
-                    columnTypes[i] = metadata.getColumnType(i+1);
-                }
-                return resultSetMetaDataToString(metadata, delimiter);
+    protected String nextLine() throws IOException, SQLException {
+        if (firstTime) {
+            firstTime = false;
+            this.metadata = source.getMetaData();
+            columnCount = metadata.getColumnCount();
+            columnTypes = new int[columnCount];
+            for (int i = 0; i < columnCount; i++) {
+                columnTypes[i] = metadata.getColumnType(i + 1);
             }
-            
-            // if you get here then we are ready to read the results.
-            if (source.next()) {
-            	rowCount++;
-            	
-                final StringBuffer sb = new StringBuffer();
-                // Walk through column values in this row
-                for (int col = 1; col <= columnCount; col++) {
-                	// this does not work when database metadata is being queried
-                	if (compareColumns) compareColumn(col);
-                     
-                    final Object anObj = source.getObject(col);
-                    if (columnTypes[col-1] == Types.CLOB) {
-                        sb.append(anObj != null ? anObj : "null"); //$NON-NLS-1$
-                    }
-                    else if (columnTypes[col-1] == Types.BLOB) {
-                        sb.append(anObj != null ? "BLOB" : "null"); //$NON-NLS-1$ //$NON-NLS-2$
-                    }
-                    else if (columnTypes[col-1] == Types.SQLXML) {
-                    	final SQLXML xml = (SQLXML)anObj;
-                    	sb.append(anObj != null ? prettyPrint(xml) : "null"); //$NON-NLS-1$
-                    }
-                    else {
-                        sb.append(anObj != null ? anObj : "null"); //$NON-NLS-1$
-                    }
-                    if (col != columnCount) {
-                        sb.append(delimiter); 
-                    }                    
+            return resultSetMetaDataToString(metadata, delimiter);
+        }
+
+        // if you get here then we are ready to read the results.
+        if (source.next()) {
+            rowCount++;
+
+            final StringBuffer sb = new StringBuffer();
+            // Walk through column values in this row
+            for (int col = 1; col <= columnCount; col++) {
+                // this does not work when database metadata is being queried
+                final Object anObj = source.getObject(col);
+                
+                if (compareColumns) compareColumn(col, anObj);
+
+                
+                if (columnTypes[col - 1] == Types.CLOB) {
+                    sb.append(anObj != null ? anObj : "null"); //$NON-NLS-1$
+                } else if (columnTypes[col - 1] == Types.BLOB) {
+                    sb.append(anObj != null ? "BLOB" : "null"); //$NON-NLS-1$ //$NON-NLS-2$
+                } else if (columnTypes[col - 1] == Types.SQLXML) {
+                    final SQLXML xml = (SQLXML)anObj;
+                    sb.append(anObj != null ? prettyPrint(xml) : "null"); //$NON-NLS-1$
+                } else {
+                    sb.append(anObj != null ? anObj : "null"); //$NON-NLS-1$
                 }
-                sb.append("\n"); //$NON-NLS-1$
-                return sb.toString();
+                if (col != columnCount) {
+                    sb.append(delimiter);
+                }
             }
-       
+            sb.append("\n"); //$NON-NLS-1$
+            return sb.toString();
+        }
+
         return null;
     }
-    
-    private void compareColumn(int col) throws SQLException {
 
-	    Object objIdx = source.getObject(col);
+    private void compareColumn( int col, Object objIdx ) throws SQLException {
 
-	    String colName = metadata.getColumnName(col);
-	    Object objName = source.getObject(colName);
-	    
-	    assertThat(objIdx, is(objName));
-	    
-	    if (objIdx == null) return;
-	    	       
-	    Value v = source.getValue(col);
-	    
-	    JcrType jcrType = JcrType.builtInTypeMap().get(PropertyType.nameFromValue(v.getType()));
-	    
-	    assertThat(objIdx, IsInstanceOf.instanceOf(jcrType.getRepresentationClass()));
-		  
+        String colName = metadata.getColumnName(col);
+        Object objName = source.getObject(colName);
+
+        assertThat(objIdx, is(objName));
+
+        if (objIdx == null) return;
+
+        Value v = source.getValue(col);
+
+        JcrType jcrType = JcrType.typeInfo(v.getType());
+
+        assertThat(objIdx, IsInstanceOf.instanceOf(jcrType.getRepresentationClass()));
+
     }
-    
+
     public int getRowCount() {
-		return rowCount;
-	}
-    
+        return rowCount;
+    }
+
     /**
-     * Get the first line from the result set. This is the resultset metadata line where
-     * we gather the column names and their types. 
-     * @param metadata 
-     * @param delimiter 
+     * Get the first line from the result set. This is the resultset metadata line where we gather the column names and their
+     * types.
+     * 
+     * @param metadata
+     * @param delimiter
      * @return String
      * @throws SQLException
      */
-    public static String resultSetMetaDataToString(ResultSetMetaData metadata, String delimiter) throws SQLException{
+    public static String resultSetMetaDataToString( ResultSetMetaData metadata,
+                                                    String delimiter ) throws SQLException {
+
         StringBuffer sb = new StringBuffer();
         int columnCount = metadata.getColumnCount();
+
         for (int col = 1; col <= columnCount; col++) {
-            sb.append(metadata.getColumnName(col))
-                .append("[")          //$NON-NLS-1$
-                .append(metadata.getColumnTypeName(col))
-                .append("]");       //$NON-NLS-1$
+            String colName = metadata.getColumnName(col);
+            String colTypeName = metadata.getColumnTypeName(col);
+
+            /**
+             * performing specific checks to make sure these are defined as expected.
+             */
+            if (colName.equalsIgnoreCase("jcr:score")) {
+                JcrType jcrType = JcrType.typeInfo(JcrType.DefaultDataTypes.DOUBLE);
+                assertThat(colTypeName, is(jcrType.getJcrName()));
+            } else if (colName.equalsIgnoreCase("mode:depth")) {
+                JcrType jcrType = JcrType.typeInfo(JcrType.DefaultDataTypes.LONG);
+                assertThat(colTypeName, is(jcrType.getJcrName()));
+            }
+
+            sb.append(colName).append("[") //$NON-NLS-1$
+            .append(colTypeName).append("]"); //$NON-NLS-1$
             if (col != columnCount) {
                 sb.append(delimiter);
             }
         }
         sb.append("\n"); //$NON-NLS-1$
-        return sb.toString();        
+        return sb.toString();
     }
-    
-	public static String prettyPrint(SQLXML xml) throws SQLException {
-		try {
-			TransformerFactory transFactory = TransformerFactory.newInstance();
-			transFactory.setAttribute("indent-number", new Integer(2)); //$NON-NLS-1$
-			
-			Transformer tf = transFactory.newTransformer();
-			tf.setOutputProperty(OutputKeys.OMIT_XML_DECLARATION, "yes"); //$NON-NLS-1$
-			tf.setOutputProperty(OutputKeys.ENCODING, "UTF-8");//$NON-NLS-1$
-			tf.setOutputProperty(OutputKeys.INDENT, "yes");//$NON-NLS-1$
-			tf.setOutputProperty(OutputKeys.METHOD, "xml");//$NON-NLS-1$
-			tf.setOutputProperty(OutputKeys.STANDALONE, "yes");//$NON-NLS-1$
-			tf.setOutputProperty("{http://xml.apache.org/xslt}indent-amount", "4"); //$NON-NLS-1$ //$NON-NLS-2$
-			
-			ByteArrayOutputStream out = new ByteArrayOutputStream();
-			StreamResult xmlOut = new StreamResult(new BufferedOutputStream(out));
-			tf.transform(xml.getSource(StreamSource.class), xmlOut);
-			
-			return out.toString();
-		} catch (Exception e) {
-			return xml.getString();
-		}
-	}   
+
+    public static String prettyPrint( SQLXML xml ) throws SQLException {
+        try {
+            TransformerFactory transFactory = TransformerFactory.newInstance();
+            transFactory.setAttribute("indent-number", new Integer(2)); //$NON-NLS-1$
+
+            Transformer tf = transFactory.newTransformer();
+            tf.setOutputProperty(OutputKeys.OMIT_XML_DECLARATION, "yes"); //$NON-NLS-1$
+            tf.setOutputProperty(OutputKeys.ENCODING, "UTF-8");//$NON-NLS-1$
+            tf.setOutputProperty(OutputKeys.INDENT, "yes");//$NON-NLS-1$
+            tf.setOutputProperty(OutputKeys.METHOD, "xml");//$NON-NLS-1$
+            tf.setOutputProperty(OutputKeys.STANDALONE, "yes");//$NON-NLS-1$
+            tf.setOutputProperty("{http://xml.apache.org/xslt}indent-amount", "4"); //$NON-NLS-1$ //$NON-NLS-2$
+
+            ByteArrayOutputStream out = new ByteArrayOutputStream();
+            StreamResult xmlOut = new StreamResult(new BufferedOutputStream(out));
+            tf.transform(xml.getSource(StreamSource.class), xmlOut);
+
+            return out.toString();
+        } catch (Exception e) {
+            return xml.getString();
+        }
+    }
 }

--- a/utils/modeshape-jdbc/src/test/java/org/modeshape/jdbc/JcrDriverIntegrationTest.java
+++ b/utils/modeshape-jdbc/src/test/java/org/modeshape/jdbc/JcrDriverIntegrationTest.java
@@ -566,24 +566,24 @@ public class JcrDriverIntegrationTest extends ConnectionResultsComparator {
 
         String[] expected = {
             "TABLE_CAT[String]    TABLE_SCHEM[String]    TABLE_NAME[String]    COLUMN_NAME[String]    DATA_TYPE[Long]    TYPE_NAME[String]    COLUMN_SIZE[Long]    BUFFER_LENGTH[Long]    DECIMAL_DIGITS[Long]    NUM_PREC_RADIX[Long]    NULLABLE[Long]    REMARKS[String]    COLUMN_DEF[String]    SQL_DATA_TYPE[Long]    SQL_DATETIME_SUB[Long]    CHAR_OCTET_LENGTH[Long]    ORDINAL_POSITION[Long]    IS_NULLABLE[String]    SCOPE_CATLOG[String]    SCOPE_SCHEMA[String]    SCOPE_TABLE[String]    SOURCE_DATA_TYPE[Long]",
-            "cars    NULL    car:Car    car:engine    12    String    50    NULL    0    0    2        NULL    0    0    0    1    YES    NULL    NULL    NULL    0",
-            "cars    NULL    car:Car    car:lengthInInches    8    Double    20    NULL    0    0    2        NULL    0    0    0    2    YES    NULL    NULL    NULL    0",
-            "cars    NULL    car:Car    car:maker    12    String    50    NULL    0    0    2        NULL    0    0    0    3    YES    NULL    NULL    NULL    0",
-            "cars    NULL    car:Car    car:model    12    String    50    NULL    0    0    2        NULL    0    0    0    4    YES    NULL    NULL    NULL    0",
-            "cars    NULL    car:Car    car:mpgCity    -5    Long    20    NULL    0    0    2        NULL    0    0    0    5    YES    NULL    NULL    NULL    0",
-            "cars    NULL    car:Car    car:mpgHighway    -5    Long    20    NULL    0    0    2        NULL    0    0    0    6    YES    NULL    NULL    NULL    0",
-            "cars    NULL    car:Car    car:msrp    12    String    50    NULL    0    0    2        NULL    0    0    0    7    YES    NULL    NULL    NULL    0",
-            "cars    NULL    car:Car    car:userRating    -5    Long    20    NULL    0    0    2        NULL    0    0    0    8    YES    NULL    NULL    NULL    0",
-            "cars    NULL    car:Car    car:valueRating    -5    Long    20    NULL    0    0    2        NULL    0    0    0    9    YES    NULL    NULL    NULL    0",
-            "cars    NULL    car:Car    car:wheelbaseInInches    8    Double    20    NULL    0    0    2        NULL    0    0    0    10    YES    NULL    NULL    NULL    0",
-            "cars    NULL    car:Car    car:year    12    String    50    NULL    0    0    2        NULL    0    0    0    11    YES    NULL    NULL    NULL    0",
-            "cars    NULL    car:Car    jcr:name    12    String    20    NULL    0    0    2        NULL    0    0    0    12    YES    NULL    NULL    NULL    0",
-            "cars    NULL    car:Car    jcr:path    12    String    50    NULL    0    0    2        NULL    0    0    0    13    YES    NULL    NULL    NULL    0",
-            "cars    NULL    car:Car    jcr:primaryType    12    String    20    NULL    0    0    1        NULL    0    0    0    14    NO    NULL    NULL    NULL    0",
-            "cars    NULL    car:Car    jcr:score    8    Double    20    NULL    0    0    2        NULL    0    0    0    15    YES    NULL    NULL    NULL    0",
-            "cars    NULL    car:Car    mode:depth    -5    Long    20    NULL    0    0    2        NULL    0    0    0    16    YES    NULL    NULL    NULL    0",
-            "cars    NULL    car:Car    mode:localName    12    String    50    NULL    0    0    2        NULL    0    0    0    17    YES    NULL    NULL    NULL    0"};
-
+            "cars    NULL    car:Car    car:engine    12    STRING    50    NULL    0    0    2        NULL    0    0    0    1    YES    NULL    NULL    NULL    0",
+            "cars    NULL    car:Car    car:lengthInInches    8    DOUBLE    20    NULL    0    0    2        NULL    0    0    0    2    YES    NULL    NULL    NULL    0",
+            "cars    NULL    car:Car    car:maker    12    STRING    50    NULL    0    0    2        NULL    0    0    0    3    YES    NULL    NULL    NULL    0",
+            "cars    NULL    car:Car    car:model    12    STRING    50    NULL    0    0    2        NULL    0    0    0    4    YES    NULL    NULL    NULL    0",
+            "cars    NULL    car:Car    car:mpgCity    -5    LONG    20    NULL    0    0    2        NULL    0    0    0    5    YES    NULL    NULL    NULL    0",
+            "cars    NULL    car:Car    car:mpgHighway    -5    LONG    20    NULL    0    0    2        NULL    0    0    0    6    YES    NULL    NULL    NULL    0",
+            "cars    NULL    car:Car    car:msrp    12    STRING    50    NULL    0    0    2        NULL    0    0    0    7    YES    NULL    NULL    NULL    0",
+            "cars    NULL    car:Car    car:userRating    -5    LONG    20    NULL    0    0    2        NULL    0    0    0    8    YES    NULL    NULL    NULL    0",
+            "cars    NULL    car:Car    car:valueRating    -5    LONG    20    NULL    0    0    2        NULL    0    0    0    9    YES    NULL    NULL    NULL    0",
+            "cars    NULL    car:Car    car:wheelbaseInInches    8    DOUBLE    20    NULL    0    0    2        NULL    0    0    0    10    YES    NULL    NULL    NULL    0",
+            "cars    NULL    car:Car    car:year    12    STRING    50    NULL    0    0    2        NULL    0    0    0    11    YES    NULL    NULL    NULL    0",
+            "cars    NULL    car:Car    jcr:name    12    NAME    20    NULL    0    0    2        NULL    0    0    0    12    YES    NULL    NULL    NULL    0",
+            "cars    NULL    car:Car    jcr:path    12    PATH    50    NULL    0    0    2        NULL    0    0    0    13    YES    NULL    NULL    NULL    0",
+            "cars    NULL    car:Car    jcr:primaryType    12    NAME    20    NULL    0    0    1        NULL    0    0    0    14    NO    NULL    NULL    NULL    0",
+            "cars    NULL    car:Car    jcr:score    8    DOUBLE    20    NULL    0    0    2        NULL    0    0    0    15    YES    NULL    NULL    NULL    0",
+            "cars    NULL    car:Car    mode:depth    -5    LONG    20    NULL    0    0    2        NULL    0    0    0    16    YES    NULL    NULL    NULL    0",
+            "cars    NULL    car:Car    mode:localName    12    STRING    50    NULL    0    0    2        NULL    0    0    0    17    YES    NULL    NULL    NULL    0"
+            };
         ResultSet rs = dbmd.getColumns("%", "%", "car:Car", "%");
 
         assertResultsSetEquals(rs, expected);
@@ -597,23 +597,24 @@ public class JcrDriverIntegrationTest extends ConnectionResultsComparator {
 
         String[] expected = {
             "TABLE_CAT[String]    TABLE_SCHEM[String]    TABLE_NAME[String]    COLUMN_NAME[String]    DATA_TYPE[Long]    TYPE_NAME[String]    COLUMN_SIZE[Long]    BUFFER_LENGTH[Long]    DECIMAL_DIGITS[Long]    NUM_PREC_RADIX[Long]    NULLABLE[Long]    REMARKS[String]    COLUMN_DEF[String]    SQL_DATA_TYPE[Long]    SQL_DATETIME_SUB[Long]    CHAR_OCTET_LENGTH[Long]    ORDINAL_POSITION[Long]    IS_NULLABLE[String]    SCOPE_CATLOG[String]    SCOPE_SCHEMA[String]    SCOPE_TABLE[String]    SOURCE_DATA_TYPE[Long]",
-            "cars    NULL    car:Car    car:engine    12    String    50    NULL    0    0    2        NULL    0    0    0    1    YES    NULL    NULL    NULL    0",
-            "cars    NULL    car:Car    car:lengthInInches    8    Double    20    NULL    0    0    2        NULL    0    0    0    2    YES    NULL    NULL    NULL    0",
-            "cars    NULL    car:Car    car:maker    12    String    50    NULL    0    0    2        NULL    0    0    0    3    YES    NULL    NULL    NULL    0",
-            "cars    NULL    car:Car    car:model    12    String    50    NULL    0    0    2        NULL    0    0    0    4    YES    NULL    NULL    NULL    0",
-            "cars    NULL    car:Car    car:mpgCity    -5    Long    20    NULL    0    0    2        NULL    0    0    0    5    YES    NULL    NULL    NULL    0",
-            "cars    NULL    car:Car    car:mpgHighway    -5    Long    20    NULL    0    0    2        NULL    0    0    0    6    YES    NULL    NULL    NULL    0",
-            "cars    NULL    car:Car    car:msrp    12    String    50    NULL    0    0    2        NULL    0    0    0    7    YES    NULL    NULL    NULL    0",
-            "cars    NULL    car:Car    car:userRating    -5    Long    20    NULL    0    0    2        NULL    0    0    0    8    YES    NULL    NULL    NULL    0",
-            "cars    NULL    car:Car    car:valueRating    -5    Long    20    NULL    0    0    2        NULL    0    0    0    9    YES    NULL    NULL    NULL    0",
-            "cars    NULL    car:Car    car:wheelbaseInInches    8    Double    20    NULL    0    0    2        NULL    0    0    0    10    YES    NULL    NULL    NULL    0",
-            "cars    NULL    car:Car    car:year    12    String    50    NULL    0    0    2        NULL    0    0    0    11    YES    NULL    NULL    NULL    0",
-            "cars    NULL    car:Car    jcr:name    12    String    20    NULL    0    0    2        NULL    0    0    0    12    YES    NULL    NULL    NULL    0",
-            "cars    NULL    car:Car    jcr:path    12    String    50    NULL    0    0    2        NULL    0    0    0    13    YES    NULL    NULL    NULL    0",
-            "cars    NULL    car:Car    jcr:primaryType    12    String    20    NULL    0    0    1        NULL    0    0    0    14    NO    NULL    NULL    NULL    0",
-            "cars    NULL    car:Car    jcr:score    8    Double    20    NULL    0    0    2        NULL    0    0    0    15    YES    NULL    NULL    NULL    0",
-            "cars    NULL    car:Car    mode:depth    -5    Long    20    NULL    0    0    2        NULL    0    0    0    16    YES    NULL    NULL    NULL    0",
-            "cars    NULL    car:Car    mode:localName    12    String    50    NULL    0    0    2        NULL    0    0    0    17    YES    NULL    NULL    NULL    0"};
+            "cars    NULL    car:Car    car:engine    12    STRING    50    NULL    0    0    2        NULL    0    0    0    1    YES    NULL    NULL    NULL    0",
+            "cars    NULL    car:Car    car:lengthInInches    8    DOUBLE    20    NULL    0    0    2        NULL    0    0    0    2    YES    NULL    NULL    NULL    0",
+            "cars    NULL    car:Car    car:maker    12    STRING    50    NULL    0    0    2        NULL    0    0    0    3    YES    NULL    NULL    NULL    0",
+            "cars    NULL    car:Car    car:model    12    STRING    50    NULL    0    0    2        NULL    0    0    0    4    YES    NULL    NULL    NULL    0",
+            "cars    NULL    car:Car    car:mpgCity    -5    LONG    20    NULL    0    0    2        NULL    0    0    0    5    YES    NULL    NULL    NULL    0",
+            "cars    NULL    car:Car    car:mpgHighway    -5    LONG    20    NULL    0    0    2        NULL    0    0    0    6    YES    NULL    NULL    NULL    0",
+            "cars    NULL    car:Car    car:msrp    12    STRING    50    NULL    0    0    2        NULL    0    0    0    7    YES    NULL    NULL    NULL    0",
+            "cars    NULL    car:Car    car:userRating    -5    LONG    20    NULL    0    0    2        NULL    0    0    0    8    YES    NULL    NULL    NULL    0",
+            "cars    NULL    car:Car    car:valueRating    -5    LONG    20    NULL    0    0    2        NULL    0    0    0    9    YES    NULL    NULL    NULL    0",
+            "cars    NULL    car:Car    car:wheelbaseInInches    8    DOUBLE    20    NULL    0    0    2        NULL    0    0    0    10    YES    NULL    NULL    NULL    0",
+            "cars    NULL    car:Car    car:year    12    STRING    50    NULL    0    0    2        NULL    0    0    0    11    YES    NULL    NULL    NULL    0",
+            "cars    NULL    car:Car    jcr:name    12    NAME    20    NULL    0    0    2        NULL    0    0    0    12    YES    NULL    NULL    NULL    0",
+            "cars    NULL    car:Car    jcr:path    12    PATH    50    NULL    0    0    2        NULL    0    0    0    13    YES    NULL    NULL    NULL    0",
+            "cars    NULL    car:Car    jcr:primaryType    12    NAME    20    NULL    0    0    1        NULL    0    0    0    14    NO    NULL    NULL    NULL    0",
+            "cars    NULL    car:Car    jcr:score    8    DOUBLE    20    NULL    0    0    2        NULL    0    0    0    15    YES    NULL    NULL    NULL    0",
+            "cars    NULL    car:Car    mode:depth    -5    LONG    20    NULL    0    0    2        NULL    0    0    0    16    YES    NULL    NULL    NULL    0",
+            "cars    NULL    car:Car    mode:localName    12    STRING    50    NULL    0    0    2        NULL    0    0    0    17    YES    NULL    NULL    NULL    0"
+            };
 
         ResultSet rs = dbmd.getColumns("%", "%", "car%", "%");
 
@@ -628,7 +629,8 @@ public class JcrDriverIntegrationTest extends ConnectionResultsComparator {
 
         String[] expected = {
             "TABLE_CAT[String]    TABLE_SCHEM[String]    TABLE_NAME[String]    COLUMN_NAME[String]    DATA_TYPE[Long]    TYPE_NAME[String]    COLUMN_SIZE[Long]    BUFFER_LENGTH[Long]    DECIMAL_DIGITS[Long]    NUM_PREC_RADIX[Long]    NULLABLE[Long]    REMARKS[String]    COLUMN_DEF[String]    SQL_DATA_TYPE[Long]    SQL_DATETIME_SUB[Long]    CHAR_OCTET_LENGTH[Long]    ORDINAL_POSITION[Long]    IS_NULLABLE[String]    SCOPE_CATLOG[String]    SCOPE_SCHEMA[String]    SCOPE_TABLE[String]    SOURCE_DATA_TYPE[Long]",
-            "cars    NULL    car:Car    car:msrp    12    String    50    NULL    0    0    2        NULL    0    0    0    1    YES    NULL    NULL    NULL    0"};
+            "cars    NULL    car:Car    car:msrp    12    STRING    50    NULL    0    0    2        NULL    0    0    0    1    YES    NULL    NULL    NULL    0"
+            };
 
         ResultSet rs = dbmd.getColumns("%", "%", "car:Car", "car:msrp");
         assertResultsSetEquals(rs, expected);


### PR DESCRIPTION
Changed the resultset related classes to return jdbc column type name, instead of the jcr name as the column type name.    Also, had to fix the logic to match the uppercase jcr name returned in the query results in order to make the match to the JcrType used to provide the jdbc type.
