### PR TITLE
MODE-1237 Corrected handling of empty results from subquery.

### DIFF
--- a/modeshape-graph/src/main/java/org/modeshape/graph/GraphI18n.java
+++ b/modeshape-graph/src/main/java/org/modeshape/graph/GraphI18n.java
@@ -221,6 +221,7 @@ public final class GraphI18n {
     public static I18n leftAndRightQueriesInSetQueryMustHaveUnionableColumns;
     public static I18n operatorIsNotValidAgainstColumnInTable;
     public static I18n columnInTableIsNotOrderable;
+    public static I18n missingVariableValue;
 
     /* Search */
     public static I18n interruptedWhileClosingChannel;

--- a/modeshape-graph/src/main/java/org/modeshape/graph/query/process/DependentQueryComponent.java
+++ b/modeshape-graph/src/main/java/org/modeshape/graph/query/process/DependentQueryComponent.java
@@ -112,16 +112,18 @@ public class DependentQueryComponent extends ProcessingComponent {
 
     protected void saveResultsToVariable( List<Object[]> results,
                                           String variableName ) {
-        if (results == null || results.isEmpty()) return;
+        if (results == null) return;
         if (variableName == null) return;
 
         // Grab the first value in each of the tuples, and set on the query context ...
         List<Object> singleColumnResults = new ArrayList<Object>(results.size());
-        // Make sure there is at least one column (in the first record; remaining tuples should be the same) ...
-        Object[] firstTuple = results.get(0);
-        if (firstTuple.length != 0) {
-            for (Object[] tuple : results) {
-                singleColumnResults.add(tuple[0]);
+        if (!results.isEmpty()) {
+            // Make sure there is at least one column (in the first record; remaining tuples should be the same) ...
+            Object[] firstTuple = results.get(0);
+            if (firstTuple.length != 0) {
+                for (Object[] tuple : results) {
+                    singleColumnResults.add(tuple[0]);
+                }
             }
         }
         // Place the single column results into the variable ...

--- a/modeshape-graph/src/main/resources/org/modeshape/graph/GraphI18n.properties
+++ b/modeshape-graph/src/main/resources/org/modeshape/graph/GraphI18n.properties
@@ -210,6 +210,7 @@ unexpectedClosingParenthesis = Unexpected closing parenthesis without a matching
 leftAndRightQueriesInSetQueryMustHaveUnionableColumns = The left and right queries in a set query must have unionable columns: {0} vs {1}
 operatorIsNotValidAgainstColumnInTable = The '{0}' operator is not valid against the '{1}' column in the '{2}' table. Only these operators are allowed: {3}
 columnInTableIsNotOrderable = The '{0}' column in the '{1}' table cannot be used in the ordering clause of a query.
+missingVariableValue = Variable '{0}' is used in the query but was not provided a value
 
 # Search
 interruptedWhileClosingChannel = Thread was interrupted while closing request processing channel for source "{0}"


### PR DESCRIPTION
Corrected how the query execution handles putting the subquery results into the variables, so that even
an empty array of tuples is put into the variables. Without this, when executing and using the subquery results,
the execution logic gets a null for the subquery 'variable' and records an error rather than just using an empty
array.

All unit and integration tests pass with these changes.
