### PR TITLE
MODE-1190 Corrected reloading of node types upon restart

### DIFF
--- a/modeshape-integration-tests/src/test/java/org/modeshape/test/integration/manual/ReadNodeTypesUponRestart.java
+++ b/modeshape-integration-tests/src/test/java/org/modeshape/test/integration/manual/ReadNodeTypesUponRestart.java
@@ -1,0 +1,227 @@
+package org.modeshape.test.integration.manual;
+
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+import javax.jcr.PropertyType;
+import javax.jcr.Repository;
+import javax.jcr.RepositoryException;
+import javax.jcr.Session;
+import javax.jcr.Workspace;
+import javax.jcr.nodetype.NoSuchNodeTypeException;
+import javax.jcr.nodetype.NodeType;
+import javax.jcr.nodetype.NodeTypeManager;
+import javax.jcr.nodetype.NodeTypeTemplate;
+import javax.jcr.nodetype.PropertyDefinitionTemplate;
+import org.eclipse.core.runtime.AssertionFailedException;
+import org.modeshape.common.collection.Problem;
+import org.modeshape.common.util.FileUtil;
+import org.modeshape.jcr.JcrConfiguration;
+import org.modeshape.jcr.JcrEngine;
+import org.xml.sax.SAXException;
+
+/**
+ * This manual test verifies that node types can be registered in an engine and can be read in successfully upon subsequent
+ * restarts. The procedure for running this test is as follows:
+ * <ol>
+ * <li>Change the value of the "FIRST_TIME" constant to "true" and recompile.</li>
+ * <li>Run this application once.</li>
+ * <li>Change the value of the "FIRST_TIME" constant to "false" and recompile.</li>
+ * <li>Run this application any number of times.</li>
+ */
+public class ReadNodeTypesUponRestart {
+
+    private static final boolean FIRST_TIME = false;
+    private static final String CONFIG_FILE_PATH = "src/test/resources/config/read-node-types-upon-restart-config.xml";
+    private static final String NODE_TYPE_NAME = "StandardArticle";
+
+    private static JcrEngine engine;
+
+    public static void main( String[] args ) {
+        if (FIRST_TIME) {
+            FileUtil.delete("target/jcr-test-db");
+        }
+
+        try {
+            startEngine(true);
+
+            try {
+                Session session = getSession();
+                Workspace workspace = session.getWorkspace();
+                getOrCreateNodeType(workspace);
+                // getNodeType(workspace);
+                // session.save();
+            } catch (RepositoryException e) {
+                // TODO Auto-generated catch block
+                System.out.print("exception" + e);
+            }
+
+            try {
+                Session session = getSession();
+                Workspace workspace = session.getWorkspace();
+                getNodeType(workspace);
+                // session.save();
+            } catch (RepositoryException e) {
+                // TODO Auto-generated catch block
+                System.out.print("exception" + e);
+            }
+
+        } finally {
+            shutdownEngine();
+        }
+
+        try {
+            startEngine(false);
+
+            try {
+                Session session = getSession();
+                Workspace workspace = session.getWorkspace();
+                getNodeType(workspace);
+                // session.save();
+            } catch (RepositoryException e) {
+                // TODO Auto-generated catch block
+                System.out.print("exception" + e);
+            }
+
+        } finally {
+            shutdownEngine();
+        }
+    }
+
+    private static void shutdownEngine() {
+        if (engine == null) return; // not yet started
+
+        // Shutdown the engine ...
+        try {
+            engine.shutdownAndAwaitTermination(5, TimeUnit.SECONDS);
+            System.out.println("Successfully shut down ModeShape engine");
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        } finally {
+            engine = null;
+        }
+    }
+
+    @SuppressWarnings( "unused" )
+    private static void startEngine( boolean firstTime ) {
+        if (engine != null) return; // already started
+
+        try {
+            JcrConfiguration config = new JcrConfiguration().loadFrom(CONFIG_FILE_PATH);
+
+            if (firstTime && FIRST_TIME) {
+                config.repositorySource("Store").setProperty("mode:autoGenerateSchema", "create");
+            } else {
+                config.repositorySource("Store").setProperty("mode:autoGenerateSchema", "disable");
+            }
+
+            engine = config.build();
+            engine.start();
+
+            if (engine.getProblems().hasProblems()) {
+                for (Problem problem : engine.getProblems()) {
+                    System.err.println(problem.getMessageString());
+                }
+                throw new RuntimeException("Could not start due to problems");
+            }
+        } catch (IOException e) {
+            System.out.print("exception" + e);
+        } catch (SAXException e) {
+            // TODO Auto-generated catch block
+            System.out.print("exception" + e);
+        }
+    }
+
+    private static Session getSession() throws RepositoryException {
+        Repository repository = engine.getRepository("Repo");
+        Session session = repository.login(); // Logs in with a guest session - works by default.
+        return session;
+    }
+
+    /**
+     * Example to add nodetype
+     * 
+     * @param workspace
+     */
+    private static void getNodeType( Workspace workspace ) {
+        NodeTypeManager mgr;
+        try {
+            mgr = workspace.getNodeTypeManager();
+            mgr.getAllNodeTypes();
+            NodeType nodeType = mgr.getNodeType(NODE_TYPE_NAME);
+            System.out.println("Found node type \"" + nodeType.getName() + "\"");
+
+        } catch (RepositoryException e) {
+            // TODO Auto-generated catch block
+            e.printStackTrace();
+        }
+    }
+
+    /**
+     * Example to create a node type Article
+     * 
+     * @param workspace
+     */
+    @SuppressWarnings( "unchecked" )
+    private static void getOrCreateNodeType( Workspace workspace ) {
+        // Obtain the ModeShape-specific node type manager ...
+        NodeTypeManager nodeTypeManager;
+        try {
+            nodeTypeManager = workspace.getNodeTypeManager();
+
+            // Check if it's already there ...
+            try {
+                NodeType newNodeType = nodeTypeManager.getNodeType(NODE_TYPE_NAME);
+                if (FIRST_TIME) {
+                    System.out.println("Should not have found existing node type \"" + newNodeType.getName()
+                                       + "\"; check instructions in JavaDoc and try again.");
+                } else {
+                    System.out.println("Found existing node type \"" + newNodeType.getName() + "\"");
+                }
+            } catch (NoSuchNodeTypeException e) {
+                if (!FIRST_TIME) {
+                    throw new AssertionFailedException("Should have found existing node type: " + e.getMessage());
+                }
+
+                // Declare a mixin node type named "searchable" (with no namespace)
+                @SuppressWarnings( "unused" )
+                NodeTypeTemplate nodeType = nodeTypeManager.createNodeTypeTemplate();
+                nodeType.setName(NODE_TYPE_NAME);
+                // nodeType.setMixin(true);
+
+                // Add a property named "headline"
+                PropertyDefinitionTemplate headline = nodeTypeManager.createPropertyDefinitionTemplate();
+                headline.setName("headline");
+                headline.setMandatory(true);
+                headline.setRequiredType(PropertyType.STRING);
+                nodeType.getPropertyDefinitionTemplates().add(headline);
+
+                // Add a property named "teaser"
+                PropertyDefinitionTemplate teaser = nodeTypeManager.createPropertyDefinitionTemplate();
+                teaser.setName("teaser");
+                teaser.setMandatory(true);
+                teaser.setRequiredType(PropertyType.STRING);
+                nodeType.getPropertyDefinitionTemplates().add(teaser);
+
+                // Add a property named "body"
+                PropertyDefinitionTemplate body = nodeTypeManager.createPropertyDefinitionTemplate();
+                body.setName("body");
+                body.setMandatory(true);
+                body.setRequiredType(PropertyType.STRING);
+
+                // Register the custom node type
+                NodeType createdNodeType = nodeTypeManager.registerNodeType(nodeType, true);
+                System.out.println("node type name:" + createdNodeType.getName());
+
+                // Check that it's still there ...
+                NodeType newNodeType = nodeTypeManager.getNodeType(NODE_TYPE_NAME);
+                System.out.println("Created node type \"" + newNodeType.getName() + "\"");
+            }
+
+        } catch (RepositoryException e) {
+            // TODO Auto-generated catch block
+            e.printStackTrace();
+        }
+
+    }
+
+}

