### PR TITLE
MODE-1214 modeshape-connector-store-jpa issue when trying to start JBoss 

### DIFF
--- a/extensions/modeshape-connector-store-jpa/src/main/java/org/modeshape/connector/store/jpa/JpaSource.java
+++ b/extensions/modeshape-connector-store-jpa/src/main/java/org/modeshape/connector/store/jpa/JpaSource.java
@@ -174,7 +174,7 @@ public class JpaSource implements RepositorySource, ObjectFactory {
     /**
      * The {@link #getCacheProviderClassName() class name of the JPA cache provider} is "{@value} ", unless otherwise specified.
      */
-    public static final String DEFAULT_CACHE_PROVIDER_CLASS_NAME = "org.hibernate.cache.HashtableCacheProvider";
+    public static final String DEFAULT_CACHE_PROVIDER_CLASS_NAME = null;
 
     /**
      * The {@link #getCacheConcurrencyStrategy() cache concurrency strategy} is "{@value} ", unless otherwise specified.

--- a/modeshape-integration-tests/src/test/java/org/modeshape/test/integration/ClusteringTest.java
+++ b/modeshape-integration-tests/src/test/java/org/modeshape/test/integration/ClusteringTest.java
@@ -62,9 +62,9 @@ import org.modeshape.common.util.FileUtil;
 import org.modeshape.connector.store.jpa.JpaSource;
 import org.modeshape.jcr.JcrConfiguration;
 import org.modeshape.jcr.JcrEngine;
-import org.modeshape.jcr.JcrRepository.Option;
 import org.modeshape.jcr.ModeShapeRoles;
 import org.modeshape.jcr.NodeTypeAssertion;
+import org.modeshape.jcr.JcrRepository.Option;
 
 public class ClusteringTest {
 
@@ -105,7 +105,9 @@ public class ClusteringTest {
                      .setProperty("retryLimit", "3")
                      .setProperty("showSql", "false")
                      .setProperty("defaultWorkspaceName", "content")
+                     .setProperty("cacheProviderClassName",(String) null)
                      .setProperty("predefinedWorkspaceNames", new String[] {"content", "system"});
+                        
         configuration.repository("cars")
                      .setSource("car-source")
                      .registerNamespace("car", "http://www.modeshape.org/examples/cars/1.0")


### PR DESCRIPTION
Fixed default cacheProviderClassName value to 'null' on JpaSource.
