### PR TITLE
MODE-1269 Changed recently-added reindexing API

### DIFF
--- a/modeshape-integration-tests/src/test/java/org/modeshape/test/integration/filesystem/FileSystemRepositoryIntegrationTest.java
+++ b/modeshape-integration-tests/src/test/java/org/modeshape/test/integration/filesystem/FileSystemRepositoryIntegrationTest.java
@@ -248,28 +248,29 @@ public class FileSystemRepositoryIntegrationTest extends ModeShapeSingleUseTest 
 
         // Reindex some of the content synchronously ...
         org.modeshape.jcr.api.Workspace workspace = (org.modeshape.jcr.api.Workspace)session.getWorkspace();
-        workspace.reindex("/folder1", 3);
+        workspace.reindex("/folder1");
 
-        printQuery("SELECT * FROM [nt:base]", 9L, Collections.<String, String>emptyMap());
+        printQuery("SELECT * FROM [nt:base] ORDER BY [jcr:path]", 9L, Collections.<String, String>emptyMap());
 
         // Add a folder to the file system ...
         new File("target/fsRepoWithProps/root/defaultWorkspace/folder1/subfolder3").mkdirs();
         new File("target/fsRepoWithProps/root/defaultWorkspace/folder1/subfolder3/file3.txt").createNewFile();
 
         // Query should show old results (because file system connector does not monitor file system) ...
-        printQuery("SELECT * FROM [nt:base]", 9L, Collections.<String, String>emptyMap());
+        printQuery("SELECT * FROM [nt:base] ORDER BY [jcr:path]", 9L, Collections.<String, String>emptyMap());
 
-        // Reindex some content synchronously (but not deep enough to get everything) ...
-        workspace.reindex("/folder1", 1);
-        printQuery("SELECT * FROM [nt:base]", 9L, Collections.<String, String>emptyMap());
+        // Reindex some content synchronously ...
+        workspace.reindex("/folder1");
+        printQuery("SELECT * FROM [nt:base] ORDER BY [jcr:path]", 12L, Collections.<String, String>emptyMap());
 
-        // Reindex some content synchronously (only deep enough to see 'subfolder3', but not what's in it) ...
-        workspace.reindex("/folder1", 2);
-        printQuery("SELECT * FROM [nt:base]", 10L, Collections.<String, String>emptyMap());
+        File newName = new File("target/fsRepoWithProps/root/defaultWorkspace/folder1/subfolder4");
+        new File("target/fsRepoWithProps/root/defaultWorkspace/folder1/subfolder3").renameTo(newName);
+
+        printQuery("SELECT * FROM [nt:base] ORDER BY [jcr:path]", 12L, Collections.<String, String>emptyMap());
 
         // Reindex some content synchronously (now deep enough to get everything) ...
-        workspace.reindex("/folder1", 10);
-        printQuery("SELECT * FROM [nt:base]", 12L, Collections.<String, String>emptyMap());
+        workspace.reindex("/folder1");
+        printQuery("SELECT * FROM [nt:base] ORDER BY [jcr:path]", 12L, Collections.<String, String>emptyMap());
 
         logout();
     }
@@ -287,7 +288,7 @@ public class FileSystemRepositoryIntegrationTest extends ModeShapeSingleUseTest 
 
         // Reindex some of the content synchronously ...
         org.modeshape.jcr.api.Workspace workspace = (org.modeshape.jcr.api.Workspace)session.getWorkspace();
-        Future<Boolean> future = workspace.reindexAsync("/folder1", 3);
+        Future<Boolean> future = workspace.reindexAsync("/folder1");
         assertThat(future.get(), is(true)); // blocks
 
         printQuery("SELECT * FROM [nt:base]", 9L, Collections.<String, String>emptyMap());
@@ -299,23 +300,8 @@ public class FileSystemRepositoryIntegrationTest extends ModeShapeSingleUseTest 
         // Query should show old results (because file system connector does not monitor file system) ...
         printQuery("SELECT * FROM [nt:base]", 9L, Collections.<String, String>emptyMap());
 
