### PR TITLE
MODE-1229 Corrected engine to allow no anonymous user roles in XML configuration

### DIFF
--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrEngine.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrEngine.java
@@ -430,7 +430,8 @@ public class JcrEngine extends ModeShapeEngine implements Repositories {
                     log.warn(JcrI18n.invalidOptionProvided, segment.getName().getLocalName());
                     continue;
                 }
-                options.put(option, valueProperty.getFirstValue().toString());
+                String value = valueProperty.getFirstValue() != null ? valueProperty.getFirstValue().toString() : "";
+                options.put(option, value);
             }
         }
 

--- a/modeshape-jcr/src/test/resources/config/configRepositoryWithNoAnonymousRoles.xml
+++ b/modeshape-jcr/src/test/resources/config/configRepositoryWithNoAnonymousRoles.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- 
+  ~ ModeShape (http://www.modeshape.org)
+  ~
+  ~ See the COPYRIGHT.txt file distributed with this work for information
+  ~ regarding copyright ownership.  Some portions may be licensed
+  ~ to Red Hat, Inc. under one or more contributor license agreements.
+  ~ See the AUTHORS.txt file in the distribution for a full listing of 
+  ~ individual contributors.
+  ~
+  ~ ModeShape is free software. Unless otherwise indicated, all code in ModeShape
+  ~ is licensed to you under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ ModeShape is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+  ~ or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+  ~ for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public License
+  ~ along with this distribution; if not, write to:
+  ~ Free Software Foundation, Inc.
+  ~ 51 Franklin Street, Fifth Floor
+  ~ Boston, MA  02110-1301  USA
+  -->
+<configuration xmlns:mode="http://www.modeshape.org/1.0"
+               xmlns:jcr="http://www.jcp.org/jcr/1.0"
+               xmlns:nt="http://www.jcp.org/jcr/nt/1.0">
+    <!-- Define the sources from which content is made available.  -->
+    <mode:sources jcr:primaryType="nt:unstructured">
+        <mode:source jcr:name="Stuff" mode:classname="org.modeshape.graph.connector.inmemory.InMemoryRepositorySource" mode:retryLimit="3" defaultWorkspaceName="default"/>
+    </mode:sources>
+    <!-- JCR Repositories.  This is required, with a separate repository for each JCR repository instance. -->
+    <mode:repositories>
+        <mode:repository jcr:name="My Repository" mode:source="Stuff">
+            <mode:options>
+                <mode:option jcr:name="jaasLoginConfigName" mode:value="modeshape-jcr"/>
+                <mode:option jcr:name="anonymousUserRoles" mode:value=""/>
+                <mode:option jcr:name="useAnonymousAccessOnFailedLogin" mode:value="false"/>
+            </mode:options>
+            <mode:authenticationProviders>
+                <mode:authenticationProvider jcr:name="CustomProviderA" mode:classname="org.modeshape.jcr.JcrConfigurationTest$TestSecurityContextProvider">
+                    <mode:description>Authentication provider that allows using SecurityContextCredentials.</mode:description>        
+                </mode:authenticationProvider>
+            </mode:authenticationProviders>
+        </mode:repository>
+    </mode:repositories>
+</configuration>


### PR DESCRIPTION
The fix was quite simple, and involved how the configuration graph is being processed when instantiating and setting up the JcrRepository instance.

Added two tests to verify this functionality. All unit and integration tests pass.
