### PR TITLE
MODE-1224 Improved restart performance

### DIFF
--- a/modeshape-graph/src/main/java/org/modeshape/graph/GraphMerger.java
+++ b/modeshape-graph/src/main/java/org/modeshape/graph/GraphMerger.java
@@ -30,6 +30,7 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
+import java.util.UUID;
 import org.modeshape.common.annotation.NotThreadSafe;
 import org.modeshape.common.util.CheckArg;
 import org.modeshape.graph.Graph.Batch;
@@ -152,6 +153,8 @@ class GraphMerger {
             Path path = childLocation.getPath();
             SubgraphNode desiredChild = desiredNode.getNode(path.getLastSegment());
             try {
+                // Remove the UUID, in case the existing node has a different UUID ...
+                childLocation = childLocation.with((UUID)null);
                 Node actualChild = actualGraph.getNodeAt(childLocation);
                 // The child exists, so match up the node properties and children ...
                 matchNode(batch, actualGraph, actualChild, desiredChild, true, true);

--- a/modeshape-integration-tests/src/test/resources/config/configRepositoryEds.xml
+++ b/modeshape-integration-tests/src/test/resources/config/configRepositoryEds.xml
@@ -1,0 +1,295 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- 
+  ~ ModeShape (http://www.modeshape.org)
+  ~
+  ~ See the COPYRIGHT.txt file distributed with this work for information
+  ~ regarding copyright ownership.  Some portions may be licensed
+  ~ to Red Hat, Inc. under one or more contributor license agreements.
+  ~ See the AUTHORS.txt file in the distribution for a full listing of 
+  ~ individual contributors.
+  ~
+  ~ ModeShape is free software. Unless otherwise indicated, all code in ModeShape
+  ~ is licensed to you under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ ModeShape is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+  ~ or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+  ~ for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public License
+  ~ along with this distribution; if not, write to:
+  ~ Free Software Foundation, Inc.
+  ~ 51 Franklin Street, Fifth Floor
+  ~ Boston, MA  02110-1301  USA
+  -->
+<configuration xmlns:mode="http://www.modeshape.org/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0">
+    <!-- Define the sources from which content is made available -->
+    <mode:sources jcr:primaryType="nt:unstructured">
+
+        <!-- 
+        If you wanted to use a JNDI datasource instead of manually specifying the database login information, you would replace this:
+            mode:driverClassName="org.hsqldb.jdbcDriver"
+            mode:username="sa"
+            mode:password=""
+            mode:url="jdbc:hsqldb:mem:target"
+            mode:maximumConnectionsInPool="5"
+        
+        With this:
+            mode:dataSourceJndiName="your JNDI name"
+
+        -->
+        <mode:source jcr:name="eds-store" mode:classname="org.modeshape.connector.store.jpa.JpaSource" 
+            mode:autoGenerateSchema="update"
+            mode:model="Simple"
+            mode:dialect="org.hibernate.dialect.HSQLDialect"
+            mode:driverClassName="org.hsqldb.jdbcDriver"
+            mode:username="sa"
+            mode:password=""
+            mode:url="jdbc:hsqldb:target/database/ConfigurationTest/db"
+            mode:maximumConnectionsInPool="2"
+            mode:showSql="false"
+            mode:creatingWorkspacesAllowed="true">
+            <defaultWorkspaceName>default</defaultWorkspaceName>
+            <predefinedWorkspaceNames>system</predefinedWorkspaceNames>
+            <predefinedWorkspaceNames>default</predefinedWorkspaceNames>
+        </mode:source>
+
+        <mode:source jcr:name="eds-store"
+                     mode:classname="org.modeshape.graph.connector.inmemory.InMemoryRepositorySource"
+                     mode:retryLimit="3" mode:defaultWorkspaceName="default" >
+            <predefinedWorkspaceNames>system</predefinedWorkspaceNames>
+            <predefinedWorkspaceNames>default</predefinedWorkspaceNames>
+        </mode:source>
+        
+    </mode:sources>
+    
+    <mode:sequencers>
+              <!-- These are configured for demonstration purposes. For real use, adjust the path expressions and use those appropriate for your use case. -->
+        <mode:sequencer jcr:name="Delimited Text File Sequencer" mode:classname="org.modeshape.sequencer.text.DelimitedTextSequencer">
+            <mode:description>Sequences *.csv text files loaded under '/files', extracting comma-separated and delimited files into columnar information.</mode:description>        
+            <mode:pathExpression>eds-store:default:/files//(*.csv[*])/jcr:content[@jcr:data] => eds-store:default:/sequenced/text/delimited/$1 </mode:pathExpression>
+            <!-- The split pattern is a regular expression used to split each row into columns. -->
+            <mode:splitPattern>,</mode:splitPattern>
+        </mode:sequencer>
+        <mode:sequencer jcr:name="Fixed Width Text File Sequencer" mode:classname="org.modeshape.sequencer.text.FixedWidthTextSequencer">
+            <mode:description>Sequences *.txt fixed-width text files loaded under '/files', extracting splitting rows into columns based on predefined positions.</mode:description>        
+            <mode:pathExpression>eds-store:default:/files//(*.txt[*])/jcr:content[@jcr:data] => eds-store:default:/sequenced/text/fixedWidth/$1 </mode:pathExpression>
+            <!-- The 'columnStartPositions' define the 0-based column start positions. Everything before the 
+                       first start position is treated as the first column. The default value is the empty string 
+                       (implying that each row should be treated as a single column). There is an implicit column 
+                       start position of 0 that never needs to be specified. -->
+                  <mode:columnStartPositions></mode:columnStartPositions>
+        </mode:sequencer>
+        <mode:sequencer jcr:name="Teiid Model Sequencer" mode:classname="org.modeshape.sequencer.teiid.ModelSequencer">
+            <mode:description>Sequences Teiid relational models (e.g., *.xmi) loaded under '/files', extracting the structure defined in the models.</mode:description>
+            <!-- Note this path expression captures the path below '/files' (in the 'store' source and 'default' workspace only)
+                 but excluding the filename, and places the sequenced content under the same relative path below '/sequenced/teiid/models'. 
+                 For example, if an XMI model is uploaded to '/files/my/favorites/CustomerDetails.xmi', then the sequenced output will be placed at
+                 the '/sequenced/teiid/models/my/favorites/CustomerDetails' node, which will have a primary type of 'xmi:model' and will
+                 contain under it the nodes representing the catalogs, schemas, tables, views, columns, etc. Of course, the 
+                 path expression can be modified as needed; for example, to include the filename of the XMI model in the 
+                 sequenced output path. -->
+            <mode:pathExpression>eds-store:default:/files(//)(*.xmi[*])/jcr:content[@jcr:data] => eds-store:default:/sequenced/teiid/models$1 </mode:pathExpression>
+        </mode:sequencer>
+        <mode:sequencer jcr:name="Teiid VDB Sequencer" mode:classname="org.modeshape.sequencer.teiid.VdbSequencer">
+            <mode:description>Sequences Teiid Virtual Databases (e.g., *.vdb) loaded under '/files', extracting the VDB metadata and the structure defined in the VDB's relational models.</mode:description>        
+            <!-- Note this path expression captures the path below '/files' (in the 'store' source and 'default' workspace only) 
+                 but excluding the filename, and places the sequenced content under the same relative path below '/sequenced/teiid/models'. 
+                 For example, if a VDB file is uploaded to '/files/my/favorites/Customers.vdb', then the sequenced output will be placed at
+                 the '/sequenced/teiid/models/my/favorites/Customer' node, which will have a primary type of 'vdb:virtualDatabase' and will
+                 contain under it the nodes representing the models (which will each contain the nodes representing that
+                 model's catalogs, schemas, tables, views, columns, etc.).  Of course, the path expression
+                 can be modified as needed; for example, to include the filename of the XMI model in the sequenced output path. -->
+            <mode:pathExpression>eds-store:default:/files(//)(*.vdb[*])/jcr:content[@jcr:data] => eds-store:default:/sequenced/teiid/vdbs$1 </mode:pathExpression>
+        </mode:sequencer>
+        <mode:sequencer jcr:name="CND File Sequencer" mode:classname="org.modeshape.sequencer.cnd.CndSequencer">
+            <mode:description>Sequences CND files loaded under '/files', extracting the contained node type definitions.</mode:description>        
+            <!-- Note this path expression captures the path below '/files' (in the 'store' source and 'default' workspace only)
+                 including the filename, and places the sequenced content under the same relative path below '/sequenced/cnd'. 
+                 For example, if a CND file is uploaded to '/files/my/favorites/Customers.cnd', then the sequenced output will be placed at
+                 the '/sequenced/ddl/my/favorites/Customer.cnd' node, which will have a primary type of 'nt:unstructured' and will
+                 contain under it the 'nt:nodeType', 'nt:propertyDefinition' and 'nt:childNodeDefinition' nodes representing 
+                 the node types, property definitions, and child node definitions contained within the CND file.
+                 Of course, the path expression can be modified as needed; for example, to exclude the filename extension, 
+                 or to exclude the relative path. -->
+            <mode:pathExpression>eds-store:default:/files(//(*.cnd[*]))/jcr:content[@jcr:data] => eds-store:default:/sequenced/cnd/$1 </mode:pathExpression>
+        </mode:sequencer>
+        <mode:sequencer jcr:name="DDL File Sequencer" mode:classname="org.modeshape.sequencer.ddl.DdlSequencer">
+            <mode:description>Sequences DDL files loaded under '/files', extracting the structured abstract syntax tree of the DDL commands and expressions.</mode:description>        
+            <!-- Note this path expression captures the path below '/files' (in the 'store' source and 'default' workspace only)
+                 including the filename, and places the sequenced content under the same relative path below '/sequenced/ddl'. 
+                 For example, if a DDL file is uploaded to '/files/my/favorites/Customers.ddl', then the sequenced output will be placed at
+                 the '/sequenced/ddl/my/favorites/Customer.ddl' node, which will have a primary type of 'nt:unstructured' and will
+                 contain under it the nodes representing the DDL statements. Of course, the path expression
+                 can be modified as needed; for example, to exclude the filename extension, or to exclude the relative path. -->
+            <mode:pathExpression>eds-store:default:/files(//(*.ddl[*]))/jcr:content[@jcr:data] => eds-store:default:/sequenced/ddl/$1 </mode:pathExpression>
+        </mode:sequencer>     
+        <mode:sequencer jcr:name="XML File Sequencer" mode:classname="org.modeshape.sequencer.xml.XmlSequencer">
+            <mode:description>Sequences XML files loaded under '/files', extracting the contents into the equivalent JCR graph structure.</mode:description>        
+            <!-- Note this path expression captures the path below '/files' (in the 'store' source and 'default' workspace only), 
+                 including the filename, and places the sequenced content under the same relative path below '/sequenced/xml'. 
+                 For example, if an XML file is uploaded to '/files/my/favorites/Customers.xml', then the sequenced output will be placed at
+                 the '/sequenced/xml/my/favorites/Customer.xml' node, which will have a primary type of 'modexml:document' and will
+                 contain under it the nodes representing the XML elements, attributes, and content nodes. Of course, the path expression
+                 can be modified as needed; for example, to exclude the filename extension, or to exclude the relative path. -->
+            <mode:pathExpression>eds-store:default:/files(//)*.xml[*]/jcr:content[@jcr:data] => eds-store:default:/sequenced/xml/$1 </mode:pathExpression>       
+        </mode:sequencer>  
+        <mode:sequencer jcr:name="ZIP File Sequencer" mode:classname="org.modeshape.sequencer.zip.ZipSequencer">
+            <mode:description>Sequences ZIP files loaded under '/files', extracting the archive file contents into the equivalent JCR graph structure of 'nt:file' and 'nt:folder' nodes.</mode:description>        
+            <!-- Note this path expression captures the path below '/files' (in the 'store' source and 'default' workspace only), 
+                 including the filename, and places the sequenced content under the same relative path below '/sequenced/zip'. 
+                 For example, if a ZIP file is uploaded to '/files/my/favorites/Customers.zip', then the sequenced output will be placed at
+                 the '/sequenced/xml/my/favorites/Customer.zip' node, which will have a primary type of 'zip:file'
+                 (a subtype of 'nt:folder') and will contain 'nt:file' and 'nt:folder' nodes for each file and folder (respectively)
+                 in the archive file. Of course, the path expression can be modified as needed; for example, to exclude the 
+                 filename extension, or to exclude the relative path. -->
+            <mode:pathExpression>eds-store:default:/files(//)(*.zip[*])/jcr:content[@jcr:data] => eds-store:default:/sequenced/zip/$1 </mode:pathExpression>
+        </mode:sequencer>  
+        <mode:sequencer jcr:name="XSD File Sequencer" mode:classname="org.modeshape.sequencer.xsd.XsdSequencer">
+            <mode:description>Sequences XSD files loaded into the repository under '/files', extracting the contents into the equivalent JCR graph structure.</mode:description>        
+            <!-- Note this path expression captures the path below '/files' (in the 'store' source and 'default' workspace only), 
+                 including the filename, and places the sequenced content under the same relative path below '/sequenced/xsd'. 
+                 For example, if an XSD file is uploaded to '/files/my/favorites/Customers.xsd', then the sequenced output will be placed at
+                 the '/sequenced/wsdl/my/favorites/Customer.xsd' node, which will have a primary type of 'xs:schemaDocument' and will
+                 contain under it the nodes representing the XSD components. Of course, the path expression
+                 can be modified as needed; for example, to exclude the filename extension, or to exclude the relative path. -->
+            <mode:pathExpression>eds-store:default:/files(//)*.xsd[*]/jcr:content[@jcr:data] => eds-store:default:/sequenced/xsd/$1 </mode:pathExpression>
+        </mode:sequencer>  
+        <mode:sequencer jcr:name="WSDL File Sequencer" mode:classname="org.modeshape.sequencer.wsdl.WsdlSequencer">
+            <mode:description>Sequences WSDL 1.1 files loaded into the repository under '/files', extracting the contents into the equivalent JCR graph structure.</mode:description>        
+            <!-- Note this path expression captures the path below '/files' (in the 'store' source and 'default' workspace only), 
+                 including the filename, and places the sequenced content under the same relative path below '/sequenced/wsdl'. 
+                 For example, if a WSDL file is uploaded to '/files/my/favorites/Customers.wsdl', then the sequenced output will be placed at
+                 the '/sequenced/wsdl/my/favorites/Customer.wsdl' node, which will have a primary type of 'wsdl:wsdlDocument' and will
+                 contain under it the nodes representing the WSDL components. Of course, the path expression
+                 can be modified as needed; for example, to exclude the filename extension, or to exclude the relative path. -->
+            <mode:pathExpression>eds-store:default:/files(//)*.wsdl[*]/jcr:content[@jcr:data] => eds-store:default:/sequenced/wsdl/$1 </mode:pathExpression>
+        </mode:sequencer>       
+          
+    </mode:sequencers>
+    
+    <!-- Define the JCR repositories -->
+    <mode:repositories>
+        <!-- Specify the source that should be used for the EDS repository -->
+        <mode:repository jcr:name="eds" >
+            <mode:source>eds-store</mode:source>
+            <!-- Define the options for the JCR repository, using camelcase version of JcrRepository.Option names-->
+            <mode:options jcr:primaryType="options">
+                <!-- The name of the JAAS application policy, used when clients get a session with credentials.
+                       (This policy is defined in the 'login-config.xml' file). -->
+                <mode:option jcr:name="jaasLoginConfigName" mode:value="modeshape"/>
+                <!-- Explicitly specify the "system" workspace in the "SystemStore" source. -->
+                <mode:option jcr:name="systemSourceName" mode:value="system@eds-store"/>
+                <!-- Explicitly specify the directory where the index files should be stored. -->
+                <mode:option jcr:name="queryIndexDirectory" mode:value="target/testConfig/modeshape/repositories/eds-store/indexes"/>                
+                
+                <!--  Should  indexes should be rebuilt synchronously when the repository restarts, default true  -->           
+                <mode:option jcr:name="queryIndexesRebuiltSynchronously" mode:value="false"/>
+
+                <!--  specifies the strategy (always or ifMissing) used to determine which query indexes need to be rebuilt when the repository restarts -->
+                <mode:option jcr:name="rebuildQueryIndexOnStartup" mode:value="ifMissing"/>
+        
+
+            </mode:options>
+            <!-- Define any custom node types. Importing CND files via JcrConfiguration is equivalent to specifying here.-->
+            <jcr:nodeTypes>
+                <mode:resource>/org/modeshape/sequencer/teiid/teiid.cnd</mode:resource>
+                <mode:resource>/org/modeshape/sequencer/text/sequencer-text.cnd</mode:resource>
+                <mode:resource>/org/modeshape/sequencer/xml/xml.cnd</mode:resource>
+                <mode:resource>/org/modeshape/sequencer/zip/zip.cnd</mode:resource>
+                <!-- the sramp.cnd is required if the wsdl.cnd and xsd.cnd are used -->
+                <mode:resource>/org/modeshape/sequencer/sramp/sramp.cnd</mode:resource>                             
+                <mode:resource>/org/modeshape/sequencer/wsdl/wsdl.cnd</mode:resource>
+                <mode:resource>/org/modeshape/sequencer/xsd/xsd.cnd</mode:resource> 
+                <mode:resource>/org/modeshape/sequencer/ddl/StandardDdl.cnd</mode:resource>
+                <mode:resource>/org/modeshape/sequencer/ddl/dialect/derby/DerbyDdl.cnd</mode:resource>
+                <mode:resource>/org/modeshape/sequencer/ddl/dialect/oracle/OracleDdl.cnd</mode:resource>
+                <mode:resource>/org/modeshape/sequencer/ddl/dialect/postgres/PostgresDdl.cnd</mode:resource>
+                
+            </jcr:nodeTypes>
+            <!-- Define what the initial content looks like for each workspace -->
+            <mode:initialContent mode:workspaces="default" mode:applyToNewWorkspaces="true" mode:content="modeshape-initial-content.xml"/>
+
+        </mode:repository>
+    </mode:repositories>
+    
+    <!--  
+        Cluster Configuration options that use JGroups
+        
+        1.  Use the JGroups default configuration (default)
+        2.  Define your own JGroups configuration, below is an example
+        
+        Uncomment one of the options to enable ModeShape clustering.
+    -->
+    
+    <!--  Option 1.  Use JGroups Default Configuration -->
+    
+      
+    <!-- 
+       <mode:clustering clusterName="modeshape-cluster" >   
+          <configuration>
+          </configuration>
+        </mode:clustering>      
+    -->
+     
+
+
+    
+    <!-- Option 2.  Example of how to define your own JGroups configuration
+          
+    <mode:clustering clusterName="modeshape-cluster" >  
+          <configuration>
+            <![CDATA[<config>
+   <UDP mcast_addr="${jboss.jgroups.modeshape.mcast_addr:228.10.10.10}"
+        mcast_port="${jboss.jgroups.modeshape.mcast_port:45690}"
+        bind_port="${jboss.jgroups.modeshape.bind_port:55275}"
+        discard_incompatible_packets="true"
+        max_bundle_size="64000"
+        max_bundle_timeout="30"
+        ip_ttl="${jgroups.udp.ip_ttl:2}"
+        enable_bundling="true"
+        thread_pool.enabled="true"
+        thread_pool.min_threads="1"
+        thread_pool.max_threads="25"
+        thread_pool.keep_alive_time="5000"
+        thread_pool.queue_enabled="false"
+        thread_pool.queue_max_size="100"
+        thread_pool.rejection_policy="Run"
+        oob_thread_pool.enabled="true"
+        oob_thread_pool.min_threads="1"
+        oob_thread_pool.max_threads="8"
+        oob_thread_pool.keep_alive_time="5000"
+        oob_thread_pool.queue_enabled="false"
+        oob_thread_pool.queue_max_size="100"
+        oob_thread_pool.rejection_policy="Run"/>
+   <PING timeout="2000"
+           num_initial_members="3"/>
+   <MERGE2 max_interval="30000"
+           min_interval="10000"/>
+   <FD_SOCK/>
+   <FD timeout="10000" max_tries="5" />
+   <VERIFY_SUSPECT timeout="1500"  />
+   <BARRIER />
+   <pbcast.NAKACK use_mcast_xmit="false" gc_lag="0"
+                  retransmit_timeout="300,600,1200,2400,4800"
+                  discard_delivered_msgs="true"/>
+   <UNICAST timeout="300,600,1200,2400,3600"/>
+   <pbcast.STABLE stability_delay="1000" desired_avg_gossip="50000"
+                  max_bytes="400000"/>
+   <VIEW_SYNC avg_send_interval="60000"   />
+   <pbcast.GMS print_local_addr="true" join_timeout="3000"
+               view_bundling="true"/>
+   <FC max_credits="20000000"
+                   min_threshold="0.10"/>
+   <FRAG2 frag_size="60000"  />
+   <pbcast.STATE_TRANSFER  />  
+            </config>]]>
+
+          </configuration>
+    </mode:clustering>
+    
+    -->
+    
+</configuration>

--- a/modeshape-integration-tests/src/test/resources/config/configRepositoryWithAsynchronousIndex.xml
+++ b/modeshape-integration-tests/src/test/resources/config/configRepositoryWithAsynchronousIndex.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration xmlns:mode="http://www.modeshape.org/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0">
+    <!--
+    Define the JCR repositories
+    -->
+    <mode:repositories>
+        <!--
+        Define a JCR repository that accesses the 'Store' source
+        -->
+        <mode:repository jcr:name="My repository" mode:source="Store">
+            <mode:options jcr:primaryType="mode:options">
+                <mode:option jcr:name="systemSourceName" mode:value="system@Store"/>
+                <mode:option jcr:name="jaasLoginConfigName" mode:value="modeshape-jcr"/>
+                <!--
+                As a convenience, ModeShape defaults to granting guest users full access.
+                In a production system, you would want to limit this access by uncommenting one of the
+                options below:
+
+                for no access:
+                <mode:option jcr:name="anonymousUserRoles" mode:value="" />
+
+                for read-only acces:
+                <mode:option jcr:name="anonymousUserRoles" mode:value="readonly" />
+                -->
+                <!--
+                Should indexes should be rebuilt synchronously when the repository restarts, default true
+                -->
+                <mode:option jcr:name="queryIndexesRebuiltSynchronously" mode:value="false"/>
+            </mode:options>
+        </mode:repository>
+    </mode:repositories>
+    <!--
+    Define the sources for the content.  These sources are directly accessible using the ModeShape-specific
+    Graph API.
+    -->
+    <mode:sources>
+        <mode:source jcr:name="Store"
+                     mode:classname="org.modeshape.graph.connector.inmemory.InMemoryRepositorySource"
+                     mode:retryLimit="3" mode:defaultWorkspaceName="default" >
+            <predefinedWorkspaceNames>system</predefinedWorkspaceNames>
+            <predefinedWorkspaceNames>default</predefinedWorkspaceNames>
+        </mode:source>
+    </mode:sources>
+    <!--
+    Define the clustering configuration. This is an optional section; leave it out when
+    running in a non-clustered (single-process) mode.
+    -->
+    <!--<mode:clustering clusterName="modeshape-cluster" configuration="jgroups-modeshape.xml"/>-->
+    <!--
+    Define the sequencers. This is an optional section.
+    -->
+    <!--<mode:sequencers>-->
+        <!--<mode:sequencer jcr:name="Image Sequencer"-->
+                        <!--mode:classname="org.modeshape.sequencer.image.ImageMetadataSequencer">-->
+            <!--<mode:description>Image metadata sequencer</mode:description>-->
+            <!--<mode:pathExpression>/foo/source => /foo/target</mode:pathExpression>-->
+            <!--<mode:pathExpression>/bar/source => /bar/target</mode:pathExpression>-->
+        <!--</mode:sequencer>-->
+    <!--</mode:sequencers>-->
+    <!--
+      Define how ModeShape will determine the MIME type of files. This is an optional section;
+      if you do not specify a MIME type detector, ModeShape will use a built-in one that is based
+      filename extensions for most commonly-used files.
+    -->
+    <!--<mode:mimeTypeDetectors>-->
+        <!--<mode:mimeTypeDetector jcr:name="Detector"-->
+                               <!--mode:description="Standard extension-based MIME type detector"/>-->
+    <!--</mode:mimeTypeDetectors>-->
+</configuration>

--- a/modeshape-integration-tests/src/test/resources/modeshape-initial-content.xml
+++ b/modeshape-integration-tests/src/test/resources/modeshape-initial-content.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- 
+  ~ ModeShape (http://www.modeshape.org)
+  ~
+  ~ See the COPYRIGHT.txt file distributed with this work for information
+  ~ regarding copyright ownership.  Some portions may be licensed
+  ~ to Red Hat, Inc. under one or more contributor license agreements.
+  ~ See the AUTHORS.txt file in the distribution for a full listing of 
+  ~ individual contributors.
+  ~
+  ~ ModeShape is free software. Unless otherwise indicated, all code in ModeShape
+  ~ is licensed to you under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ ModeShape is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+  ~ or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+  ~ for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public License
+  ~ along with this distribution; if not, write to:
+  ~ Free Software Foundation, Inc.
+  ~ 51 Franklin Street, Fifth Floor
+  ~ Boston, MA  02110-1301  USA
+  -->
+<files xmlns:jcr="http://www.jcp.org/jcr/1.0" jcr:primaryType="nt:folder" jcr:mixinTypes="mode:publishArea">
+</files>

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrI18n.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrI18n.java
@@ -66,6 +66,8 @@ public final class JcrI18n {
     public static I18n errorLoadingNodeTypeDefintions;
     public static I18n errorStartingRepositoryCheckConfiguration;
     public static I18n completedStartingRepository;
+    public static I18n registeringNodeTypesDefinedInConfiguration;
+    public static I18n completedRegisteringNodeTypesDefinedInConfiguration;
     public static I18n startingAllRepositoriesWasInterrupted;
     public static I18n unableToFindNodeTypeDefinitionsOnClasspathOrFileOrUrl;
     public static I18n unableToFindResourceOnClasspathOrFileOrUrl;

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrNodeTypeManager.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrNodeTypeManager.java
@@ -525,7 +525,7 @@ public class JcrNodeTypeManager implements NodeTypeManager {
             throw new AccessDeniedException(ace);
         }
         try {
-            return new JcrNodeTypeIterator(repositoryTypeManager.registerNodeTypes(templates, !allowUpdates));
+            return new JcrNodeTypeIterator(repositoryTypeManager.registerNodeTypes(templates, !allowUpdates, false));
         } finally {
             schemata = null;
         }
@@ -597,7 +597,7 @@ public class JcrNodeTypeManager implements NodeTypeManager {
         }
 
         try {
-            return new JcrNodeTypeIterator(this.repositoryTypeManager.registerNodeTypes(Arrays.asList(ntds), !allowUpdate));
+            return new JcrNodeTypeIterator(this.repositoryTypeManager.registerNodeTypes(Arrays.asList(ntds), !allowUpdate, false));
         } finally {
             schemata = null;
         }

--- a/modeshape-jcr/src/main/resources/org/modeshape/jcr/JcrI18n.properties
+++ b/modeshape-jcr/src/main/resources/org/modeshape/jcr/JcrI18n.properties
@@ -57,6 +57,8 @@ errorLoadingNodeTypeDefintions = Error loading CND file "{0}": {1}
 errorStartingRepositoryCheckConfiguration = Error starting the "{0}" repository (check the configuration): {1}
 startingAllRepositoriesWasInterrupted = The engine was interrupted while starting each repository, and will be left in an unknown state: {0}
 completedStartingRepository = Completed starting the "{0}" repository
+registeringNodeTypesDefinedInConfiguration = Registering the node types defined in the configuration for the "{0}" repository
+completedRegisteringNodeTypesDefinedInConfiguration Completed registering the node types defined in the configuration for the "{0}" repository
 unableToFindNodeTypeDefinitionsOnClasspathOrFileOrUrl = Unable to find the node type definition file "{0}" on the classpath, as a relative or absolute file, or resolve as a URL
 unableToFindResourceOnClasspathOrFileOrUrl = Unable to find "{0}" on the classpath, as a relative or absolute file, or resolve as a URL
 unableToImportInitialContent = Unable to import initial content for repository "{0}" from "{1}". Check that this file exists on the file system or classpath.


### PR DESCRIPTION
Added quite a few debug logging statements to help identify the issue with startup times. Also added two info-level log messages around the node registration activity.

Created a test case that uses a slightly-modified EDS configuration (different index location in 'target' area, HSQLDB stored on disk in 'target' area), and starts then restarts the engine.

I was able to see the problem, and I believe it is solely because of the re-registration of the node types listed in the configuration file. I then changed the registration process to allow a flag that will not re-register the node type if a node type already exists with the same name (there was already a flag to fail if the node type exists), and changed the startup to a) not fail but b) to skip the registration for any node type that already exists.

After implementing this change, restarting appears to be significantly faster. If fact, my tests show that the time to register the node types in subsequent restarts goes from minutes to ~0.02 seconds.

All unit and integration tests pass.
