### PR TITLE
MODE-1261 Fixed JackrabbitXmlNodeTypeRegistrationTest on Solaris.

### DIFF
--- a/modeshape-jcr/src/test/resources/xmlNodeTypeRegistration/owfe_nodetypes.xml
+++ b/modeshape-jcr/src/test/resources/xmlNodeTypeRegistration/owfe_nodetypes.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
   /*
   * Copyright 2004-2005 The Apache Software Foundation or its licensors,


### PR DESCRIPTION
BOM (Binary Order Mark) at the start of owfe_nodetypes.xml file was causing failing of two tests on Solaris 9 machines. BOM was deleted.
