### PR TITLE
MODE-1191 Updated the documentation formatting

### DIFF
--- a/docs/reference/src/main/docbook/en-US/content/connectors/disk.xml
+++ b/docs/reference/src/main/docbook/en-US/content/connectors/disk.xml
@@ -40,96 +40,130 @@
 	<para>
 		The &DiskSource; class provides a number of JavaBean properties that control its behavior:
 	</para>
-	<table frame='all'>
-		<title>&DiskSource; properties</title>
-		<tgroup cols='2' align='left' colsep='1' rowsep='1'>
-      <colspec colname='c1' colwidth="1*"/>
-      <colspec colname='c2' colwidth="1*"/>
-			<thead>
-				<row>
-		  		<entry>Property</entry>
-		  		<entry>Description</entry>
-				</row>
-			</thead>
-			<tbody>
-				<row>
-					<entry>cachePolicy</entry>
-					<entry>Optional property that, if used, defines the cache policy for this repository source.  When not used, this source will not define a specific
-						duration for caching information.</entry>
-				</row>
-				<row>
-					<entry>creatingWorkspaceAllowed</entry>
-					<entry>Optional property that defines whether clients can create additional workspaces.  The default value is "true".
-					</entry>
-				</row>
-				<row>
-					<entry>defaultWorkspaceName</entry>
-					<entry>Optional property that is initialized to <code>"default"</code> and which defines the name for the workspace that will be used by default
-						if none is specified.</entry>
-				</row>
-			   <row>
-					<entry>largeValuePath</entry>
-					<entry>Optional, advanced property that, if specified, specifies the path to the large value area.  <emphasis>This path is relative to the value of the <code>repositoryRootPath</code> property.</emphasis>
-						The default value for this property is <code>"largeValues"</code> and it only needs to be changed if there will be a workspace named <code>"largeValues"</code>. 
-					</entry>
-				</row>
-				<row>
-					<entry>largeValueSizeInBytes</entry>
-					<entry>Optional property that, if specified, sets the threshold for large values.  Binary property values that exceed this size will be copied into the large
-					value area for this repository, where they can be shared between nodes and lazily loaded to improve node retrieval time.  The default value is "8192".
-					</entry>
-				</row>
-				<row>
-					<entry>lockFileUsed</entry>
-					<entry>An advanced property that, if set to "true", indicates that repository read and write locks should be synchronized with file lock options 
-					on a file in the on-disk storage.  This causes a performance penalty, but allows disk sources in different JVMS (e.g., clustered disk sources) to
-					coordinate their locks <emphasis>as long as all cluster members share the same disk</emphasis>.  This approach uses Java NIO file locking and is 
-					subject to the limitations of the Java NIO file locking for the current
-					JVM implementation.  The default value is "false", but this should always be set to "true" when used in a clustered environment.</entry>
-			   </row>
-				<row>
-					<entry>name</entry>
-					<entry>The name of the repository source, which is used by the &RepositoryService; when obtaining a &RepositoryConnection; by name.</entry>
-				</row>
-				<row>
-					<entry>nodeCachePolicy</entry>
-					<entry>Optional property that, if used, defines the cache policy to use for caching nodes within the connector.  
-					</entry>
-				</row>
-				<row>
-					<entry>predefinedWorkspaceNames</entry>
-					<entry>Optional property that, if used, defines names of the workspaces that are predefined and need not be created before being used.
-						This can be coupled with a "false" value for the "creatingWorkspaceAllowed" property to allow only the use of only predefined workspaces.
-					</entry>
-				</row>
-				<row>
-					<entry>rootNodeUuid</entry>
-					<entry>Optional property that, if used, specifies the UUID that should be used for the root node of each workspace.  If no value is
-					specified, a default UUID is used.</entry>
-				</row>	
-				<row>
-					<entry>retryLimit</entry>
-					<entry>Optional property that, if used, defines the number of times that any single operation on a &RepositoryConnection; to this source should be retried
-						following a communication failure. The default value is '0'.</entry>
-				</row>
-				<row>
-					<entry>updatesAllowed</entry>
-					<entry>Determines whether the content in the file system can be updated ("true"), or if the content may only be read ("false").
-						The default value is "true".</entry>
-				</row>
-				<row>
-					<entry>repositoryRootPath</entry>
-					<entry>
-					<para>Optional property that specifies a path on the local file system to the root of all workspaces.  The connector will use this as the root
+  <variablelist>
+    <varlistentry>
+      <term>cachePolicy</term>
+      <listitem>
+        <para>
+          Optional property that, if used, defines the cache policy for this repository source.  When not used, this source will not define a specific
+			    duration for caching information.
+				</para>
+      </listitem>
+    </varlistentry>
+    <varlistentry>
+      <term>creatingWorkspaceAllowed</term>
+      <listitem>
+        <para>
+          Optional property that defines whether clients can create additional workspaces.  The default value is "true".
+        </para>
+      </listitem>
+    </varlistentry>
+    <varlistentry>
+      <term>defaultWorkspaceName</term>
+      <listitem>
+        <para>
+          Optional property that is initialized to <code>"default"</code> and which defines the name for the workspace that will be used by default
+					if none is specified.
+				</para>
+      </listitem>
+    </varlistentry>
+    <varlistentry>
+      <term>largeValuePath</term>
+      <listitem>
+        <para>
+          Optional, advanced property that, if specified, specifies the path to the large value area.  <emphasis>This path is relative to the value of the <code>repositoryRootPath</code> property.</emphasis>
+					The default value for this property is <code>"largeValues"</code> and it only needs to be changed if there will be a workspace named <code>"largeValues"</code>. 
+				</para>
+      </listitem>
+    </varlistentry>
+    <varlistentry>
+      <term>largeValueSizeInBytes</term>
+      <listitem>
+        <para>
+          Optional property that, if specified, sets the threshold for large values.  Binary property values that exceed this size will be copied into the large
+				  value area for this repository, where they can be shared between nodes and lazily loaded to improve node retrieval time.  The default value is "8192".
+				</para>
+      </listitem>
+    </varlistentry>
+    <varlistentry>
+      <term>lockFileUsed</term>
+      <listitem>
+        <para>
+          An advanced property that, if set to "true", indicates that repository read and write locks should be synchronized with file lock options 
+				  on a file in the on-disk storage.  This causes a performance penalty, but allows disk sources in different JVMS (e.g., clustered disk sources) to
+				  coordinate their locks <emphasis>as long as all cluster members share the same disk</emphasis>.  This approach uses Java NIO file locking and is 
+				  subject to the limitations of the Java NIO file locking for the current
+				  JVM implementation.
+				</para>
+				<para>
+				  The default value is "false", but this should always be set to "true" when used in a clustered environment.
+		    </para>
+      </listitem>
+    </varlistentry>
+    <varlistentry>
+      <term>name</term>
+      <listitem>
+        <para>
+          Required property that specifies the name of the repository source, which is used by the &RepositoryService; 
+          when obtaining a &RepositoryConnection; by name.
+        </para>
+      </listitem>
+    </varlistentry>
+    <varlistentry>
+      <term>nodeCachePolicy</term>
+      <listitem>
+        <para>
+          Optional property that, if used, defines the cache policy to use for caching nodes within the connector.
+        </para>
+      </listitem>
+    </varlistentry>
+    <varlistentry>
+      <term>predefinedWorkspaceNames</term>
+      <listitem>
+        <para>
+          Optional property that, if used, defines names of the workspaces that are predefined and need not be created before being used.
+					This can be coupled with a "false" value for the "creatingWorkspaceAllowed" property to allow only the use of only predefined workspaces.
+        </para>
+      </listitem>
+    </varlistentry>
+    <varlistentry>
+      <term>repositoryRootPath</term>
+      <listitem>
+        <para>
+          Optional property that specifies a path on the local file system to the root of all workspaces.  The connector will use this as the root
 					for a file and folder structure for storing content.  The default value is "/tmp", so setting this property to a more logical value is strongly 
 					recommended.
-					</para>
-					</entry>
-				</row>	
-				
-			</tbody>
-		</tgroup>
-	</table>
+        </para>
+      </listitem>
+    </varlistentry>
+    <varlistentry>
+      <term>retryLimit</term>
+      <listitem>
+        <para>
+          Optional property that, if used, defines the number of times that any single operation on a &RepositoryConnection; to this source should be retried
+					following a communication failure. The default value is '0'.
+        </para>
+      </listitem>
+    </varlistentry>
+    <varlistentry>
+      <term>rootNodeUuid</term>
+      <listitem>
+        <para>
+          Optional property that, if used, specifies the UUID that should be used for the root node of each workspace.  If no value is
+					specified, a default UUID is used.
+        </para>
+      </listitem>
+    </varlistentry>
+    <varlistentry>
+      <term>updatesAllowed</term>
+      <listitem>
+        <para>
+          Optional property that determines whether the content in the file system can be updated ("true"), or if the content may only be read ("false").
+					The default value is "true".
+        </para>
+      </listitem>
+    </varlistentry>
+  </variablelist>
 	<para>
 		One way to configure the file system connector is to create &JcrConfiguration; instance with a repository source that uses the &DiskSource; class.
 		For example:

--- a/docs/reference/src/main/docbook/en-US/content/connectors/federation.xml
+++ b/docs/reference/src/main/docbook/en-US/content/connectors/federation.xml
@@ -445,32 +445,28 @@
 			<title>Repository Source properties</title>
 			<para>
 				While the majority of the configuration is defined using the configuration source (as discussed above), the &FederatedRepositorySource; 
-				class have have a few JavaBean properties:
+				class does have a few JavaBean properties:
 			</para>
-			<table frame='all'>
-				<title>&FederatedRepositorySource; properties</title>
-				<tgroup cols='2' align='left' colsep='1' rowsep='1'>
-		      <colspec colname='c1' colwidth="1*"/>
-		      <colspec colname='c2' colwidth="1*"/>
-					<thead>
-						<row>
-				  		<entry>Property</entry>
-				  		<entry>Description</entry>
-						</row>
-					</thead>
-					<tbody>
-						<row>
-							<entry>name</entry>
-							<entry>The name of the repository source, which is used by the &RepositoryService; when obtaining a &RepositoryConnection; by name.</entry>
-						</row>
-						<row>
-							<entry>retryLimit</entry>
-							<entry>Optional property that, if used, defines the number of times that any single operation on a &RepositoryConnection; to this source should be retried
-								following a communication failure. The default value is '0'.</entry>
-						</row>
-					</tbody>
-				</tgroup>
-			</table>
+      <variablelist>
+        <varlistentry>
+          <term>name</term>
+          <listitem>
+            <para>
+              Required property that specifies the name of the repository source, which is used by the &RepositoryService; 
+              when obtaining a &RepositoryConnection; by name.
+    				</para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>retryLimit</term>
+          <listitem>
+            <para>
+              Optional property that, if used, defines the number of times that any single operation on a &RepositoryConnection; to this source should be retried
+							following a communication failure. The default value is '0'.
+    				</para>
+          </listitem>
+        </varlistentry>
+      </variablelist>
 		</sect1>
 </chapter>
 

--- a/docs/reference/src/main/docbook/en-US/content/connectors/file_system.xml
+++ b/docs/reference/src/main/docbook/en-US/content/connectors/file_system.xml
@@ -66,161 +66,197 @@
 	<para>
 		The &FileSystemSource; class provides a number of JavaBean properties that control its behavior:
 	</para>
