### PR TITLE
MODE-1270 Add support for setting Session's user ID based upon JAAS Subject in J2EE

### DIFF
--- a/modeshape-jcr-api/pom.xml
+++ b/modeshape-jcr-api/pom.xml
@@ -28,6 +28,11 @@
       <groupId>javax.jcr</groupId>
       <artifactId>jcr</artifactId>
     </dependency>
+
+    <!--
+    These following are defined as 'provided' in the parent POM, since ModeShape
+    has code that is optional if these APIs are available.
+    -->
     <dependency>
       <groupId>javax.servlet</groupId>
       <artifactId>servlet-api</artifactId>

--- a/modeshape-jcr/pom.xml
+++ b/modeshape-jcr/pom.xml
@@ -58,6 +58,20 @@
       <groupId>org.modeshape</groupId>
       <artifactId>modeshape-search-lucene</artifactId>
     </dependency>
+
+    <!--
+    These following are defined as 'provided' in the parent POM, since ModeShape
+    has code that is optional if these APIs are available.
+    -->
+    <dependency>
+      <groupId>javax.servlet</groupId>
+      <artifactId>servlet-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.spec.javax.security.jacc</groupId>
+      <artifactId>jboss-jacc-api_1.4_spec</artifactId>
+    </dependency>
+
     <!-- 
     Testing (note the scope)
     -->

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/security/JaasProvider.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/security/JaasProvider.java
@@ -48,6 +48,7 @@ import org.modeshape.jcr.api.JaasCredentials;
 public class JaasProvider implements AuthenticationProvider {
 
     private final String policyName;
+    private final SubjectResolver subjectResolver;
 
     /**
      * Create a JAAS provider for authentication and authorization, using the supplied name for the login configuration.
@@ -60,8 +61,26 @@ public class JaasProvider implements AuthenticationProvider {
      *            <p>
      */
     public JaasProvider( String policyName ) throws LoginException {
+        this(policyName, null);
+    }
+
+    /**
+     * Create a JAAS provider for authentication and authorization, using the supplied name for the login configuration.
+     * 
+     * @param policyName
+     * @param subjectResolver the component that can resolve the JAAS subject if not accessible via the AccessControl context; may
+     *        be null
+     * @exception LoginException if the caller-specified <code>name</code> does not appear in the <code>Configuration</code> and
+     *            there is no <code>Configuration</code> entry for "<i>other</i>", or if the
+     *            <i>auth.login.defaultCallbackHandler</i> security property was set, but the implementation class could not be
+     *            loaded.
+     *            <p>
+     */
+    public JaasProvider( String policyName,
+                         SubjectResolver subjectResolver ) throws LoginException {
         CheckArg.isNotNull(policyName, "policyName");
         this.policyName = policyName;
+        this.subjectResolver = subjectResolver;
 
         // verify that the logic context is valid ...
         try {
@@ -90,7 +109,14 @@ public class JaasProvider implements AuthenticationProvider {
                     // There is, so use this subject ...
                     return repositoryContext.with(new JaasSecurityContext(subject));
                 }
-                // There is no authentication JAAS Subject and no credentials, so we can do nothing ...
+                if (subjectResolver != null) {
+                    // The Subject is still null (see MODE-1270), so try to resolve it ...
+                    subject = subjectResolver.resolveSubject();
+                    if (subject != null) {
+                        return repositoryContext.with(new JaasSecurityContext(subject));
+                    }
+                }
+                // There is no authenticated JAAS Subject and no credentials, so we can do nothing ...
                 return null;
             }
             if (credentials instanceof SimpleCredentials) {
@@ -133,6 +159,24 @@ public class JaasProvider implements AuthenticationProvider {
                 }
             }
             if (loginContext != null) {
+                Subject subject = loginContext.getSubject();
+                if (subject == null) {
+                    // Try authenticate first ...
+                    loginContext.login();
+                    // Authentication succeeded ...
+                    subject = loginContext.getSubject();
+                    if (subject == null && this.subjectResolver != null) {
+                        // The Subject is still null (see MODE-1270), so try to resolve it ...
+                        subject = this.subjectResolver.resolveSubject();
+                        if (subject != null) {
+                            return repositoryContext.with(new JaasSecurityContext(subject));
+                        }
+                    }
+                    if (subject == null) {
+                        // Still null; we don't know what to do about this, so fail ...
+                        return null;
+                    }
+                }
                 return repositoryContext.with(new JaasSecurityContext(loginContext));
             }
         } catch (javax.security.auth.login.LoginException error) {
@@ -141,5 +185,21 @@ public class JaasProvider implements AuthenticationProvider {
         }
 
         return null;
+    }
+
+    /**
+     * An extension point for the JaasProvider class that allows for custom logic for finding the current JAAS Subject, if not
+     * already available via the {@code Subject.getSubject(AccessController.getContext())} method. That method returns null in
+     * J2EE applications.
+     * 
+     * @see JaccSubjectResolver
+     */
+    public static interface SubjectResolver {
+        /**
+         * Get the current JAAS Subject.
+         * 
+         * @return the subject, or null if the Subject could not be resolved
+         */
+        Subject resolveSubject();
     }
 }

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/security/JaccSubjectResolver.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/security/JaccSubjectResolver.java
@@ -1,0 +1,65 @@
+/*
+ * ModeShape (http://www.modeshape.org)
+ * See the COPYRIGHT.txt file distributed with this work for information
+ * regarding copyright ownership.  Some portions may be licensed
+ * to Red Hat, Inc. under one or more contributor license agreements.
+ * See the AUTHORS.txt file in the distribution for a full listing of 
+ * individual contributors.
+ *
+ * ModeShape is free software. Unless otherwise indicated, all code in ModeShape
+ * is licensed to you under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ * 
+ * ModeShape is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.modeshape.jcr.security;
+
+import javax.security.auth.Subject;
+import javax.security.jacc.PolicyContext;
+import org.modeshape.common.util.Logger;
+import org.modeshape.jcr.security.JaasProvider.SubjectResolver;
+
+/**
+ * A class that can resolve the current JAAS {@link Subject} using the JACC API. Note that the JACC API is assumed provided; if
+ * not, loading this class will fail.
+ * <p>
+ * See <a href="https://issues.jboss.org/browse/MODE-1270">MODE-1270</a> for details.
+ * </p>
+ */
+public class JaccSubjectResolver implements SubjectResolver {
+
+    /** The JACC PolicyContext key for the current Subject */
+    private static final String SUBJECT_CONTEXT_KEY = "javax.security.auth.Subject.container";
+
+    private static volatile boolean reportedWarning = false;
+
+    /**
+     * {@inheritDoc}
+     * 
+     * @see org.modeshape.jcr.security.JaasProvider.SubjectResolver#resolveSubject()
+     */
+    public Subject resolveSubject() {
+        try {
+            return (Subject)PolicyContext.getContext(SUBJECT_CONTEXT_KEY);
+        } catch (Throwable e) {
+            if (!reportedWarning) {
+                reportedWarning = true;
+                Logger.getLogger(getClass())
+                      .debug(e,
+                             "Failed to find the Subject at the 'javax.security.auth.Subject.container' key in the JACC PolicyContext. "
+                             + "Check configuration and J2EE container's suggested approach for getting the JAAS Subject.");
+            }
+            return null;
+        }
+    }
+
+}

