### PR TITLE
MODE-1232 Add support for REFERENCE nodes to FS connector

### DIFF
--- a/modeshape-graph/src/main/java/org/modeshape/graph/session/GraphSession.java
+++ b/modeshape-graph/src/main/java/org/modeshape/graph/session/GraphSession.java
@@ -2589,6 +2589,11 @@ public class GraphSession<Payload, PropertyPayload> {
             return location;
         }
 
+        public final void setUuid( UUID uuid ) {
+            assert this.location.getUuid() == null || this.location.getUuid().equals(uuid);
+            this.location = this.location.with(uuid);
+        }
+
         /**
          * Get the original location for this node prior to making any transient changes.
          * 

--- a/modeshape-integration-tests/src/test/java/org/modeshape/test/integration/filesystem/FileSystemRepositoryReferenceTest.java
+++ b/modeshape-integration-tests/src/test/java/org/modeshape/test/integration/filesystem/FileSystemRepositoryReferenceTest.java
@@ -1,0 +1,136 @@
+/*
+ * ModeShape (http://www.modeshape.org)
+ * See the COPYRIGHT.txt file distributed with this work for information
+ * regarding copyright ownership.  Some portions may be licensed
+ * to Red Hat, Inc. under one or more contributor license agreements.
+ * See the AUTHORS.txt file in the distribution for a full listing of 
+ * individual contributors.
+ *
+ * ModeShape is free software. Unless otherwise indicated, all code in ModeShape
+ * is licensed to you under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ * 
+ * ModeShape is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.modeshape.test.integration.filesystem;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+import java.io.File;
+import javax.jcr.NamespaceException;
+import javax.jcr.NamespaceRegistry;
+import javax.jcr.Node;
+import javax.jcr.PropertyType;
+import javax.jcr.RepositoryException;
+import javax.jcr.Session;
+import javax.jcr.nodetype.NoSuchNodeTypeException;
+import javax.jcr.nodetype.NodeTypeManager;
+import javax.jcr.nodetype.NodeTypeTemplate;
+import javax.jcr.nodetype.PropertyDefinitionTemplate;
+import org.junit.Test;
+import org.modeshape.common.util.FileUtil;
+import org.modeshape.test.ModeShapeSingleUseTest;
+
+public class FileSystemRepositoryReferenceTest extends ModeShapeSingleUseTest {
+
+    protected static final String README_RESOURCE_PATH = "svn/local_repos/dummy_svn_repos/README.txt";
+    protected static final String MODETEST_URL = "http://modeshape.org/test";
+
+    /**
+     * {@inheritDoc}
+     * 
+     * @see org.modeshape.test.ModeShapeSingleUseTest#beforeEach()
+     */
+    @Override
+    public void beforeEach() throws Exception {
+        // Delete the directory used for the FS store ...
+        FileUtil.delete("target/fsRepoWithProps");
+
+        // Now make the root directory ...
+        new File("target/fsRepoWithProps/root").mkdirs();
+
+        super.beforeEach();
+    }
+
+    @Test
+    public void shouldAllowCreatingReferenceToContentNode() throws Exception {
+        startEngineUsing("config/configRepositoryForFileSystemWithExtraProperties.xml");
+
+        // Make sure the required mixins are registered ...
+        addPointableMixin();
+
+        // Create the nodes ...
+        Session session = session();
+        Node root = session.getRootNode();
+        root.addNode("A", "nt:folder");
+        Node meta = root.addNode("meta", "nt:folder");
+        meta.addMixin("modetest:pointable");
+        Node readme = uploadFile(README_RESOURCE_PATH, "/A");
+
+        // Now create a reference on '/meta' to the '/A/README.txt/jcr:content' node.
+        Node content = readme.getNode("jcr:content");
+        content.addMixin("mix:referenceable");
+        meta.setProperty("contentPointer", content);
+
+        // Resolve the node before saving, since resolution can use the transient state of the session ...
+        Node referenced = meta.getProperty("contentPointer").getNode();
+        assertThat(referenced.getPath(), is(content.getPath()));
+        assertThat(referenced, is(content));
+
+        // Now save ...
+        session.save();
+
+        logout();
+
+        // Get another session and verify the reference exists and can be resolved ...
+        session = session();
+        root = session.getRootNode();
+        meta = root.getNode("meta");
+        content = root.getNode("A/README.txt/jcr:content");
+
+        referenced = meta.getProperty("contentPointer").getNode();
+        assertThat(referenced.getPath(), is(content.getPath()));
+        assertThat(referenced, is(content));
+    }
+
+    protected void registryNamespaceIfMissing( String prefix,
+                                               String url ) throws RepositoryException {
+        NamespaceRegistry registry = session().getWorkspace().getNamespaceRegistry();
+        try {
+            registry.getURI(prefix);
+        } catch (NamespaceException e) {
+            registry.registerNamespace(prefix, url);
+        }
+    }
+
+    @SuppressWarnings( "unchecked" )
+    protected void addPointableMixin() throws RepositoryException {
+        registryNamespaceIfMissing("modetest", MODETEST_URL);
+        String typeName = "modetest:pointable";
+        NodeTypeManager mgr = session().getWorkspace().getNodeTypeManager();
+        try {
+            mgr.getNodeType(typeName);
+        } catch (NoSuchNodeTypeException e) {
+            PropertyDefinitionTemplate anySinglePropertyDefn = mgr.createPropertyDefinitionTemplate();
+            anySinglePropertyDefn.setName("*");
+            anySinglePropertyDefn.setRequiredType(PropertyType.REFERENCE);
+            anySinglePropertyDefn.setMultiple(false);
+
+            NodeTypeTemplate type = mgr.createNodeTypeTemplate();
+            type.setName(typeName);
+            type.setMixin(true);
+            type.getPropertyDefinitionTemplates().add(anySinglePropertyDefn);
+
+            mgr.registerNodeType(type, false);
+        }
+    }
+}

