### PR TITLE
MODE-1251 Downgrade Hibernate to 3.3.2.GA

### DIFF
--- a/extensions/modeshape-connector-store-jpa/pom.xml
+++ b/extensions/modeshape-connector-store-jpa/pom.xml
@@ -50,12 +50,6 @@
       	</exclusion>
       </exclusions>
     </dependency>
-    <dependency>
-      <groupId>org.hibernate</groupId>
-      <artifactId>hibernate-infinispan</artifactId>
-      <version>${hibernate.version}</version>
-      <!--  >scope>provided</scope -->
-    </dependency>
     <!-- 
     HSQLDB
     -->

--- a/extensions/modeshape-connector-store-jpa/src/main/java/org/modeshape/connector/store/jpa/HibernateAdapter.java
+++ b/extensions/modeshape-connector-store-jpa/src/main/java/org/modeshape/connector/store/jpa/HibernateAdapter.java
@@ -4,9 +4,9 @@ import java.util.Map;
 import java.util.Properties;
 import javax.persistence.EntityManager;
 import javax.persistence.EntityManagerFactory;
-import org.hibernate.Session;
 import org.hibernate.cfg.Environment;
 import org.hibernate.ejb.Ejb3Configuration;
+import org.hibernate.ejb.HibernateEntityManager;
 import org.hibernate.engine.SessionFactoryImplementor;
 import org.modeshape.common.i18n.I18n;
 import org.modeshape.common.util.Logger;
@@ -151,22 +151,22 @@ public class HibernateAdapter implements JpaAdapter {
     @Override
     public String determineDialect( EntityManager entityManager ) {
         // We need the connection in order to determine the dialect ...
-        SessionFactoryImplementor sessionFactory = (SessionFactoryImplementor)entityManager.unwrap(Session.class).getSessionFactory();
+        HibernateEntityManager em = (HibernateEntityManager)entityManager;
+        SessionFactoryImplementor sessionFactory = (SessionFactoryImplementor)em.getSession().getSessionFactory();
         return sessionFactory.getDialect().toString();
     }
 
     @Override
     public EntityManagerFactory getEntityManagerFactory( JpaSource source ) {
-        return new Ejb3Configuration()
-            .addAnnotatedClass(StoreOptionEntity.class)
-            .addAnnotatedClass(NamespaceEntity.class)
-            .addAnnotatedClass(WorkspaceEntity.class)
-            .addAnnotatedClass(LargeValueEntity.class)
-            .addAnnotatedClass(NodeEntity.class)
-            .addAnnotatedClass(SubgraphNodeEntity.class)
-            .addAnnotatedClass(SubgraphQueryEntity.class)
-            .addProperties(getProperties(source))
-            .buildEntityManagerFactory();
+        return new Ejb3Configuration().addAnnotatedClass(StoreOptionEntity.class)
+                                      .addAnnotatedClass(NamespaceEntity.class)
+                                      .addAnnotatedClass(WorkspaceEntity.class)
+                                      .addAnnotatedClass(LargeValueEntity.class)
+                                      .addAnnotatedClass(NodeEntity.class)
+                                      .addAnnotatedClass(SubgraphNodeEntity.class)
+                                      .addAnnotatedClass(SubgraphQueryEntity.class)
+                                      .addProperties(getProperties(source))
+                                      .buildEntityManagerFactory();
 
         // return Persistence.createEntityManagerFactory(persistenceUnitName, getProperties(source));
     }

--- a/modeshape-parent/pom.xml
+++ b/modeshape-parent/pom.xml
@@ -203,7 +203,7 @@
 		<jackrabbit.jcr.tck.version>2.1.0</jackrabbit.jcr.tck.version>
 		<picketbox.version>3.0.0.Final</picketbox.version>
 		<byteman.version>1.5.1</byteman.version>
-		<hibernate.version>3.5.2-Final</hibernate.version>
+		<hibernate.version>3.3.2.GA</hibernate.version>
 		<hibernate.tools.version>3.2.4.GA</hibernate.tools.version>
 		<sun.xml.bind.jaxbimpl.version>2.1.12</sun.xml.bind.jaxbimpl.version>
 		<jdbc.mysql.version>5.0.7</jdbc.mysql.version>


### PR DESCRIPTION
Downgraded our use of Hibernate (only on the 2.5.x branch) to 3.3.2.GA and made one change to the POM
and to the HibernateAdapter class, which was using an API introduced in Hibernate in 3.5.

All unit and integration tests pass with these changes.
