### PR TITLE
MODE-1164 change configuration to use JDBC data source rather in-memory. 

### DIFF
--- a/deploy/jbossas/modeshape-jbossas-service/src/kit/modeshape-config.xml
+++ b/deploy/jbossas/modeshape-jbossas-service/src/kit/modeshape-config.xml
@@ -81,7 +81,7 @@
     <mode:sources jcr:primaryType="nt:unstructured">
         <!-- 
         If you wanted to use the driver directly instead of using the JNDI reference, you would replace
-			mode:dataSourceJndiName="java:/DefaultDS" 
+			mode:dataSourceJndiName="java:DefaultDS" 
 			
 		with these:
         	mode:driverClassName="org.hsqldb.jdbcDriver"


### PR DESCRIPTION
MODE-1164 change configuration to use JDBC data source rather in-memory.  HSQL will be used becuase it is the default used in jboss as
