### PR TITLE
Postgresql oid/bytea fix

### DIFF
--- a/extensions/modeshape-connector-store-jpa/src/main/java/org/modeshape/connector/store/jpa/model/simple/NodeEntity.java
+++ b/extensions/modeshape-connector-store-jpa/src/main/java/org/modeshape/connector/store/jpa/model/simple/NodeEntity.java
@@ -38,6 +38,7 @@ import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.JoinTable;
 import javax.persistence.Lob;
+import org.hibernate.annotations.Type;
 import javax.persistence.ManyToMany;
 import javax.persistence.ManyToOne;
 import javax.persistence.NamedQueries;
@@ -120,6 +121,7 @@ public class NodeEntity {
      * [MODE-1015](https://issues.jboss.org/browse/MODE-1015).
      */
     @Lob
+    @Type(type="org.hibernate.type.PrimitiveByteArrayBlobType")
     @Column( name = "DATA", nullable = true, unique = false, length = 1048576 )
     private byte[] data;
 


### PR DESCRIPTION
PostgreSQLDialect gacked on modeshape startup on the use of oid and bytea types as follows:

[ERROR] Column "data" is of type oid but expression is of type bytea

I found a post that fixed this without having to change the postgres jdbc driver.

Here is the post.

http://stackoverflow.com/questions/4488693/hibernate-postgresql-column-x-is-of-type-oid-but-expression-is-type-byte

It worked for postgresql  and passed all the tests.