-	<table frame='all'>
-		<title>&FileSystemSource; properties</title>
-		<tgroup cols='2' align='left' colsep='1' rowsep='1'>
-      <colspec colname='c1' colwidth="1*"/>
-      <colspec colname='c2' colwidth="1*"/>
-			<thead>
-				<row>
-		  		<entry>Property</entry>
-		  		<entry>Description</entry>
-				</row>
-			</thead>
-			<tbody>
-				<row>
-					<entry>cachePolicy</entry>
-					<entry>Optional property that, if used, defines the cache policy for this repository source.  When not used, this source will not define a specific
-						duration for caching information.</entry>
-				</row>
-				<row>
-					<entry>creatingWorkspaceAllowed</entry>
-					<entry>Optional property that defines whether clients can create additional workspaces.  The default value is "true".
-					</entry>
-				</row>
-				<row>
-					<entry>customPropertiesFactory</entry>
-					<entry>
-						Specifies the &CustomPropertiesFactory; implementation that should be used to augment the default properties 
-						available on each node.  This property can be set either from an object that implements the &CustomPropertiesFactory;
-						interface or from the name of a class with a public, no-argument constructor that implements the &CustomPropertiesFactory;
-						interface.  In the latter case, a the named class will be instantiated and used as the custom properties factory implementation.
-						See also the "extraPropertiesBehavior" setting.
-					</entry>
-				</row>
-				<row>
-					<entry>extraPropertiesBehavior</entry>
-					<entry>
-						Optional setting that specifies how to handle the extra properties on "nt:file", "nt:folder", and "nt:resource" nodes that
-						cannot be represented on the native files themselves. Set this to "log" if warnings are to be sent to the log 
-						(the default), or "error" if setting such properties should cause an error, or "store" if they should be stored in ancillary 
-						files next to the files and folders, or "ignore" if they should be silently ignored. The "log" value will be used by default 
-						or an invalid value is specified. This setting will be ignored if a "customPropertiesFactory" class name is specified.
-					</entry>
-				</row>
-				<row>
-					<entry>defaultWorkspaceName</entry>
-					<entry>Optional property that is initialized to <code>"default"</code> and which defines the name for the workspace that will be used by default
-						if none is specified.</entry>
-				</row>
-				<row>
-					<entry>exclusionPattern</entry>
-					<entry>
-						<para>
-						Specifies a regular expression that is used to determine which files and folders in the underlying file system should be exposed through
-						this connector.  Files and folders with a name that matches the provided regular expression will <emphasis>not</emphasis> be exposed by this source. 
-						Setting this property to <code>null</code> has the effect of removing the exclusion pattern.
-						</para>
-					</entry>
-				</row>
-				<row>
-					<entry>inclusionPattern</entry>
-					<entry>
-						<para>
-						Specifies a regular expression that is used to determine which files and folders in the underlying file system should be exposed through
-						this connector.  Files and folders with a name that matches the provided regular expression will be exposed by this source. 
-						Setting this property to <code>null</code> has the effect of removing the inclusion pattern.
-						</para>
-					</entry>
-				</row>
-				<row>
-					<entry>filenameFilter</entry>
-					<entry>
-						<para>
-						Specifies the &FilenameFilter; that is used to determine which files and folders in the underlying file system should be exposed through
-						this connector.  Only files and folders that the filter accepts will be accessible through this source.
-						</para>
-						<para>
-						This property can be set either from an object that implements the &FilenameFilter;
-						interface or from the name of a class with a public, no-argument constructor that implements the &FilenameFilter;
-						interface.  In the latter case, a the named class will be instantiated and used as the filename filter implementation.
-						Setting this property to null has the effect of clearing the filter.
-						</para>
-					</entry>
-				</row>
-				<row>
-					<entry></entry>
-					<entry>
-						<para>
-						Note: the filenameFilter, exclusionPattern, and inclusionPattern properties are somewhat mutually exclusive.  If a filenameFilter is specified, 
-						then exclusionPattern and inclusionPattern are both ignored.  
-						</para>
-					</entry>
-				</row>
-				<row>
-					<entry>name</entry>
-					<entry>The name of the repository source, which is used by the &RepositoryService; when obtaining a &RepositoryConnection; by name.</entry>
-				</row>
-				<row>
-					<entry>nodeCachePolicy</entry>
-					<entry>Optional property that, if used, defines the cache policy to use for caching nodes within the connector.  
-					</entry>
-				</row>
-				<row>
-					<entry>predefinedWorkspaceNames</entry>
-					<entry>Optional property that, if used, defines names of the workspaces that are predefined and need not be created before being used.
-						This can be coupled with a "false" value for the "creatingWorkspaceAllowed" property to allow only the use of only predefined workspaces.
-					</entry>
-				</row>
-				<row>
-					<entry>rootNodeUuid</entry>
-					<entry>Optional property that, if used, specifies the UUID that should be used for the root node of each workspace.  If no value is
-					specified, a default UUID is used.</entry>
-				</row>	
-				<row>
-					<entry>retryLimit</entry>
-					<entry>Optional property that, if used, defines the number of times that any single operation on a &RepositoryConnection; to this source should be retried
-						following a communication failure. The default value is '0'.</entry>
-				</row>
-				<row>
-					<entry>temporaryStoragePath</entry>
-					<entry><para>Optional property that allows administrators to specify a specific location for the file system connector's temporary
-				     storage. When writing file content, this connector first writes the content to a file in the temporary storage area. After
-     				 that write succeeds in full, the temporary file is moved to its final location in the workspace. This extra step is taken
-     				 so that an error or failure while writing the file does not cause corruption in the target file.
-     				 </para>
-     				 <para>
-	     				However, if the temporary storage area is located on a different file system than the file that will ultimately be written
-						to, the rename operation cannot be used and a separate file copy must occur. Therefore,
-						administrators should set the value of this path to some path in the same file system as the
-						workspace root path as specified by the <code>workspaceRootPath</code> property.
-     				 </para>
-     				 </entry>
-				</row>
-				<row>
-					<entry>updatesAllowed</entry>
-					<entry>Determines whether the content in the file system can be updated ("true"), or if the content may only be read ("false").
-						The default value is "false" to avoid unintentional security vulnerabilities.</entry>
-				</row>
-				<row>
-					<entry>workspaceRootPath</entry>
-					<entry>
-					<para>Optional property that, if used, specifies a path on the local file system to the root of all workspaces.  The source will will 
+  <variablelist>
+    <varlistentry>
+      <term>cachePolicy</term>
+      <listitem>
+        <para>
+          Optional property that, if used, defines the cache policy for this repository source.  When not used, this source will not define a specific
+					duration for caching information.
+				</para>
+      </listitem>
+    </varlistentry>
+    <varlistentry>
+      <term>creatingWorkspaceAllowed</term>
+      <listitem>
+        <para>
+          Optional property that defines whether clients can create additional workspaces.  The default value is "true".
+				</para>
+      </listitem>
+    </varlistentry>
+    <varlistentry>
+      <term>customPropertiesFactory</term>
+      <listitem>
+        <para>
+          Optional property that specifies the &CustomPropertiesFactory; implementation that should be used to augment the default properties 
+					available on each node.  This property can be set either from an object that implements the &CustomPropertiesFactory;
+					interface or from the name of a class with a public, no-argument constructor that implements the &CustomPropertiesFactory;
+					interface.  In the latter case, a the named class will be instantiated and used as the custom properties factory implementation.
+				</para>
+				<para>
+					This is really intended for cases where the "extraPropertiesBehavior" is not sufficient. Most often, however, the
+					"extraPropertiesBehavior" setting will be sufficient and should be used instead of "customPropertiesFactory".
+				</para>
+      </listitem>
+    </varlistentry>
+    <varlistentry>
+      <term>defaultWorkspaceName</term>
+      <listitem>
+        <para>
+          Optional property that defines the name for the workspace that will be used in cases when clients do not explicitly specify
+          the workspace name. If not specified, "<code>default</code>" will be used.
+				</para>
+      </listitem>
+    </varlistentry>
+    <varlistentry>
+      <term>extraPropertiesBehavior</term>
+      <listitem>
+        <para>
+          Optional setting that specifies how to handle the extra properties on "nt:file", "nt:folder", and "nt:resource" nodes that
+					cannot be represented on the native files themselves. Set this to "log" if warnings are to be sent to the log 
+					(the default), or "error" if setting such properties should cause an error, or "store" if they should be stored in ancillary 
+					files next to the files and folders, or "ignore" if they should be silently ignored. The "log" value will be used by default 
+					or an invalid value is specified.
+				</para>
+				<para>
+					This setting will be ignored if a "customPropertiesFactory" class name is specified.
+				</para>
+      </listitem>
+    </varlistentry>
+    <varlistentry>
+      <term>exclusionPattern</term>
+      <listitem>
+        <para>
+          Optional property that specifies a regular expression that is used to determine which files and folders in the underlying file system are exposed through
+					this connector. Files and folders with a name that matches the provided regular expression will <emphasis>not</emphasis> be exposed 
+					by this source. Setting this property to <code>null</code> has the effect of removing the exclusion pattern.
+				</para>
+        <para>
+          This may be combined with an "inclusionPattern", in which a file or folder will be exposed by this connector only when it
+          satisfies the "inclusionPattern" and does not satisfy the "exclusionPattern". Also, the "inclusionPattern" and "exclusionPattern"
+          cannot be used with "filenameFilter", since the latter will always override the patterns.
+        </para>
+      </listitem>
+    </varlistentry>
+    <varlistentry>
+      <term>inclusionPattern</term>
+      <listitem>
+        <para>
+          Optional property that specifies a regular expression that is used to determine which files and folders in the underlying file system are exposed through
+					this connector. Files and folders with a name that matches the provided regular expression will be exposed by this source. 
+					Setting this property to <code>null</code> has the effect of removing the inclusion pattern.
+				</para>
+        <para>
+          This may be combined with an "exclusionPattern", in which a file or folder will be exposed by this connector only when it
+          satisfies the "inclusionPattern" and does not satisfy the "exclusionPattern". Also, the "inclusionPattern" and "exclusionPattern"
+          cannot be used with "filenameFilter", since the latter will always override the patterns.
+        </para>
+      </listitem>
+    </varlistentry>
+    <varlistentry>
+      <term>filenameFilter</term>
+      <listitem>
+				<para>
+					Optional property that specifies the name of the &FilenameFilter; implementation class that used to determine which files and folders in the underlying 
+					file system are exposed through this connector. Only files and folders that the filter accepts will be accessible through this source.
+					The &FilenameFilter; implementation class must have a public, no-argument constructor.
+					Use this when the "inclusionPattern" and "exclusionPattern" values would be too complicated or are not able to represent the logic.
+				</para>
+				<para>
+					Note that the "filenameFilter", "exclusionPattern", and "inclusionPattern" properties are somewhat mutually exclusive.  
+					If a "filenameFilter" is specified, then "exclusionPattern" and "inclusionPattern" are both ignored.
+					Setting this property to an empty value (or null) has the effect of clearing the filter.
+				</para>
+      </listitem>
+    </varlistentry>
+    <varlistentry>
+      <term>name</term>
+      <listitem>
+        <para>
+          Required property that specifies the name of the repository source, which is used by the &RepositoryService; 
+          when obtaining a &RepositoryConnection; by name.
+				</para>
+      </listitem>
+    </varlistentry>
+    <varlistentry>
+      <term>nodeCachePolicy</term>
+      <listitem>
+        <para>
+          Optional property that, if used, defines the cache policy to use for caching nodes within the connector.  
+				</para>
+      </listitem>
+    </varlistentry>
+    <varlistentry>
+      <term>predefinedWorkspaceNames</term>
+      <listitem>
+        <para>
+          Optional property that, if used, defines names of the workspaces that are predefined and need not be created before being used.
+					This can be coupled with a "false" value for the "creatingWorkspaceAllowed" property to allow only the use of only predefined workspaces.
+				</para>
+      </listitem>
+    </varlistentry>
+    <varlistentry>
+      <term>rootNodeUuid</term>
+      <listitem>
+        <para>
+          Optional property that, if used, specifies the UUID that should be used for the root node of each workspace.  If no value is
+					specified, a default UUID is used.
+				</para>
+      </listitem>
+    </varlistentry>
+    <varlistentry>
+      <term>retryLimit</term>
+      <listitem>
+        <para>
+          Optional property that, if used, defines the number of times that any single operation on a &RepositoryConnection; to this source should be retried
+					following a communication failure. The default value is '0'.
+				</para>
+      </listitem>
+    </varlistentry>
+    <varlistentry>
+      <term>temporaryStoragePath</term>
+      <listitem>
+        <para>
+          Optional property that specifies a location for the file system connector's temporary storage.
+				  When writing file content, this connector first writes the content to a file in the temporary storage area. After
+     			that write succeeds in full, the temporary file is moved to its final location in the workspace. This extra step is taken
+     			so that an error or failure while writing the file does not cause corruption in the existing target file.
+     		</para>
+     		<para>
+     		  This path must be set to a path on the same file system specified by the <code>workspaceRootPath</code> property.
+     		  Otherwise, the temporary storage area will be located on a different file system than where the file will ultimately be written,
+					so the rename operation cannot be used and a separate file copy must occur, increasing the risk of data loss if a network
+					failure or hardware problem occurs.
+     		</para>
+     	</listitem>
+    </varlistentry>
+    <varlistentry>
+      <term>updatesAllowed</term>
+      <listitem>
+        <para>
+          Determines whether the content in the file system can be updated ("true"), or if the content may only be read ("false").
+					The default value is "false" to avoid unintentional security vulnerabilities.
+				</para>
+      </listitem>
+    </varlistentry>
+    <varlistentry>
+      <term>workspaceRootPath</term>
+      <listitem>
+				<para>
+				  Optional property that, if used, specifies a path on the local file system to the root of all workspaces.  The source will will 
 					use the name of the workspace as a relative path from the <code>workspaceRootPath</code> to determine the path for a particular workspace.  
 					If no value (or a <code>null</code> value) is specified, the source will use the name of the workspace as a relative path from the current working 
 					directory of this virtual machine (as defined by <code>new File(".")</code>.
-					</para>
-					<para>As an example for a workspace named <code>"default/foo"</code>,
-					the source will use <code>new File(workspaceRootPath, "default/foo")</code> as the source directory for the connector if <code>workspaceRootPath</code> is set
-					to a non-null value, or <code>new File(".", "default/foo")</code> as the source directory for the connector if <code>workspaceRootPath</code> is
-					set to <code>null</code>.
-					</para>
-					</entry>
-				</row>	
-				
-			</tbody>
-		</tgroup>
-	</table>
+				</para>
+				<para>
+				  As an example, if <code>workspaceRootPath</code> is set	to a non-null value, then for a workspace named <code>"default/foo"</code>
+				  the source will use <code>new File(workspaceRootPath, "default/foo")</code> as the source directory for the workspace content.
+				  If <code>workspaceRootPath</code> is not set (or set to an empty string or null value), then the source will use
+				  <code>new File(".", "default/foo")</code> as the source directory for the workspace content.
+				</para>
+      </listitem>
+    </varlistentry>
+  </variablelist>
 	<para>
 		One way to configure the file system connector is to create &JcrConfiguration; instance with a repository source that uses the &FileSystemSource; class.
 		For example:

--- a/docs/reference/src/main/docbook/en-US/content/connectors/in_memory.xml
+++ b/docs/reference/src/main/docbook/en-US/content/connectors/in_memory.xml
@@ -39,51 +39,63 @@
 	<para>
 		The &InMemoryRepositorySource; class provides a number of JavaBean properties that control its behavior:
 	</para>
-	<table frame='all'>
-		<title>&InMemoryRepositorySource; properties</title>
-		<tgroup cols='2' align='left' colsep='1' rowsep='1'>
-      <colspec colname='c1' colwidth="1*"/>
-      <colspec colname='c2' colwidth="1*"/>
-			<thead>
-				<row>
-		  		<entry>Property</entry>
-		  		<entry>Description</entry>
-				</row>
-			</thead>
-			<tbody>
-				<row>
-					<entry>defaultCachePolicy</entry>
-					<entry>Optional property that, if used, defines the default for how long this information provided by this source may to be 
-						cached by other, higher-level components.  The default value of null implies that this source does not define a specific
-						duration for caching information provided by this repository source.</entry>
-				</row>
-				<row>
-					<entry>defaultWorkspaceName</entry>
-					<entry>Optional property that is initialized to an empty string and which defines the name for the workspace that will be used by default
-						if none is specified.</entry>
-				</row>
-				<row>
-					<entry>jndiName</entry>
-					<entry>Optional property that, if used, specifies the name in JNDI where an &InMemoryRepository; instance can be found.
-						This is an advanced property that is infrequently used.</entry>
-				</row>
-				<row>
-					<entry>name</entry>
-					<entry>The name of the repository source, which is used by the &RepositoryService; when obtaining a &RepositoryConnection; by name.</entry>
-				</row>
-				<row>
-					<entry>rootNodeUuid</entry>
-					<entry>Optional property that, if used, defines the UUID of the root node in the in-memory repository.  If not used,
-						then a new UUID is generated.</entry>
-				</row>
-				<row>
-					<entry>retryLimit</entry>
-					<entry>Optional property that, if used, defines the number of times that any single operation on a &RepositoryConnection; to this source should be retried
-						following a communication failure. The default value is '0'.</entry>
-				</row>
-			</tbody>
-		</tgroup>
-	</table>
+  <variablelist>
+    <varlistentry>
+      <term>defaultCachePolicy</term>
+      <listitem>
+        <para>
+          Optional property that, if used, defines the default for how long this information provided by this source may to be 
+					cached by other, higher-level components.  The default value is an empty string (or null) and implies that this source 
+					does not define a specific duration for caching information provided by this repository source.
+				</para>
+      </listitem>
+    </varlistentry>
+    <varlistentry>
+      <term>defaultWorkspaceName</term>
+      <listitem>
+        <para>
+          Optional property that defines the name for the workspace that will be used in cases when clients do not explicitly specify
+          the workspace name. If not specified, "<code>default</code>" will be used.
+				</para>
+      </listitem>
+    </varlistentry>
+    <varlistentry>
+      <term>jndiName</term>
+      <listitem>
+        <para>
+          Optional property that, if used, specifies the name in JNDI where an &InMemoryRepository; instance can be found.
+					This is an advanced property that is infrequently used.
+				</para>
+      </listitem>
+    </varlistentry>
+    <varlistentry>
+      <term>name</term>
+      <listitem>
+        <para>
+          Required property that specifies the name of the repository source, which is used by the &RepositoryService; 
+          when obtaining a &RepositoryConnection; by name.
+				</para>
+      </listitem>
+    </varlistentry>
+    <varlistentry>
+      <term>rootNodeUuid</term>
+      <listitem>
+        <para>
+          Optional property that, if used, specifies the UUID that should be used for the root node of each workspace.  If no value is
+					specified, a new UUID is generated.
+				</para>
+      </listitem>
+    </varlistentry>
+    <varlistentry>
+      <term>retryLimit</term>
+      <listitem>
+        <para>
+          Optional property that, if used, defines the number of times that any single operation on a &RepositoryConnection; to this source should be retried
+					following a communication failure. The default value is '0'.
+				</para>
+      </listitem>
+    </varlistentry>
+  </variablelist>
 	<para>
 		One way to configure the in-memory connector is to create &JcrConfiguration; instance with a repository source that uses the &InMemoryRepositorySource; class.
 		For example:

--- a/docs/reference/src/main/docbook/en-US/content/connectors/infinispan.xml
+++ b/docs/reference/src/main/docbook/en-US/content/connectors/infinispan.xml
@@ -46,134 +46,180 @@
 	<para>
 		The &InfinispanSource; class provides a number of JavaBean properties that control its behavior:
 	</para>
-	<table frame='all'>
-		<title>&InfinispanSource; properties</title>
-		<tgroup cols='2' align='left' colsep='1' rowsep='1'>
-      <colspec colname='c1' colwidth="1*"/>
-      <colspec colname='c2' colwidth="1*"/>
-			<thead>
-				<row>
-		  		<entry>Property</entry>
-		  		<entry>Description</entry>
-				</row>
-			</thead>
-			<tbody>
-				<row>
-					<entry>cacheContainerJndiName</entry>
-					<entry>Optional property that, if used, specifies the name in JNDI where an existing Infinispan Cache Manager instance can be found.
-						That factory would then be used if needed to create an Infinispan Cache instance.  If no value is provided, then the
-						Infinispan <code>DefaultCacheManager</code> class is used.</entry>
-				</row>
-				<row>
-					<entry>cacheConfigurationName</entry>
-					<entry>
-						<para>Optional property that, if used, specifies the name of the configuration resource or file that is supplied to the cache manager
-						when creating a new Infinispan DefaultCacheManager instance.  The configuration name is first treated as a resource name and will be attempted
-						to be loaded from the &ClassLoader;.  If that is unsuccessful, the configuration name is assumed to be a file name and will be loaded
-						from the file system.  This initialization happens the first time that the source is used.
-						</para>
-						<para><emphasis>Note that the <code>cacheManagerJndiName</code> property is checked first as a pointer to the Infinispan <code>CacheManager</code>.
-							If the JNDI name points to a CacheManager, the <code>cacheConfigurationName</code> property will not be considered. 
-						</emphasis></para>
-					</entry>
-				</row>
-				<row>
-					<entry>defaultCachePolicy</entry>
-					<entry>Optional property that, if used, defines the default for how long this information provided by this source may to be 
-						cached by other, higher-level components.  The default value of null implies that this source does not define a specific
-						duration for caching information provided by this repository source.</entry>
-				</row>
-				<row>
-					<entry>defaultWorkspaceName</entry>
-					<entry>Optional property that is initialized to an empty string and which defines the name for the workspace that will be used by default
-						if none is specified.</entry>
-				</row>
-				<row>
-					<entry>name</entry>
-					<entry>The name of the repository source, which is used by the &RepositoryService; when obtaining a &RepositoryConnection; by name.</entry>
-				</row>
-				<row>
-					<entry>predefinedWorkspaceNames</entry>
-					<entry>Optional property that defines the names of the workspaces that exist and that are available for use without having to create them.</entry>
-				</row>
-				<row>
-					<entry>retryLimit</entry>
-					<entry>Optional property that, if used, defines the number of times that any single operation on a &RepositoryConnection; to this source should be retried
-						following a communication failure. The default value is '0'.</entry>
-				</row>	
-				<row>
-					<entry>rootNodeUuid</entry>
-					<entry>Optional property that, if used, specifies the UUID that should be used for the root node of each workspace.  If no value is
+  <variablelist>
+    <varlistentry>
+      <term>cacheContainerJndiName</term>
+      <listitem>
+        <para>
+          Optional property that, if used, specifies the name in JNDI where an existing Infinispan Cache Manager instance can be found.
+					That factory would then be used if needed to create an Infinispan Cache instance.  If no value is provided, then the
+					Infinispan <code>DefaultCacheManager</code> class is used.
+				</para>
+				<para>
+				  <emphasis>Note that the "<code>cacheManagerJndiName</code>" property is checked first as a pointer to the Infinispan <code>CacheManager</code>.
+					If the JNDI name points to a CacheManager, the "<code>cacheConfigurationName</code>" property will not be considered.</emphasis>
+				</para>
+      </listitem>
+    </varlistentry>
+    <varlistentry>
+      <term>cacheConfigurationName</term>
+      <listitem>
+				<para>
+				  Optional property that, if used, specifies the name of the configuration resource or file that is supplied to the cache manager
+					when creating a new Infinispan DefaultCacheManager instance.  The configuration name is first treated as a resource name and will be attempted
+					to be loaded from the &ClassLoader;.  If that is unsuccessful, the configuration name is assumed to be a file name and will be loaded
+					from the file system.  This initialization happens the first time that the source is used.
+				</para>
+				<para>
+				  <emphasis>Note that the "<code>cacheManagerJndiName</code>" property is checked first as a pointer to the Infinispan <code>CacheManager</code>.
+					If the JNDI name points to a CacheManager, the "<code>cacheConfigurationName</code>" property will not be considered.</emphasis>
+				</para>
+      </listitem>
+    </varlistentry>
+    <varlistentry>
+      <term>defaultCachePolicy</term>
+      <listitem>
+        <para>
+          Optional property that, if used, defines the default for how long this information provided by this source may to be 
+					cached by other, higher-level components.  The default value is an empty string (or null) and implies that this source 
+					does not define a specific duration for caching information provided by this repository source.
+				</para>
+      </listitem>
+    </varlistentry>
+    <varlistentry>
+      <term>defaultWorkspaceName</term>
+      <listitem>
+        <para>
+          Optional property that defines the name for the workspace that will be used in cases when clients do not explicitly specify
+          the workspace name. If not specified, "<code>default</code>" will be used.
+				</para>
+      </listitem>
+    </varlistentry>
+    <varlistentry>
+      <term>name</term>
+      <listitem>
+        <para>
+          Required property that specifies the name of the repository source, which is used by the &RepositoryService; 
+          when obtaining a &RepositoryConnection; by name.
+				</para>
+      </listitem>
+    </varlistentry>
+    <varlistentry>
+      <term>predefinedWorkspaceNames</term>
+      <listitem>
+        <para>
+          Optional property that defines the names of the workspaces that exist and that are available for use without having to create them.
+				</para>
+      </listitem>
+    </varlistentry>
+    <varlistentry>
+      <term>rootNodeUuid</term>
+      <listitem>
+        <para>
+          Optional property that, if used, specifies the UUID that should be used for the root node of each workspace.  If no value is
 					specified, a pre-defined UUID constant is used. A custom value need only be supplied for Infinispan sources created prior to ModeShape 2.0,
-					or if a specific UUID is desired or needed.</entry>
-				</row>	
-				<row>
-					<entry>updatesAllowed</entry>
-					<entry>Determines whether the content in the connector is can be updated ("true"), or if the content may only be read ("false").
-						The default value is "true".</entry>
-				</row>
-			</tbody>
-		</tgroup>
-	</table>
+					or if a specific UUID is desired or needed.
+				</para>
+      </listitem>
+    </varlistentry>
+    <varlistentry>
+      <term>retryLimit</term>
+      <listitem>
+        <para>
+          Optional property that, if used, defines the number of times that any single operation on a &RepositoryConnection; to this source should be retried
+					following a communication failure. The default value is '0'.
+				</para>
+      </listitem>
+    </varlistentry>
+    <varlistentry>
+      <term>updatesAllowed</term>
+      <listitem>
+        <para>
+          Optional property that determines whether the content in the connector is can be updated ("true"), or if the content may only be read ("false").
+					The default value is "true".
+				</para>
+      </listitem>
+    </varlistentry>
+  </variablelist>
 	<para>
 		The &RemoteInfinispanSource; class provides a number of JavaBean properties that control its behavior:
 	</para>
-	<table frame='all'>
-		<title>&RemoteInfinispanSource; properties</title>
-		<tgroup cols='2' align='left' colsep='1' rowsep='1'>
-      <colspec colname='c1' colwidth="1*"/>
-      <colspec colname='c2' colwidth="1*"/>
-			<thead>
-				<row>
-		  		<entry>Property</entry>
-		  		<entry>Description</entry>
-				</row>
-			</thead>
-			<tbody>
-				<row>
-					<entry>remoteInfinispanServerList</entry>
-					<entry>Optional property that defines the list of servers.  The servers must be Infinispan HotRod servers.  The list must be in
-					       the appropriate format of host:port[;host:port...] that would be used when defining an Infinispan <code>RemoteCacheManager</code> 
-					       instance.  If the value is missing, localhost:11311 is assumed.</entry>
-				</row>
-				<row>
-					<entry>defaultCachePolicy</entry>
-					<entry>Optional property that, if used, defines the default for how long this information provided by this source may to be 
-						cached by other, higher-level components.  The default value of null implies that this source does not define a specific
-						duration for caching information provided by this repository source.</entry>
-				</row>
-				<row>
-					<entry>defaultWorkspaceName</entry>
-					<entry>Optional property that is initialized to an empty string and which defines the name for the workspace that will be used by default
-						if none is specified.</entry>
-				</row>
-				<row>
-					<entry>name</entry>
-					<entry>The name of the repository source, which is used by the &RepositoryService; when obtaining a &RepositoryConnection; by name.</entry>
-				</row>
-				<row>
-					<entry>predefinedWorkspaceNames</entry>
-					<entry>Optional property that defines the names of the workspaces that exist and that are available for use without having to create them.</entry>
-				</row>
-				<row>
-					<entry>retryLimit</entry>
-					<entry>Optional property that, if used, defines the number of times that any single operation on a &RepositoryConnection; to this source should be retried
-						following a communication failure. The default value is '0'.</entry>
-				</row>	
-				<row>
-					<entry>rootNodeUuid</entry>
-					<entry>Optional property that, if used, specifies the UUID that should be used for the root node of each workspace.  If no value is
+  <variablelist>
+    <varlistentry>
+      <term>defaultCachePolicy</term>
+      <listitem>
+        <para>
+          Optional property that, if used, defines the default for how long this information provided by this source may to be 
+					cached by other, higher-level components.  The default value is an empty string (or null) and implies that this source 
+					does not define a specific duration for caching information provided by this repository source.
+				</para>
+      </listitem>
+    </varlistentry>
+    <varlistentry>
+      <term>defaultWorkspaceName</term>
+      <listitem>
+        <para>
+          Optional property that defines the name for the workspace that will be used in cases when clients do not explicitly specify
+          the workspace name. If not specified, "<code>default</code>" will be used.
+				</para>
+      </listitem>
+    </varlistentry>
+    <varlistentry>
+      <term>name</term>
+      <listitem>
+        <para>
+          Required property that specifies the name of the repository source, which is used by the &RepositoryService; 
+          when obtaining a &RepositoryConnection; by name.
+				</para>
+      </listitem>
+    </varlistentry>
+    <varlistentry>
+      <term>predefinedWorkspaceNames</term>
+      <listitem>
+        <para>
+          Optional property that defines the names of the workspaces that exist and that are available for use without having to create them.
+				</para>
+      </listitem>
+    </varlistentry>
+    <varlistentry>
+      <term>remoteInfinispanServerList</term>
+      <listitem>
+        <para>
+          Optional property that defines the list of Infinispan HotRod servers.  The list must be in
+					the appropriate format of "<code>host:port[;host:port...]</code>" that would be used when defining an Infinispan <code>RemoteCacheManager</code> 
+					instance.  If the value is missing, "<code>localhost:11311</code>" is assumed.
+				</para>
+      </listitem>
+    </varlistentry>
+    <varlistentry>
+      <term>rootNodeUuid</term>
+      <listitem>
+        <para>
+          Optional property that, if used, specifies the UUID that should be used for the root node of each workspace.  If no value is
 					specified, a pre-defined UUID constant is used. A custom value need only be supplied for Infinispan sources created prior to ModeShape 2.0,
-					or if a specific UUID is desired or needed.</entry>
-				</row>	
-				<row>
-					<entry>updatesAllowed</entry>
-					<entry>Determines whether the content in the connector is can be updated ("true"), or if the content may only be read ("false").
-						The default value is "true".</entry>
-				</row>
-			</tbody>
-		</tgroup>
-	</table>
+					or if a specific UUID is desired or needed.
+				</para>
+      </listitem>
+    </varlistentry>
+    <varlistentry>
+      <term>retryLimit</term>
+      <listitem>
+        <para>
+          Optional property that, if used, defines the number of times that any single operation on a &RepositoryConnection; to this source should be retried
+					following a communication failure. The default value is '0'.
+				</para>
+      </listitem>
+    </varlistentry>
+    <varlistentry>
+      <term>updatesAllowed</term>
+      <listitem>
+        <para>
+          Optional property that determines whether the content in the connector is can be updated ("true"), or if the content may only be read ("false").
+					The default value is "true".
+				</para>
+      </listitem>
+    </varlistentry>
+  </variablelist>
  	<para>
 		One way to configure the Infinispan connector is to create &JcrConfiguration; instance with a repository source that uses the &InfinispanSource; class.
 		For example:

--- a/docs/reference/src/main/docbook/en-US/content/connectors/jboss_cache.xml
+++ b/docs/reference/src/main/docbook/en-US/content/connectors/jboss_cache.xml
@@ -38,82 +38,117 @@
 	<para>
 		The &JBossCacheSource; class provides a number of JavaBean properties that control its behavior:
 	</para>
-	<table frame='all'>
-		<title>&JBossCacheSource; properties</title>
-		<tgroup cols='2' align='left' colsep='1' rowsep='1'>
-      <colspec colname='c1' colwidth="1*"/>
-      <colspec colname='c2' colwidth="1*"/>
-			<thead>
-				<row>
-		  		<entry>Property</entry>
-		  		<entry>Description</entry>
-				</row>
-			</thead>
-			<tbody>
-				<row>
-					<entry>cacheConfigurationName</entry>
-					<entry>Optional property that, if used, specifies the name of the configuration that is supplied to the cache factory
-						when creating a new JBoss Cache instance.</entry>
-				</row>
-				<row>
-					<entry>cacheFactoryJndiName</entry>
-					<entry>Optional property that, if used, specifies the name in JNDI where an existing JBoss Cache Factory instance can be found.
-						That factory would then be used if needed to create a JBoss Cache instance.  If no value is provided, then the
-						JBoss Cache <code>DefaultCacheFactory</code> class is used.</entry>
-				</row>
-				<row>
-					<entry>cacheJndiName</entry>
-					<entry>Optional property that, if used, specifies the name in JNDI where an existing JBoss Cache instance can be found.
-						This should be used if your application already has a cache that is used, or if you need to configure the cache in
-						a special way.</entry>
-				</row>
-				<row>
-					<entry>creatingWorkspacesAllowed</entry>
-					<entry>Optional property that is by default 'true' that defines whether clients can create new workspaces.</entry>
-				</row>
-				<row>
-					<entry>defaultCachePolicy</entry>
-					<entry>Optional property that, if used, defines the default for how long this information provided by this source may to be 
-						cached by other, higher-level components.  The default value of null implies that this source does not define a specific
-						duration for caching information provided by this repository source.</entry>
-				</row>
-				<row>
-					<entry>defaultWorkspaceName</entry>
-					<entry>Optional property that is initialized to an empty string and which defines the name for the workspace that will be used by default
-						if none is specified.</entry>
-				</row>
-				<row>
-					<entry>name</entry>
-					<entry>The name of the repository source, which is used by the &RepositoryService; when obtaining a &RepositoryConnection; by name.</entry>
-				</row>
-				<row>
-					<entry>predefinedWorkspaceNames</entry>
-					<entry>Optional property that defines the names of the workspaces that exist and that are available for use without having to create them.</entry>
-				</row>
-				<row>
-					<entry>retryLimit</entry>
-					<entry>Optional property that, if used, defines the number of times that any single operation on a &RepositoryConnection; to this source should be retried
-						following a communication failure. The default value is '0'.</entry>
-				</row>
-				<row>
-					<entry>rootNodeUuid</entry>
-					<entry>Optional property that, if used, specifies the UUID that should be used for the root node of each workspace.  If no value is
-					specified, a random UUID is generated each time that the repository is started.</entry>
-				</row>	
-				<row>
-					<entry>updatesAllowed</entry>
-					<entry>Determines whether the content in the connector is can be updated ("true"), or if the content may only be read ("false").
-						The default value is "true".</entry>
-				</row>
-				<row>
-					<entry>uuidPropertyName</entry>
-					<entry>Optional property that, if used, defines the property that should be used to find the UUID value for each node
-						in the cache.  "<code>mode:uuid</code>" is the default.</entry>
-				</row>
-				
-			</tbody>
-		</tgroup>
-	</table>
+  <variablelist>
+    <varlistentry>
+      <term>cacheConfigurationName</term>
+      <listitem>
+				<para>
+				  Optional property that, if used, specifies the name of the configuration that is supplied to the cache factory
+					when creating a new JBoss Cache instance.
+				</para>
+      </listitem>
+    </varlistentry>
+    <varlistentry>
+      <term>cacheFactoryJndiName</term>
+      <listitem>
+				<para>
+				  Optional property that, if used, specifies the name in JNDI where an existing JBoss Cache Factory instance can be found.
+					That factory would then be used if needed to create a JBoss Cache instance.  If no value is provided, then the
+					JBoss Cache <code>DefaultCacheFactory</code> class is used.
+				</para>
+      </listitem>
+    </varlistentry>
+    <varlistentry>
+      <term>cacheJndiName</term>
+      <listitem>
+				<para>
+				  Optional property that, if used, specifies the name in JNDI where an existing JBoss Cache instance can be found.
+					This should be used if your application already defines a cache, or if you need to configure the cache in
+					a special way.
+				</para>
+      </listitem>
+    </varlistentry>
+    <varlistentry>
+      <term>creatingWorkspacesAllowed</term>
+      <listitem>
+				<para>
+				  Optional property that is by default 'true' that defines whether clients can create new workspaces.
+				</para>
+      </listitem>
+    </varlistentry>
+    <varlistentry>
+      <term>defaultCachePolicy</term>
+      <listitem>
+        <para>
+          Optional property that, if used, defines the default for how long this information provided by this source may to be 
+					cached by other, higher-level components.  The default value is an empty string (or null) and implies that this source 
+					does not define a specific duration for caching information provided by this repository source.
+				</para>
+      </listitem>
+    </varlistentry>
+    <varlistentry>
+      <term>defaultWorkspaceName</term>
+      <listitem>
+        <para>
+          Optional property that defines the name for the workspace that will be used in cases when clients do not explicitly specify
+          the workspace name. If not specified, "<code>default</code>" will be used.
+				</para>
+      </listitem>
+    </varlistentry>
+    <varlistentry>
+      <term>name</term>
+      <listitem>
+        <para>
+          Required property that specifies the name of the repository source, which is used by the &RepositoryService; 
+          when obtaining a &RepositoryConnection; by name.
+				</para>
+      </listitem>
+    </varlistentry>
+    <varlistentry>
+      <term>predefinedWorkspaceNames</term>
+      <listitem>
+        <para>
+          Optional property that defines the names of the workspaces that exist and that are available for use without having to create them.
+				</para>
+      </listitem>
+    </varlistentry>
+    <varlistentry>
+      <term>rootNodeUuid</term>
+      <listitem>
+        <para>
+          Optional property that, if used, specifies the UUID that should be used for the root node of each workspace.  If no value is
+					specified, a random UUID is generated each time that the repository is started.
+				</para>
+      </listitem>
+    </varlistentry>
+    <varlistentry>
+      <term>retryLimit</term>
+      <listitem>
+        <para>
+          Optional property that, if used, defines the number of times that any single operation on a &RepositoryConnection; to this source should be retried
+					following a communication failure. The default value is '0'.
+				</para>
+      </listitem>
+    </varlistentry>
+    <varlistentry>
+      <term>updatesAllowed</term>
+      <listitem>
+        <para>
+          Optional property that determines whether the content in the connector is can be updated ("true"), or if the content may only be read ("false").
+					The default value is "true".
+				</para>
+      </listitem>
+    </varlistentry>
+    <varlistentry>
+      <term>uuidPropertyName</term>
+      <listitem>
+        <para>
+          Optional property that, if used, defines the property that should be used to find the UUID value for each node
+					in the cache.  "<code>mode:uuid</code>" is the default.
+				</para>
+      </listitem>
+    </varlistentry>
+  </variablelist>
 	<para>
 		One way to configure the JBoss Cache connector is to create &JcrConfiguration; instance with a repository source that uses the &JBossCacheSource; class.
 		For example:

--- a/docs/reference/src/main/docbook/en-US/content/connectors/jcr.xml
+++ b/docs/reference/src/main/docbook/en-US/content/connectors/jcr.xml
@@ -66,58 +66,70 @@
 	<para>
 		The &JcrRepositorySource; class provides a number of JavaBean properties that control its behavior:
 	</para>
-	<table frame='all'>
-		<title>&JcrRepositorySource; properties</title>
-		<tgroup cols='2' align='left' colsep='1' rowsep='1'>
-      <colspec colname='c1' colwidth="1*"/>
-      <colspec colname='c2' colwidth="1*"/>
-			<thead>
-				<row>
-		  		<entry>Property</entry>
-		  		<entry>Description</entry>
-				</row>
-			</thead>
-			<tbody>
-				<row>
-					<entry>defaultCachePolicy</entry>
-					<entry>Optional property that, if used, defines the default cache policy for this repository source.  When not used, this source will not define a specific
-						duration for caching information.</entry>
-				</row>
-				<row>
-					<entry>repositoryJndiName</entry>
-					<entry>Property that defines where in JNDI the connector can find the <code>javax.jcr.Repository</code> instance.
-					</entry>
-				</row>
-				<row>
-					<entry>username</entry>
-					<entry>Optional property that defines the username that should be used when logging into the Repository to obtain a &Session;.
-						When used, the connector creates a &SimpleCredentials; instance. Should not be used if the "credentials" properties is to be used.
-					</entry>
-				</row>
-				<row>
-					<entry>password</entry>
-					<entry>Optional property that defines the password that should be used when logging into the Repository to obtain a &Session;.
-						When used, the connector creates a &SimpleCredentials; instance. Should not be used if the "credentials" properties is to be used.
-					</entry>
-				</row>
-				<row>
-					<entry>name</entry>
-					<entry>The name of the repository source, which is used by the &RepositoryService; when obtaining a &RepositoryConnection; by name.</entry>
-				</row>
-				<row>
-					<entry>credentials</entry>
-					<entry>Optional property that, if used, defines &Credentials; instance that should be used when logging into the Repository to
-						obtain a &Session;. Should be used only if the "username" and "password" properties are not set.
-					</entry>
-				</row>
-				<row>
-					<entry>retryLimit</entry>
-					<entry>Optional property that, if used, defines the number of times that any single operation on a &RepositoryConnection; to this source should be retried
-						following a communication failure. The default value is '0'.</entry>
-				</row>
-			</tbody>
-		</tgroup>
-	</table>
+  <variablelist>
+    <varlistentry>
+      <term>defaultCachePolicy</term>
+      <listitem>
+        <para>
+          Optional property that, if used, defines the default cache policy for this repository source.  When not used, this source will not define a specific
+					duration for caching information.
+				</para>
+      </listitem>
+    </varlistentry>
+    <varlistentry>
+      <term>repositoryJndiName</term>
+      <listitem>
+        <para>
+          Property that defines where in JNDI the connector can find the <code>javax.jcr.Repository</code> instance.
+				</para>
+      </listitem>
+    </varlistentry>
+    <varlistentry>
+      <term>username</term>
+      <listitem>
+        <para>
+          Optional property that defines the username that should be used when logging into the Repository to obtain a &Session;.
+					When used, the connector creates a &SimpleCredentials; instance. Should not be used if the "credentials" properties is to be used.
+				</para>
+      </listitem>
+    </varlistentry>
+    <varlistentry>
+      <term>password</term>
+      <listitem>
+        <para>
+          Optional property that defines the password that should be used when logging into the Repository to obtain a &Session;.
+					When used, the connector creates a &SimpleCredentials; instance. Should not be used if the "credentials" properties is to be used.
+				</para>
+      </listitem>
+    </varlistentry>
+    <varlistentry>
+      <term>credentials</term>
+      <listitem>
+        <para>
+          Optional property that, if used, defines &Credentials; instance that should be used when logging into the Repository to
+					obtain a &Session;. Should be used only if the "username" and "password" properties are not set.
+				</para>
+      </listitem>
+    </varlistentry>
+    <varlistentry>
+      <term>name</term>
+      <listitem>
+        <para>
+          Required property that specifies the name of the repository source, which is used by the &RepositoryService; 
+          when obtaining a &RepositoryConnection; by name.
+				</para>
+      </listitem>
+    </varlistentry>
+    <varlistentry>
+      <term>retryLimit</term>
+      <listitem>
+        <para>
+          Optional property that, if used, defines the number of times that any single operation on a &RepositoryConnection; to this source should be retried
+					following a communication failure. The default value is '0'.
+				</para>
+      </listitem>
+    </varlistentry>
+  </variablelist>
 	<para>
 		One way to configure the JCR connector is to create &JcrConfiguration; instance with a repository source that uses the &JcrRepositorySource; class.
 		For example:

--- a/docs/reference/src/main/docbook/en-US/content/connectors/jdbc_metadata.xml
+++ b/docs/reference/src/main/docbook/en-US/content/connectors/jdbc_metadata.xml
@@ -59,160 +59,197 @@
 	<para>
 		The &JdbcMetadataSource; class provides a number of JavaBean properties that control its behavior:
 	</para>
-	<table frame='all'>
-		<title>&JdbcMetadataSource; properties</title>
-		<tgroup cols='2' align='left' colsep='1' rowsep='1'>
-      <colspec colname='c1' colwidth="1*"/>
-      <colspec colname='c2' colwidth="1*"/>
-			<thead>
-				<row>
-		  		<entry>Property</entry>
-		  		<entry>Description</entry>
-				</row>
-			</thead>
-			<tbody>
-				<row>
-					<entry>cachePolicy</entry>
-					<entry>Optional property that, if used, defines the cache policy to use for this repository source.  When not used, this source will not define a specific
-						duration for caching information.
-					</entry>
-				</row>
-				<row>
-					<entry>dataSourceJndiName</entry>
-					<entry>
-						The JNDI name of the JDBC DataSource instance that should be used.  If not specified, the other driver properties must be set.
-					</entry>
-				</row>
-				<row>
-					<entry>defaultCatalogName</entry>
-					<entry>
-						The name to use for the catalog name if the database does not support catalogs or the database has a catalog with the empty string
-						as a name.  The default value is "default".
-					</entry>
-				</row>
-				<row>
-					<entry>defaultSchemaName</entry>
-					<entry>
-						The name to use for the schema name if the database does not support schemas or the database has a schema with the empty string
-						as a name.  The default value is "default".
-					</entry>
-				</row>
-				<row>
-					<entry>driverClassloaderName</entry>
-					<entry>
-						The name of the <!-- link linkend="class_loader_factory" -->class loader or classpath<!--  /link --> that should be used to load the JDBC driver class.
-						This is not required if the DataSource is found in JNDI.
-					</entry>
-				</row>
-				<row>
-					<entry>driverClassName</entry>
-					<entry>
-						The name of the JDBC driver class.
-						This is not required if the DataSource is found in JNDI, but is required otherwise.
-					</entry>
-				</row>
-				<row>
-					<entry>idleTimeInSecondsBeforeTestingConnections</entry>
-					<entry>
-						The number of seconds after a connection remains in the pool that the connection should be tested to ensure it is still valid.
-						The default is 180 seconds (or 3 minutes).
-					</entry>
-				</row>
-				<row>
-					<entry>maximumConnectionsInPool</entry>
-					<entry>
-						The maximum number of connections that may be in the connection pool.
-						The default is "5".
-					</entry>
-				</row>
-				<row>
-					<entry>maximumConnectionIdleTimeInSeconds</entry>
-					<entry>
-						The maximum number of seconds that a connection should remain in the pool before being closed.
-						The default is "600" seconds (or 10 minutes).
-					</entry>
-				</row>
-				<row>
-					<entry>maximumSizeOfStatementCache</entry>
-					<entry>
-						The maximum number of statements that should be cached.  
-						Statement caching can be disabled by setting to "0".  
-						The default is "100".
-					</entry>
-				</row>
-				<row>
-					<entry>metadataCollectorClassName</entry>
-					<entry>
-						The name of a custom class to use for metadata collection.  The class must implement the &MetadataCollector; interface.  If a null
-						value is specified for this property, a default &MetadataCollector; implementation will be used that relies on the &DatabaseMetaData;
-						provided by the JDBC driver for the connection.  This property is provided as a means for connecting to databases with a JDBC driver
-						that provides a non-standard &DatabaseMetaData; implementation or no &DatabaseMetaData; implementation at all. 
-					</entry>
-				</row>
-				<row>
-					<entry>minimumConnectionsInPool</entry>
-					<entry>
-						The minimum number of connections that will be kept in the connection pool.
-						The default is "0".
-					</entry>
-				</row>
-				<row>
-					<entry>name</entry>
-					<entry>The name of the repository source, which is used by the &RepositoryService; when obtaining a &RepositoryConnection; by name.</entry>
-				</row>
-				<row>
-					<entry>nameOfDefaultWorkspace</entry>
-					<entry>Optional property that is initialized to an empty string and which defines the name for the workspace that will be used by default
-						if none is specified.</entry>
-				</row>
-				<row>
-					<entry>nodeCachePolicy</entry>
-					<entry>Optional property that, if used, defines the cache policy to use for caching nodes within the connector.  
-					</entry>
-				</row>
-				<row>
-					<entry>numberOfConnectionsToAcquireAsNeeded</entry>
-					<entry>
-						The number of connections that should be added to the pool when there are not enough to be used.
-						The default is "1".
-					</entry>
-				</row>
-				<row>
-					<entry>retryLimit</entry>
-					<entry>Optional property that, if used, defines the number of times that any single operation on a &RepositoryConnection; to this source should be retried
-						following a communication failure. 
-						The default value is '0'.
-					</entry>
-				</row>
-				<row>
-					<entry>password</entry>
-					<entry>
-						The password that should be used when creating JDBC connections using the JDBC driver class.  
-						This is not required if the DataSource is found in JNDI.
-					</entry>
-				</row>
-				<row>
-					<entry>rootNodeUuid</entry>
-					<entry>Optional property that, if used, defines the UUID of the root node in the repository.  If not used,
-						then a new UUID is generated.</entry>
-				</row>
-				<row>
-					<entry>url</entry>
-					<entry>
-						The URL that should be used when creating JDBC connections using the JDBC driver class.
-						This is not required if the DataSource is found in JNDI.
-					</entry>
-				</row>
-				<row>
-					<entry>username</entry>
-					<entry>
-						The username that should be used when creating JDBC connections using the JDBC driver class.
-						This is not required if the DataSource is found in JNDI.
-					</entry>
-				</row>
-			</tbody>
-		</tgroup>
-	</table>
+  <variablelist>
+    <varlistentry>
+      <term>cachePolicy</term>
+      <listitem>
+        <para>
+          Optional property that, if used, defines the cache policy to use for this repository source.  When not used, this source will not define a specific
+					duration for caching information.
+				</para>
+      </listitem>
+    </varlistentry>
+    <varlistentry>
+      <term>dataSourceJndiName</term>
+      <listitem>
+        <para>
+          The JNDI name of the JDBC DataSource instance that should be used.  If not specified, the other driver properties must be set.
+				</para>
+      </listitem>
+    </varlistentry>
+    <varlistentry>
+      <term>defaultCatalogName</term>
+      <listitem>
+        <para>
+          Optional property that defines the name to use for the catalog name if the database does not support catalogs or the database has a catalog with the empty string
+					as a name.  The default value is "default".
+				</para>
+      </listitem>
+    </varlistentry>
+    <varlistentry>
+      <term>defaultSchemaName</term>
+      <listitem>
+        <para>
+          Optional property that defines the name to use for the schema name if the database does not support schemas or the database has a schema with the empty string
+					as a name.  The default value is "default".
+				</para>
+      </listitem>
+    </varlistentry>
+    <varlistentry>
+      <term>driverClassloaderName</term>
+      <listitem>
+        <para>
+          Optional property that defines the name of the ModeShape class loader or classpath that should be used to load the JDBC driver class.
+					This is not required if the DataSource is found in JNDI, or if the driver is on the application's classpath.
+				</para>
+      </listitem>
+    </varlistentry>
+    <varlistentry>
+      <term>driverClassName</term>
+      <listitem>
+        <para>
+					The name of the JDBC driver class. This is not required if the DataSource is found in JNDI, but is required otherwise.
+				</para>
+      </listitem>
+    </varlistentry>
+    <varlistentry>
+      <term>idleTimeInSecondsBeforeTestingConnections</term>
+      <listitem>
+        <para>
+          Optional property that defines the number of seconds after a connection remains in the pool that the connection should be tested to ensure it is still valid.
+					The default is 180 seconds (or 3 minutes).
+				</para>
+      </listitem>
+    </varlistentry>
+    <varlistentry>
+      <term>maximumConnectionsInPool</term>
+      <listitem>
+        <para>
+          Optional property that defines the maximum number of connections that may be in the connection pool. The default is "5".
+				</para>
+      </listitem>
+    </varlistentry>
+    <varlistentry>
+      <term>maximumConnectionIdleTimeInSeconds</term>
+      <listitem>
+        <para>
+          Optional property that defines the maximum number of seconds that a connection should remain in the pool before being closed.
+					The default is "600" seconds (or 10 minutes).
+				</para>
+      </listitem>
+    </varlistentry>
+    <varlistentry>
+      <term>maximumSizeOfStatementCache</term>
+      <listitem>
+        <para>
+          Optional property that defines the maximum number of statements that should be cached.  The default value is "100", but 
+					statement caching can be disabled by setting to "0".
+				</para>
+      </listitem>
+    </varlistentry>
+    <varlistentry>
+      <term>metadataCollectorClassName</term>
+      <listitem>
+        <para>
+					Advanced optional property that defines the name of a custom class to use for metadata collection, which is typically needed
+					for JDBC drivers that don't properly support the standard &DatabaseMetaData; methods. 
+					The specified class must implement the &MetadataCollector; interface and must have a public no-argument constructor.
+					If an empty string (or null) value is specified for this property, a default &MetadataCollector; implementation will be used 
+					that relies on the driver's &DatabaseMetaData;.
+				</para>
+      </listitem>
+    </varlistentry>
+    <varlistentry>
+      <term>minimumConnectionsInPool</term>
+      <listitem>
+        <para>
+					Optional property that defines the minimum number of connections that will be kept in the connection pool.
+					The default is "0".
+				</para>
+      </listitem>
+    </varlistentry>
+    <varlistentry>
+      <term>name</term>
+      <listitem>
+        <para>
+          Required property that specifies the name of the repository source, which is used by the &RepositoryService; 
+          when obtaining a &RepositoryConnection; by name.
+				</para>
+      </listitem>
+    </varlistentry>
+    <varlistentry>
+      <term>nameOfDefaultWorkspace</term>
+      <listitem>
+        <para>
+          Optional property that is initialized to an empty string and which defines the name for the workspace that will be used by default
+					if none is specified.
+				</para>
+      </listitem>
+    </varlistentry>
+    <varlistentry>
+      <term>nodeCachePolicy</term>
+      <listitem>
+        <para>
+          Optional property that, if used, defines the cache policy to use for caching nodes within the connector. 
+				</para>
+      </listitem>
+    </varlistentry>
+    <varlistentry>
+      <term>numberOfConnectionsToAcquireAsNeeded</term>
+      <listitem>
+        <para>
+          The number of connections that should be added to the pool when there are not enough to be used.
+					The default is "1".
+				</para>
+      </listitem>
+    </varlistentry>
+    <varlistentry>
+      <term>password</term>
+      <listitem>
+        <para>
+          The password that should be used when creating JDBC connections using the JDBC driver class.  
+					This is not required if the DataSource is found in JNDI.
+				</para>
+      </listitem>
+    </varlistentry>
+    <varlistentry>
+      <term>retryLimit</term>
+      <listitem>
+        <para>
+          Optional property that, if used, defines the number of times that any single operation on a &RepositoryConnection; to this source should be retried
+					following a communication failure. The default value is '0'.
+				</para>
+      </listitem>
+    </varlistentry>
+    <varlistentry>
+      <term>rootNodeUuid</term>
+      <listitem>
+        <para>
+          Optional property that, if used, specifies the UUID that should be used for the root node of each workspace.  If no value is
+					specified, a new UUID is generated.
+				</para>
+      </listitem>
+    </varlistentry>
+    <varlistentry>
+      <term>url</term>
+      <listitem>
+        <para>
+          The URL that should be used when creating JDBC connections using the JDBC driver class.
+					This is not required if the DataSource is found in JNDI.
+				</para>
+      </listitem>
+    </varlistentry>
+    <varlistentry>
+      <term>username</term>
+      <listitem>
+        <para>
+					The username that should be used when creating JDBC connections using the JDBC driver class.
+					This is not required if the DataSource is found in JNDI.
+				</para>
+      </listitem>
+    </varlistentry>
+  </variablelist>
+
  	<para>
 		One way to configure the JDBC metadata connector is to create &JcrConfiguration; instance with a repository source that uses the &JdbcMetadataSource; class.
 		For example:

--- a/docs/reference/src/main/docbook/en-US/content/connectors/jdbc_storage.xml
+++ b/docs/reference/src/main/docbook/en-US/content/connectors/jdbc_storage.xml
@@ -39,241 +39,322 @@
 	<para>
 		The &JpaSource; class provides a number of JavaBean properties that control its behavior:
 	</para>
-	<table frame='all'>
-		<title>&JpaSource; properties</title>
-		<tgroup cols='2' align='left' colsep='1' rowsep='1'>
-      <colspec colname='c1' colwidth="1*"/>
-      <colspec colname='c2' colwidth="1*"/>
-			<thead>
-				<row>
-		  		<entry>Property</entry>
-		  		<entry>Description</entry>
-				</row>
-			</thead>
-			<tbody>
-				<row>
-					<entry>autoGenerateSchema</entry>
-					<entry>
-			      Sets the Hibernate setting dictating what it does with the database schema upon first connection. Valid values are as
-			      follows (though the value is not checked):
-			      <itemizedlist>
-			      <listitem><para>"<code>create</code>" - Create the database schema objects when the &EntityManagerFactory; is created (actually
-			      when Hibernate's SessionFactory is created by the entity manager factory). If a file named "import.sql" exists in
-			      the root of the class path (e.g., '/import.sql') Hibernate will read and execute the SQL statements in this file after it
-			      has created the database objects. Note that Hibernate first delete all tables, constraints, or any other database object
-			      that is going to be created in the process of building the schema.</para></listitem>
-			      <listitem><para>"<code>create-drop</code>" - Same as "<code>create</code>", except that the schema will be dropped after the
-			      &EntityManagerFactory; is closed.</para></listitem>
-			      <listitem><para>"<code>update</code>" - Attempt to update the database structure to the current mapping (but does not read and invoke
-			      the SQL statements from "import.sql"). <emphasis>Use with caution.</emphasis></para></listitem>
-			      <listitem><para>"<code>validate</code>" - Validates the existing schema with the current entities configuration, but does not make any
-			      changes to the schema (and does not read and invoke the SQL statements from "import.sql"). This is the default value
-     				because it is the least intrusive and safest option, since it will verify the database's schema matches what the connector
-     				expects.</para></listitem>
-			      <listitem><para>"<code>disable</code>" - Does nothing and assumes that the database is already properly configured. This should be the
-     				setting used in production, as it is a best-practice that DB administrators explicitly configure/upgrade production
-     				database schemas (using scripts).</para></listitem>
-			      </itemizedlist>
-					</entry>
-				</row>
-				<row>
-					<entry>cacheConcurrencyStrategy</entry>
-					<entry>
-						Optional property that specifies the cache concurrency strategy to use.  When Hibernate, ModeShape's default JPA provider, is used,
-						this value should be one of "read-only", "read-write", "nonstrict-read-write", or "transactional".
-						The default value is "read-write".
-					</entry>
-				</row>
-				<row>
-					<entry>cacheProviderClassName</entry>
-					<entry>
-						Optional property that specifies the class name of the cache provider.  The default value of "null" indicates that no caching should occur.  
-						Valid values for this property are JPA implementation-dependent.  When Hibernate, ModeShape's default JPA provider, is used, this value
-						is used to set the "hibernate.cache.provider_class" property.
-					</entry>
-				</row>								
-				<row>
-					<entry>cacheTimeToLiveInMilliseconds</entry>
-					<entry>Optional property that, if used, defines the maximum time in milliseconds that any information returned by this connector
-						is allowed to be cached before being considered invalid.  When not used, this source will not define a specific
-						duration for caching information.
-						The default value is "600000" milliseconds, or 10 minutes.
-					</entry>
-				</row>
-				<row>
-					<entry>compressData</entry>
-					<entry>
-						An advanced boolean property that dictates whether large binary and string values should be stored in a compressed form.  
-						This is enabled by default.  Setting this value only affects how new records are stored; records can always be read
-						regardless of the value of this setting.
-						The default value is "true".
-					</entry>
-				</row>
-				<row>
-					<entry>creatingWorkspaceAllowed</entry>
-					<entry>
-						Optional property that defines whether clients can create additional workspaces.  The default value is "true".
-					</entry>
-				</row>
-				<row>
-					<entry>dialect</entry>
-					<entry>
-						Optional property that defines the dialect of the database. If not provided, the dialect will be auto-discovered by Hibernate. 
-						Otherwise, this must match one of the Hibernate dialect names, and must correspond to the type of driver being used.
-						And because Hibernate does a good job of auto-determining the dialect, it is recommended that you set this only if auto-discovery fails
-						for your database. (Note that auto-discovering the dialect does not always work well with MySQL, since Hibernate has multiple
-						dialects for MySQL and will often choose  MySQL 4 MyISAM.)
-					</entry>
-				</row>
-				<row>
-					<entry>dataSourceJndiName</entry>
-					<entry>
-						The JNDI name of the JDBC DataSource instance that should be used.  If not specified, the other driver properties must be set.
-					</entry>
-				</row>
-				<row>
-					<entry>driverClassloaderName</entry>
-					<entry>
-						The name of the <!-- link linkend="class_loader_factory" -->class loader or classpath<!--  /link --> that should be used to load the JDBC driver class.
-						This is not required if the DataSource is found in JNDI.
-					</entry>
-				</row>
-				<row>
-					<entry>driverClassName</entry>
-					<entry>
-						The name of the JDBC driver class.
-						This is not required if the DataSource is found in JNDI, but is required otherwise.
-					</entry>
-				</row>
-				<row>
-					<entry>idleTimeInSecondsBeforeTestingConnections</entry>
-					<entry>
-						The number of seconds after a connection remains in the pool that the connection should be tested to ensure it is still valid.
-						The default is 180 seconds (or 3 minutes).
-					</entry>
-				</row>
-				<row>
-                     <entry>isolationLevel</entry>
-                     <entry>Optional property that, if used, denotes which
-                     of the java.sql.Connection#TRANSACTION_* constants should be used to control the transaction isolation level.  Valid values are:
-                     "TRANSACTION_READ_COMMITTED", "TRANSACTION_READ_UNCOMMITTED", "TRANSACTION_REPEATABLE_READ", "TRANSACTION_SERIALIZABLE", and "TRANSACTION_NONE".
-                     Note that not all JDBC drivers support all isolation levels.
-                             When this property is not used, the default
-                             isolation level is set to whichever isolation level was previously set on the connection.
-                     </entry>
-                 </row>
-                 <row>
-					<entry>largeValueSizeInBytes</entry>
-					<entry>
-						An advanced boolean property that controls the size of property values at which they are considered to be "large values".  
-						Depending upon the model, large property values may be stored in a centralized area and keyed by a secure hash
-						of the value.  This is an space and performance optimization that stores each unique large value only once.
-						The default value is "1024" bytes, or 1 kilobyte.
-					</entry>
-				</row>
-				<row>
-					<entry>maximumConnectionsInPool</entry>
-					<entry>
-						The maximum number of connections that may be in the connection pool.
-						The default is "5".
-					</entry>
-				</row>
-				<row>
-					<entry>maximumConnectionIdleTimeInSeconds</entry>
-					<entry>
-						The maximum number of seconds that a connection should remain in the pool before being closed.
-						The default is "600" seconds (or 10 minutes).
-					</entry>
-				</row>
-				<row>
-					<entry>maximumSizeOfStatementCache</entry>
-					<entry>
-						The maximum number of statements that should be cached.  
-						Statement caching can be disabled by setting to "0".  
-						The default is "100".
-					</entry>
-				</row>
-				<row>
-					<entry>minimumConnectionsInPool</entry>
-					<entry>
-						The minimum number of connections that will be kept in the connection pool.
-						The default is "0".
-					</entry>
-				</row>
-				<row>
-					<entry>model</entry>
-					<entry>
-						An advanced property that dictates the type of storage schema that is used.  Currently, the only supported value is "Simple".  
-					</entry>
-				</row>
-				<row>
-					<entry>name</entry>
-					<entry>The name of the repository source, which is used by the &RepositoryService; when obtaining a &RepositoryConnection; by name.</entry>
-				</row>
-				<row>
-					<entry>nameOfDefaultWorkspace</entry>
-					<entry>Optional property that is initialized to an empty string and which defines the name for the workspace that will be used by default
-						if none is specified.</entry>
-				</row>
-				<row>
-					<entry>numberOfConnectionsToAcquireAsNeeded</entry>
-					<entry>
-						The number of connections that should be added to the pool when there are not enough to be used.
-						The default is "1".
-					</entry>
-				</row>
-				<row>
-					<entry>password</entry>
-					<entry>
-						The password that should be used when creating JDBC connections using the JDBC driver class.  
-						This is not required if the DataSource is found in JNDI.
-					</entry>
-				</row>
-				<row>
-					<entry>predefinedWorkspaceNames</entry>
-					<entry>Optional property that, if used, defines names of the workspaces that are predefined and need not be created before being used.
-						This can be coupled with a "false" value for the "creatingWorkspaceAllowed" property to allow only the use of only predefined workspaces.
-					</entry>
-				</row>
-				<row>
-					<entry>retryLimit</entry>
-					<entry>Optional property that, if used, defines the number of times that any single operation on a &RepositoryConnection; to this source should be retried
-						following a communication failure. 
-						The default value is '0'.
-					</entry>
-				</row>
-				<row>
-					<entry>rootNodeUuid</entry>
-					<entry>Optional property that, if used, defines the UUID of the root node in the repository.  If not used,
-						then a new UUID is generated.</entry>
-				</row>
-				<row>
-					<entry>schemaName</entry>
-					<entry>Optional property that, if set, specifies the name of the schema in which this repository source will read and write data.  If no schema name
-						is specified, then data will be read from the default schema associated with the database connection.</entry>
-				</row>
-				<row>
-					<entry>updatesAllowed</entry>
-					<entry>Determines whether the content in the database is can be updated ("true"), or if the content may only be read ("false").
-						The default value is "true".</entry>
-				</row>
-				<row>
-					<entry>url</entry>
-					<entry>
-						The URL that should be used when creating JDBC connections using the JDBC driver class.
-						This is not required if the DataSource is found in JNDI.
-					</entry>
-				</row>
-				<row>
-					<entry>username</entry>
-					<entry>
-						The username that should be used when creating JDBC connections using the JDBC driver class.
-						This is not required if the DataSource is found in JNDI.
-					</entry>
-				</row>
-			</tbody>
-		</tgroup>
-	</table>
+  <variablelist>
+    <varlistentry>
+      <term>autoGenerateSchema</term>
+      <listitem>
+        <para>
+          Sets the Hibernate setting dictating what it does with the database schema upon first connection. Valid values are as
+			    follows (though the value is not checked):
+			    <itemizedlist>
+			      <listitem>
+			        <para>
+			          "<code>create</code>" - Create the database schema objects when the &EntityManagerFactory; is created (actually
+			          when Hibernate's SessionFactory is created by the entity manager factory). If a file named "import.sql" exists in
+			          the root of the class path (e.g., '/import.sql') Hibernate will read and execute the SQL statements in this file after it
+			          has created the database objects. Note that Hibernate first delete all tables, constraints, or any other database object
+			          that is going to be created in the process of building the schema.
+			        </para>
+			      </listitem>
+			      <listitem>
+			        <para>
+			          "<code>create-drop</code>" - Same as "<code>create</code>", except that the schema will be dropped after the
+			          &EntityManagerFactory; is closed.
+			        </para>
+			      </listitem>
+			      <listitem>
+			        <para>
+			          "<code>update</code>" - Attempt to update the database structure to the current mapping (but does not read and invoke
+			          the SQL statements from "import.sql"). <emphasis>Use with caution.</emphasis>
+			        </para>
+			      </listitem>
+			      <listitem>
+			        <para>
+			          "<code>validate</code>" - Validates the existing schema with the current entities configuration, but does not make any
+			          changes to the schema (and does not read and invoke the SQL statements from "import.sql"). This is the default value
+     				    because it is the least intrusive and safest option, since it will verify the database's schema matches what the connector
+     				    expects.
+     				  </para>
+     				</listitem>
+			      <listitem>
+			        <para>
+			          "<code>disable</code>" - Does nothing and assumes that the database is already properly configured. This should be the
+     				    setting used in production, as it is a best-practice that DB administrators explicitly configure/upgrade production
+     				    database schemas (using scripts).
+     				  </para>
+     				</listitem>
+		      </itemizedlist>
+				</para>
+      </listitem>
+    </varlistentry>
+    <varlistentry>
+      <term>cacheConcurrencyStrategy</term>
+      <listitem>
+        <para>
+					Optional property that specifies the cache concurrency strategy to use.  When Hibernate, ModeShape's default JPA provider, is used,
+					this value should be one of "<code>read-only</code>", "<code>read-write</code>" (the default), "<code>nonstrict-read-write</code>", or
+					"<code>transactional</code>".
+				</para>
+      </listitem>
+    </varlistentry>
+    <varlistentry>
+      <term>cacheProviderClassName</term>
+      <listitem>
+        <para>
+					Optional property that specifies the class name of the cache provider.  The default value of an empty string (or null) 
+					indicates that no caching should occur. Valid values for this property are JPA implementation-dependent.  When using Hibernate, 
+					(ModeShape's default JPA provider), this value is used to set the "<code>hibernate.cache.provider_class</code>" property.
+				</para>
+      </listitem>
+    </varlistentry>
+    <varlistentry>
+      <term>cacheTimeToLiveInMilliseconds</term>
+      <listitem>
+        <para>
+          Optional property that, if used, defines the maximum time in milliseconds that any information returned by this connector
+					is allowed to be cached before being considered invalid.  When not used, this source will not define a specific
+					duration for caching information.	The default value is "600000" milliseconds, or 10 minutes.
+				</para>
+      </listitem>
+    </varlistentry>
+    <varlistentry>
+      <term>compressData</term>
+      <listitem>
+        <para>
+					An advanced optional boolean property that dictates whether large binary and string values should be stored in a compressed form.  
+					This is enabled by default.  Setting this value only affects how new records are stored; records can always be read
+					regardless of the value of this setting. The default value is "true".
+				</para>
+      </listitem>
+    </varlistentry>
+    <varlistentry>
+      <term>creatingWorkspaceAllowed</term>
+      <listitem>
+        <para>
+					Optional property that defines whether clients can create additional workspaces. The default value is "true".
+				</para>
+      </listitem>
+    </varlistentry>
+    <varlistentry>
+      <term>dialect</term>
+      <listitem>
+        <para>
+					The dialect of the database, which must match one of the 
+					<ulink url="&HibernateDocs;/#configuration-optional-dialects">Hibernate dialect names</ulink>, 
+					and must correspond to the type of driver being used.
+				  If not provided, the dialect will be auto-discovered by Hibernate. Because Hibernate does a good job of auto-determining the dialect, 
+				  it is recommended that you set this only if auto-discovery fails for your database.
+				</para>
+				<para>
+				  <emphasis> However, it is recommended that MySQL users always set this value, as Hibernate's auto-discovery of the dialect does not work
+				  for many MySQL installations.</emphasis> For example, the most common MySQL installation is MySQL 5.x with InnoDB, which requires a value of
+				  "<code>org.hibernate.dialect.MySQLInnoDBDialect</code>" for the "dialect" property.
+				</para>
+      </listitem>
+    </varlistentry>
+    <varlistentry>
+      <term>dataSourceJndiName</term>
+      <listitem>
+        <para>
+					The JNDI name of the JDBC DataSource instance that should be used. If not specified, the other driver properties must be set.
+				</para>
+      </listitem>
+    </varlistentry>
+    <varlistentry>
+      <term>driverClassloaderName</term>
+      <listitem>
+        <para>
+          Optional property that defines the name of the ModeShape class loader or classpath that should be used to load the JDBC driver class.
+					This is not required if the DataSource is found in JNDI, or if the driver is on the application's classpath.
+				</para>
+      </listitem>
+    </varlistentry>
+    <varlistentry>
+      <term>driverClassName</term>
+      <listitem>
+        <para>
+					The name of the JDBC driver class. This is not required if the DataSource is found in JNDI, but is required otherwise.
+				</para>
+      </listitem>
+    </varlistentry>
+    <varlistentry>
+      <term>idleTimeInSecondsBeforeTestingConnections</term>
+      <listitem>
+        <para>
+					Optional property that specifies the number of seconds after a connection remains in the pool that the connection should be 
+					tested to ensure it is still valid. The default is 180 seconds (or 3 minutes).
+				</para>
+      </listitem>
+    </varlistentry>
+    <varlistentry>
+      <term>isolationLevel</term>
+      <listitem>
+        <para>
+          Optional property that, if used, denotes which of the <code>java.sql.Connection#TRANSACTION_*</code> constants should 
+          be used to control the transaction isolation level. Valid values are:  "<code>TRANSACTION_READ_COMMITTED</code>", 
+          "<code>TRANSACTION_READ_UNCOMMITTED</code>", "<code>TRANSACTION_REPEATABLE_READ</code>", "<code>TRANSACTION_SERIALIZABLE</code>", 
+          and "<code>TRANSACTION_NONE</code>". When this property is not used, the default isolation level is set to whichever 
+          isolation level was previously set on the connection.
+          Note that not all JDBC drivers support all isolation levels. 
+				</para>
+      </listitem>
+    </varlistentry>
+    <varlistentry>
+      <term>largeValueSizeInBytes</term>
+      <listitem>
+        <para>
+          An advanced optional boolean property that controls the size of property values at which they are considered to be "large values".  
+					Depending upon the model, large property values may be stored in a centralized area and keyed by a secure hash
+					of the value.  This is a space and performance optimization that stores each unique large value only once.
+					The default value is "1024" bytes, or 1 kilobyte.
+				</para>
+      </listitem>
+    </varlistentry>
+    <varlistentry>
+      <term>maximumConnectionsInPool</term>
+      <listitem>
+        <para>
+					Optional property that specifies the maximum number of connections that may be in the connection pool. The default is "5".
+				</para>
+      </listitem>
+    </varlistentry>
+    <varlistentry>
+      <term>maximumConnectionIdleTimeInSeconds</term>
+      <listitem>
+        <para>
+					Optional property that specifies the maximum number of seconds that a connection should remain in the pool before being closed.
+					The default is "600" seconds (or 10 minutes).
+				</para>
+      </listitem>
+    </varlistentry>
+    <varlistentry>
+      <term>maximumSizeOfStatementCache</term>
+      <listitem>
+        <para>
+          Optional property that specifies the maximum number of statements that should be cached.  
+					Statement caching can be disabled by setting to "0". The default is "100".
+				</para>
+      </listitem>
+    </varlistentry>
+    <varlistentry>
+      <term>minimumConnectionsInPool</term>
+      <listitem>
+        <para>
+          Optional property that specifies the minimum number of connections that will be kept in the connection pool.
+					The default is "0".
+				</para>
+      </listitem>
+    </varlistentry>
+    <varlistentry>
+      <term>model</term>
+      <listitem>
+        <para>
+					An advanced property that dictates the type of storage schema that is used. Currently, the only supported value is 
+					"<code>Simple</code>", which is also the default value.
+				</para>
+      </listitem>
+    </varlistentry>
+    <varlistentry>
+      <term>name</term>
+      <listitem>
+        <para>
+          Required property that specifies the name of the repository source, which is used by the &RepositoryService; 
+          when obtaining a &RepositoryConnection; by name.
+				</para>
+      </listitem>
+    </varlistentry>
+    <varlistentry>
+      <term>nameOfDefaultWorkspace</term>
+      <listitem>
+        <para>
+          Optional property that is initialized to an empty string and which defines the name for the workspace that will be used by default
+					if none is specified.
+				</para>
+      </listitem>
+    </varlistentry>
+    <varlistentry>
+      <term>numberOfConnectionsToAcquireAsNeeded</term>
+      <listitem>
+        <para>
+          Optional property that defines the number of connections that should be added to the pool when there are not enough to be used.
+					The default is "1".
+				</para>
+      </listitem>
+    </varlistentry>
+    <varlistentry>
+      <term>password</term>
+      <listitem>
+        <para>
+					The password that should be used when creating JDBC connections using the JDBC driver class.  
+					This is not required or used if the DataSource is found in JNDI.
+				</para>
+      </listitem>
+    </varlistentry>
+    <varlistentry>
+      <term>predefinedWorkspaceNames</term>
+      <listitem>
+        <para>
+          Optional property that, if used, defines names of the workspaces that are predefined and need not be created before being used.
+					This can be coupled with a "false" value for the "<code>creatingWorkspaceAllowed</code>" property to allow only the use of only 
+					predefined workspaces.
+				</para>
+      </listitem>
+    </varlistentry>
+    <varlistentry>
+      <term>retryLimit</term>
+      <listitem>
+        <para>
+          Optional property that, if used, defines the number of times that any single operation on a &RepositoryConnection; to this source should be retried
+					following a communication failure. The default value is '0'.
+				</para>
+      </listitem>
+    </varlistentry>
+    <varlistentry>
+      <term>rootNodeUuid</term>
+      <listitem>
+        <para>
+          Optional property that, if used, specifies the UUID that should be used for the root node of each workspace.  If no value is
+					specified, a default UUID is used.
+				</para>
+      </listitem>
+    </varlistentry>
+    <varlistentry>
+      <term>schemaName</term>
+      <listitem>
+        <para>
+          Optional property that, if set, specifies the name of the schema in which this repository source will read and write data.  If no schema name
+					is specified, then data will be read from the default schema associated with the database connection.
+				</para>
+      </listitem>
+    </varlistentry>
+    <varlistentry>
+      <term>updatesAllowed</term>
+      <listitem>
+        <para>
+          Determines whether the content in the database is can be updated ("true"), or if the content may only be read ("false").
+					The default value is "true".
+				</para>
+      </listitem>
+    </varlistentry>
+    <varlistentry>
+      <term>url</term>
+      <listitem>
+        <para>
+          The URL that should be used when creating JDBC connections using the JDBC driver class.
+					This is not required or used if the DataSource is found in JNDI.
+				</para>
+      </listitem>
+    </varlistentry>
+    <varlistentry>
+      <term>username</term>
+      <listitem>
+        <para>
+          The username that should be used when creating JDBC connections using the JDBC driver class.
+					This is not required or used if the DataSource is found in JNDI.
+				</para>
+      </listitem>
+    </varlistentry>
+  </variablelist>
  	<para>
 		One way to configure the JPA connector is to create &JcrConfiguration; instance with a repository source that uses the &JpaSource; class.
 		For example:

--- a/docs/reference/src/main/docbook/en-US/content/connectors/subversion.xml
+++ b/docs/reference/src/main/docbook/en-US/content/connectors/subversion.xml
@@ -40,79 +40,99 @@
 	<para>
 		The &SVNRepositorySource; class provides a number of JavaBean properties that control its behavior:
 	</para>
-	<table frame='all'>
-		<title>&SVNRepositorySource; properties</title>
-		<tgroup cols='2' align='left' colsep='1' rowsep='1'>
-      <colspec colname='c1' colwidth="1*"/>
-      <colspec colname='c2' colwidth="1*"/>
-			<thead>
-				<row>
-		  		<entry>Property</entry>
-		  		<entry>Description</entry>
-				</row>
-			</thead>
-			<tbody>
-				<row>
-					<entry>cachePolicy</entry>
-					<entry>Optional property that, if used, defines the cache policy to use for caching information in the repository.  When not used, this source will not define a specific
-						duration for caching information.</entry>
-				</row>
-				<row>
-					<entry>creatingWorkspaceAllowed</entry>
-					<entry>Optional property that defines whether clients can create additional workspaces.  The default value is "true".
-					</entry>
-				</row>
-				<row>
-					<entry>defaultWorkspaceName</entry>
-					<entry>Optional property that, if used, specifies the name of the workspace to use when no workspace name is specified in an operation.
-						Each workspace name is treated as a path relative to the SVN repository being exposed (e.g., a workspace name of "trunk" will map 
-						to the URL "http://acme.com/repo/trunk" if the repository root URL is "http://acme.com/repo/").
-					</entry>
-				</row>
-				<row>
-					<entry>name</entry>
-					<entry>The name of the repository source, which is used by the &RepositoryService; when obtaining a &RepositoryConnection; by name.</entry>
-				</row>
-				<row>
-					<entry>nodeCachePolicy</entry>
-					<entry>Optional property that, if used, defines the cache policy to use for caching nodes within the connector.  
-					</entry>
-				</row>
-				<row>
-					<entry>password</entry>
-					<entry>
-						The password that should be used to establish a connection to the repository.  This is not required if the URL represents an
-						anonymous SVN repository address.
-					</entry>
-				</row>
-				<row>
-					<entry>predefinedWorkspaceNames</entry>
-					<entry>Optional property that, if used, defines names of the workspaces that are predefined and need not be created before being used.
-						Each workspace name is treated as a path relative to the SVN repository being exposed (e.g., a workspace name of "trunk" will map 
-						to the URL "http://acme.com/repo/trunk" if the repository root URL is "http://acme.com/repo/").
-						This can be coupled with a "false" value for the "creatingWorkspaceAllowed" property to allow only the use of predefined workspaces.
-					</entry>
-				</row>
-				<row>
-					<entry>repositoryRootURL</entry>
-					<entry>
-						Required property that should be set with the URL to the Subversion repository.
-					</entry>
-				</row>
-				<row>
-					<entry>retryLimit</entry>
-					<entry>Optional property that, if used, defines the number of times that any single operation on a &RepositoryConnection; to this source should be retried
-						following a communication failure. The default value is '0'.</entry>
-				</row>
-				<row>
-					<entry>username</entry>
-					<entry>
-						The username that should be used to establish a connection to the repository.
-					</entry>
-				</row>
-			</tbody>
-		</tgroup>
-	</table>
+  <variablelist>
+    <varlistentry>
+      <term>cachePolicy</term>
+      <listitem>
+        <para>
+          Optional property that, if used, defines the cache policy for this repository source.  When not used, this source will not define a specific
+			    duration for caching information.
+				</para>
+      </listitem>
+    </varlistentry>
+    <varlistentry>
+      <term>creatingWorkspaceAllowed</term>
+      <listitem>
+        <para>
+          Optional property that defines whether clients can create additional workspaces.  The default value is "true".
+        </para>
+      </listitem>
+    </varlistentry>
+    <varlistentry>
+      <term>defaultWorkspaceName</term>
+      <listitem>
+        <para>
+          Optional property that, if used, specifies the name of the workspace to use when no workspace name is specified in an operation.
+          If not specified, "<code>trunk</code>" is used.
+        </para>
+        <para>
+					Each workspace name is treated as a path relative to the SVN repository being exposed. For example, given a repository root URL
+					of "http://acme.com/repo/", a workspace name of "<code>trunk</code>" will map to "http://acme.com/repo/trunk".
+				</para>
+      </listitem>
+    </varlistentry>
+    <varlistentry>
+      <term>name</term>
+      <listitem>
+        <para>
+          Required property that specifies the name of the repository source, which is used by the &RepositoryService; 
+          when obtaining a &RepositoryConnection; by name.
+        </para>
+      </listitem>
+    </varlistentry>
+    <varlistentry>
+      <term>nodeCachePolicy</term>
+      <listitem>
+        <para>
+          Optional property that, if used, defines the cache policy to use for caching nodes within the connector.
+        </para>
+      </listitem>
+    </varlistentry>
+    <varlistentry>
+      <term>password</term>
+      <listitem>
+        <para>
+          The password that should be used to establish a connection to the repository. This is not required if the URL represents an
+					anonymous SVN repository address.
+				</para>
+      </listitem>
+    </varlistentry>
+    <varlistentry>
+      <term>predefinedWorkspaceNames</term>
+      <listitem>
+        <para>
+          Optional property that, if used, defines names of the workspaces that are predefined and need not be created before being used.
+					This can be coupled with a "false" value for the "creatingWorkspaceAllowed" property to allow only the use of only predefined workspaces.
+        </para>
+      </listitem>
+    </varlistentry>
+    <varlistentry>
+      <term>retryLimit</term>
+      <listitem>
+        <para>
+          Optional property that, if used, defines the number of times that any single operation on a &RepositoryConnection; to this source should be retried
+					following a communication failure. The default value is '0'.
+				</para>
+      </listitem>
+    </varlistentry>
+    <varlistentry>
+      <term>repositoryRootURL</term>
+      <listitem>
+        <para>
+          Required property that should be set with the URL to the Subversion repository.
+				</para>
+      </listitem>
+    </varlistentry>
+    <varlistentry>
+      <term>username</term>
+      <listitem>
+        <para>
+          The username that should be used to establish a connection to the repository. This is not required if the URL represents an
+					anonymous SVN repository address.
+				</para>
+      </listitem>
+    </varlistentry>
+  </variablelist>
  	<para>
 		One way to configure the Subversion connector is to create &JcrConfiguration; instance with a repository source that uses the &SVNRepositorySource; class.
 		For example:

--- a/docs/reference/src/main/docbook/en-US/content/core/graph.xml
+++ b/docs/reference/src/main/docbook/en-US/content/core/graph.xml
@@ -994,55 +994,54 @@ for ( &Location; child : results.getNode(path2) ) {
 			together into "units of work".  The submitted requests are then processed by the underlying system (e.g., connector)
 			and returned back to the &Graph; object, which then extracts and returns the results.
 		</para>
+
+	  <sect2 id="graph-basic-requests">
+		<title>Basic Requests</title>
 		<para>
 			There are actually quite a few different types of &Request; classes:
 		</para>
-		<table frame='all'>
-			<title>Types of Read Requests</title>
-			<tgroup cols='2' align='left' colsep='1' rowsep='1'>
-	      <colspec colname='c1' colwidth="1*"/>
-	      <colspec colname='c2' colwidth="1*"/>
-				<thead>
-					<row>
-			  		<entry>Name</entry>
-			  		<entry>Description</entry>
-					</row>
-				</thead>
-				<tbody>
-					<row>
-						<entry>ReadNodeRequest</entry>
-						<entry>
+		<variablelist>
+      <varlistentry>
+        <term>ReadNodeRequest</term>
+        <listitem>
+          <para>
 							A request to read a node's properties and children from the named workspace in the source.
 							The node may be specified by path and/or by identification properties.
 							The connector returns all properties and the locations for all children,
 							or sets a &PathNotFoundException; error on the request if the node did not exist in the workspace.
 							If the node is found, the connector sets on the request the actual location of the node (including the path and identification properties).
 							The connector sets a &InvalidWorkspaceException; error on the request if the named workspace does not exist.
-						</entry>
-					</row>
-					<row>
-						<entry>VerifyNodeExistsRequest</entry>
-						<entry>
+  				</para>
+        </listitem>
+      </varlistentry>
+      <varlistentry>
+        <term>VerifyNodeExistsRequest</term>
+        <listitem>
+          <para>
 							A request to verify the existence of a node at the specified location in the named workspace of the source.
 							The connector returns all the actual location for the node if it exists, or
 							sets a &PathNotFoundException; error on the request if the node does not exist in the workspace.
 							The connector sets a &InvalidWorkspaceException; error on the request if the named workspace does not exist.
-						</entry>
-					</row>
-					<row>
-						<entry>ReadAllPropertiesRequest</entry>
-						<entry>
+  				</para>
+        </listitem>
+      </varlistentry>
+      <varlistentry>
+        <term>ReadAllPropertiesRequest</term>
+        <listitem>
+          <para>
 							A request to read all of the properties of a node from the named workspace in the source.
 							The node may be specified by path and/or by identification properties.
 							The connector returns all properties that were found on the node,
 							or sets a &PathNotFoundException; error on the request if the node did not exist in the workspace.
 							If the node is found, the connector sets on the request the actual location of the node (including the path and identification properties).
 							The connector sets a &InvalidWorkspaceException; error on the request if the named workspace does not exist.
-						</entry>
-					</row>
-					<row>
-						<entry>ReadPropertyRequest</entry>
-						<entry>
+  				</para>
+        </listitem>
+      </varlistentry>
+      <varlistentry>
+        <term>ReadPropertyRequest</term>
+        <listitem>
+          <para>
 							A request to read  a single property of a node from the named workspace in the source.
 							The node may be specified by path and/or by identification properties,
 							and the property is specified by name.
@@ -1050,11 +1049,13 @@ for ( &Location; child : results.getNode(path2) ) {
 							or sets a &PathNotFoundException; error on the request if the node or property did not exist in the workspace.
 							If the node is found, the connector sets on the request the actual location of the node (including the path and identification properties).
 							The connector sets a &InvalidWorkspaceException; error on the request if the named workspace does not exist.
-						</entry>
-					</row>
-					<row>
-						<entry>ReadAllChildrenRequest</entry>
-						<entry>
+  				</para>
+        </listitem>
+      </varlistentry>
+      <varlistentry>
+        <term>ReadAllChildrenRequest</term>
+        <listitem>
+          <para>
 							A request to read all of the children of a node from the named workspace in the source.
 							The node may be specified by path and/or by identification properties.
 							The connector returns an ordered list of locations for each child found on the node,
@@ -1062,11 +1063,13 @@ for ( &Location; child : results.getNode(path2) ) {
 							or sets a &PathNotFoundException; error on the request if the node did not exist in the workspace.
 							If the node is found, the connector sets on the request the actual location of the parent node (including the path and identification properties).
 							The connector sets a &InvalidWorkspaceException; error on the request if the named workspace does not exist.
-						</entry>
-					</row>
-					<row>
-						<entry>ReadBlockOfChildrenRequest</entry>
-						<entry>
+  				</para>
+        </listitem>
+      </varlistentry>
+      <varlistentry>
+        <term>ReadBlockOfChildrenRequest</term>
+        <listitem>
+          <para>
 							A request to read a block of children of a node, starting with the n<superscript>th</superscript> child from the named workspace in the source.
 							This is designed to allow paging through the children, which is much more efficient for large numbers of children.
 							The node may be specified by path and/or by identification properties, and the block
@@ -1076,11 +1079,13 @@ for ( &Location; child : results.getNode(path2) ) {
 							The connector also sets on the request the actual location of the parent node (including the path and identification properties)
 							or sets a &PathNotFoundException; error on the request if the parent node did not exist in the workspace.
 							The connector sets a &InvalidWorkspaceException; error on the request if the named workspace does not exist.
-						</entry>
-					</row>
-					<row>
-						<entry>ReadNextBlockOfChildrenRequest</entry>
-						<entry>
+  				</para>
+        </listitem>
+      </varlistentry>
+      <varlistentry>
+        <term>ReadNextBlockOfChildrenRequest</term>
+        <listitem>
+          <para>
 							A request to read a block of children of a node, starting with the children that immediately follow
 							a previously-returned child from the named workspace in the source.
 							This is designed to allow paging through the children, which is much more efficient for large numbers of children.
@@ -1091,11 +1096,13 @@ for ( &Location; child : results.getNode(path2) ) {
 							The connector also sets on the request the actual location of the parent node (including the path and identification properties)
 							or sets a &PathNotFoundException; error on the request if the parent node did not exist in the workspace.
 							The connector sets a &InvalidWorkspaceException; error on the request if the named workspace does not exist.
-						</entry>
-					</row>
-					<row>
-						<entry>ReadBranchRequest</entry>
-						<entry>
+  				</para>
+        </listitem>
+      </varlistentry>
+      <varlistentry>
+        <term>ReadBranchRequest</term>
+        <listitem>
+          <para>
 							A request to read a portion of a subgraph that has as its root a particular node, up to a maximum depth.
 							This request is an efficient mechanism when a branch (or part of a branch) is to be navigated and processed,
 							and replaces some non-trivial code to read the branch iteratively using multiple <code>ReadNodeRequest</code>s.
@@ -1105,31 +1112,38 @@ for ( &Location; child : results.getNode(path2) ) {
 							The connector sets a &PathNotFoundException; error on the request if the node at 
 							the top of the branch does not exist in the workspace.
 							The connector sets a &InvalidWorkspaceException; error on the request if the named workspace does not exist.
-						</entry>
-					</row>
-				</tbody>
-			</tgroup>
-		</table>
+  				</para>
+        </listitem>
+      </varlistentry>
+      <varlistentry>
+        <term>CompositeRequest</term>
+        <listitem>
+          <para>
+							A request that actually comprises multiple requests (none of which will be a composite).
+							The connector simply processes all of the requests in the composite request, but should set on the composite
+							request any error (usually the first error) that occurs during processing of the contained requests.
+  				</para>
+        </listitem>
+      </varlistentry>
+    </variablelist>
+    
+    </sect2>
+	  <sect2 id="graph-change-requests">
+		<title>Change Requests</title>
 		<para>
 		  &ChangeRequest; is a subclass of &Request; that provides a base class for all the requests that request a change
 		  be made to the content.  As we'll see later, these &ChangeRequest; objects also get reused by the
 		  <link linkend="graph-observation">observation</link> system.
 		</para>
-		<table frame='all'>
-			<title>Types of Change Requests</title>
-			<tgroup cols='2' align='left' colsep='1' rowsep='1'>
-	      <colspec colname='c1' colwidth="1*"/>
-	      <colspec colname='c2' colwidth="1*"/>
-				<thead>
-					<row>
-			  		<entry>Name</entry>
-			  		<entry>Description</entry>
-					</row>
-				</thead>
-				<tbody>
-					<row>
-						<entry>CreateNodeRequest</entry>
-						<entry>
+		<para>
+			There specific subclasses of &ChangeRequest; are:
+    </para>
+		
+    <variablelist>
+      <varlistentry>
+        <term>CreateNodeRequest</term>
+        <listitem>
+          <para>
 							A request to create a node at the specified location and setting on the new node the properties included in the request.
 							The connector creates the node at the desired location, adjusting any same-name-sibling indexes as required.
 							(If an SNS index is provided in the new node's location, existing children with the same name after that SNS index
@@ -1138,41 +1152,49 @@ for ( &Location; child : results.getNode(path2) ) {
 							The connector also sets on the request the actual location of the new node (including the path and identification properties)..
 							The connector sets a &PathNotFoundException; error on the request if the parent node does not exist in the workspace.
 							The connector sets a &InvalidWorkspaceException; error on the request if the named workspace does not exist.
-						</entry>
-					</row>
-					<row>
-						<entry>RemovePropertiesRequest</entry>
-						<entry>
+  				</para>
+        </listitem>
+      </varlistentry>
+      <varlistentry>
+        <term>RemovePropertiesRequest</term>
+        <listitem>
+          <para>
 							A request to remove a set of properties on an existing node.  The request contains the location of the node as well as the
 							names of the properties to be removed.  The connector performs these changes and sets on the request the
 							actual location (including the path and identification properties) of the node.
 							The connector sets a &PathNotFoundException; error on the request if the node does not exist in the workspace.
 							The connector sets a &InvalidWorkspaceException; error on the request if the named workspace does not exist.
-						</entry>
-					</row>
-					<row>
-						<entry>UpdatePropertiesRequest</entry>
-						<entry>
+  				</para>
+        </listitem>
+      </varlistentry>
+      <varlistentry>
+        <term>UpdatePropertiesRequest</term>
+        <listitem>
+          <para>
 							A request to set or update properties on an existing node.  The request contains the location of the node as well as the
 							properties to be set and those to be deleted.  The connector performs these changes and sets on the request the
 							actual location (including the path and identification properties) of the node.
 							The connector sets a &PathNotFoundException; error on the request if the node does not exist in the workspace.
 							The connector sets a &InvalidWorkspaceException; error on the request if the named workspace does not exist.
-						</entry>
-					</row>
-					<row>
-						<entry>RenameNodeRequest</entry>
-						<entry>
+  				</para>
+        </listitem>
+      </varlistentry>
+      <varlistentry>
+        <term>RenameNodeRequest</term>
+        <listitem>
+          <para>
 							A request to change the name of a node.  The connector changes the node's name, adjusts all SNS indexes
 							accordingly, and returns the actual locations (including the path and identification properties) of both the original
 							location and the new location.
 							The connector sets a &PathNotFoundException; error on the request if the node does not exist in the workspace.
 							The connector sets a &InvalidWorkspaceException; error on the request if the named workspace does not exist.
-						</entry>
-					</row>
-					<row>
-						<entry>CopyBranchRequest</entry>
-						<entry>
+  				</para>
+        </listitem>
+      </varlistentry>
+      <varlistentry>
+        <term>CopyBranchRequest</term>
+        <listitem>
+          <para>
 							A request to copy a portion of a subgraph that has as its root a particular node, up to a maximum depth.
 							The request includes the name of the workspace where the original node is located as well as the name of the
 							workspace where the copy is to be placed (these may be the same, but may be different).
@@ -1183,11 +1205,13 @@ for ( &Location; child : results.getNode(path2) ) {
 							The connector sets a &PathNotFoundException; error on the request if the node at 
 							the top of the branch does not exist in the workspace.
 							The connector sets a &InvalidWorkspaceException; error on the request if one of the named workspaces does not exist.
-						</entry>
-					</row>
-					<row>
-						<entry>MoveBranchRequest</entry>
-						<entry>
+  				</para>
+        </listitem>
+      </varlistentry>
+      <varlistentry>
+        <term>MoveBranchRequest</term>
+        <listitem>
+          <para>
 							A request to move a subgraph that has a particular node as its root.
 							The connector moves the branch from the original location and places it as child of the specified new location.
 							The connector also sets on the request the actual location (including the path and identification properties)
@@ -1195,104 +1219,134 @@ for ( &Location; child : results.getNode(path2) ) {
 							The connector sets a &PathNotFoundException; error on the request if the node that is to be moved or the
 							new location do not exist in the workspace.
 							The connector sets a &InvalidWorkspaceException; error on the request if the named workspace does not exist.
-						</entry>
-					</row>
-					<row>
-						<entry>DeleteBranchRequest</entry>
-						<entry>
+  				</para>
+        </listitem>
+      </varlistentry>
+      <varlistentry>
+        <term>DeleteBranchRequest</term>
+        <listitem>
+          <para>
 							A request to delete an entire branch specified by a single node's location.
 							The connector deletes the specified node and all nodes below it, and sets the actual location,
 							including the path and identification properties, of the node that was deleted.
 							The connector sets a &PathNotFoundException; error on the request if the node being deleted does not exist in the workspace.
 							The connector sets a &InvalidWorkspaceException; error on the request if the named workspace does not exist.
-						</entry>
-					</row>
-					<row>
-						<entry>CompositeRequest</entry>
-						<entry>
-							A request that actually comprises multiple requests (none of which will be a composite).
-							The connector simply processes all of the requests in the composite request, but should set on the composite
-							request any error (usually the first error) that occurs during processing of the contained requests.
-						</entry>
-					</row>
-				</tbody>
-			</tgroup>
-		</table>
-		<para>There are also requests that deal with workspaces:</para>
-		<table frame='all'>
-			<title>Types of Workspace Read Requests</title>
-			<tgroup cols='2' align='left' colsep='1' rowsep='1'>
-	      <colspec colname='c1' colwidth="1*"/>
-	      <colspec colname='c2' colwidth="1*"/>
-				<thead>
-					<row>
-			  		<entry>Name</entry>
-			  		<entry>Description</entry>
-					</row>
-				</thead>
-				<tbody>
-					<row>
-						<entry>GetWorkspacesRequest</entry>
-						<entry>
+  				</para>
+        </listitem>
+      </varlistentry>
+    </variablelist>
+		
+    </sect2>
+	  <sect2 id="graph-workspace-read-requests">
+		<title>Workspace Read Requests</title>
+		<para>There are also requests that read information about workspaces:</para>
+
+    <variablelist>
+      <varlistentry>
+        <term><emphasis role="strong">GetWorkspacesRequest</emphasis></term>
+        <listitem>
+          <para>
 							A request to obtain the names of the existing workspaces that are accessible to the caller.
-						</entry>
-					</row>
-					<row>
-						<entry>VerifyWorkspaceRequest</entry>
-						<entry>
+  				</para>
+        </listitem>
+      </varlistentry>
+      <varlistentry>
+        <term><emphasis role="strong">VerifyWorkspaceRequest</emphasis></term>
+        <listitem>
+          <para>
 							A request to verify that a workspace with a particular name exists.
 							The connector returns the actual location for the root node if the workspace exists, as well as the actual name of the workspace
 							(e.g., the default workspace name if a null name is supplied).
-						</entry>
-					</row>
-				</tbody>
-			</tgroup>
-		</table>
+  				</para>
+        </listitem>
+      </varlistentry>
+    </variablelist>
+
+    </sect2>
+	  <sect2 id="graph-workspace-change-requests">
+		<title>Workspace Change Requests</title>
 		<para>And there are also requests that deal with changing workspaces (and thus extend &ChangeRequest;):</para>
-		<table frame='all'>
-			<title>Types of Workspace Change Requests</title>
-			<tgroup cols='2' align='left' colsep='1' rowsep='1'>
-	      <colspec colname='c1' colwidth="1*"/>
-	      <colspec colname='c2' colwidth="1*"/>
-				<thead>
-					<row>
-			  		<entry>Name</entry>
-			  		<entry>Description</entry>
-					</row>
-				</thead>
-				<tbody>
-					<row>
-						<entry>CreateWorkspaceRequest</entry>
-						<entry>
+		
+		<variablelist>
+      <varlistentry>
+        <term>CreateWorkspaceRequest</term>
+        <listitem>
+          <para>
 							A request to create a workspace with a particular name.
 							The connector returns the actual location for the root node if the workspace exists, as well as the actual name of the workspace
 							(e.g., the default workspace name if a null name is supplied).
 							The connector sets a &InvalidWorkspaceException; error on the request if the named workspace already exists.
-						</entry>
-					</row>
-					<row>
-						<entry>DestroyWorkspaceRequest</entry>
-						<entry>
+  				</para>
+        </listitem>
+      </varlistentry>
+      <varlistentry>
+        <term>DestroyWorkspaceRequest</term>
+        <listitem>
+          <para>
 							A request to destroy a workspace with a particular name.
 							The connector sets a &InvalidWorkspaceException; error on the request if the named workspace does not exist.
-						</entry>
-					</row>
-					<row>
-						<entry>CloneWorkspaceRequest</entry>
-						<entry>
+  				</para>
+        </listitem>
+      </varlistentry>
+      <varlistentry>
+        <term>CloneWorkspaceRequest</term>
+        <listitem>
+          <para>
 							A request to clone one named workspace as another new named workspace.
 							The connector sets a &InvalidWorkspaceException; error on the request if the original workspace does not exist, 
 							or if the new workspace already exists.
-						</entry>
-					</row>
-				</tbody>
-			</tgroup>
-		</table>
-    <para>
-			Although there are over a dozen different kinds of requests, we do anticipate adding more in future releases.
-			For example, ModeShape has recently added support for searching repository content in sources through an additional subclass of &Request;.
-			Getting the version history for a node will likely be another kind of request added in an upcoming release.
-		</para>
+  				</para>
+        </listitem>
+      </varlistentry>
+    </variablelist>
+    
+    </sect2>
+	  <sect2 id="graph-search-requests">
+		<title>Search Requests</title>
+		<para>Several requests are designed to push searches and queries down to the connector, if connectors support such operations:</para>
+		
+		<variablelist>
+      <varlistentry>
+        <term><emphasis role="strong">SearchRequest</emphasis></term>
+        <listitem>
+          <para>
+							A request to query a named workspace using a supplied query.
+							The connector returns tuples containing the columns and resulting values, plus statistics about the execution of the query.
+  				</para>
+        </listitem>
+      </varlistentry>
+      <varlistentry>
+        <term><emphasis role="strong">FullTextSearchRequest</emphasis></term>
+        <listitem>
+          <para>
+							A request to search a named workspace using a supplied full-text search string and optional offset and limit values.
+							The connector returns tuples containing the columns and resulting values, plus statistics about the execution of the query.
+  				</para>
+        </listitem>
+      </varlistentry>
+    </variablelist>
+    
+    </sect2>
+	  <sect2 id="graph-function-requests">
+		<title>Function Requests</title>
+		<para>One type of request allows a function to be passed to the connector:</para>
+		
+		<variablelist>
+      <varlistentry>
+        <term><emphasis role="strong">FunctionRequest</emphasis></term>
+        <listitem>
+          <para>
+							A request that executes a supplied function at a particular location within a named workspace. The inputs to the function
+							can be set on the request (as a series of name-value pairs), and when executed the function will set the outputs as
+							name-value pairs on the request. This request is extremely useful for (complex) operations that must first read information from
+							the workspace and then perform other actions.
+  				</para>
+        </listitem>
+      </varlistentry>
+    </variablelist>
+    
+    </sect2>
+
 		<para>
 			This section covered the different kinds of &Request; classes.  The next section provides a easy way to encapsulate how
 			a component should responds to these requests, and after that we'll see how these &Request; objects are also used

--- a/docs/reference/src/main/docbook/en-US/custom.dtd
+++ b/docs/reference/src/main/docbook/en-US/custom.dtd
@@ -40,6 +40,7 @@
 <!ENTITY SLF4JManual          "http://www.slf4j.org/manual.html">
 <!ENTITY JGroups							"http://jgroups.org">
 <!ENTITY JGroupsManual				"&JGroups;/ug.html">
+<!ENTITY HibernateDocs		    "http://docs.jboss.org/hibernate/core/3.5/reference/en-US/html_single">
 
 <!ENTITY Java									"http://java.sun.com/javase/6/docs/api/">
 <!ENTITY JavaEE               "http://java.sun.com/javaee/6/docs/api/">

--- a/extensions/modeshape-connector-filesystem/src/main/java/org/modeshape/connector/filesystem/FileSystemSource.java
+++ b/extensions/modeshape-connector-filesystem/src/main/java/org/modeshape/connector/filesystem/FileSystemSource.java
@@ -274,8 +274,8 @@ public class FileSystemSource extends AbstractNodeCachingRepositorySource<Path, 
     /**
      * Sets the regular expression that, if matched by a file or folder, indicates that the file or folder should be ignored
      * <p>
-     * Only one of FilenameFilter or Inclusion/Exclusion Pattern are used at a given time. If Inclusion/exclusion are set, then
-     * FilenameFilter is ignored.
+     * Only one of FilenameFilter or Inclusion/Exclusion Pattern are used at a given time. If FilenameFilter is used, then the
+     * inclusion and exclusion patterns are ignored.
      * </p>
      * 
      * @param exclusionPattern the regular expression that, if matched by a file or folder, indicates that the file or folder
@@ -301,8 +301,8 @@ public class FileSystemSource extends AbstractNodeCachingRepositorySource<Path, 
     /**
      * Sets the regular expression that, if matched by a file or folder, indicates that the file or folder should be included
      * <p>
-     * Only one of FilenameFilter or Inclusion/Exclusion Pattern are used at a given time. If Inclusion/exclusion are set, then
-     * FilenameFilter is ignored.
+     * Only one of FilenameFilter or Inclusion/Exclusion Pattern are used at a given time. If FilenameFilter is used, then the
+     * inclusion and exclusion patterns are ignored.
      * </p>
      * 
      * @param inclusionPattern the regular expression that, if matched by a file or folder, indicates that the file or folder
@@ -323,8 +323,8 @@ public class FileSystemSource extends AbstractNodeCachingRepositorySource<Path, 
     /**
      * Sets the filename filter that is used to restrict which content can be accessed by this connector
      * <p>
-     * Only one of FilenameFilter or Inclusion/Exclusion Pattern are used at a given time. If Inclusion/exclusion are set, then
-     * FilenameFilter is ignored.
+     * Only one of FilenameFilter or Inclusion/Exclusion Pattern are used at a given time. If FilenameFilter is used, then the
+     * inclusion and exclusion patterns are ignored.
      * </p>
      * 
      * @param filenameFilter the filename filter that is used to restrict which content can be accessed by this connector. If this

--- a/modeshape-graph/src/main/java/org/modeshape/graph/request/FunctionRequest.java
+++ b/modeshape-graph/src/main/java/org/modeshape/graph/request/FunctionRequest.java
@@ -58,7 +58,7 @@ public final class FunctionRequest extends Request implements Cloneable {
     private Location actualLocation;
 
     /**
-     * Create a request to execute the function the properties and number of children of a node at the supplied location.
+     * Create a request to execute the function at the supplied location.
      * 
      * @param function the function to be performed
      * @param at the location of the node to be read


### PR DESCRIPTION
All of the tables used in connector chapters were changed to variable lists, which seem to format better
(since the tables didn't have lines between rows). Also added a link to the Hiberante dialects
to address MODE-1191.
