### PR TITLE
MODE-1228 Corrected restore of copied nodes below restored node

### DIFF
--- a/modeshape-jcr/src/test/java/org/modeshape/jcr/ModeShapeTckTest.java
+++ b/modeshape-jcr/src/test/java/org/modeshape/jcr/ModeShapeTckTest.java
@@ -223,6 +223,11 @@ public class ModeShapeTckTest extends AbstractJCRTest {
         tools.printSubgraph(node);
     }
 
+    protected void printVersionHistory( Node node ) throws RepositoryException {
+        VersionHistory history = session.getWorkspace().getVersionManager().getVersionHistory(node.getPath());
+        printSubgraph(history);
+    }
+
     /**
      * Tests that read-only sessions can read nodes by loading all of the children of the root node
      * 
@@ -760,7 +765,8 @@ public class ModeShapeTckTest extends AbstractJCRTest {
 
         Version version = checkin(versionNode);
 
-        assertThat(version.getProperty("jcr:frozenNode/copyNode/jcr:primaryType").getString(), is("modetest:versionTest"));
+        assertThat(version.getProperty("jcr:frozenNode/copyNode/jcr:primaryType").getString(), is("nt:frozenNode"));
+        assertThat(version.getProperty("jcr:frozenNode/copyNode/jcr:frozenPrimaryType").getString(), is("modetest:versionTest"));
         try {
             version.getProperty("jcr:frozenNode/copyNode/copyProp");
         } catch (PathNotFoundException pnfe) {
@@ -818,6 +824,301 @@ public class ModeShapeTckTest extends AbstractJCRTest {
             // Expected
         }
 
+    }
+
+    @FixFor( "MODE-1228" )
+    public void testShouldRestoreWithNoReplaceTheNonReferenceableCopiedChildNode() throws Exception {
+        session = getHelper().getReadWriteSession();
+        Node node = session.getRootNode().addNode("/checkInTest", "modetest:versionTest");
+        session.save();
+
+        /*
+        * Create /checkinTest/copyNode with copyNode being versionable. This should be able
+        * to be checked in, as the ABORT status of abortNode is ignored when copyNode is checked in.
+        */
+
+        Node copyNode = node.addNode("copyNode", "modetest:versionTest");
+        copyNode.addMixin("mix:versionable");
+        copyNode.setProperty("copyProp", "copyPropValue");
+        copyNode.setProperty("ignoreProp", "ignorePropValue");
+        copyNode.setProperty("computeProp", "computePropValue");
+        Node belowCopyNode = copyNode.addNode("copyNode", "nt:unstructured");
+        belowCopyNode.addMixin("mix:title");
+        belowCopyNode.setProperty("copyProp", "copyPropValue");
+        belowCopyNode.setProperty("ignoreProp", "ignorePropValue");
+        belowCopyNode.setProperty("computeProp", "computePropValue");
+        belowCopyNode.setProperty("versionProp", "versionPropValue");
+        session.save();
+
+        assertThat(belowCopyNode.getProperty("copyProp").getString(), is("copyPropValue"));
+        assertThat(belowCopyNode.getProperty("ignoreProp").getString(), is("ignorePropValue"));
+        assertThat(belowCopyNode.getProperty("computeProp").getString(), is("computePropValue"));
+        assertThat(belowCopyNode.getProperty("versionProp").getString(), is("versionPropValue"));
+        assertThat(belowCopyNode.getMixinNodeTypes()[0].getName(), is("mix:title"));
+
+        Version version = checkin(copyNode);
+
+        /*
+        * Make some changes
+        */
+        checkout(copyNode);
+        copyNode.addMixin("mix:lockable");
+        copyNode.setProperty("copyProp", "copyPropValueNew");
+        copyNode.setProperty("ignoreProp", "ignorePropValueNew");
+        copyNode.setProperty("versionProp", "versionPropValueNew");
+        copyNode.setProperty("computeProp", "computePropValueNew");
+        belowCopyNode.setProperty("versionProp", "versionPropValueNew");
+        belowCopyNode.setProperty("computeProp", "computePropValueNew");
+        session.save();
+        checkin(copyNode);
+
+        restore(copyNode, version, false);
+
+        assertThat(copyNode.getProperty("copyProp").getString(), is("copyPropValue"));
+        assertThat(copyNode.getProperty("ignoreProp").getString(), is("ignorePropValueNew"));
+        assertThat(copyNode.getProperty("computeProp").getString(), is("computePropValueNew"));
+
+        try {
+            copyNode.getProperty("versionProp");
+            fail("Property with OnParentVersionAction of VERSION added after version should be removed during restore");
+        } catch (PathNotFoundException pnfe) {
+            // Expected
+        }
+
+        // Note that in the case of properties on copied subnodes of a restored node, they replace the nodes
+        // in the workspace unless there is a node with the same identifier. See Section 15.7.6 for details.
+
+        Node belowCopyNode2 = copyNode.getNode("copyNode");
+        assertThat(belowCopyNode2.getProperty("copyProp").getString(), is("copyPropValue"));
+        assertThat(belowCopyNode2.getProperty("ignoreProp").getString(), is("ignorePropValue"));
+        assertThat(belowCopyNode2.getProperty("computeProp").getString(), is("computePropValue"));
+        assertThat(belowCopyNode2.getProperty("versionProp").getString(), is("versionPropValue"));
+        assertThat(belowCopyNode2.getMixinNodeTypes()[0].getName(), is("mix:title"));
+    }
+
+    @FixFor( "MODE-1228" )
+    public void testShouldRestoreWithReplaceTheNonReferenceableCopiedChildNode() throws Exception {
+        session = getHelper().getReadWriteSession();
+        Node node = session.getRootNode().addNode("/checkInTest", "modetest:versionTest");
+        session.save();
+
+        /*
+        * Create /checkinTest/copyNode with copyNode being versionable. This should be able
+        * to be checked in, as the ABORT status of abortNode is ignored when copyNode is checked in.
+        */
+
+        Node copyNode = node.addNode("copyNode", "modetest:versionTest");
+        copyNode.addMixin("mix:versionable");
+        copyNode.setProperty("copyProp", "copyPropValue");
+        copyNode.setProperty("ignoreProp", "ignorePropValue");
+        copyNode.setProperty("computeProp", "computePropValue");
+        Node belowCopyNode = copyNode.addNode("copyNode", "nt:unstructured");
+        belowCopyNode.addMixin("mix:title");
+        belowCopyNode.setProperty("copyProp", "copyPropValue");
+        belowCopyNode.setProperty("ignoreProp", "ignorePropValue");
+        belowCopyNode.setProperty("computeProp", "computePropValue");
+        belowCopyNode.setProperty("versionProp", "versionPropValue");
+        session.save();
+
+        assertThat(belowCopyNode.getProperty("copyProp").getString(), is("copyPropValue"));
+        assertThat(belowCopyNode.getProperty("ignoreProp").getString(), is("ignorePropValue"));
+        assertThat(belowCopyNode.getProperty("computeProp").getString(), is("computePropValue"));
+        assertThat(belowCopyNode.getProperty("versionProp").getString(), is("versionPropValue"));
+        assertThat(belowCopyNode.getMixinNodeTypes()[0].getName(), is("mix:title"));
+
+        Version version = checkin(copyNode);
+
+        /*
+        * Make some changes
+        */
+        checkout(copyNode);
+        copyNode.addMixin("mix:lockable");
+        copyNode.setProperty("copyProp", "copyPropValueNew");
+        copyNode.setProperty("ignoreProp", "ignorePropValueNew");
+        copyNode.setProperty("versionProp", "versionPropValueNew");
+        copyNode.setProperty("computeProp", "computePropValueNew");
+        belowCopyNode.setProperty("versionProp", "versionPropValueNew");
+        belowCopyNode.setProperty("computeProp", "computePropValueNew");
+        session.save();
+        checkin(copyNode);
+
+        restore(copyNode, version, true);
+
+        assertThat(copyNode.getProperty("copyProp").getString(), is("copyPropValue"));
+        assertThat(copyNode.getProperty("ignoreProp").getString(), is("ignorePropValueNew"));
+        assertThat(copyNode.getProperty("computeProp").getString(), is("computePropValueNew"));
+
+        try {
+            copyNode.getProperty("versionProp");
+            fail("Property with OnParentVersionAction of VERSION added after version should be removed during restore");
+        } catch (PathNotFoundException pnfe) {
+            // Expected
+        }
+
+        // Note that in the case of properties on copied subnodes of a restored node, they replace the nodes
+        // in the workspace unless there is a node with the same identifier. See Section 15.7.6 for details.
+
+        Node belowCopyNode2 = copyNode.getNode("copyNode");
+        assertThat(belowCopyNode2.getProperty("copyProp").getString(), is("copyPropValue"));
+        assertThat(belowCopyNode2.getProperty("ignoreProp").getString(), is("ignorePropValue"));
+        assertThat(belowCopyNode2.getProperty("computeProp").getString(), is("computePropValue"));
+        assertThat(belowCopyNode2.getProperty("versionProp").getString(), is("versionPropValue"));
+        assertThat(belowCopyNode2.getMixinNodeTypes()[0].getName(), is("mix:title"));
+    }
+
+    @FixFor( "MODE-1228" )
+    public void testShouldRestoreWithNoReplaceTheReferenceableCopiedChildNode() throws Exception {
+        session = getHelper().getReadWriteSession();
+        Node node = session.getRootNode().addNode("/checkInTest", "modetest:versionTest");
+        session.save();
+
+        /*
+        * Create /checkinTest/copyNode with copyNode being versionable. This should be able
+        * to be checked in, as the ABORT status of abortNode is ignored when copyNode is checked in.
+        */
+
+        Node copyNode = node.addNode("copyNode", "modetest:versionTest");
+        copyNode.addMixin("mix:versionable");
+        copyNode.setProperty("copyProp", "copyPropValue");
+        copyNode.setProperty("ignoreProp", "ignorePropValue");
+        copyNode.setProperty("computeProp", "computePropValue");
+        Node belowCopyNode = copyNode.addNode("copyNode", "nt:unstructured");
+        belowCopyNode.addMixin("mix:referenceable");
+        belowCopyNode.setProperty("copyProp", "copyPropValue");
+        belowCopyNode.setProperty("ignoreProp", "ignorePropValue");
+        belowCopyNode.setProperty("computeProp", "computePropValue");
+        belowCopyNode.setProperty("versionProp", "versionPropValue");
+        session.save();
+
+        assertThat(belowCopyNode.getProperty("copyProp").getString(), is("copyPropValue"));
+        assertThat(belowCopyNode.getProperty("ignoreProp").getString(), is("ignorePropValue"));
+        assertThat(belowCopyNode.getProperty("computeProp").getString(), is("computePropValue"));
+        assertThat(belowCopyNode.getProperty("versionProp").getString(), is("versionPropValue"));
+        assertThat(belowCopyNode.getMixinNodeTypes()[0].getName(), is("mix:referenceable"));
+        String belowCopyNodeId = belowCopyNode.getIdentifier();
+
+        Version version = checkin(copyNode);
+
+        // printSubgraph(version);
+
+        /*
+        * Make some changes
+        */
+        checkout(copyNode);
+        copyNode.addMixin("mix:lockable");
+        copyNode.setProperty("copyProp", "copyPropValueNew");
+        copyNode.setProperty("ignoreProp", "ignorePropValueNew");
+        copyNode.setProperty("versionProp", "versionPropValueNew");
+        copyNode.setProperty("computeProp", "computePropValueNew");
+        belowCopyNode.setProperty("versionProp", "versionPropValueNew");
+        belowCopyNode.setProperty("computeProp", "computePropValueNew");
+        session.save();
+        checkin(copyNode);
+
+        // printVersionHistory(copyNode);
+
+        restore(copyNode, version, false);
+
+        assertThat(copyNode.getProperty("copyProp").getString(), is("copyPropValue"));
+        assertThat(copyNode.getProperty("ignoreProp").getString(), is("ignorePropValueNew"));
+        assertThat(copyNode.getProperty("computeProp").getString(), is("computePropValueNew"));
+
+        try {
+            copyNode.getProperty("versionProp");
+            fail("Property with OnParentVersionAction of VERSION added after version should be removed during restore");
+        } catch (PathNotFoundException pnfe) {
+            // Expected
+        }
+
+        // Note that in the case of properties on copied subnodes of a restored node, they do NOT replace the
+        // referenceable nodes (with the same identifier) in the workspace. See Section 15.7.6 for details.
+        // Therefore, the properties should match the updated values...
+
+        Node belowCopyNode2 = copyNode.getNode("copyNode");
+        String belowCopyNode2Id = belowCopyNode.getIdentifier();
+        assertThat(belowCopyNodeId, is(belowCopyNode2Id));
+        assertThat(belowCopyNode2.getProperty("copyProp").getString(), is("copyPropValue"));
+        assertThat(belowCopyNode2.getProperty("ignoreProp").getString(), is("ignorePropValue"));
+        assertThat(belowCopyNode2.getProperty("computeProp").getString(), is("computePropValue"));
+        assertThat(belowCopyNode2.getProperty("versionProp").getString(), is("versionPropValue"));
+        assertThat(belowCopyNode2.getMixinNodeTypes()[0].getName(), is("mix:referenceable"));
+    }
+
+    @FixFor( "MODE-1228" )
+    public void testShouldRestoreWithReplaceTheReferenceableCopiedChildNode() throws Exception {
+        session = getHelper().getReadWriteSession();
+        Node node = session.getRootNode().addNode("/checkInTest", "modetest:versionTest");
+        session.save();
+
+        /*
+        * Create /checkinTest/copyNode with copyNode being versionable. This should be able
+        * to be checked in, as the ABORT status of abortNode is ignored when copyNode is checked in.
+        */
+
+        Node copyNode = node.addNode("copyNode", "modetest:versionTest");
+        copyNode.addMixin("mix:versionable");
+        copyNode.setProperty("copyProp", "copyPropValue");
+        copyNode.setProperty("ignoreProp", "ignorePropValue");
+        copyNode.setProperty("computeProp", "computePropValue");
+        Node belowCopyNode = copyNode.addNode("copyNode", "nt:unstructured");
+        belowCopyNode.addMixin("mix:referenceable");
+        belowCopyNode.setProperty("copyProp", "copyPropValue");
+        belowCopyNode.setProperty("ignoreProp", "ignorePropValue");
+        belowCopyNode.setProperty("computeProp", "computePropValue");
+        belowCopyNode.setProperty("versionProp", "versionPropValue");
+        session.save();
+
+        assertThat(belowCopyNode.getProperty("copyProp").getString(), is("copyPropValue"));
+        assertThat(belowCopyNode.getProperty("ignoreProp").getString(), is("ignorePropValue"));
+        assertThat(belowCopyNode.getProperty("computeProp").getString(), is("computePropValue"));
+        assertThat(belowCopyNode.getProperty("versionProp").getString(), is("versionPropValue"));
+        assertThat(belowCopyNode.getMixinNodeTypes()[0].getName(), is("mix:referenceable"));
+        String belowCopyNodeId = belowCopyNode.getIdentifier();
+
+        Version version = checkin(copyNode);
+
+        // printSubgraph(version);
+
+        /*
+        * Make some changes
+        */
+        checkout(copyNode);
+        copyNode.addMixin("mix:lockable");
+        copyNode.setProperty("copyProp", "copyPropValueNew");
+        copyNode.setProperty("ignoreProp", "ignorePropValueNew");
+        copyNode.setProperty("versionProp", "versionPropValueNew");
+        copyNode.setProperty("computeProp", "computePropValueNew");
+        belowCopyNode.setProperty("versionProp", "versionPropValueNew");
+        belowCopyNode.setProperty("computeProp", "computePropValueNew");
+        session.save();
+        checkin(copyNode);
+
+        // printVersionHistory(copyNode);
+
+        restore(copyNode, version, true);
+
+        assertThat(copyNode.getProperty("copyProp").getString(), is("copyPropValue"));
+        assertThat(copyNode.getProperty("ignoreProp").getString(), is("ignorePropValueNew"));
+        assertThat(copyNode.getProperty("computeProp").getString(), is("computePropValueNew"));
+
+        try {
+            copyNode.getProperty("versionProp");
+            fail("Property with OnParentVersionAction of VERSION added after version should be removed during restore");
+        } catch (PathNotFoundException pnfe) {
+            // Expected
+        }
+
+        // Note that in the case of properties on copied subnodes of a restored node, they replace the nodes
+        // in the workspace unless there is a node with the same identifier. See Section 15.7.6 for details.
+
+        Node belowCopyNode2 = copyNode.getNode("copyNode");
+        String belowCopyNode2Id = belowCopyNode.getIdentifier();
+        assertThat(belowCopyNodeId, is(belowCopyNode2Id));
+        assertThat(belowCopyNode2.getProperty("copyProp").getString(), is("copyPropValue"));
+        assertThat(belowCopyNode2.getProperty("ignoreProp").getString(), is("ignorePropValue"));
+        assertThat(belowCopyNode2.getProperty("computeProp").getString(), is("computePropValue"));
+        assertThat(belowCopyNode2.getProperty("versionProp").getString(), is("versionPropValue"));
+        assertThat(belowCopyNode2.getMixinNodeTypes()[0].getName(), is("mix:referenceable"));
     }
 
     @FixFor( "MODE-693" )

