### PR TITLE
MODE-1236 Added INFO-level log messages for reindexing

### DIFF
--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrI18n.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrI18n.java
@@ -40,6 +40,8 @@ public final class JcrI18n {
     public static I18n repositoryReferencesNonExistantSource;
     public static I18n indexRebuildingStarted;
     public static I18n indexRebuildingComplete;
+    public static I18n indexRebuildingOfWorkspaceStarted;
+    public static I18n indexRebuildingOfWorkspaceComplete;
 
     public static I18n cannotConvertValue;
     public static I18n loginFailed;

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrRepository.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrRepository.java
@@ -868,7 +868,7 @@ public class JcrRepository implements Repository {
             // We can query the federated source if it supports queries and searches
             // AND the original source supports queries and searches ...
             if (canQuerySource && canQueryFederated) {
-                this.queryManager = new PushDown(this.sourceName, this.executionContext, connectionFactory);
+                this.queryManager = new PushDown(repositoryName(), this.sourceName, this.executionContext, connectionFactory);
             } else {
                 // Otherwise create a repository query manager that maintains its own search engine ...
                 String indexDirectory = this.options.get(Option.QUERY_INDEX_DIRECTORY);
@@ -877,14 +877,15 @@ public class JcrRepository implements Repository {
                 boolean rebuildIndexesSynchronously = Boolean.TRUE.equals(Boolean.valueOf(this.options.get(Option.QUERY_INDEXES_REBUILT_SYNCHRONOUSLY)));
 
                 int maxDepthToRead = Integer.valueOf(this.options.get(Option.INDEX_READ_DEPTH));
-                this.queryManager = new RepositoryQueryManager.SelfContained(this.executionContext, this.sourceName,
-                                                                             connectionFactory, repositoryObservable,
-                                                                             repositoryTypeManager, indexDirectory,
-                                                                             updateIndexesSynchronously, forceIndexRebuild,
-                                                                             rebuildIndexesSynchronously, maxDepthToRead);
+                this.queryManager = new RepositoryQueryManager.SelfContained(repositoryName(), this.executionContext,
+                                                                             this.sourceName, connectionFactory,
+                                                                             repositoryObservable, repositoryTypeManager,
+                                                                             indexDirectory, updateIndexesSynchronously,
+                                                                             forceIndexRebuild, rebuildIndexesSynchronously,
+                                                                             maxDepthToRead);
             }
         } else {
-            this.queryManager = new RepositoryQueryManager.Disabled(this.sourceName);
+            this.queryManager = new RepositoryQueryManager.Disabled(repositoryName(), this.sourceName);
         }
 
         // Initialize the observer, which receives events from all repository sources

--- a/modeshape-jcr/src/main/resources/org/modeshape/jcr/JcrI18n.properties
+++ b/modeshape-jcr/src/main/resources/org/modeshape/jcr/JcrI18n.properties
@@ -28,8 +28,10 @@ couldNotStartEngine = Could not start the JcrEngine
 engineStopping = JcrEngine stopping...
 engineStopped = JcrEngine stopped in {0} ms
 repositoryReferencesNonExistantSource = The '{0}' repository references the '{1}' repository source that does not exist
-indexRebuildingStarted = Index rebuilding started...
-indexRebuildingComplete = Index rebuilding complete.
+indexRebuildingStarted = Started rebuilding indexes for repository '{0}'
+indexRebuildingComplete = Completed rebuilding indexes for repository '{0}'
+indexRebuildingOfWorkspaceStarted = Started rebuilding indexes for workspace '{1}' in repository '{0}'
+indexRebuildingOfWorkspaceComplete = Completed rebuilding indexes for workspace '{1}' in repository '{0}'
 
 cannotConvertValue = Cannot convert {0} value to {1}
 loginFailed = Unable to create session for workspace {1} in repository {0}: authentication failed. Check credentials.


### PR DESCRIPTION
Changed the existing log messages used during the beginning and end of the reindexing process from debug-level to info-level, and adjusted the messages to include the repository name (and workspace name if an entire workspace is being reindexed).

All unit and integration tests pass.