-        // Reindex some content synchronously (but not deep enough to get everything) ...
-        future = workspace.reindexAsync("/folder1", 1);
-        assertThat(future.get(), is(true)); // blocks
-        printQuery("SELECT * FROM [nt:base]", 9L, Collections.<String, String>emptyMap());
-
-        // Reindex some content synchronously (only deep enough to see 'subfolder3', but not what's in it) ...
-        future = workspace.reindexAsync("/folder1", 2);
-        assertThat(future.get(), is(true)); // blocks
-        printQuery("SELECT * FROM [nt:base]", 10L, Collections.<String, String>emptyMap());
-
-        // Reindex some content synchronously (only deep enough to see 'subfolder3/file3.txt', but not what's in it) ...
-        future = workspace.reindexAsync("/folder1", 3);
-        assertThat(future.get(), is(true)); // blocks
-        printQuery("SELECT * FROM [nt:base]", 11L, Collections.<String, String>emptyMap());
-
         // Reindex some content synchronously (now deep enough to get everything) ...
-        future = workspace.reindexAsync("/folder1", 10);
+        future = workspace.reindexAsync("/folder1");
         assertThat(future.get(), is(true)); // blocks
         printQuery("SELECT * FROM [nt:base]", 12L, Collections.<String, String>emptyMap());
 