--- a/modeshape-parent/pom.xml
+++ b/modeshape-parent/pom.xml
@@ -221,6 +221,7 @@
 		<java.version>1.6</java.version>
 		<java.version.jcr.graph>1.5</java.version.jcr.graph>
 		<javax.servlet.version>2.5</javax.servlet.version>
+		<javax.jacc.version>1.0.0.Final</javax.jacc.version>
 		<!--
 		Maven plugin versions
 		-->
@@ -1074,6 +1075,12 @@
         <artifactId>servlet-api</artifactId>
         <version>${javax.servlet.version}</version>
 				<scope>provided</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.jboss.spec.javax.security.jacc</groupId>
+        <artifactId>jboss-jacc-api_1.4_spec</artifactId>
+        <version>${javax.jacc.version}</version>
+        <scope>provided</scope>
       </dependency>
 			<!-- 
 		    Time and Date


### PR DESCRIPTION
The standard way to get the current JAAS Subject given the LoginContext or AccessController works in standard Java but not in J2EE. Apparently this is a well-known issue. The recommended approach for J2EE is to instead get the Subject via the JACC API.

This change adds an optional (e.g., "provided") dependency on the JACC API, changes the JaasProvider implementation to accept an optional SubjectResolver implementation that the provider will use to resolve the Subject should the standard JAAS technique not work, and to change the JcrRepository implementation to give the JaasProvider a new JaccSubjectResolver implementation (when the JACC API is available).

It is not really possible to test whether this technique works in our unit or integration tests (as we don't deploy to a J2EE container). However, all existing unit and integration tests do pass (meaning it doesn't break their functionality), and Kurt is verifying that the JACC-style approach works within Guvnor and will (after this commit) verify that these changes do indeed work within Guvnor (which uses Seam in JBoss AS).