--- a/modeshape-integration-tests/src/test/resources/config/configRepositoryForDiskStorage.xml
+++ b/modeshape-integration-tests/src/test/resources/config/configRepositoryForDiskStorage.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- 
+  ~ ModeShape (http://www.modeshape.org)
+  ~
+  ~ See the COPYRIGHT.txt file distributed with this work for information
+  ~ regarding copyright ownership.  Some portions may be licensed
+  ~ to Red Hat, Inc. under one or more contributor license agreements.
+  ~ See the AUTHORS.txt file in the distribution for a full listing of 
+  ~ individual contributors.
+  ~
+  ~ ModeShape is free software. Unless otherwise indicated, all code in ModeShape
+  ~ is licensed to you under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ ModeShape is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+  ~ or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+  ~ for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public License
+  ~ along with this distribution; if not, write to:
+  ~ Free Software Foundation, Inc.
+  ~ 51 Franklin Street, Fifth Floor
+  ~ Boston, MA  02110-1301  USA
+  -->
+<configuration xmlns:mode="http://www.modeshape.org/1.0"
+               xmlns:jcr="http://www.jcp.org/jcr/1.0"
+               xmlns:nt="http://www.jcp.org/jcr/nt/1.0">
+    <!-- Define the sources from which content is made available.  -->
+    <mode:sources jcr:primaryType="nt:unstructured">
+        <mode:source jcr:name="Store" 
+            mode:classname="org.modeshape.connector.disk.DiskSource"
+            mode:description="The repository for our content"
+            mode:repositoryRootPath="target/database/ConfigurationTest/files"
+            mode:defaultWorkspaceName="default"
+            mode:creatingWorkspacesAllowed="false"
+            mode:predefinedWorkspaceNames="default, otherWorkspace, system"
+            mode:updatesAllowed="true" >
+            <mode:cachePolicy jcr:name="nodeCachePolicy" 
+                mode:classname="org.modeshape.graph.connector.base.cache.InMemoryNodeCache$MapCachePolicy"
+                mode:timeToLive="300" />
+        </mode:source>
+    </mode:sources>
+    <!-- JCR Repositories.  This is required, with a separate repository for each JCR repository instance. -->
+    <mode:repositories>
+        <mode:repository jcr:name="Repo" mode:source="Store">
+            <!-- Define the options for the JCR repository, using camelcase version of JcrRepository.Option names-->
+            <mode:options jcr:primaryType="options" >
+                <!-- Explicitly specify the "system" workspace in the "SystemStore" source. -->
+                <mode:option jcr:name="systemSourceName" mode:value="system@Store"/>
+                <!-- Explicitly specify the directory where the index files should be stored. -->
+                <mode:option jcr:name="queryIndexDirectory" mode:value="target/database/ConfigurationTest/indexes"/>
+                <!--  Should  indexes should be rebuilt synchronously when the repository restarts, default true  -->                           
+                <mode:option jcr:name="queryIndexesRebuiltSynchronously" mode:value="true"/>
+                <!--  specifies the strategy (always or ifMissing) used to determine which query indexes need to be rebuilt when the repository restarts -->
+                <mode:option jcr:name="rebuildQueryIndexOnStartup" mode:value="ifMissing"/>
+            </mode:options>
+        </mode:repository>
+    </mode:repositories>
+</configuration>

--- a/modeshape-integration-tests/src/test/resources/config/read-node-types-upon-restart-config.xml
+++ b/modeshape-integration-tests/src/test/resources/config/read-node-types-upon-restart-config.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- 
+  ~ ModeShape (http://www.modeshape.org)
+  ~
+  ~ See the COPYRIGHT.txt file distributed with this work for information
+  ~ regarding copyright ownership.  Some portions may be licensed
+  ~ to Red Hat, Inc. under one or more contributor license agreements.
+  ~ See the AUTHORS.txt file in the distribution for a full listing of 
+  ~ individual contributors.
+  ~
+  ~ ModeShape is free software. Unless otherwise indicated, all code in ModeShape
+  ~ is licensed to you under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ ModeShape is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+  ~ or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+  ~ for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public License
+  ~ along with this distribution; if not, write to:
+  ~ Free Software Foundation, Inc.
+  ~ 51 Franklin Street, Fifth Floor
+  ~ Boston, MA  02110-1301  USA
+  -->
+<configuration xmlns:mode="http://www.modeshape.org/1.0"
+               xmlns:jcr="http://www.jcp.org/jcr/1.0"
+               xmlns:nt="http://www.jcp.org/jcr/nt/1.0">
+    <!-- JCR Repositories.  This is required, with a separate repository for each JCR repository instance. -->
+    <mode:repositories>
+        <mode:repository jcr:name="Repo" mode:source="Store">
+            <mode:options jcr:primaryType="options" >
+                <!-- Explicitly specify the "system" workspace in the "SystemStore" source. -->
+                <mode:option jcr:name="systemSourceName" mode:value="system@Store"/>
+            </mode:options>
+        </mode:repository>
+    </mode:repositories>
+    <!-- Define the sources from which content is made available.  -->
+    <mode:sources jcr:primaryType="nt:unstructured">
+        <mode:source jcr:name="Store" mode:classname="org.modeshape.connector.store.jpa.JpaSource"
+            mode:model="Simple"
+            mode:dialect="org.hibernate.dialect.HSQLDialect"
+            mode:driverClassName="org.hsqldb.jdbcDriver"
+            mode:username="sa"
+            mode:password=""
+            mode:url="jdbc:hsqldb:target/jcr-test-db/db"
+            mode:maximumConnectionsInPool="2"
+            mode:referentialIntegrityEnforced="true"
+            mode:largeValueSizeInBytes="150"
+            mode:retryLimit="3"
+            mode:compressData="true"
+            mode:predefinedWorkspaceNames="default, otherWorkspace, system"
+            mode:showSql="false"
+            mode:autoGenerateSchema="disable"
+            mode:creatingWorkspacesAllowed="true"
+            mode:defaultWorkspaceName="default"/>    
+    </mode:sources>
+</configuration>

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrItemDefinitionTemplate.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrItemDefinitionTemplate.java
@@ -32,8 +32,8 @@ import org.modeshape.graph.ExecutionContext;
 import org.modeshape.graph.property.Name;
 import org.modeshape.graph.property.NamespaceRegistry;
 import org.modeshape.graph.property.Path;
-import org.modeshape.graph.property.ValueFormatException;
 import org.modeshape.graph.property.Path.Segment;
+import org.modeshape.graph.property.ValueFormatException;
 
 /**
  * ModeShape convenience implementation to support the JCR 2 NodeDefinitionTemplate and PropertyDefinitionTemplate classes.
@@ -181,5 +181,10 @@ abstract class JcrItemDefinitionTemplate implements ItemDefinition {
                || onParentVersion == OnParentVersionAction.COPY || onParentVersion == OnParentVersionAction.IGNORE
                || onParentVersion == OnParentVersionAction.INITIALIZE || onParentVersion == OnParentVersionAction.VERSION;
         this.onParentVersion = onParentVersion;
+    }
+
+    @Override
+    public String toString() {
+        return getName();
     }
 }

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrNodeTypeTemplate.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrNodeTypeTemplate.java
@@ -310,4 +310,9 @@ public class JcrNodeTypeTemplate implements NodeTypeDefinition, NodeTypeTemplate
     public void setQueryable( boolean queryable ) {
         this.queryable = queryable;
     }
+
+    @Override
+    public String toString() {
+        return getName();
+    }
 }


### PR DESCRIPTION
I've finally replicated the problem and identified a fix. Normally when restarting the engine reads the node types from the system store, and these node types are usually in a specific order. Somehow, the node types are reordered so that the built-ins are not first in the list, and when registering these the built-ins (often "nt:unstructured" or "nt:base") are not able to be resolved. Fixing the ordering won't help with existing installations, so instead I chose to change RepositoryNodeTypeManager to be more tolerant of the order of the node types by simply iterating multiple times through the list and only failing when no more node types can be successfully registered.

In addition to the change to RepositoryNodeTypeManager, the bulk of the rest of the changes are new (manual) integration tests that are successful at replicating the problem. (Note that I was not able to replicate the problem when restarting the engine while in the same process - only when restarting ModeShape in a separate VM.)
All unit and integration tests pass, as does the new manual test.