--- a/modeshape-jcr-api/src/main/java/org/modeshape/jcr/api/Workspace.java
+++ b/modeshape-jcr-api/src/main/java/org/modeshape/jcr/api/Workspace.java
@@ -36,8 +36,8 @@ public interface Workspace extends javax.jcr.Workspace {
      * 
      * @throws RepositoryException if there is a problem with this session or workspace
      * @see #reindexAsync()
-     * @see #reindexAsync(String, int)
-     * @see #reindex(String, int)
+     * @see #reindexAsync(String)
+     * @see #reindex(String)
      */
     void reindex() throws RepositoryException;
 
@@ -45,15 +45,13 @@ public interface Workspace extends javax.jcr.Workspace {
      * Crawl and index the content starting at the supplied path in this workspace, to the designated depth.
      * 
      * @param path the path of the content to be indexed
-     * @param depth the depth of the content to be indexed
      * @throws IllegalArgumentException if the workspace or path are null, or if the depth is less than 1
      * @throws RepositoryException if there is a problem with this session or workspace
      * @see #reindex()
      * @see #reindexAsync()
-     * @see #reindexAsync(String, int)
+     * @see #reindexAsync(String)
      */
-    void reindex( String path,
-                  int depth ) throws RepositoryException;
+    void reindex( String path ) throws RepositoryException;
 
     /**
      * Asynchronously crawl and re-index the content in this workspace.
@@ -61,8 +59,8 @@ public interface Workspace extends javax.jcr.Workspace {
      * @return a future representing the asynchronous operation; never null
      * @throws RepositoryException if there is a problem with this session or workspace
      * @see #reindex()
-     * @see #reindex(String, int)
-     * @see #reindexAsync(String, int)
+     * @see #reindex(String)
+     * @see #reindexAsync(String)
      */
     Future<Boolean> reindexAsync() throws RepositoryException;
 
@@ -70,15 +68,13 @@ public interface Workspace extends javax.jcr.Workspace {
      * Asynchronously crawl and index the content starting at the supplied path in this workspace, to the designated depth.
      * 
      * @param path the path of the content to be indexed
-     * @param depth the depth of the content to be indexed
      * @return a future representing the asynchronous operation; never null
      * @throws IllegalArgumentException if the workspace or path are null, or if the depth is less than 1
      * @throws RepositoryException if there is a problem with this session or workspace
      * @see #reindex()
-     * @see #reindex(String, int)
+     * @see #reindex(String)
      * @see #reindexAsync()
      */
-    Future<Boolean> reindexAsync( String path,
-                                  int depth ) throws RepositoryException;
+    Future<Boolean> reindexAsync( String path ) throws RepositoryException;
 
 }

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrWorkspace.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrWorkspace.java
@@ -991,7 +991,24 @@ class JcrWorkspace implements org.modeshape.jcr.api.Workspace {
     /**
      * {@inheritDoc}
      * 
-     * @see org.modeshape.jcr.api.Workspace#reindex(java.lang.String, int)
+     * @see org.modeshape.jcr.api.Workspace#reindex(java.lang.String)
+     */
+    public void reindex( String path ) throws RepositoryException {
+        reindex(path, Integer.MAX_VALUE);
+    }
+
+    /**
+     * This is not included in the public API because users can easily mess up the indexes if the depth is incorrect. For example,
+     * if a node with children is renamed, but the depth is only sufficient to re-index the node, then the children will appear
+     * under the old path. Because of this complexity, we can hide this full re-indexing capability until it is actually needed to
+     * be exposed.
+     * <p>
+     * However, this method is still useful when used properly, so we are keeping it (just not exposing it).
+     * </p>
+     * 
+     * @param path
+     * @param depth
+     * @throws RepositoryException
      */
     public void reindex( String path,
                          int depth ) throws RepositoryException {
@@ -1024,7 +1041,25 @@ class JcrWorkspace implements org.modeshape.jcr.api.Workspace {
     /**
      * {@inheritDoc}
      * 
-     * @see org.modeshape.jcr.api.Workspace#reindexAsync(java.lang.String, int)
+     * @see org.modeshape.jcr.api.Workspace#reindexAsync(java.lang.String)
+     */
+    public Future<Boolean> reindexAsync( String path ) throws RepositoryException {
+        return reindexAsync(path, Integer.MAX_VALUE);
+    }
+
+    /**
+     * This is not included in the public API because users can easily mess up the indexes if the depth is incorrect. For example,
+     * if a node with children is renamed, but the depth is only sufficient to re-index the node, then the children will appear
+     * under the old path. Because of this complexity, we can hide this full re-indexing capability until it is actually needed to
+     * be exposed.
+     * <p>
+     * However, this method is still useful when used properly, so we are keeping it (just not exposing it).
+     * </p>
+     * 
+     * @param path
+     * @param depth
+     * @return the future
+     * @throws RepositoryException
      */
     public Future<Boolean> reindexAsync( final String path,
                                          final int depth ) throws RepositoryException {

--- a/modeshape-jcr/src/test/java/org/modeshape/jcr/JcrRepositoryTest.java
+++ b/modeshape-jcr/src/test/java/org/modeshape/jcr/JcrRepositoryTest.java
@@ -814,7 +814,7 @@ public class JcrRepositoryTest {
     @FixFor( "MODE-1269" )
     public void shouldAllowReindexingSubsetOfWorkspace() throws Exception {
         session = createSession();
-        session.getWorkspace().reindex("/", 2);
+        session.getWorkspace().reindex("/");
     }
 
     @Test
@@ -830,7 +830,7 @@ public class JcrRepositoryTest {
     @FixFor( "MODE-1269" )
     public void shouldAllowAsynchronousReindexingSubsetOfWorkspace() throws Exception {
         session = createSession();
-        Future<Boolean> future = session.getWorkspace().reindexAsync("/", 2);
+        Future<Boolean> future = session.getWorkspace().reindexAsync("/");
         assertThat(future, is(notNullValue()));
         assertThat(future.get(), is(true)); // get() blocks until done
     }


### PR DESCRIPTION
Having the maximum depth parameter in the reindex methods will likely cause far more issues and problems that will be difficult to track down. In fact, specifying the depth can be more optimum (but no better) than indexing to the fullest depth only in a few cases. Since keeping the depth parameter is extremely risky with very little benefit, I've removed the depth parameter from the public methods (which have not yet appeared in a release).

We may indeed discover that the depth is very useful, and if that's the case we can always add additional methods with a depth parameter. Adding methods to a public API is easy; removing methods is nearly impossible.

This testing also highlighted a bug in the way the Lucene indexes were updated to remove children below some depth. This bug was corrected.

As always, all unit and integration tests pass with these changes.
