### PR TITLE
MODE-456 Create SequencerOutputMap.addProperty Method

### DIFF
--- a/docs/gettingstarted/src/main/docbook/en-US/content/sequencer_example.xml
+++ b/docs/gettingstarted/src/main/docbook/en-US/content/sequencer_example.xml
@@ -337,58 +337,6 @@ public ConsoleInput( SequencerClient client ) {
   }
 }
   ]]></programlisting>
-		<para>
-			There is one more aspect of this example that is worth discussing.  While the repository example in the
-			<link linkend="repository_example">next chapter</link> does show how to use JAAS, this example intentionally shows how
-			you might integrate a different security system into ModeShape.  In the <code>createSession()</code> method,
-			the <code>RepositoryClient</code> creates a <code>SecurityContextCredentials</code> wrapper around a custom
-			<code>SecurityContext</code> implementation, then passes that credentials into the <code>login(Credentials,String)</code>
-			method:
-		</para>
-    <programlisting language="JAVA" role="JAVA"><![CDATA[
-protected Session createSession() throws RepositoryException {
-    SecurityContext securityContext = new MyCustomSecurityContext();
-    SecurityContextCredentials credentials = new SecurityContextCredentials(securityContext);
-    return this.repository.login(credentials, workspaceName);
-}
-  ]]></programlisting>
-		<para>
-			where the custom <code>SecurityContext</code> implementation is as follows:
-		</para>
-   <programlisting language="JAVA" role="JAVA"><![CDATA[
-protected class MyCustomSecurityContext implements SecurityContext {
-    /**
-     * @see org.modeshape.graph.SecurityContext#getUserName()
-     */
-    public String getUserName() {
-        return "Fred";
-    }
-
-    /**
-     * @see org.modeshape.graph.SecurityContext#hasRole(java.lang.String)
-     */
-    public boolean hasRole( String roleName ) {
-        return true;
-    }
-
-    /**
-     * @see org.modeshape.graph.SecurityContext#logout()
-     */
-    public void logout() {
-        // do something
-    }
-}
- ]]></programlisting>
-		<para>
-			Obviously you would want to implement this correctly.  If you're using ModeShape in a web application, your <code>SecurityContext</code>
-			implementation would likely delegate to the <code>HttpServletRequest</code>.
-		</para>
-		<para>
-			But if you're using JAAS, then you could just pass in a <code>javax.jcr.SimpleCredentials</code> with the username and password,
-			as long as your <code>JcrConfiguration</code>'s repository definitions are set up to use the correct JAAS login context name
-			(see the repository example in the <link linkend="repository_example">next chapter</link>).  Or, you could use the approach listed
-			above and supply an instance of the <code>JaasSecurityContext</code> to the <code>SecurityContextCredentials</code>.
-		</para>
 		<para>At this point, we've reviewed all of the interesting code in the example application related to ModeShape.  However, feel free
     to play with the application, trying different things.</para>
 	</sect1>

--- a/docs/reference/src/main/docbook/en-US/content/core/sequencing.xml
+++ b/docs/reference/src/main/docbook/en-US/content/core/sequencing.xml
@@ -142,6 +142,34 @@ public interface &SequencerOutput; {
    * may be empty if any existing property is to be removed
    */
   void setReference( String nodePath, String property, String... paths );
+  
+
+  /**
+   * Adds values to the supplied property on the supplied node.
+   * 
+   * This method adds values to the property without modifying the existing values. No JCR  
+   * type checking is performed by this method, so it is the responsibility of the caller 
+   * to ensure that adding these values does not violate JCR type constraints.
+   * 
+   * The {@link StreamSequencerContext#getValueFactories() value factories} should be used 
+   * to create paths, names, and values.  These factories can be used to create new values 
+   * or convert values from one property type to another. (Note that each of the factories 
+   * have methods that create values from all of the property types.)
+   * 
+   * NOTE: Calling addValues against an existing node with a nonexistent property name will 
+   * result in that property being created with the given values, but calling addValues 
+   * against a nonexistent node will result in a PathNotFoundException when the sequenced 
+   * content is applied to the underlying repository.
+   * 
+   * @param nodePath the path to the node containing the property; may not be null
+   * @param propertyName the name of the property to be modified
+   * @param values the value(s) for the property; if these values are empty, no values 
+   * 			will be added
+   */
+  void addValues( Path nodePath,
+                  Name propertyName,
+                  Object... values );
+
 }
 		</programlisting>
 		<note>