--- a/sandbox/modeshape-test-reference-impl/src/test/java/org/modeshape/test/ri/VersioningTest.java
+++ b/sandbox/modeshape-test-reference-impl/src/test/java/org/modeshape/test/ri/VersioningTest.java
@@ -23,7 +23,13 @@
  */
 package org.modeshape.test.ri;
 
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
 import javax.jcr.Node;
+import javax.jcr.PathNotFoundException;
+import javax.jcr.Session;
+import javax.jcr.version.Version;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -59,6 +65,304 @@ public class VersioningTest extends AbstractTest {
         print("Version history after second checkin");
         printVersionHistory(node);
 
+    }
+
+    @Test
+    public void shouldRestoreWithReplacingNodeWithCopyOpvAndNonReferenceableChildren() throws Exception {
+        loadNodeTypes("version-test-nodetypes.cnd");
+        verifyNodeTypeExists("modetest:versionTest");
+
+        Session session = session();
+
+        Node node = session.getRootNode().addNode("checkInTest", "modetest:versionTest");
+        session.save();
+
+        Node copyNode = node.addNode("copyNode", "modetest:versionTest");
+        copyNode.addMixin("mix:versionable");
+        copyNode.setProperty("copyProp", "copyPropValue");
+        copyNode.setProperty("ignoreProp", "ignorePropValue");
+        copyNode.setProperty("computeProp", "computePropValue");
+        Node belowCopyNode = copyNode.addNode("copyNode", "nt:unstructured");
+        belowCopyNode.addMixin("mix:title");
+        belowCopyNode.setProperty("copyProp", "copyPropValue");
+        belowCopyNode.setProperty("ignoreProp", "ignorePropValue");
+        belowCopyNode.setProperty("computeProp", "computePropValue");
+        belowCopyNode.setProperty("versionProp", "versionPropValue");
+        session.save();
+
+        assertThat(belowCopyNode.getProperty("copyProp").getString(), is("copyPropValue"));
+        assertThat(belowCopyNode.getProperty("ignoreProp").getString(), is("ignorePropValue"));
+        assertThat(belowCopyNode.getProperty("computeProp").getString(), is("computePropValue"));
+        assertThat(belowCopyNode.getProperty("versionProp").getString(), is("versionPropValue"));
+        assertThat(belowCopyNode.getMixinNodeTypes()[0].getName(), is("mix:title"));
+
+        Version version = checkin(copyNode);
+
+        printSubgraph(version);
+
+        /*
+        * Make some changes
+        */
+        checkout(copyNode);
+        copyNode.addMixin("mix:lockable");
+        copyNode.setProperty("copyProp", "copyPropValueNew");
+        copyNode.setProperty("ignoreProp", "ignorePropValueNew");
+        copyNode.setProperty("versionProp", "versionPropValueNew");
+        copyNode.setProperty("computeProp", "computePropValueNew");
+        belowCopyNode.setProperty("versionProp", "versionPropValueNew");
+        belowCopyNode.setProperty("computeProp", "computePropValueNew");
+        session.save();
+        checkin(copyNode);
+
+        printVersionHistory(copyNode);
+
+        restore(copyNode, version, true);
+
+        assertThat(copyNode.getProperty("copyProp").getString(), is("copyPropValue"));
+        assertThat(copyNode.getProperty("ignoreProp").getString(), is("ignorePropValueNew"));
+        assertThat(copyNode.getProperty("computeProp").getString(), is("computePropValueNew"));
+
+        try {
+            copyNode.getProperty("versionProp");
+            fail("Property with OnParentVersionAction of VERSION added after version should be removed during restore");
+        } catch (PathNotFoundException pnfe) {
+            // Expected
+        }
+
+        // Note that in the case of properties on copied subnodes of a restored node, they replace the nodes
+        // in the workspace unless there is a node with the same identifier. See Section 15.7.6 for details.
+
+        Node belowCopyNode2 = copyNode.getNode("copyNode");
+        assertThat(belowCopyNode2.getProperty("copyProp").getString(), is("copyPropValue"));
+        assertThat(belowCopyNode2.getProperty("ignoreProp").getString(), is("ignorePropValue"));
+        assertThat(belowCopyNode2.getProperty("computeProp").getString(), is("computePropValue"));
+        assertThat(belowCopyNode2.getProperty("versionProp").getString(), is("versionPropValue"));
+        assertThat(belowCopyNode2.getMixinNodeTypes()[0].getName(), is("mix:title"));
+    }
+
+    @Test
+    public void shouldRestoreWithoutReplacingNodeWithCopyOpvAndNonReferenceableChildren() throws Exception {
+        loadNodeTypes("version-test-nodetypes.cnd");
+        verifyNodeTypeExists("modetest:versionTest");
+
+        Session session = session();
+
+        Node node = session.getRootNode().addNode("checkInTest", "modetest:versionTest");
+        session.save();
+
+        Node copyNode = node.addNode("copyNode", "modetest:versionTest");
+        copyNode.addMixin("mix:versionable");
+        copyNode.setProperty("copyProp", "copyPropValue");
+        copyNode.setProperty("ignoreProp", "ignorePropValue");
+        copyNode.setProperty("computeProp", "computePropValue");
+        Node belowCopyNode = copyNode.addNode("copyNode", "nt:unstructured");
+        belowCopyNode.addMixin("mix:title");
+        belowCopyNode.setProperty("copyProp", "copyPropValue");
+        belowCopyNode.setProperty("ignoreProp", "ignorePropValue");
+        belowCopyNode.setProperty("computeProp", "computePropValue");
+        belowCopyNode.setProperty("versionProp", "versionPropValue");
+        session.save();
+
+        assertThat(belowCopyNode.getProperty("copyProp").getString(), is("copyPropValue"));
+        assertThat(belowCopyNode.getProperty("ignoreProp").getString(), is("ignorePropValue"));
+        assertThat(belowCopyNode.getProperty("computeProp").getString(), is("computePropValue"));
+        assertThat(belowCopyNode.getProperty("versionProp").getString(), is("versionPropValue"));
+        assertThat(belowCopyNode.getMixinNodeTypes()[0].getName(), is("mix:title"));
+
+        Version version = checkin(copyNode);
+
+        printSubgraph(version);
+
+        /*
+        * Make some changes
+        */
+        checkout(copyNode);
+        copyNode.addMixin("mix:lockable");
+        copyNode.setProperty("copyProp", "copyPropValueNew");
+        copyNode.setProperty("ignoreProp", "ignorePropValueNew");
+        copyNode.setProperty("versionProp", "versionPropValueNew");
+        copyNode.setProperty("computeProp", "computePropValueNew");
+        belowCopyNode.setProperty("versionProp", "versionPropValueNew");
+        belowCopyNode.setProperty("computeProp", "computePropValueNew");
+        session.save();
+        checkin(copyNode);
+
+        printVersionHistory(copyNode);
+
+        restore(copyNode, version, false);
+
+        assertThat(copyNode.getProperty("copyProp").getString(), is("copyPropValue"));
+        assertThat(copyNode.getProperty("ignoreProp").getString(), is("ignorePropValueNew"));
+        assertThat(copyNode.getProperty("computeProp").getString(), is("computePropValueNew"));
+
+        try {
+            copyNode.getProperty("versionProp");
+            fail("Property with OnParentVersionAction of VERSION added after version should be removed during restore");
+        } catch (PathNotFoundException pnfe) {
+            // Expected
+        }
+
+        // Note that in the case of properties on copied subnodes of a restored node, they replace the nodes
+        // in the workspace unless there is a node with the same identifier. See Section 15.7.6 for details.
+
+        Node belowCopyNode2 = copyNode.getNode("copyNode");
+        assertThat(belowCopyNode2.getProperty("copyProp").getString(), is("copyPropValue"));
+        assertThat(belowCopyNode2.getProperty("ignoreProp").getString(), is("ignorePropValue"));
+        assertThat(belowCopyNode2.getProperty("computeProp").getString(), is("computePropValue"));
+        assertThat(belowCopyNode2.getProperty("versionProp").getString(), is("versionPropValue"));
+        assertThat(belowCopyNode2.getMixinNodeTypes()[0].getName(), is("mix:title"));
+    }
+
+    @Test
+    public void shouldRestoreWithReplacingNodeWithCopyOpvAndReferenceableChildren() throws Exception {
+        loadNodeTypes("version-test-nodetypes.cnd");
+        verifyNodeTypeExists("modetest:versionTest");
+
+        Session session = session();
+
+        Node node = session.getRootNode().addNode("checkInTest", "modetest:versionTest");
+        session.save();
+
+        Node copyNode = node.addNode("copyNode", "modetest:versionTest");
+        copyNode.addMixin("mix:versionable");
+        copyNode.setProperty("copyProp", "copyPropValue");
+        copyNode.setProperty("ignoreProp", "ignorePropValue");
+        copyNode.setProperty("computeProp", "computePropValue");
+        Node belowCopyNode = copyNode.addNode("copyNode", "nt:unstructured");
+        belowCopyNode.addMixin("mix:referenceable");
+        belowCopyNode.setProperty("copyProp", "copyPropValue");
+        belowCopyNode.setProperty("ignoreProp", "ignorePropValue");
+        belowCopyNode.setProperty("computeProp", "computePropValue");
+        belowCopyNode.setProperty("versionProp", "versionPropValue");
+        session.save();
+
+        assertThat(belowCopyNode.getProperty("copyProp").getString(), is("copyPropValue"));
+        assertThat(belowCopyNode.getProperty("ignoreProp").getString(), is("ignorePropValue"));
+        assertThat(belowCopyNode.getProperty("computeProp").getString(), is("computePropValue"));
+        assertThat(belowCopyNode.getProperty("versionProp").getString(), is("versionPropValue"));
+        assertThat(belowCopyNode.getMixinNodeTypes()[0].getName(), is("mix:referenceable"));
+        String belowCopyNodeId = belowCopyNode.getIdentifier();
+
+        Version version = checkin(copyNode);
+
+        printSubgraph(version);
+
+        /*
+        * Make some changes
+        */
+        checkout(copyNode);
+        copyNode.addMixin("mix:lockable");
+        copyNode.setProperty("copyProp", "copyPropValueNew");
+        copyNode.setProperty("ignoreProp", "ignorePropValueNew");
+        copyNode.setProperty("versionProp", "versionPropValueNew");
+        copyNode.setProperty("computeProp", "computePropValueNew");
+        belowCopyNode.setProperty("versionProp", "versionPropValueNew");
+        belowCopyNode.setProperty("computeProp", "computePropValueNew");
+        session.save();
+        checkin(copyNode);
+
+        printVersionHistory(copyNode);
+
+        restore(copyNode, version, true);
+
+        assertThat(copyNode.getProperty("copyProp").getString(), is("copyPropValue"));
+        assertThat(copyNode.getProperty("ignoreProp").getString(), is("ignorePropValueNew"));
+        assertThat(copyNode.getProperty("computeProp").getString(), is("computePropValueNew"));
+
+        try {
+            copyNode.getProperty("versionProp");
+            fail("Property with OnParentVersionAction of VERSION added after version should be removed during restore");
+        } catch (PathNotFoundException pnfe) {
+            // Expected
+        }
+
+        // Note that in the case of properties on copied subnodes of a restored node, they replace the nodes
+        // in the workspace unless there is a node with the same identifier. See Section 15.7.6 for details.
+
+        Node belowCopyNode2 = copyNode.getNode("copyNode");
+        String belowCopyNode2Id = belowCopyNode.getIdentifier();
+        assertThat(belowCopyNodeId, is(belowCopyNode2Id));
+        assertThat(belowCopyNode2.getProperty("copyProp").getString(), is("copyPropValue"));
+        assertThat(belowCopyNode2.getProperty("ignoreProp").getString(), is("ignorePropValue"));
+        assertThat(belowCopyNode2.getProperty("computeProp").getString(), is("computePropValue"));
+        assertThat(belowCopyNode2.getProperty("versionProp").getString(), is("versionPropValue"));
+        assertThat(belowCopyNode2.getMixinNodeTypes()[0].getName(), is("mix:referenceable"));
+    }
+
+    @Test
+    public void shouldRestoreWithoutReplacingNodeWithCopyOpvAndReferenceableChildren() throws Exception {
+        loadNodeTypes("version-test-nodetypes.cnd");
+        verifyNodeTypeExists("modetest:versionTest");
+
+        Session session = session();
+
+        Node node = session.getRootNode().addNode("checkInTest", "modetest:versionTest");
+        session.save();
+
+        Node copyNode = node.addNode("copyNode", "modetest:versionTest");
+        copyNode.addMixin("mix:versionable");
+        copyNode.setProperty("copyProp", "copyPropValue");
+        copyNode.setProperty("ignoreProp", "ignorePropValue");
+        copyNode.setProperty("computeProp", "computePropValue");
+        Node belowCopyNode = copyNode.addNode("copyNode", "nt:unstructured");
+        belowCopyNode.addMixin("mix:referenceable");
+        belowCopyNode.setProperty("copyProp", "copyPropValue");
+        belowCopyNode.setProperty("ignoreProp", "ignorePropValue");
+        belowCopyNode.setProperty("computeProp", "computePropValue");
+        belowCopyNode.setProperty("versionProp", "versionPropValue");
+        session.save();
+
+        assertThat(belowCopyNode.getProperty("copyProp").getString(), is("copyPropValue"));
+        assertThat(belowCopyNode.getProperty("ignoreProp").getString(), is("ignorePropValue"));
+        assertThat(belowCopyNode.getProperty("computeProp").getString(), is("computePropValue"));
+        assertThat(belowCopyNode.getProperty("versionProp").getString(), is("versionPropValue"));
+        assertThat(belowCopyNode.getMixinNodeTypes()[0].getName(), is("mix:referenceable"));
+        String belowCopyNodeId = belowCopyNode.getIdentifier();
+
+        Version version = checkin(copyNode);
+
+        printSubgraph(version);
+
+        /*
+        * Make some changes
+        */
+        checkout(copyNode);
+        copyNode.addMixin("mix:lockable");
+        copyNode.setProperty("copyProp", "copyPropValueNew");
+        copyNode.setProperty("ignoreProp", "ignorePropValueNew");
+        copyNode.setProperty("versionProp", "versionPropValueNew");
+        copyNode.setProperty("computeProp", "computePropValueNew");
+        belowCopyNode.setProperty("versionProp", "versionPropValueNew");
+        belowCopyNode.setProperty("computeProp", "computePropValueNew");
+        session.save();
+        checkin(copyNode);
+
+        printVersionHistory(copyNode);
+
+        restore(copyNode, version, false);
+
+        assertThat(copyNode.getProperty("copyProp").getString(), is("copyPropValue"));
+        assertThat(copyNode.getProperty("ignoreProp").getString(), is("ignorePropValueNew"));
+        assertThat(copyNode.getProperty("computeProp").getString(), is("computePropValueNew"));
+
+        try {
+            copyNode.getProperty("versionProp");
+            fail("Property with OnParentVersionAction of VERSION added after version should be removed during restore");
+        } catch (PathNotFoundException pnfe) {
+            // Expected
+        }
+
+        // Note that in the case of properties on copied subnodes of a restored node, they replace the nodes
+        // in the workspace unless there is a node with the same identifier. See Section 15.7.6 for details.
+
+        Node belowCopyNode2 = copyNode.getNode("copyNode");
+        String belowCopyNode2Id = belowCopyNode.getIdentifier();
+        assertThat(belowCopyNodeId, is(belowCopyNode2Id));
+        assertThat(belowCopyNode2.getProperty("copyProp").getString(), is("copyPropValue"));
+        assertThat(belowCopyNode2.getProperty("ignoreProp").getString(), is("ignorePropValue"));
+        assertThat(belowCopyNode2.getProperty("computeProp").getString(), is("computePropValue"));
+        assertThat(belowCopyNode2.getProperty("versionProp").getString(), is("versionPropValue"));
+        assertThat(belowCopyNode2.getMixinNodeTypes()[0].getName(), is("mix:referenceable"));
     }
 
 }

