### PR TITLE
MODE-931 Corrected offset projection behavior

### DIFF
--- a/modeshape-graph/src/main/java/org/modeshape/graph/connector/federation/JoinRequestProcessor.java
+++ b/modeshape-graph/src/main/java/org/modeshape/graph/connector/federation/JoinRequestProcessor.java
@@ -278,10 +278,13 @@ class JoinRequestProcessor extends RequestProcessor {
                 // We needed to verify the existance of a child node ...
                 VerifyNodeExistsRequest verify = (VerifyNodeExistsRequest)sourceRequest;
                 Location childInSource = verify.getActualLocationOfNode();
-                Location childInRepos = getChildLocationWithCorrectSnsIndex(childInSource,
-                                                                            federatedPath,
-                                                                            childSnsIndexes,
-                                                                            projection);
+                Location childInRepos = determineActualLocation(childInSource, projection);
+                childInRepos = getChildLocationWithCorrectSnsIndex(childInRepos, federatedPath, childSnsIndexes, projection);
+
+                // Location childInRepos = getChildLocationWithCorrectSnsIndex(childInSource,
+                // federatedPath,
+                // childSnsIndexes,
+                // projection);
                 request.addChild(childInRepos);
                 if (federatedPath == null) federatedPath = childInRepos.getPath().getParent();
             } else {

--- a/modeshape-graph/src/main/java/org/modeshape/graph/search/SearchEngineIndexer.java
+++ b/modeshape-graph/src/main/java/org/modeshape/graph/search/SearchEngineIndexer.java
@@ -299,7 +299,7 @@ public class SearchEngineIndexer {
         }
 
         Iterator<Location> locationIter = readSubgraph.iterator();
-        assert locationIter.hasNext();
+        if (!locationIter.hasNext()) return;
 
         // Destroy the nodes at the supplied location ...
         if (startingLocation.getPath().isRoot()) {

--- a/modeshape-integration-tests/src/test/java/org/modeshape/test/integration/federation/FederationConnectorRepositoryTest.java
+++ b/modeshape-integration-tests/src/test/java/org/modeshape/test/integration/federation/FederationConnectorRepositoryTest.java
@@ -1,0 +1,133 @@
+/*
+ * ModeShape (http://www.modeshape.org)
+ * See the COPYRIGHT.txt file distributed with this work for information
+ * regarding copyright ownership.  Some portions may be licensed
+ * to Red Hat, Inc. under one or more contributor license agreements.
+ * See the AUTHORS.txt file in the distribution for a full listing of 
+ * individual contributors.
+ *
+ * ModeShape is free software. Unless otherwise indicated, all code in ModeShape
+ * is licensed to you under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ * 
+ * ModeShape is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.modeshape.test.integration.federation;
+
+import java.util.ArrayList;
+import java.util.List;
+import javax.jcr.Node;
+import javax.jcr.NodeIterator;
+import javax.jcr.Repository;
+import javax.jcr.RepositoryException;
+import javax.jcr.Session;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.modeshape.common.collection.Problem;
+import org.modeshape.jcr.JcrConfiguration;
+import org.modeshape.jcr.JcrEngine;
+
+public class FederationConnectorRepositoryTest {
+
+    private static JcrConfiguration configuration;
+    private static JcrEngine engine;
+    private static List<Session> sessions = new ArrayList<Session>();
+    private boolean print = false;
+
+    @BeforeClass
+    public static void beforeAll() throws Exception {
+        configuration = new JcrConfiguration();
+        configuration.loadFrom("src/test/resources/config/configRepositoryForFederatedConnector.xml");
+
+        // Create an engine and use it to populate the source ...
+        engine = configuration.build();
+        try {
+            engine.start(true);
+        } catch (RuntimeException e) {
+            // There was a problem starting the engine ...
+            System.err.println("There were problems starting the engine:");
+            for (Problem problem : engine.getProblems()) {
+                System.err.println(problem);
+            }
+            throw e;
+        }
+    }
+
+    @AfterClass
+    public static void afterAll() throws Exception {
+        // Close all of the sessions ...
+        for (Session session : sessions) {
+            if (session.isLive()) session.logout();
+        }
+        sessions.clear();
+
+        // Shut down the engines ...
+        if (engine != null) {
+            try {
+                engine.shutdown();
+            } finally {
+                engine = null;
+            }
+        }
+    }
+
+    @Before
+    public void beforeEach() {
+        print = true;
+    }
+
+    void printNodes( Node node,
+                     int indent ) throws RepositoryException {
+        if (!print) return;
+
+        NodeIterator i = node.getNodes();
+        while (i.hasNext()) {
+            Node child = i.nextNode();
+            for (int j = 0; j < indent * 4; j++) {
+                System.out.print(' ');
+            }
+            System.out.println(child);
+            if (!"jcr:system".equals(child.getName())) {
+                printNodes(child, indent + 1);
+            }
+        }
+    }
+
+    @Test
+    public void shouldCreateRecord() throws Exception {
+
+        Repository repository = engine.getRepository("test-inmemory");
+        Session session = repository.login("default");
+        sessions.add(session);
+
+        session.getRootNode().addNode("a");
+        session.getRootNode().addNode("a/b");
+        session.save();
+        printNodes(session.getRootNode(), 0);
+        session.logout();
+
+        repository = engine.getRepository("test-inmemory");
+        session = repository.login("default");
+        printNodes(session.getRootNode(), 0);
+        session.logout();
+
+        repository = engine.getRepository("test-federated");
+        session = repository.login("default");
+        printNodes(session.getRootNode(), 0);
+        session.getNode("/jcr:system");
+        session.getNode("/source1");
+        session.getNode("/source1/b");
+        session.logout();
+    }
+}

--- a/modeshape-integration-tests/src/test/resources/config/configRepositoryForFederatedConnector.xml
+++ b/modeshape-integration-tests/src/test/resources/config/configRepositoryForFederatedConnector.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration xmlns:mode="http://www.modeshape.org/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0">
+  <!-- Define the sources from which content is made available -->
+  <mode:sources>
+    <mode:source jcr:name="test-inmemory" 
+        mode:classname="org.modeshape.graph.connector.inmemory.InMemoryRepositorySource"
+        mode:predefinedWorkspaceNames="custom-federated"
+        mode:defaultWorkspaceName="default">
+    </mode:source>
+    <mode:source jcr:name="repository" 
+        mode:classname="org.modeshape.connector.store.jpa.JpaSource" 
+        mode:dialect="org.hibernate.dialect.HSQLDialect"
+        mode:driverClassName="org.hsqldb.jdbcDriver"
+        mode:username="sa"
+        mode:password=""
+        mode:url="jdbc:hsqldb:mem:target"
+        mode:maximumConnectionsInPool="1"
+        mode:autoGenerateSchema="create"
+        mode:creatingWorkspacesAllowed="true"
+        mode:predefinedWorkspaceNames="workspace2"
+        mode:defaultWorkspaceName="default" />
+    <mode:source jcr:name="test-federated" mode:classname="org.modeshape.graph.connector.federation.FederatedRepositorySource"
+      mode:defaultWorkspaceName="default">
+      <mode:workspaces>
+        <mode:workspace jcr:name="default">
+          <mode:projections>
+            <mode:projection jcr:name="JPA projection" mode:source="test-inmemory" mode:workspaceName="default">
+              <mode:projectionRules>/source1 => /a</mode:projectionRules>
+            </mode:projection>
+          </mode:projections>
+        </mode:workspace>
+      </mode:workspaces>
+    </mode:source>
+  </mode:sources>
+  <!-- Define the JCR repositories -->
+  <mode:repositories>
+    <mode:repository jcr:name="test-inmemory" mode:source="test-inmemory"/>
+    <mode:repository jcr:name="test-federated" mode:source="test-federated">
+        <mode:options>
+            <!-- projectNodeTypes jcr:primaryType="mode:option" value="false"/-->
+        </mode:options>
+    </mode:repository>
+  </mode:repositories>
+</configuration>


### PR DESCRIPTION
Changed the logic in the JoinRequestProcessor to correctly handle offset projections (along with other projections) when processing ReadNodeRequests.

A new integration test was added, and all unit and integration tests pass with these changes.