--- a/extensions/modeshape-sequencer-cnd/src/main/java/org/modeshape/sequencer/cnd/CndSequencer.java
+++ b/extensions/modeshape-sequencer-cnd/src/main/java/org/modeshape/sequencer/cnd/CndSequencer.java
@@ -33,6 +33,7 @@ import org.modeshape.graph.ExecutionContext;
 import org.modeshape.graph.JcrLexicon;
 import org.modeshape.graph.NodeConflictBehavior;
 import org.modeshape.graph.io.Destination;
+import org.modeshape.graph.property.Name;
 import org.modeshape.graph.property.Path;
 import org.modeshape.graph.property.PathFactory;
 import org.modeshape.graph.property.Property;
@@ -185,6 +186,20 @@ public class CndSequencer implements StreamSequencer {
             for (Property property : properties) {
                 output.setProperty(path, property.getName(), property.getValuesAsArray());
             }
+        }
+
+        /**
+         * {@inheritDoc}
+         * 
+         * @see org.modeshape.graph.io.Destination#addPropertyValues(Path, Name, Object...)
+         */
+        @Override
+        public void addPropertyValues( Path path,
+                                       Name propertyName,
+                                       Object... values ) {
+            if (values == null || values.length == 0) return;
+
+            output.addValues(path, propertyName, values);
         }
 
         /**

--- a/modeshape-graph/src/main/java/org/modeshape/graph/Graph.java
+++ b/modeshape-graph/src/main/java/org/modeshape/graph/Graph.java
@@ -65,13 +65,13 @@ import org.modeshape.graph.property.DateTime;
 import org.modeshape.graph.property.Name;
 import org.modeshape.graph.property.NameFactory;
 import org.modeshape.graph.property.Path;
-import org.modeshape.graph.property.Path.Segment;
 import org.modeshape.graph.property.PathNotFoundException;
 import org.modeshape.graph.property.Property;
 import org.modeshape.graph.property.PropertyFactory;
 import org.modeshape.graph.property.Reference;
 import org.modeshape.graph.property.ValueFactory;
 import org.modeshape.graph.property.ValueFormatException;
+import org.modeshape.graph.property.Path.Segment;
 import org.modeshape.graph.query.QueryContext;
 import org.modeshape.graph.query.QueryEngine;
 import org.modeshape.graph.query.QueryResults;
@@ -94,11 +94,9 @@ import org.modeshape.graph.request.AccessQueryRequest;
 import org.modeshape.graph.request.BatchRequestBuilder;
 import org.modeshape.graph.request.CacheableRequest;
 import org.modeshape.graph.request.CloneWorkspaceRequest;
-import org.modeshape.graph.request.CloneWorkspaceRequest.CloneConflictBehavior;
 import org.modeshape.graph.request.CompositeRequest;
 import org.modeshape.graph.request.CreateNodeRequest;
 import org.modeshape.graph.request.CreateWorkspaceRequest;
-import org.modeshape.graph.request.CreateWorkspaceRequest.CreateConflictBehavior;
 import org.modeshape.graph.request.DestroyWorkspaceRequest;
 import org.modeshape.graph.request.FullTextSearchRequest;
 import org.modeshape.graph.request.InvalidRequestException;
@@ -113,6 +111,8 @@ import org.modeshape.graph.request.RequestBuilder;
 import org.modeshape.graph.request.RequestType;
 import org.modeshape.graph.request.UnsupportedRequestException;
 import org.modeshape.graph.request.VerifyWorkspaceRequest;
+import org.modeshape.graph.request.CloneWorkspaceRequest.CloneConflictBehavior;
+import org.modeshape.graph.request.CreateWorkspaceRequest.CreateConflictBehavior;
 import org.modeshape.graph.request.function.Function;
 import org.xml.sax.SAXException;
 
@@ -7287,6 +7287,7 @@ public class Graph {
 
         void addProperty( Property property ) {
             if (this.properties == null) this.properties = new HashMap<Name, Property>();
+            if (property == null) return;
             this.properties.put(property.getName(), property);
         }
 

--- a/modeshape-graph/src/main/java/org/modeshape/graph/io/Destination.java
+++ b/modeshape-graph/src/main/java/org/modeshape/graph/io/Destination.java
@@ -26,6 +26,7 @@ package org.modeshape.graph.io;
 import org.modeshape.common.annotation.NotThreadSafe;
 import org.modeshape.graph.ExecutionContext;
 import org.modeshape.graph.NodeConflictBehavior;
+import org.modeshape.graph.property.Name;
 import org.modeshape.graph.property.Path;
 import org.modeshape.graph.property.Property;
 
@@ -94,6 +95,17 @@ public interface Destination {
      */
     public void setProperties( Path path,
                                Iterable<Property> properties );
