### PR TITLE
MODE-1277 Corrected result behavior for multi-selector join queries

### DIFF
--- a/modeshape-graph/src/main/java/org/modeshape/graph/query/QueryResults.java
+++ b/modeshape-graph/src/main/java/org/modeshape/graph/query/QueryResults.java
@@ -291,6 +291,15 @@ public interface QueryResults extends Serializable {
         public int getColumnIndexForName( String columnName );
 
         /**
+         * Get the name of the selector that produced the column with the given name.
+         * 
+         * @param columnName the column name
+         * @return the selector name
+         * @throws NoSuchElementException if the column name is invalid or doesn't match an existing column
+         */
+        public String getSelectorNameForColumnName( String columnName );
+
+        /**
          * Get the index of the column given the name of the selector and the property name from where the column should be
          * obtained.
          * 

--- a/modeshape-graph/src/main/java/org/modeshape/graph/query/process/QueryResultColumns.java
+++ b/modeshape-graph/src/main/java/org/modeshape/graph/query/process/QueryResultColumns.java
@@ -75,6 +75,7 @@ public class QueryResultColumns implements Columns {
     private final List<String> columnTypes;
     private final List<String> selectorNames;
     private List<String> tupleValueNames;
+    private final Map<String, String> selectorNameByColumnName;
     private final Map<String, Integer> columnIndexByColumnName;
     private final Map<String, Integer> locationIndexBySelectorName;
     private final Map<String, Integer> locationIndexByColumnName;
@@ -118,6 +119,7 @@ public class QueryResultColumns implements Columns {
         this.locationIndexBySelectorName = new HashMap<String, Integer>();
         this.locationIndexByColumnIndex = new HashMap<Integer, Integer>();
         this.locationIndexByColumnName = new HashMap<String, Integer>();
+        this.selectorNameByColumnName = new HashMap<String, String>();
         this.columnIndexByPropertyNameBySelectorName = new HashMap<String, Map<String, Integer>>();
         List<String> selectorNames = new ArrayList<String>(columnCount);
         List<String> names = new ArrayList<String>(columnCount);
@@ -133,6 +135,7 @@ public class QueryResultColumns implements Columns {
             }
             String columnName = columnNameFor(column, names, sameNameColumns);
             assert columnName != null;
+            selectorNameByColumnName.put(columnName, selectorName);
             columnIndexByColumnName.put(columnName, new Integer(i));
             locationIndexByColumnIndex.put(new Integer(i), selectorIndex);
             locationIndexByColumnName.put(columnName, selectorIndex);
@@ -173,6 +176,7 @@ public class QueryResultColumns implements Columns {
         this.locationIndexByColumnIndex = new HashMap<Integer, Integer>();
         this.locationIndexByColumnName = new HashMap<String, Integer>();
         this.columnIndexByPropertyNameBySelectorName = new HashMap<String, Map<String, Integer>>();
+        this.selectorNameByColumnName = new HashMap<String, String>();
         this.selectorNames = new ArrayList<String>(columns.size());
         List<String> types = new ArrayList<String>(columns.size());
         List<String> names = new ArrayList<String>(columns.size());
@@ -184,6 +188,7 @@ public class QueryResultColumns implements Columns {
             if (!selectorNames.contains(selectorName)) selectorNames.add(selectorName);
             String columnName = columnNameFor(column, names, sameNameColumns);
             assert columnName != null;
+            selectorNameByColumnName.put(columnName, selectorName);
             Integer columnIndex = wrappedAround.columnIndexForName(columnName);
             if (columnIndex == null) {
                 String columnNameWithoutSelector = column.columnName() != null ? column.columnName() : column.propertyName();
@@ -458,6 +463,15 @@ public class QueryResultColumns implements Columns {
 
     protected Integer columnIndexForName( String columnName ) {
         return columnIndexByColumnName.get(columnName);
+    }
+
+    /**
+     * {@inheritDoc}
+     * 
+     * @see org.modeshape.graph.query.QueryResults.Columns#getSelectorNameForColumnName(java.lang.String)
+     */
+    public String getSelectorNameForColumnName( String columnName ) {
+        return selectorNameByColumnName.get(columnName);
     }
 
     /**

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/query/JcrQueryResult.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/query/JcrQueryResult.java
@@ -631,11 +631,11 @@ public class JcrQueryResult implements org.modeshape.jcr.api.query.QueryResult {
          * @see org.modeshape.jcr.api.query.Row#getNode(java.lang.String)
          */
         public Node getNode( String selectorName ) throws RepositoryException {
-            int locationIndex = iterator.columns.getLocationIndex(selectorName);
-            if (locationIndex == -1) {
+            int nodeIndex = iterator.columns.getSelectorNames().indexOf(selectorName);
+            if (nodeIndex == -1) {
                 throw new RepositoryException(JcrI18n.selectorNotUsedInQuery.text(selectorName, iterator.query));
             }
-            return nodes[locationIndex];
+            return nodes[nodeIndex];
         }
 
         /**
@@ -644,13 +644,15 @@ public class JcrQueryResult implements org.modeshape.jcr.api.query.QueryResult {
          * @see javax.jcr.query.Row#getValue(java.lang.String)
          */
         public Value getValue( String columnName ) throws ItemNotFoundException, RepositoryException {
-            int locationIndex = iterator.columns.getLocationIndexForColumn(columnName);
-            if (locationIndex == -1) {
+            String selectorName = iterator.columns.getSelectorNameForColumnName(columnName);
+            int nodeIndex = iterator.columns.getSelectorNames().indexOf(selectorName);
+            if (nodeIndex == -1) {
                 throw new RepositoryException(JcrI18n.queryResultsDoNotIncludeColumn.text(columnName, iterator.query));
             }
-            Node node = nodes[locationIndex];
+            Node node = nodes[nodeIndex];
             if (node == null) return null;
             if (PSEUDO_COLUMNS.contains(columnName)) {
+                int locationIndex = iterator.columns.getLocationIndexForColumn(columnName);
                 if (JCR_PATH_COLUMN_NAME.equals(columnName)) {
                     Location location = (Location)tuple[locationIndex];
                     return iterator.jcrPath(location.getPath());


### PR DESCRIPTION
I've replicated the error in a test case, and it appears to be a problem in the results of join queries. The problem was that the code for MultiSelectorQueryResultRow was a) using the wrong index and b) calculating the index incorrectly. The problems were fixed and verified with a successful test. 

All unit and integration tests pass with the changes.

Note that the changes are limited in scope to the MultiSelectorQueryResult class (used only in join queries) and a few additional methods (and state) in some of the o.m.g.query.\* classes that are never used outside of the MultiSelectorQueryResult class. Therefore, the risk of unintentional changing the behavior of other functionality is quite low, while the benefit is that this issue is fixed.
