### PR TITLE
MODE-1259 Change modeshape-distribution pom.xml to attach javadocs to the mead repo

### DIFF
--- a/modeshape-distribution/pom.xml
+++ b/modeshape-distribution/pom.xml
@@ -1285,7 +1285,7 @@
 		            <artifactId>apiviz</artifactId>
 		            <version>1.3.0.GA</version>
 		          </docletArtifact>
-		          <attach>false</attach>
+		          <attach>true</attach>
 		          <useStandardDocletOptions>true</useStandardDocletOptions>
 		          <charset>UTF-8</charset>
 		          <docencoding>UTF-8</docencoding>


### PR DESCRIPTION
MODE-1259 Change modeshape-distribution pom.xml to attach javadocs to the mead repository
