### PR TITLE
MODE-1267 Correct setting property to Value containing null

### DIFF
--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/AbstractJcrNode.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/AbstractJcrNode.java
@@ -1557,6 +1557,7 @@ abstract class AbstractJcrNode extends AbstractJcrItem implements javax.jcr.Node
     public final Property setProperty( String name,
                                        boolean value )
         throws ValueFormatException, VersionException, LockException, ConstraintViolationException, RepositoryException {
+        CheckArg.isNotNull(name, "name");
         checkSession();
         return editor().setProperty(nameFrom(name), valueFrom(PropertyType.BOOLEAN, value));
     }
@@ -1569,6 +1570,7 @@ abstract class AbstractJcrNode extends AbstractJcrItem implements javax.jcr.Node
     public Property setProperty( String name,
                                  Binary value )
         throws ValueFormatException, VersionException, LockException, ConstraintViolationException, RepositoryException {
+        CheckArg.isNotNull(name, "name");
         return editor().setProperty(nameFrom(name), valueFrom(PropertyType.BINARY, value));
     }
 
@@ -1580,6 +1582,7 @@ abstract class AbstractJcrNode extends AbstractJcrItem implements javax.jcr.Node
     public Property setProperty( String name,
                                  BigDecimal value )
         throws ValueFormatException, VersionException, LockException, ConstraintViolationException, RepositoryException {
+        CheckArg.isNotNull(name, "name");
         return editor().setProperty(nameFrom(name), valueFrom(PropertyType.DECIMAL, value));
     }
 