+
+    /**
+     * Sets the given properties on the node at the supplied path. The path will be absolute.
+     * 
+     * @param path the absolute path of the node
+     * @param propertyName the name of the property to modify; may not be null
+     * @param values the values to add to the property; null or empty values indicate that no modification will be performed
+     */
+    public void addPropertyValues( Path path,
+                                   Name propertyName,
+                                   Object... values );
 
     /**
      * Signal to this destination that any enqueued create requests should be submitted. Usually this happens at the end of the

--- a/modeshape-graph/src/main/java/org/modeshape/graph/io/GraphBatchDestination.java
+++ b/modeshape-graph/src/main/java/org/modeshape/graph/io/GraphBatchDestination.java
@@ -26,9 +26,11 @@ package org.modeshape.graph.io;
 import org.modeshape.common.annotation.NotThreadSafe;
 import org.modeshape.graph.ExecutionContext;
 import org.modeshape.graph.Graph;
+import org.modeshape.graph.NodeConflictBehavior;
+import org.modeshape.graph.Graph.AddValue;
 import org.modeshape.graph.Graph.Batch;
 import org.modeshape.graph.Graph.Create;
-import org.modeshape.graph.NodeConflictBehavior;
+import org.modeshape.graph.property.Name;
 import org.modeshape.graph.property.Path;
 import org.modeshape.graph.property.Property;
 
@@ -185,6 +187,30 @@ public class GraphBatchDestination implements Destination {
                                Iterable<Property> properties ) {
         if (properties == null) return;
         batch.set(properties).on(path);
+    }
+
+    /**
+     * {@inheritDoc}
+     * 
+     * @see org.modeshape.graph.io.Destination#addPropertyValues(Path, Name, Object...)
+     */
+    public void addPropertyValues( Path path,
+                                   Name propertyName,
+                                   Object... values ) {
+        if (values == null || values.length == 0) return;
+
+        if (values.length == 1 && values[0] instanceof Object[]) {
+            values = (Object[])values[0];
+        }
+
+        AddValue<Batch> addValue = batch.addValue(values[0]);
+
+        for (int i = 1; i < values.length; i++) {
+            addValue = addValue.andValue(values[i]);
+        }
+
+        addValue.to(propertyName).on(path);
+
     }
 
     /**

--- a/modeshape-graph/src/main/java/org/modeshape/graph/sequencer/SequencerOutput.java
+++ b/modeshape-graph/src/main/java/org/modeshape/graph/sequencer/SequencerOutput.java
@@ -25,6 +25,7 @@ package org.modeshape.graph.sequencer;
 
 import org.modeshape.graph.property.Name;
 import org.modeshape.graph.property.Path;
+import org.modeshape.graph.property.PathNotFoundException;
 
 /**
  * Interface for sequencers to use to generate their output.
@@ -92,4 +93,30 @@ public interface SequencerOutput {
     void setProperty( Path nodePath,
                       Name propertyName,
                       Object... values );
+
+    /**
+     * Adds values to the supplied property on the supplied node.
+     * <p>
+     * This method adds values to the property without modifying the existing values. No JCR type checking is performed by this
+     * method, so it is the responsibility of the caller to ensure that adding these values does not violate JCR type constraints.
+     * </p>
+     * <p>
+     * The {@link StreamSequencerContext#getValueFactories() value factories} should be used to create paths, names, and values.
+     * These factories can be used to create new values or convert values from one property type to another. (Note that each of
+     * the factories have methods that create values from all of the property types.)
+     * </p>
+     * <p>
+     * <b>NOTE: Calling addValues against an existing node with a nonexistent property name will result in that property being
+     * created with the given values, but calling addValues against a nonexistent node will result in a
+     * {@link PathNotFoundException} when the sequenced content is applied to the underlying repository.</b>
+     * </p>
+     * 
+     * @param nodePath the path to the node containing the property; may not be null
+     * @param propertyName the name of the property to be modified
+     * @param values the value(s) for the property; if these values are empty, no values will be added
+     */
+    void addValues( Path nodePath,
+                    Name propertyName,
+                    Object... values );
+
 }

