### PR TITLE
MODE-1243 Improved JndiRepositoryFactory logic and logging

### DIFF
--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrI18n.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrI18n.java
@@ -160,6 +160,12 @@ public final class JcrI18n {
     public static I18n searchIndexDirectoryOptionSpecifiesDirectoryThatCannotBeCreated;
     public static I18n errorUpdatingQueryIndexes;
 
+    public static I18n typeMissingWhenRegisteringEngineInJndi;
+    public static I18n repositoryNameProvidedWhenRegisteringEngineInJndi;
+    public static I18n repositoryNameNotProvidedWhenRegisteringRepositoryInJndi;
+    public static I18n invalidRepositoryNameWhenRegisteringRepositoryInJndi;
+    public static I18n emptyRepositoryNameProvidedWhenRegisteringRepositoryInJndi;
+
     // Used in AbstractJcrNode#getAncestor
     public static I18n noNegativeDepth;
     public static I18n tooDeep;

--- a/modeshape-jcr/src/main/resources/org/modeshape/jcr/JcrI18n.properties
+++ b/modeshape-jcr/src/main/resources/org/modeshape/jcr/JcrI18n.properties
@@ -158,6 +158,12 @@ searchIndexDirectoryOptionSpecifiesDirectoryThatCannotBeWrittenTo = The JCR Repo
 searchIndexDirectoryOptionSpecifiesDirectoryThatCannotBeCreated = The JCR Repository '{1}' option value "{0}" specifies a non-existant directory on the local file system that cannot be created
 errorUpdatingQueryIndexes = Error updating the query indexes: {0}
 
+typeMissingWhenRegisteringEngineInJndi = JNDI registration of engine at "{0}": the 'type' parameter should be specified with a value of '{1}'
+repositoryNameProvidedWhenRegisteringEngineInJndi = JNDI registration of engine at "{0}": a 'repositoryName' parameter with value "{1}" will be ignored because the 'type' parameter says to register an object of type "{2}"
+repositoryNameNotProvidedWhenRegisteringRepositoryInJndi = JNDI registration failed: unable to register in JNDI a repository at "{0}" because a 'repositoryName' parameter was not provided
+invalidRepositoryNameWhenRegisteringRepositoryInJndi = JNDI registration failed: unable to register in JNDI a repository at "{0}" because the 'repositoryName' parameter with value "{1}" does not match the known repositories: {2}
+emptyRepositoryNameProvidedWhenRegisteringRepositoryInJndi = JNDI registration failed: unable to register in JNDI a repository at "{0}" because the 'repositoryName' parameter was empty or contained only whitespace
+
 noNegativeDepth=Depth parameter ({0}) cannot be negative
 tooDeep=Depth parameter ({0}) cannot be greater than the result of getDepth() for this node
 


### PR DESCRIPTION
The JndiRepositoryFactory now uses the "type" value (as specified in the 'conf/context.xml' for Tomcat) as the major impetus for registering the ModeShape JcrEngine instance or a javax.jcr.Repository instance. If an engine is to be registered, then the existence of a 'repositoryName' is logged as a warning. If a repository is to be registered, then the 'repositoryName' value is expected and must match an existing repository; all other cases are logged as an error.
