### PR TITLE
MODE-1207 Added logging of sequencer problems

### DIFF
--- a/modeshape-common/src/main/java/org/modeshape/common/collection/ImmutableProblems.java
+++ b/modeshape-common/src/main/java/org/modeshape/common/collection/ImmutableProblems.java
@@ -25,8 +25,10 @@ package org.modeshape.common.collection;
 
 import java.util.Iterator;
 import org.modeshape.common.annotation.Immutable;
+import org.modeshape.common.collection.Problem.Status;
 import org.modeshape.common.i18n.I18n;
 import org.modeshape.common.util.CheckArg;
+import org.modeshape.common.util.Logger;
 
 /**
  * An immutable wrapper for a mutable {@link Problems}.
@@ -459,5 +461,28 @@ public class ImmutableProblems implements Problems {
     @Override
     public String toString() {
         return delegate.toString();
+    }
+
+    /**
+     * {@inheritDoc}
+     * 
+     * @see org.modeshape.common.collection.Problems#writeTo(org.modeshape.common.util.Logger)
+     */
+    @Override
+    public void writeTo( Logger logger ) {
+        delegate.writeTo(logger);
+    }
+
+    /**
+     * {@inheritDoc}
+     * 
+     * @see org.modeshape.common.collection.Problems#writeTo(org.modeshape.common.util.Logger,
+     *      org.modeshape.common.collection.Problem.Status, org.modeshape.common.collection.Problem.Status[])
+     */
+    @Override
+    public void writeTo( Logger logger,
+                         Status firstStatus,
+                         Status... additionalStatuses ) {
+        delegate.writeTo(logger, firstStatus, additionalStatuses);
     }
 }

--- a/modeshape-common/src/main/java/org/modeshape/common/collection/Problems.java
+++ b/modeshape-common/src/main/java/org/modeshape/common/collection/Problems.java
@@ -25,7 +25,9 @@ package org.modeshape.common.collection;
 
 import java.io.Serializable;
 import java.util.Iterator;
+import org.modeshape.common.collection.Problem.Status;
 import org.modeshape.common.i18n.I18n;
+import org.modeshape.common.util.Logger;
 
 /**
  * An interface for a collection of {@link Problem} objects, with multiple overloaded methods for adding errors, warnings, and
@@ -422,4 +424,22 @@ public interface Problems extends Iterable<Problem>, Serializable {
      */
     @Override
     Iterator<Problem> iterator();
+
+    /**
+     * Write the problems to the supplied logger.
+     * 
+     * @param logger the logger
+     */
+    void writeTo( Logger logger );
+
+    /**
+     * Write the problems to the supplied logger.
+     * 
+     * @param logger the logger
+     * @param firstStatus the first status to be logged
+     * @param additionalStatuses the additional statuses to be logged
+     */
+    void writeTo( Logger logger,
+                  Status firstStatus,
+                  Status... additionalStatuses );
 }

--- a/modeshape-repository/src/main/java/org/modeshape/repository/RepositoryI18n.java
+++ b/modeshape-repository/src/main/java/org/modeshape/repository/RepositoryI18n.java
@@ -72,6 +72,7 @@ public final class RepositoryI18n {
     public static I18n unableToChangeExecutionContextWhileRunning;
     public static I18n unableToStartSequencingServiceWithoutExecutionContext;
     public static I18n errorWhileSequencingNode;
+    public static I18n problemsWhileSequencingNode;
     public static I18n errorInRepositoryWhileSequencingNode;
     public static I18n errorFindingSequencersToRunAgainstNode;
     public static I18n errorInRepositoryWhileFindingSequencersToRunAgainstNode;

--- a/modeshape-repository/src/main/java/org/modeshape/repository/sequencer/SequencingService.java
+++ b/modeshape-repository/src/main/java/org/modeshape/repository/sequencer/SequencingService.java
@@ -500,6 +500,11 @@ public class SequencingService implements AdministeredService {
                                 } catch (SequencerException e) {
                                     logger.error(e, RepositoryI18n.errorWhileSequencingNode, sequencerName, change);
                                 }
+                                if (problems.hasProblems()) {
+                                    // This is running in a background thread, so at this time we can only log the problems ...
+                                    logger.error(RepositoryI18n.problemsWhileSequencingNode, sequencerName, change);
+                                    problems.writeTo(logger);
+                                }
                             }
                         }
                         this.statistics.recordNodeSequenced();

--- a/modeshape-repository/src/main/resources/org/modeshape/repository/RepositoryI18n.properties
+++ b/modeshape-repository/src/main/resources/org/modeshape/repository/RepositoryI18n.properties
@@ -54,6 +54,7 @@ sequencingServiceName = Sequencing Service
 unableToChangeExecutionContextWhileRunning = Unable to change the execution context while running
 unableToStartSequencingServiceWithoutExecutionContext = Unable to start the Sequencing Service without an execution context
 errorWhileSequencingNode = Error while sequencer {0} is sequencing node {1}
+problemsWhileSequencingNode = Problem(s) while sequencer {0} is sequencing node {1}
 errorInRepositoryWhileSequencingNode = Error in repository while sequencer {0} is sequencing node {1}
 errorInRepositoryWhileFindingSequencersToRunAgainstNode = Error in repository while finding sequencers to run against node {0}
 errorFindingSequencersToRunAgainstNode = Error finding sequencers to run against node {0}


### PR DESCRIPTION
When sequencers have problems, nothing is done with them. This change now logs the errors, warnings and info problems. This also moves the logic of logging the Problems into the Problems interface/implementations.

**_This does not fix the underlying problem, but merely adds logging so that we can hopefully diagnose the underlying cause.**_ Note that the unit/integration tests all work fine with this exact file.
