### PR TITLE
MODE-1269 Methods to re-index workspace content are now public

### DIFF
--- a/modeshape-jcr-api/src/main/java/org/modeshape/jcr/api/Repository.java
+++ b/modeshape-jcr-api/src/main/java/org/modeshape/jcr/api/Repository.java
@@ -6,7 +6,7 @@ import java.util.HashSet;
 import java.util.Set;
 
 /**
- * Replicates JCR 2.0's Repository interface.
+ * An extension of JCR 2.0's Repository interface, with a few ModeShape-specific enhancements.
  */
 public interface Repository extends javax.jcr.Repository {
 

--- a/modeshape-jcr-api/src/main/java/org/modeshape/jcr/api/Workspace.java
+++ b/modeshape-jcr-api/src/main/java/org/modeshape/jcr/api/Workspace.java
@@ -1,0 +1,84 @@
+/*
+ * ModeShape (http://www.modeshape.org)
+ * See the COPYRIGHT.txt file distributed with this work for information
+ * regarding copyright ownership.  Some portions may be licensed
+ * to Red Hat, Inc. under one or more contributor license agreements.
+ * See the AUTHORS.txt file in the distribution for a full listing of 
+ * individual contributors.
+ *
+ * ModeShape is free software. Unless otherwise indicated, all code in ModeShape
+ * is licensed to you under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ * 
+ * ModeShape is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.modeshape.jcr.api;
+
+import java.util.concurrent.Future;
+import javax.jcr.RepositoryException;
+
+/**
+ * An extension of JCR 2.0's Workspace interface, with a few ModeShape-specific enhancements.
+ */
+public interface Workspace extends javax.jcr.Workspace {
+
+    /**
+     * Crawl and re-index the content in this workspace. This method blocks until the indexing is completed.
+     * 
+     * @throws RepositoryException if there is a problem with this session or workspace
+     * @see #reindexAsync()
+     * @see #reindexAsync(String, int)
+     * @see #reindex(String, int)
+     */
+    void reindex() throws RepositoryException;
+
+    /**
+     * Crawl and index the content starting at the supplied path in this workspace, to the designated depth.
+     * 
+     * @param path the path of the content to be indexed
+     * @param depth the depth of the content to be indexed
+     * @throws IllegalArgumentException if the workspace or path are null, or if the depth is less than 1
+     * @throws RepositoryException if there is a problem with this session or workspace
+     * @see #reindex()
+     * @see #reindexAsync()
+     * @see #reindexAsync(String, int)
+     */
+    void reindex( String path,
+                  int depth ) throws RepositoryException;
+
+    /**
+     * Asynchronously crawl and re-index the content in this workspace.
+     * 
+     * @return a future representing the asynchronous operation; never null
+     * @throws RepositoryException if there is a problem with this session or workspace
+     * @see #reindex()
+     * @see #reindex(String, int)
+     * @see #reindexAsync(String, int)
+     */
+    Future<Boolean> reindexAsync() throws RepositoryException;
+
+    /**
+     * Asynchronously crawl and index the content starting at the supplied path in this workspace, to the designated depth.
+     * 
+     * @param path the path of the content to be indexed
+     * @param depth the depth of the content to be indexed
+     * @return a future representing the asynchronous operation; never null
+     * @throws IllegalArgumentException if the workspace or path are null, or if the depth is less than 1
+     * @throws RepositoryException if there is a problem with this session or workspace
+     * @see #reindex()
+     * @see #reindex(String, int)
+     * @see #reindexAsync()
+     */
+    Future<Boolean> reindexAsync( String path,
+                                  int depth ) throws RepositoryException;
+
+}

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrRepository.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrRepository.java
@@ -655,6 +655,8 @@ public class JcrRepository implements Repository {
     // package-scoped to facilitate testing
     final WeakHashMap<JcrSession, Object> activeSessions = new WeakHashMap<JcrSession, Object>();
 
+    private final ExecutorService backgroundService = Executors.newSingleThreadExecutor();
+
     /**
      * Creates a JCR repository that uses the supplied {@link RepositoryConnectionFactory repository connection factory} to
      * establish {@link Session sessions} to the underlying repository source upon {@link #login() login}.
@@ -1021,6 +1023,10 @@ public class JcrRepository implements Repository {
 
         // Make sure the workspace names are in the descriptor ...
         updateWorkspaceNames();
+    }
+
+    protected ExecutorService backgroundService() {
+        return backgroundService;
     }
 
     protected String repositoryName() {

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrSession.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrSession.java
@@ -52,7 +52,6 @@ import javax.jcr.Session;
 import javax.jcr.SimpleCredentials;
 import javax.jcr.UnsupportedRepositoryOperationException;
 import javax.jcr.Value;
-import javax.jcr.Workspace;
 import javax.jcr.lock.LockException;
 import javax.jcr.nodetype.ConstraintViolationException;
 import javax.jcr.query.Query;
@@ -77,7 +76,6 @@ import org.modeshape.graph.property.PathFactory;
 import org.modeshape.graph.query.QueryBuilder;
 import org.modeshape.graph.query.model.QueryCommand;
 import org.modeshape.graph.query.model.TypeSystem;
-import org.modeshape.graph.request.InvalidWorkspaceException;
 import org.modeshape.graph.session.GraphSession;
 import org.modeshape.jcr.JcrContentHandler.EnclosingSAXException;
 import org.modeshape.jcr.JcrContentHandler.SaveMode;
@@ -283,7 +281,7 @@ class JcrSession implements Session {
      * 
      * @see javax.jcr.Session#getWorkspace()
      */
-    public Workspace getWorkspace() {
+    public org.modeshape.jcr.api.Workspace getWorkspace() {
         return this.workspace;
     }
 
@@ -1307,29 +1305,6 @@ class JcrSession implements Session {
         checkReferentialIntegrityOfChanges(null);
         removedNodes = null;
         cache.save();
-    }
-
-    /**
-     * Crawl and index the content in this workspace.
-     * 
-     * @throws IllegalArgumentException if the workspace is null
-     * @throws InvalidWorkspaceException if there is no workspace with the supplied name
-     */
-    public void reindexContent() {
-        repository().queryManager().reindexContent(workspace());
-    }
-
-    /**
-     * Crawl and index the content starting at the supplied path in this workspace, to the designated depth.
-     * 
-     * @param path the path of the content to be indexed
-     * @param depth the depth of the content to be indexed
-     * @throws IllegalArgumentException if the workspace or path are null, or if the depth is less than 1
-     * @throws InvalidWorkspaceException if there is no workspace with the supplied name
-     */
-    public void reindexContent( String path,
-                                int depth ) {
-        repository().queryManager().reindexContent(workspace(), path, depth);
     }
 
     /**

--- a/modeshape-jcr/src/test/java/org/modeshape/jcr/AbstractJcrNodeTest.java
+++ b/modeshape-jcr/src/test/java/org/modeshape/jcr/AbstractJcrNodeTest.java
@@ -44,7 +44,6 @@ import javax.jcr.Property;
 import javax.jcr.PropertyIterator;
 import javax.jcr.PropertyType;
 import javax.jcr.Repository;
-import javax.jcr.Workspace;
 import javax.jcr.lock.LockException;
 import javax.jcr.nodetype.NoSuchNodeTypeException;
 import javax.jcr.nodetype.NodeDefinitionTemplate;
@@ -55,6 +54,7 @@ import org.junit.Test;
 import org.mockito.Mockito;
 import org.modeshape.graph.Graph;
 import org.modeshape.graph.connector.inmemory.InMemoryRepositorySource;
+import org.modeshape.jcr.api.Workspace;
 
 /**
  * 

--- a/modeshape-jcr/src/test/java/org/modeshape/jcr/AbstractJcrPropertyTest.java
+++ b/modeshape-jcr/src/test/java/org/modeshape/jcr/AbstractJcrPropertyTest.java
@@ -36,13 +36,13 @@ import javax.jcr.ItemVisitor;
 import javax.jcr.Node;
 import javax.jcr.Repository;
 import javax.jcr.Session;
-import javax.jcr.Workspace;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
 import org.modeshape.common.FixFor;
 import org.modeshape.graph.Graph;
 import org.modeshape.graph.connector.inmemory.InMemoryRepositorySource;
+import org.modeshape.jcr.api.Workspace;
 
 /**
  * 

--- a/modeshape-jcr/src/test/java/org/modeshape/jcr/AbstractJcrTest.java
+++ b/modeshape-jcr/src/test/java/org/modeshape/jcr/AbstractJcrTest.java
@@ -29,7 +29,6 @@ import static org.mockito.Mockito.when;
 import java.io.IOException;
 import java.util.UUID;
 import javax.jcr.RepositoryException;
-import javax.jcr.Workspace;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.mockito.invocation.InvocationOnMock;
@@ -43,6 +42,7 @@ import org.modeshape.graph.connector.RepositorySourceException;
 import org.modeshape.graph.connector.inmemory.InMemoryRepositorySource;
 import org.modeshape.graph.property.Name;
 import org.modeshape.graph.property.Path;
+import org.modeshape.jcr.api.Workspace;
 
 /**
  * Abstract test that sets up a SessionCache environment with a real {@link RepositoryNodeTypeManager}, albeit with a mocked

--- a/modeshape-jcr/src/test/java/org/modeshape/jcr/JcrRepositoryTest.java
+++ b/modeshape-jcr/src/test/java/org/modeshape/jcr/JcrRepositoryTest.java
@@ -37,6 +37,7 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import javax.jcr.Credentials;
 import javax.jcr.Repository;
@@ -54,10 +55,11 @@ import org.junit.Ignore;
 import org.junit.Test;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
+import org.modeshape.common.FixFor;
 import org.modeshape.graph.ExecutionContext;
 import org.modeshape.graph.Graph;
-import org.modeshape.graph.Node;
 import org.modeshape.graph.JaasSecurityContext.UserPasswordCallbackHandler;
+import org.modeshape.graph.Node;
 import org.modeshape.graph.connector.RepositoryConnection;
 import org.modeshape.graph.connector.RepositoryConnectionFactory;
 import org.modeshape.graph.connector.RepositorySource;
@@ -799,6 +801,38 @@ public class JcrRepositoryTest {
             }
             assertThat("Did not find '" + expect + "' in the actuals: " + actuals, found, is(true));
         }
+    }
+
+    @Test
+    @FixFor( "MODE-1269" )
+    public void shouldAllowReindexingEntireWorkspace() throws Exception {
+        session = createSession();
+        session.getWorkspace().reindex();
+    }
+
+    @Test
+    @FixFor( "MODE-1269" )
+    public void shouldAllowReindexingSubsetOfWorkspace() throws Exception {
+        session = createSession();
+        session.getWorkspace().reindex("/", 2);
+    }
+
+    @Test
+    @FixFor( "MODE-1269" )
+    public void shouldAllowAsynchronousReindexingEntireWorkspace() throws Exception {
+        session = createSession();
+        Future<Boolean> future = session.getWorkspace().reindexAsync();
+        assertThat(future, is(notNullValue()));
+        assertThat(future.get(), is(true)); // get() blocks until done
+    }
+
+    @Test
+    @FixFor( "MODE-1269" )
+    public void shouldAllowAsynchronousReindexingSubsetOfWorkspace() throws Exception {
+        session = createSession();
+        Future<Boolean> future = session.getWorkspace().reindexAsync("/", 2);
+        assertThat(future, is(notNullValue()));
+        assertThat(future.get(), is(true)); // get() blocks until done
     }
 
 }


### PR DESCRIPTION
The re-indexing methods were previously on JcrSession, which was a package-protected class, and thus the re-indexing methods were not publicly accessible. This change moves the methods to the org.modeshape.jcr.api.Workspace interface is ModeShape's public API. Now there are synchronous and asynchronous methods to re-index the entire workspace and to re-index a subgraph below some path to a maximum depth.

Additional tests were added to verify the methods work. All unit and integration tests pass.
