### PR TITLE
MODE-1263 Corrected indexing logic for file system content

### DIFF
--- a/modeshape-graph/src/main/java/org/modeshape/graph/search/SearchEngineIndexer.java
+++ b/modeshape-graph/src/main/java/org/modeshape/graph/search/SearchEngineIndexer.java
@@ -332,6 +332,16 @@ public class SearchEngineIndexer {
         // Create a queue that we'll use to walk the content ...
         LinkedList<Location> locationsToRead = new LinkedList<Location>();
 
+        // If there are no more locations to read, we've only read one node per subgraph (because of the connector's
+        // max depth limitation), so we need to add any children of the top-level node to the list of
+        // locations to read...
+        if (!locationIter.hasNext()) {
+            for (Location child : readSubgraph.getChildren(topNode)) {
+                // The subgraph did not contain the child, so record the location as needing to be read ...
+                locationsToRead.add(child);
+            }
+        }
+
         // Now walk the remaining nodes in the subgraph ...
         while (true) {
             while (locationIter.hasNext()) {

--- a/modeshape-integration-tests/src/test/java/org/modeshape/test/integration/filesystem/FileSystemRepositoryIntegrationTest.java
+++ b/modeshape-integration-tests/src/test/java/org/modeshape/test/integration/filesystem/FileSystemRepositoryIntegrationTest.java
@@ -59,6 +59,8 @@ public class FileSystemRepositoryIntegrationTest extends ModeShapeSingleUseTest 
 
         // Now make the root directory ...
         new File("target/fsRepoWithProps/root").mkdirs();
+        new File("target/fsRepoWithProps/root/defaultWorkspace/folder1").mkdirs();
+        new File("target/fsRepoWithProps/root/defaultWorkspace/folder2").mkdirs();
 
         super.beforeEach();
     }
@@ -128,9 +130,9 @@ public class FileSystemRepositoryIntegrationTest extends ModeShapeSingleUseTest 
         // Get another session and verify the reference exists and can be resolved ...
         session = session();
         // print = true;
-        printQuery("SELECT * FROM [nt:base]", 5L, Collections.<String, String>emptyMap());
+        printQuery("SELECT * FROM [nt:base]", 7L, Collections.<String, String>emptyMap());
     }
-    
+
     /*
      * The test verifies that maxPathLength is being overridden in the configuration
      * by setting to something small and should result in a <code>RepositoryException</code> 
@@ -156,9 +158,25 @@ public class FileSystemRepositoryIntegrationTest extends ModeShapeSingleUseTest 
         session.save();
 
         logout();
-        
+
     }
-    
+
+    @FixFor( "MODE-1263" )
+    @Test
+    public void shouldIncludeExistingContent() throws Exception {
+        startEngineUsing("config/configRepositoryForFileSystemWithExtraProperties.xml");
+        Session session = session();
+
+        // Create a new Node (after session is started)
+        session.getRootNode().addNode("NewFolder", "nt:folder");
+        session.save();
+
+        // Query all nodes
+        // print = true;
+        printQuery("SELECT * FROM [nt:base]", 4L, Collections.<String, String>emptyMap());
+
+        logout();
+    }
 
     protected void registryNamespaceIfMissing( String prefix,
                                                String url ) throws RepositoryException {


### PR DESCRIPTION
Added the integration test supplied by Danny (with some minor modifications) and updated the @Before method in the FileSystemRepositoryIntegrationTest, and verified the query does not include any of the files or folders already present on the file system.

After a bit of debugging, I was able to figure out what the problem is and why we're only seeing it for the file system connector.

The actual bug is in SearchEngineIndexer logic: when the subgraph comes back with just a single node (i.e., the subgraph only contains a single level), the loop at line 336 will exit without processing the children of the single node in the subgraph. The fix is to check for this condition and add the children to the locationsToRead list before going into the loop.

The problem only manifests itself with the FileSystemConnector because it is the only connector to override the 'absoluteMaximumDepthForBranches()' method to return 1. All other connectors return the default value, 4 (or some other number > 1), and therefore the subgraph contains multiple levels and the while loop is entered and the children processed.

After the fix to SearchEngineIndexer, all unit and integration tests pass, including the new integration test.

Thanks again to Danny C for identifying this issue and creating an easily reproducible test case!
