### PR TITLE
Upgrade SLF4J to 1.6.1 (MODE-1150)

### DIFF
--- a/modeshape-parent/pom.xml
+++ b/modeshape-parent/pom.xml
@@ -196,8 +196,8 @@
 		<junit.version>4.8.2</junit.version>
 		<hamcrest.version>1.1</hamcrest.version>
 		<mockito.all.version>1.8.4</mockito.all.version>
-		<slf4j.api.version>1.5.11</slf4j.api.version>
-		<slf4j.log4j.version>1.5.11</slf4j.log4j.version>
+		<slf4j.api.version>1.6.1</slf4j.api.version>
+		<slf4j.log4j.version>1.6.1</slf4j.log4j.version>
 		<log4j.version>1.2.16</log4j.version>
 		<jcr.version>2.0</jcr.version>
 		<jackrabbit.jcr.tck.version>2.1.0</jackrabbit.jcr.tck.version>


### PR DESCRIPTION
MODE-1150

JIRA: https://issues.jboss.org/browse/MODE-1150

I've tested core modules and they pass the test :

mvn --projects modeshape-parent,modeshape-assembly-descriptors,modeshape-common,modeshape-graph,modeshape-repository,modeshape-cnd,extensions/modeshape-search-lucene,extensions/modeshape-clustering,modeshape-jcr-api,modeshape-jcr install