--- a/sandbox/modeshape-test-reference-impl/src/test/resources/version-test-nodetypes.cnd
+++ b/sandbox/modeshape-test-reference-impl/src/test/resources/version-test-nodetypes.cnd
@@ -1,0 +1,17 @@
+<nt  = "http://www.jcp.org/jcr/nt/1.0">
+<mix = "http://www.jcp.org/jcr/mix/1.0">
+<modetest = "http://www.modeshape.org/test/1.0">
+
+[modetest:versionableUnstructured] > nt:unstructured, mix:versionable
+
+[modetest:versionTest]
+- abortProp (STRING) abort
+- computeProp (STRING) compute
+- copyProp (STRING) copy
+- ignoreProp (STRING) ignore
+- initializeProp (STRING) = 'Default' initialize
+- versionProp (STRING) version
++ abortNode (nt:base) = nt:unstructured abort
++ copyNode (nt:base) = nt:unstructured copy
++ ignoreNode (nt:base) = nt:unstructured ignore
++ versionNode (nt:base) = nt:unstructured version


### PR DESCRIPTION
The logic of restoring a versioned node was not properly handling nodes below the versioned node - it was ignoring the 'jcr:mixinTypes' and 'jcr:uuid' properties. This change corrects that behavior to properly set these properties.

Note that while testing a fix, a case involving storing 'mix:versionable' nodes was found to not really be addressed by the JCR 2.0 specification. After some investigation, the reference implementation appears to use 'nt:frozenNode' for all nodes underneath a Version. This definitely works around the issue, so the ModeShape behavior was reverted (from MODE-1172) back to doing the same thing. The code is backward compatible for old version histories using node types other than nt:frozenNode (other than the 'mix:referenceable' issue). See the JIRA issue for details.

Several tests were added to verify the problematic scenarios, and after the change all unit and integration tests pass. Similar tests using the reference implementation were added to the 'modeshape-test-reference-impl' module in the sandbox.