--- a/modeshape-integration-tests/src/test/resources/config/configRepositoryForFileSystemWithExtraProperties.xml
+++ b/modeshape-integration-tests/src/test/resources/config/configRepositoryForFileSystemWithExtraProperties.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- 
+  ~ ModeShape (http://www.modeshape.org)
+  ~
+  ~ See the COPYRIGHT.txt file distributed with this work for information
+  ~ regarding copyright ownership.  Some portions may be licensed
+  ~ to Red Hat, Inc. under one or more contributor license agreements.
+  ~ See the AUTHORS.txt file in the distribution for a full listing of 
+  ~ individual contributors.
+  ~
+  ~ ModeShape is free software. Unless otherwise indicated, all code in ModeShape
+  ~ is licensed to you under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ ModeShape is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+  ~ or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+  ~ for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public License
+  ~ along with this distribution; if not, write to:
+  ~ Free Software Foundation, Inc.
+  ~ 51 Franklin Street, Fifth Floor
+  ~ Boston, MA  02110-1301  USA
+  -->
+<configuration xmlns:mode="http://www.modeshape.org/1.0"
+               xmlns:jcr="http://www.jcp.org/jcr/1.0"
+               xmlns:nt="http://www.jcp.org/jcr/nt/1.0">
+    <!-- Define the sources from which content is made available.  -->
+    <mode:sources jcr:primaryType="nt:unstructured">
+        <!-- 
+        The 'JCR' repository is a file system source with two predefined workspaces.
+        In a production release, the mode:rootNodeUuid would be specified here as well to ensure stability over restarts.  
+        Since we don't specify a rootNodeUuid, a random UUID will be generated each time that the corresponding test is run.
+        -->
+        <mode:source jcr:name="Store" mode:classname="org.modeshape.connector.filesystem.FileSystemSource"
+            mode:workspaceRootPath="./target/fsRepoWithProps/root"
+            mode:defaultWorkspaceName="defaultWorkspace"
+            mode:predefinedWorkspaceNames="otherWorkspace"
+            mode:creatingWorkspacesAllowed="false"
+            mode:extraPropertiesBehavior="store"
+            mode:updatesAllowed="true"
+            />    
+    </mode:sources>
+    <!-- JCR Repositories.  This is required, with a separate repository for each JCR repository instance. -->
+    <mode:repositories>
+        <mode:repository jcr:name="Repo" mode:source="Store">
+            <!-- Define the options for the JCR repository, using camelcase version of JcrRepository.Option names -->
+            <mode:options jcr:primaryType="mode:options">
+               <mode:option jcr:name="rebuildQueryIndexOnStartup" mode:value="ifMissing"/>
+               <mode:option jcr:name="queryIndexDirectory" mode:value="./target/fsRepoWithProps/indexes" />
+            </mode:options>
+        </mode:repository>
+    </mode:repositories>
+</configuration>

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrObservationManager.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrObservationManager.java
@@ -1010,7 +1010,8 @@ final class JcrObservationManager implements ObservationManager {
                 // process event making sure we have the right event type
                 Path path = change.getPath();
                 PathFactory pathFactory = getValueFactories().getPathFactory();
-                String id = change.getLocation().getUuid().toString();
+                UUID uuid = change.getLocation().getUuid();
+                String id = uuid != null ? uuid.toString() : null;
 
                 if (change.includes(ChangeType.NODE_MOVED)) {
                     Location original = change.getOriginalLocation();

--- a/utils/modeshape-unit-test/src/main/java/org/modeshape/test/ModeShapeUnitTest.java
+++ b/utils/modeshape-unit-test/src/main/java/org/modeshape/test/ModeShapeUnitTest.java
@@ -447,18 +447,18 @@ public abstract class ModeShapeUnitTest {
         return getClass().getClassLoader().getResource(name);
     }
 
-    protected void uploadFile( String resourceFilePath,
+    protected Node uploadFile( String resourceFilePath,
                                String parentPath ) throws RepositoryException, IOException {
-        uploadFile(resourceUrl(resourceFilePath), parentPath);
+        return uploadFile(resourceUrl(resourceFilePath), parentPath);
     }
 
-    protected void uploadFile( String folder,
+    protected Node uploadFile( String folder,
                                String fileName,
                                String parentPath ) throws RepositoryException, IOException {
-        uploadFile(resourceUrl(folder + fileName), parentPath);
+        return uploadFile(resourceUrl(folder + fileName), parentPath);
     }
 
-    protected void uploadFile( URL url,
+    protected Node uploadFile( URL url,
                                String parentPath ) throws RepositoryException, IOException {
         // Grab the last segment of the URL path, using it as the filename
         String filename = url.getPath().replaceAll("([^/]*/)*", "");
@@ -503,7 +503,7 @@ public abstract class ModeShapeUnitTest {
         session.getWorkspace()
                .getObservationManager()
                .addEventListener(listener, Event.NODE_ADDED, parentPath, true, null, null, false);
-        tools.uploadFile(session, nodePath, url);
+        Node newFileNode = tools.uploadFile(session, nodePath, url);
 
         // Save the session ...
         session.save();
@@ -514,6 +514,7 @@ public abstract class ModeShapeUnitTest {
         } catch (InterruptedException e) {
             fail(e.getMessage());
         }
+        return newFileNode;
     }
 
     protected void uploadFiles( String destinationPath,


### PR DESCRIPTION
Added support in the file system connector for handling 'mix:referenceable' nodes and correctly handling the 'jcr:uuid' property. The connector still does not handle finding nodes by identifier (e.g., UUID).

Also changed the JcrSession (and associated classes) to better handle looking up nodes by identifier if the connector doesn't support doing so. In such cases, the JcrSession performs a query to search for the path of the node given the UUID, and then looks up the node by path. Note that when the referenceable nodes are still in the session's transient state, the session is now able to find them without resorting to the connector or queries.

A new integration test case was added to test for this functionality. Prior to the above fixes, this test case failed (as expected); after the above fixes, the test case passes.

All unit and integration tests pass.
