### PR TITLE
MODE-1234 Corrected indexing and querying of BOOLEAN properties

### DIFF
--- a/extensions/modeshape-search-lucene/src/main/java/org/modeshape/search/lucene/IndexRules.java
+++ b/extensions/modeshape-search-lucene/src/main/java/org/modeshape/search/lucene/IndexRules.java
@@ -27,11 +27,11 @@ import java.math.BigDecimal;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
-import org.modeshape.common.annotation.Immutable;
-import org.modeshape.common.annotation.NotThreadSafe;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.document.Field.Index;
 import org.apache.lucene.document.Field.Store;
+import org.modeshape.common.annotation.Immutable;
+import org.modeshape.common.annotation.NotThreadSafe;
 import org.modeshape.common.util.CheckArg;
 import org.modeshape.graph.property.Name;
 
@@ -53,6 +53,31 @@ public class IndexRules {
         REFERENCE,
         WEAK_REFERENCE,
         DECIMAL;
+    }
+
+    public static interface Factory {
+        IndexRules getRules();
+    }
+
+    /**
+     * A simple {@link Factory} that always returns the same {@link IndexRules}.
+     */
+    public static class FixedFactory implements Factory {
+        private final IndexRules rules;
+
+        public FixedFactory( IndexRules rules ) {
+            this.rules = rules;
+        }
+
+        /**
+         * {@inheritDoc}
+         * 
+         * @see org.modeshape.search.lucene.IndexRules.Factory#getRules()
+         */
+        @Override
+        public IndexRules getRules() {
+            return rules;
+        }
     }
 
     /**

--- a/extensions/modeshape-search-lucene/src/main/java/org/modeshape/search/lucene/LuceneSearchEngine.java
+++ b/extensions/modeshape-search-lucene/src/main/java/org/modeshape/search/lucene/LuceneSearchEngine.java
@@ -81,6 +81,13 @@ public class LuceneSearchEngine extends AbstractLuceneSearchEngine<LuceneSearchW
      */
     public static final IndexRules DEFAULT_RULES;
 
+    protected static final IndexRules.Factory DEFAULT_RULES_FACTORY = new IndexRules.Factory() {
+        @Override
+        public IndexRules getRules() {
+            return DEFAULT_RULES;
+        }
+    };
+
     static {
         // We know that the earliest creation/modified dates cannot be before November 1 2009,
         // which is before this feature was implemented
@@ -113,7 +120,7 @@ public class LuceneSearchEngine extends AbstractLuceneSearchEngine<LuceneSearchW
     };
 
     private final LuceneConfiguration configuration;
-    private final IndexRules rules;
+    private final IndexRules.Factory rulesFactory;
     private final Analyzer analyzer;
     private final int maxDepthPerIndexRead;
     private final ReadWriteLock processingLock = new ReentrantReadWriteLock();
@@ -128,7 +135,7 @@ public class LuceneSearchEngine extends AbstractLuceneSearchEngine<LuceneSearchW
      *        in a way such that all workspaces are known to exist
      * @param maxDepthPerIndexRead the maximum depth that any single request is to read when indexing
      * @param configuration the configuration of the Lucene indexes
-     * @param rules the index rule, or null if the default index rules should be used
+     * @param rulesFactory the factory for getting the index rules, or null if the default index rules should be used
      * @param analyzer the analyzer, or null if the default analyzer should be used
      * @throws IllegalArgumentException if any of the source name, connection factory, or configuration are null
      */
@@ -137,13 +144,13 @@ public class LuceneSearchEngine extends AbstractLuceneSearchEngine<LuceneSearchW
                                boolean verifyWorkspaceInSource,
                                int maxDepthPerIndexRead,
                                LuceneConfiguration configuration,
-                               IndexRules rules,
+                               IndexRules.Factory rulesFactory,
                                Analyzer analyzer ) {
         super(sourceName, connectionFactory, verifyWorkspaceInSource);
         CheckArg.isNotNull(configuration, "configuration");
         this.configuration = configuration;
         this.analyzer = analyzer != null ? analyzer : new StandardAnalyzer(configuration.getVersion());
-        this.rules = rules != null ? rules : DEFAULT_RULES;
+        this.rulesFactory = rulesFactory != null ? rulesFactory : DEFAULT_RULES_FACTORY;
         this.maxDepthPerIndexRead = maxDepthPerIndexRead;
     }
 
