### PR TITLE
MODE-1248 Corrected properties passed to authorization providers

### DIFF
--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrEngine.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrEngine.java
@@ -582,10 +582,10 @@ public class JcrEngine extends ModeShapeEngine implements Repositories {
                     Name propertyName = authProp.getName();
                     if (skipNamespaces.contains(propertyName.getNamespaceUri())) continue;
                     if (skipProperties.contains(propertyName)) continue;
-                    if (property.isSingle()) {
-                        properties.put(propertyName.getLocalName(), property.getFirstValue());
+                    if (authProp.isSingle()) {
+                        properties.put(propertyName.getLocalName(), authProp.getFirstValue());
                     } else {
-                        properties.put(propertyName.getLocalName(), property.getValuesAsArray());
+                        properties.put(propertyName.getLocalName(), authProp.getValuesAsArray());
                     }
                 }
                 try {


### PR DESCRIPTION
The JcrEngine was passing the wrong properties to the AuthoriziationProvider configuration.
A simple change fixes the issue.

All unit and integration tests pass with these changes.