--- a/modeshape-graph/src/test/java/org/modeshape/graph/io/GraphSequencerOutput.java
+++ b/modeshape-graph/src/test/java/org/modeshape/graph/io/GraphSequencerOutput.java
@@ -28,6 +28,8 @@ import java.util.Iterator;
 import java.util.Set;
 import org.modeshape.graph.ExecutionContext;
 import org.modeshape.graph.Graph;
+import org.modeshape.graph.Graph.AddValue;
+import org.modeshape.graph.Graph.Batch;
 import org.modeshape.graph.property.Name;
 import org.modeshape.graph.property.Path;
 import org.modeshape.graph.property.PathFactory;
@@ -104,6 +106,33 @@ public class GraphSequencerOutput implements SequencerOutput {
             batch.create(nodePath).and();
         }
         batch.set(propertyName).on(nodePath).to(values);
+    }
+
+    /**
+     * {@inheritDoc}
+     * 
+     * @see org.modeshape.graph.sequencer.SequencerOutput#addValues(org.modeshape.graph.property.Path,
+     *      org.modeshape.graph.property.Name, java.lang.Object[])
+     */
+    public void addValues( Path nodePath,
+                           Name propertyName,
+                           Object... values ) {
+        assert valuesAreNotIterators(values);
+
+        if (values == null || values.length == 0) return;
+
+        nodePath = absolute(nodePath);
+        if (paths.add(nodePath)) {
+            batch.create(nodePath).and();
+        }
+
+        AddValue<Batch> addValue = batch.addValue(values[0]);
+
+        for (int i = 1; i < values.length; i++) {
+            addValue = addValue.andValue(values[i]);
+        }
+
+        addValue.to(propertyName).on(nodePath);
     }
 
     private final Path absolute( Path path ) {

--- a/modeshape-graph/src/test/java/org/modeshape/graph/xml/XmlHandlerTest.java
+++ b/modeshape-graph/src/test/java/org/modeshape/graph/xml/XmlHandlerTest.java
@@ -608,6 +608,12 @@ public class XmlHandlerTest {
             create(path, firstProp, additionalProperties);
         }
 
+        public void addPropertyValues( Path path,
+                                       Name propertyName,
+                                       Object... values ) {
+            throw new UnsupportedOperationException();
+        }
+
         @SuppressWarnings( "synthetic-access" )
         public ExecutionContext getExecutionContext() {
             return XmlHandlerTest.this.context;


### PR DESCRIPTION
Added SequencerOutputMap.addPropertyValues(Path, Name, Object...) that adds values to the named property at the given path if it exists, or creates the named property at the given path with the given values if the property did not already exist.  This method will cause a PathNotFoundException if no node exists at the given path.

Added new tests to verify behavior and did a quick cleanup on the Getting Started guide where a few paragraphs reviewed the custom security context that no longer exists in the sequencer example.  All tests pass.
