### PR TITLE
MODE-1215 java.lang.StackOverflowError seen in the server when accessing 

### DIFF
--- a/utils/modeshape-jdbc-local/src/main/resources/org/modeshape/jdbc/JdbcLocalI18n.properties
+++ b/utils/modeshape-jdbc-local/src/main/resources/org/modeshape/jdbc/JdbcLocalI18n.properties
@@ -33,8 +33,7 @@ i18nLocalizationProblems = Problems were encountered while localizing internatio
 i18nPropertyDuplicate = Duplicate property values were found for property "{0}"  in localization file "{1}";
 i18nPropertyMissing = Missing property "{0}" in localization file "{1}".
 i18nPropertyUnused = An unused property, "{0}", was found in localization file "{1}".
-i18nRequiredToSuppliedParameterMismatch = Internationalization field "{0}" in {1}: {2}
-
+i18nRequiredToSuppliedParameterMismatch = {0} parameter{1} supplied, but {2} parameter{3} required: "{4}" => "{5}"
 
 driverName = ModeShape JDBC Driver for JCR
 driverVendor=${jcr.repository.vendor}

--- a/utils/modeshape-jdbc-local/src/test/java/org/modeshape/jdbc/util/StringUtilTest.java
+++ b/utils/modeshape-jdbc-local/src/test/java/org/modeshape/jdbc/util/StringUtilTest.java
@@ -1,0 +1,29 @@
+package org.modeshape.jdbc.util;
+
+import org.junit.Test;
+
+public class StringUtilTest {
+
+    @Test( expected = IllegalArgumentException.class )
+    public void createStringShouldFailIfTooFewArgumentsSupplied() {
+        String pattern = "This {0} is {1} should {2} not {3} last {4}";
+        try {
+            StringUtil.createString(pattern, "one", "two", "three", "four");
+        } catch (IllegalArgumentException err) {
+            System.err.println(err);
+            throw err;
+        }
+    }
+
+    @Test( expected = IllegalArgumentException.class )
+    public void createStringShouldFailIfTooManyArgumentsSupplied() {
+        String pattern = "This {0} is {1} should {2} not {3} last {4}";
+        try {
+            StringUtil.createString(pattern, "one", "two", "three", "four", "five", "six");
+        } catch (IllegalArgumentException err) {
+            System.err.println(err);
+            throw err;
+        }
+    }
+
+}


### PR DESCRIPTION
MODE-1215 java.lang.StackOverflowError seen in the server when accessing ModeShape through Teiid

Fixed a bad I18n message and added a test case to verify that the behavior was broken and is now fixed.  Unfortunately, the I18n message that was bad was the same error message that gets used when the I18n message is bad - hence the stack overflow.
