### PR TITLE
MODE-1279 Corrected deadlock between save() and query execution.

### DIFF
--- a/extensions/modeshape-search-lucene/src/main/java/org/modeshape/search/lucene/LuceneSearchEngine.java
+++ b/extensions/modeshape-search-lucene/src/main/java/org/modeshape/search/lucene/LuceneSearchEngine.java
@@ -31,9 +31,6 @@ import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.locks.Lock;
-import java.util.concurrent.locks.ReadWriteLock;
-import java.util.concurrent.locks.ReentrantReadWriteLock;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.standard.StandardAnalyzer;
 import org.apache.lucene.document.Field;
@@ -65,10 +62,7 @@ import org.modeshape.graph.search.SearchEngineException;
 import org.modeshape.graph.search.SearchEngineIndexer;
 
 /**
- * A {@link SearchEngine} implementation that relies upon two separate indexes to manage the node properties and the node
- * structure (path and children). Using two indexes is more efficient when the node content and structure are updated
- * independently. For example, the structure of the nodes changes whenever same-name-sibling indexes are changed, when sibling
- * nodes are deleted, or when nodes are moved around; in all of these cases, the properties of the nodes do not change.
+ * A {@link SearchEngine} implementation that uses Lucene for the backing indexes.
  */
 public class LuceneSearchEngine extends AbstractLuceneSearchEngine<LuceneSearchWorkspace, LuceneSearchProcessor> {
 
@@ -123,7 +117,6 @@ public class LuceneSearchEngine extends AbstractLuceneSearchEngine<LuceneSearchW
     private final IndexRules.Factory rulesFactory;
     private final Analyzer analyzer;
     private final int maxDepthPerIndexRead;
-    private final ReadWriteLock processingLock = new ReentrantReadWriteLock();
 
     /**
      * Create a new instance of a {@link SearchEngine} that uses Lucene and a two-index design, and that stores the indexes using
@@ -233,9 +226,7 @@ public class LuceneSearchEngine extends AbstractLuceneSearchEngine<LuceneSearchW
                                                      Workspaces<LuceneSearchWorkspace> workspaces,
                                                      Observer observer,
                                                      boolean readOnly ) {
-        final Lock lock = readOnly ? processingLock.readLock() : processingLock.writeLock();
-        lock.lock();
-        return new LuceneSearchProcessor(getSourceName(), context, workspaces, observer, null, readOnly, lock);
+        return new LuceneSearchProcessor(getSourceName(), context, workspaces, observer, null, readOnly);
     }
 
     /**

--- a/extensions/modeshape-search-lucene/src/main/java/org/modeshape/search/lucene/LuceneSearchProcessor.java
+++ b/extensions/modeshape-search-lucene/src/main/java/org/modeshape/search/lucene/LuceneSearchProcessor.java
@@ -29,7 +29,6 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.concurrent.locks.Lock;
 import org.apache.lucene.queryParser.ParseException;
 import org.apache.lucene.search.Query;
 import org.modeshape.common.annotation.NotThreadSafe;
@@ -73,17 +72,13 @@ public class LuceneSearchProcessor extends AbstractLuceneProcessor<LuceneSearchW
     protected static final Columns FULL_TEXT_RESULT_COLUMNS = new FullTextSearchResultColumns();
     private static final Logger logger = Logger.getLogger(LuceneSearchProcessor.class);
 
-    private final Lock lock;
-
     protected LuceneSearchProcessor( String sourceName,
                                      ExecutionContext context,
                                      Workspaces<LuceneSearchWorkspace> workspaces,
                                      Observer observer,
                                      DateTime now,
-                                     boolean readOnly,
-                                     Lock lock ) {
+                                     boolean readOnly ) {
         super(sourceName, context, workspaces, observer, now, readOnly);
-        this.lock = lock;
     }
 
     /**
@@ -93,11 +88,7 @@ public class LuceneSearchProcessor extends AbstractLuceneProcessor<LuceneSearchW
      */
     @Override
     public void close() {
-        try {
-            super.close();
-        } finally {
-            this.lock.unlock();
-        }
+        super.close();
     }
 
     /**

--- a/extensions/modeshape-search-lucene/src/test/java/org/modeshape/search/lucene/LuceneSearchSessionTest.java
+++ b/extensions/modeshape-search-lucene/src/test/java/org/modeshape/search/lucene/LuceneSearchSessionTest.java
@@ -26,7 +26,6 @@ package org.modeshape.search.lucene;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.mock;
-import java.util.concurrent.locks.ReentrantLock;
 import org.junit.Before;
 import org.junit.Test;
 import org.modeshape.graph.ExecutionContext;
@@ -48,7 +47,7 @@ public class LuceneSearchSessionTest {
         DateTime now = context.getValueFactories().getDateFactory().create();
         Workspaces<LuceneSearchWorkspace> workspaces = mock(Workspaces.class);
         LuceneSearchWorkspace workspace = mock(LuceneSearchWorkspace.class);
-        processor = new LuceneSearchProcessor("source", context, workspaces, observer, now, true, new ReentrantLock());
+        processor = new LuceneSearchProcessor("source", context, workspaces, observer, now, true);
         search = new LuceneSearchSession(workspace, processor);
     }
 

--- a/modeshape-graph/src/main/java/org/modeshape/graph/connector/federation/ForkRequestProcessor.java
+++ b/modeshape-graph/src/main/java/org/modeshape/graph/connector/federation/ForkRequestProcessor.java
@@ -108,6 +108,7 @@ class ForkRequestProcessor extends RequestProcessor {
     private final RepositoryConnectionFactory connectionFactory;
     private final Map<String, CompositeRequestChannel> channelBySourceName = new HashMap<String, CompositeRequestChannel>();
     private final Queue<FederatedRequest> federatedRequestQueue;
+    private final boolean readonly;
 
     /**
      * Create a new fork processor
@@ -115,15 +116,18 @@ class ForkRequestProcessor extends RequestProcessor {
      * @param repository the federated repository configuration; never null
      * @param context the execution context in which this processor is executing; may not be null
      * @param now the timestamp representing the current time in UTC; may not be null
+     * @param readonly true if the requests are known to be read only, or false otherwise
      * @param federatedRequestQueue the queue into which should be placed the {@link FederatedRequest} objects created by this
      *        processor that still must be post-processed
      */
     public ForkRequestProcessor( FederatedRepository repository,
                                  ExecutionContext context,
                                  DateTime now,
+                                 boolean readonly,
                                  Queue<FederatedRequest> federatedRequestQueue ) {
         super(repository.getSourceName(), context, null, now);
         this.repository = repository;
+        this.readonly = readonly;
         this.executor = this.repository.getExecutor();
         this.connectionFactory = this.repository.getConnectionFactory();
         this.federatedRequestQueue = federatedRequestQueue;
@@ -146,7 +150,7 @@ class ForkRequestProcessor extends RequestProcessor {
         assert request != null;
         CompositeRequestChannel channel = channelBySourceName.get(sourceName);
         if (channel == null) {
-            channel = new CompositeRequestChannel(sourceName);
+            channel = new CompositeRequestChannel(sourceName, readonly);
             channelBySourceName.put(sourceName, channel);
             channel.start(executor, getExecutionContext(), connectionFactory);
         }
@@ -170,7 +174,7 @@ class ForkRequestProcessor extends RequestProcessor {
         assert request != null;
         CompositeRequestChannel channel = channelBySourceName.get(sourceName);
         if (channel == null) {
-            channel = new CompositeRequestChannel(sourceName);
+            channel = new CompositeRequestChannel(sourceName, readonly);
             channelBySourceName.put(sourceName, channel);
             channel.start(executor, getExecutionContext(), connectionFactory);
         }
@@ -199,7 +203,7 @@ class ForkRequestProcessor extends RequestProcessor {
         assert request != null;
         CompositeRequestChannel channel = channelBySourceName.get(sourceName);
         if (channel == null) {
-            channel = new CompositeRequestChannel(sourceName);
+            channel = new CompositeRequestChannel(sourceName, readonly);
             channelBySourceName.put(sourceName, channel);
             channel.start(executor, getExecutionContext(), connectionFactory);
         }

--- a/modeshape-graph/src/main/java/org/modeshape/graph/request/CompositeRequestChannel.java
+++ b/modeshape-graph/src/main/java/org/modeshape/graph/request/CompositeRequestChannel.java
@@ -88,11 +88,13 @@ public class CompositeRequestChannel {
      * 
      * @param sourceName the name of the repository source used to execute this channel's {@link #allRequests() requests}; may not
      *        be null or empty
+     * @param readonly true if the requests are known to be read only, or false otherwise
      */
-    public CompositeRequestChannel( final String sourceName ) {
+    public CompositeRequestChannel( final String sourceName,
+                                    boolean readonly ) {
         assert sourceName != null;
         this.sourceName = sourceName;
-        this.composite = new ChannelCompositeRequest();
+        this.composite = new ChannelCompositeRequest(readonly);
     }
 
     /**
@@ -374,8 +376,8 @@ public class CompositeRequestChannel {
         private static final long serialVersionUID = 1L;
         private final LinkedList<Request> allRequests = CompositeRequestChannel.this.allRequests;
 
-        protected ChannelCompositeRequest() {
-            super(false);
+        protected ChannelCompositeRequest( boolean readonly ) {
+            super(readonly);
         }
 
         /**

--- a/modeshape-graph/src/main/java/org/modeshape/graph/request/VerifyWorkspaceRequest.java
+++ b/modeshape-graph/src/main/java/org/modeshape/graph/request/VerifyWorkspaceRequest.java
@@ -104,7 +104,7 @@ public final class VerifyWorkspaceRequest extends Request implements Cloneable {
      */
     @Override
     public boolean isReadOnly() {
-        return false;
+        return true;
     }
 
     /**

--- a/modeshape-graph/src/main/java/org/modeshape/graph/search/SearchableRepositorySource.java
+++ b/modeshape-graph/src/main/java/org/modeshape/graph/search/SearchableRepositorySource.java
@@ -481,7 +481,7 @@ public class SearchableRepositorySource implements RepositorySource {
                                                 return delegateConnection();
                                             }
                                         };
-                                        channel = new CompositeRequestChannel(delegate().getName());
+                                        channel = new CompositeRequestChannel(delegate().getName(), true);
                                         channel.start(executorService, context, connectionFactory);
                                     }
                                     channel.add(request);

--- a/modeshape-graph/src/test/java/org/modeshape/graph/connector/federation/ForkRequestProcessorTest.java
+++ b/modeshape-graph/src/test/java/org/modeshape/graph/connector/federation/ForkRequestProcessorTest.java
@@ -38,6 +38,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
 import org.modeshape.graph.ExecutionContext;
 import org.modeshape.graph.Location;
 import org.modeshape.graph.connector.MockRepositoryConnection;
@@ -46,15 +50,11 @@ import org.modeshape.graph.connector.federation.Projection.Rule;
 import org.modeshape.graph.property.DateTime;
 import org.modeshape.graph.property.Name;
 import org.modeshape.graph.property.Path;
+import org.modeshape.graph.property.Path.Segment;
 import org.modeshape.graph.property.PathNotFoundException;
 import org.modeshape.graph.property.Property;
-import org.modeshape.graph.property.Path.Segment;
 import org.modeshape.graph.request.InvalidWorkspaceException;
 import org.modeshape.graph.request.ReadNodeRequest;
-import org.junit.Before;
-import org.junit.Test;
-import org.mockito.MockitoAnnotations;
-import org.mockito.Mock;
 
 /**
  * 
@@ -134,7 +134,7 @@ public class ForkRequestProcessorTest {
         // projectionC = new Projection(sourceNameC, workspaceNameC, rules("/c => /"));
 
         // Now set up the processor ...
-        processor = new ForkRequestProcessor(repository, context, now, federatedRequests);
+        processor = new ForkRequestProcessor(repository, context, now, false, federatedRequests);
     }
 
     protected Rule[] rules( String... rule ) {

--- a/modeshape-graph/src/test/java/org/modeshape/graph/request/CompositeRequestChannelTest.java
+++ b/modeshape-graph/src/test/java/org/modeshape/graph/request/CompositeRequestChannelTest.java
@@ -64,7 +64,7 @@ public class CompositeRequestChannelTest {
         MockitoAnnotations.initMocks(this);
         context = new ExecutionContext();
         sourceName = "SourceA";
-        channel = new CompositeRequestChannel(sourceName);
+        channel = new CompositeRequestChannel(sourceName, false);
         requests = new ArrayList<Request>();
         requests.add(new MockRequest());
         requests.add(new MockRequest());
@@ -94,8 +94,7 @@ public class CompositeRequestChannelTest {
         public RequestType getType() {
             return RequestType.INVALID;
         }
-        
-        
+
     }
 
     @Test

--- a/modeshape-integration-tests/src/test/java/org/modeshape/test/integration/jdbc/JcrDriverIntegrationTest.java
+++ b/modeshape-integration-tests/src/test/java/org/modeshape/test/integration/jdbc/JcrDriverIntegrationTest.java
@@ -71,10 +71,11 @@ import org.modeshape.test.ModeShapeMultiUseTest;
  * </p>
  * <p>
  * To create the expected results to be used to run a test, use the test and print method: example:
- * ConnectionResultsComparator.executeTestAndPrint(this.connection, "SELECT * FROM [nt:base]"); This will print the expected results like this:
- * String[] expected = { "jcr:primaryType[STRING]", "mode:root", "car:Car", "car:Car", "nt:unstructured" } Now copy the expected
- * results to the test method. Then change the test to run the executeTest method passing in the <code>expected</code> results:
- * example: ConnectionResultsComparator.executeTest(this.connection, "SELECT * FROM [nt:base]", expected);
+ * ConnectionResultsComparator.executeTestAndPrint(this.connection, "SELECT * FROM [nt:base]"); This will print the expected
+ * results like this: String[] expected = { "jcr:primaryType[STRING]", "mode:root", "car:Car", "car:Car", "nt:unstructured" } Now
+ * copy the expected results to the test method. Then change the test to run the executeTest method passing in the
+ * <code>expected</code> results: example: ConnectionResultsComparator.executeTest(this.connection, "SELECT * FROM [nt:base]",
+ * expected);
  * </p>
  */
 public class JcrDriverIntegrationTest extends ModeShapeMultiUseTest {
@@ -188,54 +189,34 @@ public class JcrDriverIntegrationTest extends ModeShapeMultiUseTest {
     public void shouldBeAbleToExecuteSqlSelectAllNodes() throws SQLException {
         String[] expected = {
             "jcr:primaryType[STRING]    jcr:path[STRING]    jcr:name[STRING]    jcr:score[DOUBLE]    mode:localName[STRING]    mode:depth[LONG]",
-            "mode:root    /        1.0        0", "car:Car    /Cars/Utility/Hummer H3    Hummer H3    1.0    Hummer H3    3",
-            "car:Car    /Cars/Sports/Infiniti G37    Infiniti G37    1.0    Infiniti G37    3",
-            "nt:unstructured    /Cars/Utility    Utility    1.0    Utility    2",
-            "nt:unstructured    /Cars    Cars    1.0    Cars    1",
-            "car:Car    /Cars/Luxury/Cadillac DTS    Cadillac DTS    1.0    Cadillac DTS    3",
+            "mode:root    /        1.0        0", "nt:unstructured    /Cars    Cars    1.0    Cars    1",
             "nt:unstructured    /Cars/Hybrid    Hybrid    1.0    Hybrid    2",
             "car:Car    /Cars/Hybrid/Nissan Altima    Nissan Altima    1.0    Nissan Altima    3",
-            "car:Car    /Cars/Utility/Land Rover LR2    Land Rover LR2    1.0    Land Rover LR2    3",
+            "car:Car    /Cars/Hybrid/Toyota Highlander    Toyota Highlander    1.0    Toyota Highlander    3",
             "car:Car    /Cars/Hybrid/Toyota Prius    Toyota Prius    1.0    Toyota Prius    3",
-            "car:Car    /Cars/Utility/Ford F-150    Ford F-150    1.0    Ford F-150    3",
-            "nt:unstructured    /Cars/Sports    Sports    1.0    Sports    2",
-            "car:Car    /Cars/Sports/Aston Martin DB9    Aston Martin DB9    1.0    Aston Martin DB9    3",
             "nt:unstructured    /Cars/Luxury    Luxury    1.0    Luxury    2",
             "car:Car    /Cars/Luxury/Bentley Continental    Bentley Continental    1.0    Bentley Continental    3",
-            "car:Car    /Cars/Utility/Land Rover LR3    Land Rover LR3    1.0    Land Rover LR3    3",
-            "car:Car    /Cars/Hybrid/Toyota Highlander    Toyota Highlander    1.0    Toyota Highlander    3",
+            "car:Car    /Cars/Luxury/Cadillac DTS    Cadillac DTS    1.0    Cadillac DTS    3",
             "car:Car    /Cars/Luxury/Lexus IS350    Lexus IS350    1.0    Lexus IS350    3",
-            "nt:unstructured    /Other/NodeA[2]    NodeA    1.0    NodeA    2",
+            "nt:unstructured    /Cars/Sports    Sports    1.0    Sports    2",
+            "car:Car    /Cars/Sports/Aston Martin DB9    Aston Martin DB9    1.0    Aston Martin DB9    3",
+            "car:Car    /Cars/Sports/Infiniti G37    Infiniti G37    1.0    Infiniti G37    3",
+            "nt:unstructured    /Cars/Utility    Utility    1.0    Utility    2",
+            "car:Car    /Cars/Utility/Ford F-150    Ford F-150    1.0    Ford F-150    3",
+            "car:Car    /Cars/Utility/Hummer H3    Hummer H3    1.0    Hummer H3    3",
+            "car:Car    /Cars/Utility/Land Rover LR2    Land Rover LR2    1.0    Land Rover LR2    3",
+            "car:Car    /Cars/Utility/Land Rover LR3    Land Rover LR3    1.0    Land Rover LR3    3",
+            "nt:unstructured    /NodeB    NodeB    1.0    NodeB    1", "nt:unstructured    /Other    Other    1.0    Other    1",
             "nt:unstructured    /Other/NodeA    NodeA    1.0    NodeA    2",
-            "nt:unstructured    /NodeB    NodeB    1.0    NodeB    1",
-            "nt:unstructured    /Other/NodeA[3]    NodeA    1.0    NodeA    2",
-            "nt:unstructured    /Other    Other    1.0    Other    1"};
+            "nt:unstructured    /Other/NodeA[2]    NodeA    1.0    NodeA    2",
+            "nt:unstructured    /Other/NodeA[3]    NodeA    1.0    NodeA    2"};
 
-        ConnectionResultsComparator.executeTest(this.connection, "SELECT * FROM [nt:base]", expected, 23);
+        ConnectionResultsComparator.executeTest(this.connection, "SELECT * FROM [nt:base] ORDER BY [jcr:path]", expected, 23);
     }
 
     @Test
     public void shouldBeAbleToExecuteSqlSelectAllCars() throws SQLException {
 
-        String[] expected = {
-            "car:maker[STRING]    car:model[STRING]    car:year[STRING]    car:msrp[STRING]    car:userRating[LONG]    car:valueRating[LONG]    car:mpgCity[LONG]    car:mpgHighway[LONG]    car:lengthInInches[DOUBLE]    car:wheelbaseInInches[DOUBLE]    car:engine[STRING]    jcr:primaryType[STRING]    jcr:path[STRING]    jcr:name[STRING]    jcr:score[DOUBLE]    mode:localName[STRING]    mode:depth[LONG]",
-            "Hummer    H3    2008    $30,595    3    4    13    16    null    null    null    car:Car    /Cars/Utility/Hummer H3    Hummer H3    1.5705448389053345    Hummer H3    3",
-            "Infiniti    G37    2008    $34,900    3    4    18    24    null    null    null    car:Car    /Cars/Sports/Infiniti G37    Infiniti G37    1.5705448389053345    Infiniti G37    3",
-            "Cadillac    DTS    2008    null    1    null    null    null    null    null    3.6 liter V6    car:Car    /Cars/Luxury/Cadillac DTS    Cadillac DTS    1.5705448389053345    Cadillac DTS    3",
-            "Nissan    Altima    2008    $18,260    null    null    23    32    null    null    null    car:Car    /Cars/Hybrid/Nissan Altima    Nissan Altima    1.5705448389053345    Nissan Altima    3",
-            "Land Rover    LR2    2008    $33,985    4    5    16    23    null    null    null    car:Car    /Cars/Utility/Land Rover LR2    Land Rover LR2    1.5705448389053345    Land Rover LR2    3",
-            "Toyota    Prius    2008    $21,500    4    5    48    45    null    null    null    car:Car    /Cars/Hybrid/Toyota Prius    Toyota Prius    1.5705448389053345    Toyota Prius    3",
-            "Ford    F-150    2008    $23,910    5    1    14    20    null    null    null    car:Car    /Cars/Utility/Ford F-150    Ford F-150    1.5705448389053345    Ford F-150    3",
-            "Aston Martin    DB9    2008    $171,600    5    null    12    19    185.5    108.0    5,935 cc 5.9 liters V 12    car:Car    /Cars/Sports/Aston Martin DB9    Aston Martin DB9    1.5705448389053345    Aston Martin DB9    3",
-            "Bentley    Continental    2008    $170,990    null    null    10    17    null    null    null    car:Car    /Cars/Luxury/Bentley Continental    Bentley Continental    1.5705448389053345    Bentley Continental    3",
-            "Land Rover    LR3    2008    $48,525    5    2    12    17    null    null    null    car:Car    /Cars/Utility/Land Rover LR3    Land Rover LR3    1.5705448389053345    Land Rover LR3    3",
-            "Toyota    Highlander    2008    $34,200    4    5    27    25    null    null    null    car:Car    /Cars/Hybrid/Toyota Highlander    Toyota Highlander    1.5705448389053345    Toyota Highlander    3",
-            "Lexus    IS350    2008    $36,305    4    5    18    25    null    null    null    car:Car    /Cars/Luxury/Lexus IS350    Lexus IS350    1.5705448389053345    Lexus IS350    3"};
-        ConnectionResultsComparator.executeTest(this.connection, "SELECT * FROM [car:Car]", expected, 12);
-    }
-
-    @Test
-    public void shouldBeAbleToExecuteSqlQueryWithOrderByClauseUsingDefault() throws SQLException {
         String[] expected = {
             "car:maker[STRING]    car:model[STRING]    car:year[STRING]    car:msrp[STRING]    car:userRating[LONG]    car:valueRating[LONG]    car:mpgCity[LONG]    car:mpgHighway[LONG]    car:lengthInInches[DOUBLE]    car:wheelbaseInInches[DOUBLE]    car:engine[STRING]    jcr:primaryType[STRING]    jcr:path[STRING]    jcr:name[STRING]    jcr:score[DOUBLE]    mode:localName[STRING]    mode:depth[LONG]",
             "Aston Martin    DB9    2008    $171,600    5    null    12    19    185.5    108.0    5,935 cc 5.9 liters V 12    car:Car    /Cars/Sports/Aston Martin DB9    Aston Martin DB9    1.5705448389053345    Aston Martin DB9    3",
@@ -248,11 +229,12 @@ public class JcrDriverIntegrationTest extends ModeShapeMultiUseTest {
             "Land Rover    LR3    2008    $48,525    5    2    12    17    null    null    null    car:Car    /Cars/Utility/Land Rover LR3    Land Rover LR3    1.5705448389053345    Land Rover LR3    3",
             "Lexus    IS350    2008    $36,305    4    5    18    25    null    null    null    car:Car    /Cars/Luxury/Lexus IS350    Lexus IS350    1.5705448389053345    Lexus IS350    3",
             "Nissan    Altima    2008    $18,260    null    null    23    32    null    null    null    car:Car    /Cars/Hybrid/Nissan Altima    Nissan Altima    1.5705448389053345    Nissan Altima    3",
-            "Toyota    Prius    2008    $21,500    4    5    48    45    null    null    null    car:Car    /Cars/Hybrid/Toyota Prius    Toyota Prius    1.5705448389053345    Toyota Prius    3",
-            "Toyota    Highlander    2008    $34,200    4    5    27    25    null    null    null    car:Car    /Cars/Hybrid/Toyota Highlander    Toyota Highlander    1.5705448389053345    Toyota Highlander    3"};
-
-        ConnectionResultsComparator.executeTest(this.connection, "SELECT * FROM [car:Car] ORDER BY [car:maker]", expected, 12);
-
+            "Toyota    Highlander    2008    $34,200    4    5    27    25    null    null    null    car:Car    /Cars/Hybrid/Toyota Highlander    Toyota Highlander    1.5705448389053345    Toyota Highlander    3",
+            "Toyota    Prius    2008    $21,500    4    5    48    45    null    null    null    car:Car    /Cars/Hybrid/Toyota Prius    Toyota Prius    1.5705448389053345    Toyota Prius    3"};
+        ConnectionResultsComparator.executeTest(this.connection,
+                                                "SELECT * FROM [car:Car] ORDER BY [car:maker], [car:model]",
+                                                expected,
+                                                12);
     }
 
     @Test
@@ -296,7 +278,7 @@ public class JcrDriverIntegrationTest extends ModeShapeMultiUseTest {
             "Toyota    Highlander    2008    $34,200"};
 
         ConnectionResultsComparator.executeTest(this.connection,
-                                                "SELECT car.[car:maker], car.[car:model], car.[car:year], car.[car:msrp] FROM [car:Car] AS car WHERE PATH(car) LIKE '%/Hybrid/%'",
+                                                "SELECT car.[car:maker], car.[car:model], car.[car:year], car.[car:msrp] FROM [car:Car] AS car WHERE PATH(car) LIKE '%/Hybrid/%' ORDER BY car.[car:maker]",
                                                 expected,
                                                 3);
 
@@ -312,7 +294,7 @@ public class JcrDriverIntegrationTest extends ModeShapeMultiUseTest {
             "Toyota    Highlander    2008    $34,200"};
 
         ConnectionResultsComparator.executeTest(this.connection,
-                                                "SELECT car.[car:maker], car.[car:model], car.[car:year], car.[car:msrp] FROM [car:Car] AS car JOIN [nt:unstructured] AS hybrid ON ISCHILDNODE(car,hybrid) WHERE NAME(hybrid) = 'Hybrid'",
+                                                "SELECT car.[car:maker], car.[car:model], car.[car:year], car.[car:msrp] FROM [car:Car] AS car JOIN [nt:unstructured] AS hybrid ON ISCHILDNODE(car,hybrid) WHERE NAME(hybrid) = 'Hybrid' ORDER BY car.[car:maker]",
                                                 expected,
                                                 3);
 
@@ -359,12 +341,12 @@ public class JcrDriverIntegrationTest extends ModeShapeMultiUseTest {
     public void shouldBeAbleToExecuteSqlQueryWithChildAxisCriteria() throws SQLException {
         String[] expected = {
             "jcr:primaryType[STRING]    jcr:path[STRING]    jcr:name[STRING]    jcr:score[DOUBLE]    mode:localName[STRING]    mode:depth[LONG]",
-            "nt:unstructured    /Cars/Utility    Utility    1.4142135381698608    Utility    2",
             "nt:unstructured    /Cars/Hybrid    Hybrid    1.4142135381698608    Hybrid    2",
+            "nt:unstructured    /Cars/Luxury    Luxury    1.4142135381698608    Luxury    2",
             "nt:unstructured    /Cars/Sports    Sports    1.4142135381698608    Sports    2",
-            "nt:unstructured    /Cars/Luxury    Luxury    1.4142135381698608    Luxury    2"};
+            "nt:unstructured    /Cars/Utility    Utility    1.4142135381698608    Utility    2"};
         ConnectionResultsComparator.executeTest(this.connection,
-                                                "SELECT * FROM nt:base WHERE jcr:path LIKE '/Cars/%' AND NOT jcr:path LIKE '/Cars/%/%' ",
+                                                "SELECT * FROM nt:base WHERE jcr:path LIKE '/Cars/%' AND NOT jcr:path LIKE '/Cars/%/%'  ORDER BY jcr:path",
                                                 expected,
                                                 4,
                                                 QueryLanguage.JCR_SQL);
@@ -380,13 +362,13 @@ public class JcrDriverIntegrationTest extends ModeShapeMultiUseTest {
     public void shouldBeAbleToExecuteSqlQueryWithContainsCriteria() throws SQLException {
         String[] expected = {
             "jcr:primaryType[STRING]    jcr:path[STRING]    jcr:name[STRING]    jcr:score[DOUBLE]    mode:localName[STRING]    mode:depth[LONG]",
-            "nt:unstructured    /Cars/Utility    Utility    1.4142135381698608    Utility    2",
             "nt:unstructured    /Cars/Hybrid    Hybrid    1.4142135381698608    Hybrid    2",
+            "nt:unstructured    /Cars/Luxury    Luxury    1.4142135381698608    Luxury    2",
             "nt:unstructured    /Cars/Sports    Sports    1.4142135381698608    Sports    2",
-            "nt:unstructured    /Cars/Luxury    Luxury    1.4142135381698608    Luxury    2"};
+            "nt:unstructured    /Cars/Utility    Utility    1.4142135381698608    Utility    2"};
 
         ConnectionResultsComparator.executeTest(this.connection,
-                                                "SELECT * FROM nt:base WHERE jcr:path LIKE '/Cars/%' AND NOT jcr:path LIKE '/Cars/%/%'",
+                                                "SELECT * FROM nt:base WHERE jcr:path LIKE '/Cars/%' AND NOT jcr:path LIKE '/Cars/%/%' ORDER BY jcr:path",
                                                 expected,
                                                 4,
                                                 QueryLanguage.JCR_SQL);
@@ -750,7 +732,7 @@ public class JcrDriverIntegrationTest extends ModeShapeMultiUseTest {
     @Test
     public void shouldGetAllColumnsFor1Table() throws SQLException {
         results.compareColumns = false;
-       
+
         String[] expected = {
             "TABLE_CAT[String]    TABLE_SCHEM[String]    TABLE_NAME[String]    COLUMN_NAME[String]    DATA_TYPE[Long]    TYPE_NAME[String]    COLUMN_SIZE[Long]    BUFFER_LENGTH[Long]    DECIMAL_DIGITS[Long]    NUM_PREC_RADIX[Long]    NULLABLE[Long]    REMARKS[String]    COLUMN_DEF[String]    SQL_DATA_TYPE[Long]    SQL_DATETIME_SUB[Long]    CHAR_OCTET_LENGTH[Long]    ORDINAL_POSITION[Long]    IS_NULLABLE[String]    SCOPE_CATLOG[String]    SCOPE_SCHEMA[String]    SCOPE_TABLE[String]    SOURCE_DATA_TYPE[Long]",
             "Repo    NULL    car:Car    car:engine    12    STRING    50    NULL    0    0    2        NULL    0    0    0    1    YES    NULL    NULL    NULL    0",
@@ -769,10 +751,8 @@ public class JcrDriverIntegrationTest extends ModeShapeMultiUseTest {
             "Repo    NULL    car:Car    jcr:primaryType    12    STRING    20    NULL    0    0    1        NULL    0    0    0    14    NO    NULL    NULL    NULL    0",
             "Repo    NULL    car:Car    jcr:score    8    DOUBLE    20    NULL    0    0    2        NULL    0    0    0    15    YES    NULL    NULL    NULL    0",
             "Repo    NULL    car:Car    mode:depth    -5    LONG    20    NULL    0    0    2        NULL    0    0    0    16    YES    NULL    NULL    NULL    0",
-            "Repo    NULL    car:Car    mode:localName    12    STRING    50    NULL    0    0    2        NULL    0    0    0    17    YES    NULL    NULL    NULL    0"
-            };
-        
-        
+            "Repo    NULL    car:Car    mode:localName    12    STRING    50    NULL    0    0    2        NULL    0    0    0    17    YES    NULL    NULL    NULL    0"};
+
         ResultSet rs = dbmd.getColumns("%", "%", "car:Car", "%");
 
         results.assertResultsSetEquals(rs, expected);
@@ -821,14 +801,12 @@ public class JcrDriverIntegrationTest extends ModeShapeMultiUseTest {
             "Repo    NULL    car:Car    jcr:primaryType    12    STRING    20    NULL    0    0    1        NULL    0    0    0    14    NO    NULL    NULL    NULL    0",
             "Repo    NULL    car:Car    jcr:score    8    DOUBLE    20    NULL    0    0    2        NULL    0    0    0    15    YES    NULL    NULL    NULL    0",
             "Repo    NULL    car:Car    mode:depth    -5    LONG    20    NULL    0    0    2        NULL    0    0    0    16    YES    NULL    NULL    NULL    0",
-            "Repo    NULL    car:Car    mode:localName    12    STRING    50    NULL    0    0    2        NULL    0    0    0    17    YES    NULL    NULL    NULL    0"
-            };
+            "Repo    NULL    car:Car    mode:localName    12    STRING    50    NULL    0    0    2        NULL    0    0    0    17    YES    NULL    NULL    NULL    0"};
 
         ResultSet rs = dbmd.getColumns("%", "%", "car%", "%");
 
         results.assertResultsSetEquals(rs, expected);
         results.assertRowCount(11);
-
 
     }
 
@@ -838,14 +816,13 @@ public class JcrDriverIntegrationTest extends ModeShapeMultiUseTest {
 
         String[] expected = {
             "TABLE_CAT[String]    TABLE_SCHEM[String]    TABLE_NAME[String]    COLUMN_NAME[String]    DATA_TYPE[Long]    TYPE_NAME[String]    COLUMN_SIZE[Long]    BUFFER_LENGTH[Long]    DECIMAL_DIGITS[Long]    NUM_PREC_RADIX[Long]    NULLABLE[Long]    REMARKS[String]    COLUMN_DEF[String]    SQL_DATA_TYPE[Long]    SQL_DATETIME_SUB[Long]    CHAR_OCTET_LENGTH[Long]    ORDINAL_POSITION[Long]    IS_NULLABLE[String]    SCOPE_CATLOG[String]    SCOPE_SCHEMA[String]    SCOPE_TABLE[String]    SOURCE_DATA_TYPE[Long]",
-            "Repo    NULL    car:Car    car:msrp    12    STRING    50    NULL    0    0    2        NULL    0    0    0    1    YES    NULL    NULL    NULL    0"
-            };
-        
+            "Repo    NULL    car:Car    car:msrp    12    STRING    50    NULL    0    0    2        NULL    0    0    0    1    YES    NULL    NULL    NULL    0"};
+
         ResultSet rs = dbmd.getColumns("%", "%", "car:Car", "car:msrp");
-      
+
         results.assertResultsSetEquals(rs, expected);
         results.assertRowCount(1);
-        
+
     }
 
     @FixFor( "MODE-981" )

--- a/utils/modeshape-unit-test/src/main/java/org/modeshape/test/ModeShapeUnitTest.java
+++ b/utils/modeshape-unit-test/src/main/java/org/modeshape/test/ModeShapeUnitTest.java
@@ -1155,15 +1155,15 @@ public abstract class ModeShapeUnitTest {
         }
         assertThat(results, is(notNullValue()));
         assert results != null;
-        if (expectedNumberOfResults >= 0L) {
-            assertThat("Expected different number of rows from '" + queryExpression + "'",
-                       results.getRows().getSize(),
-                       is(expectedNumberOfResults));
-        }
         if (print) {
             System.out.println(queryExpression);
             System.out.println(results);
             System.out.println();
+        }
+        if (expectedNumberOfResults >= 0L) {
+            assertThat("Expected different number of rows from '" + queryExpression + "'",
+                       results.getRows().getSize(),
+                       is(expectedNumberOfResults));
         }
         return results;
     }


### PR DESCRIPTION
I've replicated the issue with a new unit test and discovered the bug was caused by a deadlock between the indexing that resulted from a save() and the user-invoked query.

I found a fix for this that is minimally intrusive and low-risk. It basically involves a few things:

1) A few changes to the federation connector to do a better job about knowing whether the incoming requests are all read-only, and if so to submit this info with the corresponding requests to the source connector(s). IOW, passing down a bit more state. This change is very low-risk.

2) Eliminating a read-write lock within the search engine component that wraps Lucene. Lucene 2.x used a pretty poor locking mechanism for the indexes, so we had to put a read-write lock in our layer to prevent concurrent writes. However, Lucene 3.x (which we've been using for a while), Lucene has had a really good native file system locking mechanism, so our lock was actually superfluous. Yet that lock was the thing that was causing our contention, and eliminating it results in my unit test passing (even when repeating it over and over).

3) Changes to some test cases to accommodate the changes in several constructors.

With these changes, all unit and integration tests pass.