@@ -240,7 +247,7 @@ public class LuceneSearchEngine extends AbstractLuceneSearchEngine<LuceneSearchW
     @Override
     protected LuceneSearchWorkspace createWorkspace( ExecutionContext context,
                                                      String workspaceName ) throws SearchEngineException {
-        return new LuceneSearchWorkspace(workspaceName, configuration, rules, analyzer);
+        return new LuceneSearchWorkspace(workspaceName, configuration, rulesFactory, analyzer);
     }
 
     /**

--- a/extensions/modeshape-search-lucene/src/main/java/org/modeshape/search/lucene/LuceneSearchWorkspace.java
+++ b/extensions/modeshape-search-lucene/src/main/java/org/modeshape/search/lucene/LuceneSearchWorkspace.java
@@ -73,7 +73,7 @@ public class LuceneSearchWorkspace implements SearchEngineWorkspace {
 
     private final String workspaceName;
     private final String workspaceDirectoryName;
-    protected final IndexRules rules;
+    protected final IndexRules.Factory rulesFactory;
     private final LuceneConfiguration configuration;
     protected final Directory contentDirectory;
     protected final Analyzer analyzer;
@@ -82,14 +82,14 @@ public class LuceneSearchWorkspace implements SearchEngineWorkspace {
 
     protected LuceneSearchWorkspace( String workspaceName,
                                      LuceneConfiguration configuration,
-                                     IndexRules rules,
+                                     IndexRules.Factory rulesFactory,
                                      Analyzer analyzer ) {
         assert workspaceName != null;
         assert configuration != null;
         this.workspaceName = workspaceName;
         this.workspaceDirectoryName = workspaceName.trim().length() != 0 ? workspaceName : UUID.randomUUID().toString();
         this.analyzer = analyzer != null ? analyzer : new StandardAnalyzer(configuration.getVersion());
-        this.rules = rules != null ? rules : LuceneSearchEngine.DEFAULT_RULES;
+        this.rulesFactory = rulesFactory != null ? rulesFactory : LuceneSearchEngine.DEFAULT_RULES_FACTORY;
         this.configuration = configuration;
         this.contentDirectory = this.configuration.getDirectory(workspaceDirectoryName, INDEX_NAME);
     }
@@ -118,7 +118,7 @@ public class LuceneSearchWorkspace implements SearchEngineWorkspace {
      * @return rules
      */
     public IndexRules getRules() {
-        return rules;
+        return rulesFactory.getRules();
     }
 
     /**

--- a/extensions/modeshape-search-lucene/src/test/java/org/modeshape/search/lucene/LuceneSearchEngineObservationTest.java
+++ b/extensions/modeshape-search-lucene/src/test/java/org/modeshape/search/lucene/LuceneSearchEngineObservationTest.java
@@ -147,11 +147,12 @@ public class LuceneSearchEngineObservationTest {
         rulesBuilder.integerField(name("mpgCity"), Field.Store.YES, Field.Index.NOT_ANALYZED, 0, 50);
         rulesBuilder.integerField(name("mpgHighway"), Field.Store.YES, Field.Index.NOT_ANALYZED, 0, 50);
         // rulesBuilder.analyzeAndStoreAndFullText(name("maker"));
-        IndexRules rules = rulesBuilder.build();
         LuceneConfiguration luceneConfig = LuceneConfigurations.inMemory();
         // LuceneConfiguration luceneConfig = LuceneConfigurations.using(new File("target/testIndexes"));
         Analyzer analyzer = null;
-        searchEngine = new LuceneSearchEngine(sourceName, connectionFactory, false, depthToRead, luceneConfig, rules, analyzer);
+        IndexRules.Factory rulesFactory = new IndexRules.FixedFactory(rulesBuilder.build());
+        searchEngine = new LuceneSearchEngine(sourceName, connectionFactory, false, depthToRead, luceneConfig, rulesFactory,
+                                              analyzer);
 
         // Initialize the source so that the search engine observes the events ...
         @SuppressWarnings( "synthetic-access" )

--- a/extensions/modeshape-search-lucene/src/test/java/org/modeshape/search/lucene/LuceneSearchEngineTest.java
+++ b/extensions/modeshape-search-lucene/src/test/java/org/modeshape/search/lucene/LuceneSearchEngineTest.java
@@ -126,11 +126,11 @@ public class LuceneSearchEngineTest {
         rulesBuilder.integerField(name("mpgCity"), Field.Store.YES, Field.Index.NOT_ANALYZED, 0, 50);
         rulesBuilder.integerField(name("mpgHighway"), Field.Store.YES, Field.Index.NOT_ANALYZED, 0, 50);
         // rulesBuilder.analyzeAndStoreAndFullText(name("maker"));
-        IndexRules rules = rulesBuilder.build();
+        IndexRules.Factory rulesFactory = new IndexRules.FixedFactory(rulesBuilder.build());
         LuceneConfiguration luceneConfig = LuceneConfigurations.inMemory();
         // LuceneConfiguration luceneConfig = LuceneConfigurations.using(new File("target/testIndexes"));
         Analyzer analyzer = null;
-        engine = new LuceneSearchEngine(sourceName, connectionFactory, true, depthToRead, luceneConfig, rules, analyzer);
+        engine = new LuceneSearchEngine(sourceName, connectionFactory, true, depthToRead, luceneConfig, rulesFactory, analyzer);
         loadContent();
 
         // Load the workspaces into the engine ...

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrPropertyDefinition.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrPropertyDefinition.java
@@ -655,7 +655,7 @@ class JcrPropertyDefinition extends JcrItemDefinition implements PropertyDefinit
                  * @see org.modeshape.jcr.JcrPropertyDefinition.Range#getMaximum()
                  */
                 public Comparable<T> getMaximum() {
-                    return lower;
+                    return upper;
                 }
 
                 /**
@@ -664,7 +664,7 @@ class JcrPropertyDefinition extends JcrItemDefinition implements PropertyDefinit
                  * @see org.modeshape.jcr.JcrPropertyDefinition.Range#getMinimum()
                  */
                 public Comparable<T> getMinimum() {
-                    return upper;
+                    return lower;
                 }
             };
         }

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/RepositoryNodeTypeManager.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/RepositoryNodeTypeManager.java
@@ -242,6 +242,13 @@ class RepositoryNodeTypeManager implements JcrSystemObserver {
     }
 
     NodeTypeSchemata getRepositorySchemata() {
+        // Try reading first, since this will work most of the time ...
+        try {
+            nodeTypeManagerLock.readLock().lock();
+            if (schemata != null) return schemata;
+        } finally {
+            nodeTypeManagerLock.readLock().unlock();
+        }
         try {
             nodeTypeManagerLock.writeLock().lock();
             if (schemata == null) {

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/RepositoryQueryManager.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/RepositoryQueryManager.java
@@ -236,7 +236,7 @@ abstract class RepositoryQueryManager {
                        String nameOfSourceToBeSearchable,
                        RepositoryConnectionFactory connectionFactory,
                        Observable observable,
-                       RepositoryNodeTypeManager nodeTypeManager,
+                       final RepositoryNodeTypeManager nodeTypeManager,
                        String indexDirectory,
                        boolean updateIndexesSynchronously,
                        boolean forceIndexRebuild,
@@ -288,13 +288,17 @@ abstract class RepositoryQueryManager {
             assert configuration != null;
 
             // Set up the indexing rules ...
-            IndexRules indexRules = nodeTypeManager.getRepositorySchemata().getIndexRules();
+            IndexRules.Factory indexRulesFactory = new IndexRules.Factory() {
+                public IndexRules getRules() {
+                    return nodeTypeManager.getRepositorySchemata().getIndexRules();
+                }
+            };
 
             // Set up the search engine ...
             org.apache.lucene.analysis.Analyzer analyzer = new EnglishAnalyzer(Version.LUCENE_30);
             boolean verifyWorkspaces = false;
             searchEngine = new LuceneSearchEngine(nameOfSourceToBeSearchable, connectionFactory, verifyWorkspaces,
-                                                  maxDepthPerRead, configuration, indexRules, analyzer);
+                                                  maxDepthPerRead, configuration, indexRulesFactory, analyzer);
 
             // Set up an original source observer to keep the index up to date ...
             if (updateIndexesSynchronously) {

--- a/modeshape-jcr/src/test/resources/notionalTypes.cnd
+++ b/modeshape-jcr/src/test/resources/notionalTypes.cnd
@@ -1,0 +1,17 @@
+//------------------------------------------------------------------------------
+// N A M E S P A C E S
+//------------------------------------------------------------------------------
+<jcr='http://www.jcp.org/jcr/1.0'>
+<nt='http://www.jcp.org/jcr/nt/1.0'>
+<mix='http://www.jcp.org/jcr/mix/1.0'>
+<notion='http://www.modeshape.org/examples/notion/1.0'>
+
+//------------------------------------------------------------------------------
+// N O D E T Y P E S
+//------------------------------------------------------------------------------
+
+[notion:typed] > nt:unstructured
+- notion:booleanProperty (boolean)
+- notion:booleanProperty2 (boolean)
+- notion:longProperty (long)
+- notion:stringProperty (string)

--- a/release_notes.md
+++ b/release_notes.md
@@ -17,6 +17,13 @@ the following changes:
 
 while Beta2 included an additional dozen bug fixes and minor improvements.
 
+> ***NOTE***: This release makes changes to the way the indexes store property values,
+> so it is strongly recommended that all users force re-indexing their content
+> after upgrading to &version;. To do this, simply remove the directory containing
+> the repository's indexes, as defined by the "queryIndexDirectory" repository 
+> configuration option.
+
+
 ## JCR Supported Features
 
 **ModeShape implements all of the required JCR 2.0 features** (repository acquisition, 


### PR DESCRIPTION
Query nodes based upon custom node types with BOOLEAN properties did work, whereas querying nodes based upon built-in node types with BOOLEAN properties did not work. This fix corrects one error in the way properties are indexed, and another in how constraints against BOOLEAN properties are transformed into Lucene queries. These two errors cancelled each other out for properties on custom node types, but caused issues with properties on built-ins.

Once this fix is applied (through an upgrade to 2.6.0.Final, the indexes should be rebuilt to correct the existing indexes.

All unit and integration tests pass, including several new tests written to duplicate/verify the problem.
