### PR TITLE
MODE-1247 Corrected PropertyType of Binary value

### DIFF
--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/AbstractJcrNode.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/AbstractJcrNode.java
@@ -225,7 +225,7 @@ abstract class AbstractJcrNode extends AbstractJcrItem implements javax.jcr.Node
     final JcrValue valueFrom( Binary value ) {
         ValueFactories factories = cache.factories();
         org.modeshape.graph.property.Binary binary = ((JcrBinary)value).binary();
-        return new JcrValue(factories, cache, PropertyType.DATE, binary);
+        return new JcrValue(factories, cache, PropertyType.BINARY, binary);
     }
 
     final JcrValue valueFrom( javax.jcr.Node value ) throws UnsupportedRepositoryOperationException, RepositoryException {


### PR DESCRIPTION
The code was using the wrong PropertyType when setting the Property value to a Binary object.
