### PR TITLE
MODE-1257 Corrected class cast exception

### DIFF
--- a/modeshape-graph/src/main/java/org/modeshape/graph/connector/federation/JoinRequestProcessor.java
+++ b/modeshape-graph/src/main/java/org/modeshape/graph/connector/federation/JoinRequestProcessor.java
@@ -924,7 +924,7 @@ class JoinRequestProcessor extends RequestProcessor {
         // Check the projection first ...
         if (checkErrorOrCancel(request, federatedRequest)) return;
 
-        SetPropertyRequest source = (SetPropertyRequest)projected.getRequest();
+        RemovePropertyRequest source = (RemovePropertyRequest)projected.getRequest();
         if (checkErrorOrCancel(request, source)) return;
         Location sourceLocation = source.getActualLocationOfNode();
         request.setActualLocationOfNode(projectToFederated(request.from(), projected.getProjection(), sourceLocation, request));


### PR DESCRIPTION
The JoinRequestProcessor.process(RemovePropertyRequest) was incorrectly casting the forked request
to SetPropertyRequest. This was a copy-and-paste error, and fixing it appears to fix the issue.
(Additional tests being added under MODE-1256.)

All unit and integration tests pass with these changes.