@@ -1591,6 +1594,7 @@ abstract class AbstractJcrNode extends AbstractJcrItem implements javax.jcr.Node
     public final Property setProperty( String name,
                                        Calendar value )
         throws ValueFormatException, VersionException, LockException, ConstraintViolationException, RepositoryException {
+        CheckArg.isNotNull(name, "name");
         checkSession();
 
         if (value == null) {
@@ -1608,6 +1612,7 @@ abstract class AbstractJcrNode extends AbstractJcrItem implements javax.jcr.Node
     public final Property setProperty( String name,
                                        double value )
         throws ValueFormatException, VersionException, LockException, ConstraintViolationException, RepositoryException {
+        CheckArg.isNotNull(name, "name");
         checkSession();
         return editor().setProperty(nameFrom(name), valueFrom(PropertyType.DOUBLE, value));
     }
@@ -1620,6 +1625,7 @@ abstract class AbstractJcrNode extends AbstractJcrItem implements javax.jcr.Node
     public final Property setProperty( String name,
                                        InputStream value )
         throws ValueFormatException, VersionException, LockException, ConstraintViolationException, RepositoryException {
+        CheckArg.isNotNull(name, "name");
         checkSession();
         if (value == null) {
             return removeExistingValuedProperty(name);
@@ -1636,6 +1642,7 @@ abstract class AbstractJcrNode extends AbstractJcrItem implements javax.jcr.Node
     public final Property setProperty( String name,
                                        long value )
         throws ValueFormatException, VersionException, LockException, ConstraintViolationException, RepositoryException {
+        CheckArg.isNotNull(name, "name");
         checkSession();
         return editor().setProperty(nameFrom(name), valueFrom(PropertyType.LONG, value));
     }
@@ -1648,6 +1655,7 @@ abstract class AbstractJcrNode extends AbstractJcrItem implements javax.jcr.Node
     public final Property setProperty( String name,
                                        javax.jcr.Node value )
         throws ValueFormatException, VersionException, LockException, ConstraintViolationException, RepositoryException {
+        CheckArg.isNotNull(name, "name");
         checkSession();
         if (value == null) {
             return removeExistingValuedProperty(name);
@@ -1664,6 +1672,7 @@ abstract class AbstractJcrNode extends AbstractJcrItem implements javax.jcr.Node
     public final Property setProperty( String name,
                                        String value )
         throws ValueFormatException, VersionException, LockException, ConstraintViolationException, RepositoryException {
+        CheckArg.isNotNull(name, "name");
         checkSession();
         if (value == null) {
             return removeExistingValuedProperty(name);
@@ -1681,6 +1690,7 @@ abstract class AbstractJcrNode extends AbstractJcrItem implements javax.jcr.Node
                                        String value,
                                        int type )
         throws ValueFormatException, VersionException, LockException, ConstraintViolationException, RepositoryException {
+        CheckArg.isNotNull(name, "name");
         checkSession();
         if (value == null) {
             return removeExistingValuedProperty(name);
@@ -1697,6 +1707,7 @@ abstract class AbstractJcrNode extends AbstractJcrItem implements javax.jcr.Node
     public final Property setProperty( String name,
                                        String[] values )
         throws ValueFormatException, VersionException, LockException, ConstraintViolationException, RepositoryException {
+        CheckArg.isNotNull(name, "name");
         checkSession();
         if (values == null) {
             return removeExistingValuedProperty(name);
@@ -1714,6 +1725,7 @@ abstract class AbstractJcrNode extends AbstractJcrItem implements javax.jcr.Node
                                        String[] values,
                                        int type )
         throws ValueFormatException, VersionException, LockException, ConstraintViolationException, RepositoryException {
+        CheckArg.isNotNull(name, "name");
         checkSession();
         if (values == null) {
             return removeExistingValuedProperty(name);
@@ -1730,12 +1742,17 @@ abstract class AbstractJcrNode extends AbstractJcrItem implements javax.jcr.Node
     public final Property setProperty( String name,
                                        Value value )
         throws ValueFormatException, VersionException, LockException, ConstraintViolationException, RepositoryException {
+        CheckArg.isNotNull(name, "name");
         checkSession();
         if (value == null) {
             return removeExistingValuedProperty(name);
         }
 
-        return editor().setProperty(nameFrom(name), (JcrValue)value);
+        JcrValue jcrValue = (JcrValue)value;
+        if (jcrValue.value() == null) {
+            throw new ValueFormatException(JcrI18n.valueMayNotContainNull.text(name));
+        }
+        return editor().setProperty(nameFrom(name), jcrValue);
     }
 
     /**
@@ -1747,12 +1764,17 @@ abstract class AbstractJcrNode extends AbstractJcrItem implements javax.jcr.Node
                                        Value value,
                                        int type )
         throws ValueFormatException, VersionException, LockException, ConstraintViolationException, RepositoryException {
+        CheckArg.isNotNull(name, "name");
         checkSession();
         if (value == null) {
             return removeExistingValuedProperty(name);
         }
 
-        return editor().setProperty(nameFrom(name), ((JcrValue)value).asType(type));
+        JcrValue jcrValue = (JcrValue)value;
+        if (jcrValue.value() == null) {
+            throw new ValueFormatException(JcrI18n.valueMayNotContainNull.text(name));
+        }
+        return editor().setProperty(nameFrom(name), jcrValue.asType(type));
     }
 
     /**
@@ -1763,6 +1785,7 @@ abstract class AbstractJcrNode extends AbstractJcrItem implements javax.jcr.Node
     public final Property setProperty( String name,
                                        Value[] values )
         throws ValueFormatException, VersionException, LockException, ConstraintViolationException, RepositoryException {
+        CheckArg.isNotNull(name, "name");
         checkSession();
         if (values == null) {
             // If there is an existing property, then remove it ...
@@ -1781,10 +1804,19 @@ abstract class AbstractJcrNode extends AbstractJcrItem implements javax.jcr.Node
                                        Value[] values,
                                        int type )
         throws ValueFormatException, VersionException, LockException, ConstraintViolationException, RepositoryException {
+        CheckArg.isNotNull(name, "name");
         checkSession();
         if (values == null) {
             // If there is an existing property, then remove it ...
             return removeExistingValuedProperty(name);
+        }
+
+        // Check for a non-null Value that contains a null reference ...
+        for (Value value : values) {
+            JcrValue jcrValue = (JcrValue)value;
+            if (jcrValue != null && jcrValue.value() == null) {
+                throw new ValueFormatException(JcrI18n.valueMayNotContainNull.text(name));
+            }
         }
 
         // Set the value, perhaps to an empty array ...

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrI18n.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrI18n.java
@@ -134,6 +134,7 @@ public final class JcrI18n {
     public static I18n unableToBindToJndi;
     public static I18n invalidOptionProvided;
     public static I18n noOptionValueProvided;
+    public static I18n valueMayNotContainNull;
 
     public static I18n cannotRemoveRootNode;
     public static I18n cannotRemoveParentNodeOfTarget;

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrMultiValueProperty.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrMultiValueProperty.java
@@ -201,7 +201,13 @@ final class JcrMultiValueProperty extends AbstractJcrProperty {
 
         for (int i = 0; i < values.length; i++) {
             // Force a conversion as per SetValueValueFormatExceptionTest in JR TCK
-            if (values[i] != null) ((JcrValue)values[i]).asType(this.getType());
+            JcrValue val = (JcrValue)values[i];
+            if (val != null) {
+                if (val.value() == null) {
+                    throw new ValueFormatException(JcrI18n.valueMayNotContainNull.text(getName()));
+                }
+                val.asType(this.getType());
+            }
         }
 
         editor().setProperty(name(), values, PropertyType.UNDEFINED);

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrSingleValueProperty.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrSingleValueProperty.java
@@ -281,6 +281,9 @@ final class JcrSingleValueProperty extends AbstractJcrProperty {
 
         if (value instanceof JcrValue) {
             jcrValue = (JcrValue)value;
+            if (jcrValue.value() == null) {
+                throw new ValueFormatException(JcrI18n.valueMayNotContainNull.text(getName()));
+            }
 
             // Force a conversion as per SetValueValueFormatExceptionTest in JR TCK
             jcrValue.asType(this.getType());
@@ -337,6 +340,9 @@ final class JcrSingleValueProperty extends AbstractJcrProperty {
 
         checkSession();
         checkForLock();
+        if (jcrValue.value() == null) {
+            throw new ValueFormatException(JcrI18n.valueMayNotContainNull.text(getName()));
+        }
 
         editor().setProperty(name(), jcrValue);
     }

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrValue.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrValue.java
@@ -143,6 +143,7 @@ final class JcrValue implements org.modeshape.jcr.api.Value {
      * @see javax.jcr.Value#getDate()
      */
     public Calendar getDate() throws ValueFormatException {
+        if (value == null) return null;
         try {
             Calendar convertedValue = valueFactories.getDateFactory().create(value).toCalendar();
             return convertedValue;
@@ -180,6 +181,7 @@ final class JcrValue implements org.modeshape.jcr.api.Value {
     }
 
     long getLength() throws RepositoryException {
+        if (value == null) return 0L;
         if (type == PropertyType.BINARY) {
             return valueFactories.getBinaryFactory().create(value).getSize();
         }
@@ -209,6 +211,7 @@ final class JcrValue implements org.modeshape.jcr.api.Value {
         try {
             if (asStream == null) {
                 Binary binary = valueFactories.getBinaryFactory().create(value);
+                if (binary == null) return null;
                 asStream = new SelfClosingInputStream(binary);
             }
             return asStream;
@@ -225,7 +228,7 @@ final class JcrValue implements org.modeshape.jcr.api.Value {
     public javax.jcr.Binary getBinary() throws RepositoryException {
         try {
             Binary binary = valueFactories.getBinaryFactory().create(value);
-            return new JcrBinary(binary);
+            return binary != null ? new JcrBinary(binary) : null;
         } catch (RuntimeException error) {
             throw createValueFormatException(InputStream.class);
         }

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrValueFactory.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrValueFactory.java
@@ -32,6 +32,7 @@ import javax.jcr.PropertyType;
 import javax.jcr.RepositoryException;
 import javax.jcr.ValueFactory;
 import javax.jcr.ValueFormatException;
+import org.modeshape.common.util.CheckArg;
 import org.modeshape.graph.property.Binary;
 import org.modeshape.graph.property.DateTime;
 import org.modeshape.graph.property.NamespaceRegistry;
@@ -58,6 +59,7 @@ class JcrValueFactory implements ValueFactory {
 
     public JcrValue[] createValues( List<?> values,
                                     int propertyType ) throws ValueFormatException {
+        CheckArg.isNotNull(values, "values");
         final int size = values.size();
         if (size == 0) return EMPTY_ARRAY;
         JcrValue[] jcrValues = new JcrValue[size];
@@ -76,6 +78,7 @@ class JcrValueFactory implements ValueFactory {
 
     public JcrValue createValue( String value,
                                  int propertyType ) throws ValueFormatException {
+        CheckArg.isNotNull(value, "value");
         return new JcrValue(valueFactories, sessionCache, propertyType, convertValueToType(value, propertyType));
     }
 

--- a/modeshape-jcr/src/main/resources/org/modeshape/jcr/JcrI18n.properties
+++ b/modeshape-jcr/src/main/resources/org/modeshape/jcr/JcrI18n.properties
@@ -124,6 +124,7 @@ constraintViolatedOnReference = The property "{0}" on node "{1}" does not satisf
 unableToBindToJndi = Unable to bind repository to JNDI location {0}
 invalidOptionProvided = The provided option {0} is not a valid ModeShape option, it will be ignored
 noOptionValueProvided = No value provided for option {0}, it will be ignored
+valueMayNotContainNull = The value for the '{0}' property is invalid because the javax.jcr.Value object contains a null reference. To remove the value, a null javax.jcr.Value reference may be used.
 
 cannotRemoveRootNode = Unable to remove the root node
 cannotRemoveParentNodeOfTarget = The node at "{0}" with UUID "{1}" is a parent of the target node for this operation "{2}"


### PR DESCRIPTION
The JCR specification is not terribly clear on the behavior when null references are passed into the ValueFactory.create(…) methods. According to the JavaDoc, the spec, and the reference implementation, no error should be thrown. However, a ValueFormatException must be thrown when a non-null Value object (containing a null reference) is passed to Property.setValue(Value) or Property.setValues(Value[]) or Node.setProperty(String,Value) or Node.setProperty(String,Value[]). (Note that setting a property to a null Value reference is equivalent to removing the property.)

This change enables this behavior in ModeShape. Prior to this, ModeShape would allow setting a Value for a property even if that Value contained a null reference.
