### PR TITLE
MODE-1254 Okay to call toString on ModeShape's Node and Property objects  with Binary values

### DIFF
--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/AbstractJcrProperty.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/AbstractJcrProperty.java
@@ -38,6 +38,7 @@ import javax.jcr.nodetype.ConstraintViolationException;
 import javax.jcr.version.VersionException;
 import org.modeshape.common.annotation.NotThreadSafe;
 import org.modeshape.common.util.CheckArg;
+import org.modeshape.graph.property.Binary;
 import org.modeshape.graph.property.Name;
 import org.modeshape.graph.property.Path;
 import org.modeshape.graph.property.ValueFactory;
@@ -314,12 +315,22 @@ abstract class AbstractJcrProperty extends AbstractJcrItem implements Property, 
                 sb.append('[');
                 Iterator<?> iter = property.iterator();
                 if (iter.hasNext()) {
-                    sb.append(stringFactory.create(iter.next()));
+                    Object value = iter.next();
+                    if (value instanceof Binary) {
+                        sb.append("**binary-value-not-shown**");
+                    } else {
+                        sb.append(stringFactory.create(value));
+                    }
                     if (iter.hasNext()) sb.append(',');
                 }
                 sb.append(']');
             } else {
-                sb.append(stringFactory.create(property.getFirstValue()));
+                Object value = property.getFirstValue();
+                if (value instanceof Binary) {
+                    sb.append("**binary-value-not-shown**");
+                } else {
+                    sb.append(stringFactory.create(value));
+                }
             }
             return sb.toString();
         } catch (RepositoryException e) {

--- a/modeshape-jcr/src/test/java/org/modeshape/jcr/AbstractJcrPropertyTest.java
+++ b/modeshape-jcr/src/test/java/org/modeshape/jcr/AbstractJcrPropertyTest.java
@@ -28,6 +28,8 @@ import static org.hamcrest.core.IsNot.not;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import java.io.ByteArrayInputStream;
+import javax.jcr.Binary;
 import javax.jcr.Item;
 import javax.jcr.ItemNotFoundException;
 import javax.jcr.ItemVisitor;
@@ -38,6 +40,7 @@ import javax.jcr.Workspace;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
+import org.modeshape.common.FixFor;
 import org.modeshape.graph.Graph;
 import org.modeshape.graph.connector.inmemory.InMemoryRepositorySource;
 
@@ -274,6 +277,18 @@ public class AbstractJcrPropertyTest extends AbstractJcrTest {
         javax.jcr.Property year2 = prius2.getProperty("vehix:year");
         assertThat(model.isSame(model2), is(true));
         assertThat(model.isSame(year2), is(false));
+    }
+
+    @FixFor( "MODE-1254" )
+    @Test
+    public void shouldNotIncludeBinaryContentsInToString() throws Exception {
+        altima = cache.findJcrNode(null, path("/Cars/Hybrid/Nissan Altima"));
+        Node node = rootNode.addNode("nodeWithBinaryProperty", "nt:unstructured");
+        String value = "This is the string value";
+        Binary binaryValue = cache.session().getValueFactory().createBinary(new ByteArrayInputStream(value.getBytes()));
+        node.setProperty("binProp", binaryValue);
+        String toString = node.toString();
+        assertThat(toString.indexOf("**binary-value") > 0, is(true));
     }
 
 }

--- a/modeshape-jcr/src/test/java/org/modeshape/jcr/AbstractJcrTest.java
+++ b/modeshape-jcr/src/test/java/org/modeshape/jcr/AbstractJcrTest.java
@@ -142,6 +142,9 @@ public abstract class AbstractJcrTest {
 
         when(jcrSession.lockManager()).thenReturn(jcrLockManager);
 
+        JcrValueFactory valueFactory = new JcrValueFactory(jcrSession);
+        when(jcrSession.getValueFactory()).thenReturn(valueFactory);
+
         // Create the node type manager for the session ...
         // no need to stub the 'JcrSession.checkPermission' methods, since we're never calling 'register' on the
         // JcrNodeTypeManager


### PR DESCRIPTION
Large Binary values would cause an out-of-memory exception when 'toString()' is called. This change corrects that behavior to place "**binary-value**" in the toString() result any place where a Binary value is encountered.

A new unit test was added to verify the behavior, and all unit and integration tests pass.
