### PR TITLE
MODE-1285 JPA entities are now Serializable

### DIFF
--- a/extensions/modeshape-connector-store-jpa/src/main/java/org/modeshape/connector/store/jpa/model/common/ChangeLogEntity.java
+++ b/extensions/modeshape-connector-store-jpa/src/main/java/org/modeshape/connector/store/jpa/model/common/ChangeLogEntity.java
@@ -40,7 +40,7 @@ import org.modeshape.graph.property.basic.JodaDateTime;
  * Represents a record of the changes that have been made to the repository. The actual change events are serialized and stored in
  * a binary (and compressed) format.
  * 
- * @deprecated
+ * @deprecated This is no longer used.
  */
 @Deprecated
 @Entity

--- a/extensions/modeshape-connector-store-jpa/src/main/java/org/modeshape/connector/store/jpa/model/common/NamespaceEntity.java
+++ b/extensions/modeshape-connector-store-jpa/src/main/java/org/modeshape/connector/store/jpa/model/common/NamespaceEntity.java
@@ -23,6 +23,7 @@
  */
 package org.modeshape.connector.store.jpa.model.common;
 
+import java.io.Serializable;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.EntityManager;
@@ -46,7 +47,9 @@ import org.modeshape.common.util.CheckArg;
 @org.hibernate.annotations.Table( appliesTo = "DNA_NAMESPACES", indexes = @Index( name = "NS_URI_INX", columnNames = {"URI"} ) )
 @NamedQueries( {@NamedQuery( name = "NamespaceEntity.findAll", query = "select ns from NamespaceEntity as ns" ),
     @NamedQuery( name = "NamespaceEntity.findByUri", query = "select ns from NamespaceEntity as ns where ns.uri = ?1" )} )
-public class NamespaceEntity {
+public class NamespaceEntity implements Serializable {
+
+    private static final long serialVersionUID = 1L;
 
     @Id
     @GeneratedValue( strategy = GenerationType.AUTO )

--- a/extensions/modeshape-connector-store-jpa/src/main/java/org/modeshape/connector/store/jpa/model/common/WorkspaceEntity.java
+++ b/extensions/modeshape-connector-store-jpa/src/main/java/org/modeshape/connector/store/jpa/model/common/WorkspaceEntity.java
@@ -23,6 +23,7 @@
  */
 package org.modeshape.connector.store.jpa.model.common;
 
+import java.io.Serializable;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -50,7 +51,9 @@ import org.modeshape.common.util.CheckArg;
 @NamedQueries( {@NamedQuery( name = "WorkspaceEntity.findAll", query = "select ws from WorkspaceEntity as ws" ),
     @NamedQuery( name = "WorkspaceEntity.findByName", query = "select ws from WorkspaceEntity as ws where ws.name = :name" ),
     @NamedQuery( name = "WorkspaceEntity.findAllNames", query = "select ws.name from WorkspaceEntity as ws" )} )
-public class WorkspaceEntity {
+public class WorkspaceEntity implements Serializable {
+
+    private static final long serialVersionUID = 1L;
 
     @Id
     @GeneratedValue( strategy = GenerationType.AUTO )

--- a/extensions/modeshape-connector-store-jpa/src/main/java/org/modeshape/connector/store/jpa/model/simple/LargeValueEntity.java
+++ b/extensions/modeshape-connector-store-jpa/src/main/java/org/modeshape/connector/store/jpa/model/simple/LargeValueEntity.java
@@ -23,6 +23,7 @@
  */
 package org.modeshape.connector.store.jpa.model.simple;
 
+import java.io.Serializable;
 import java.security.NoSuchAlgorithmException;
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -47,7 +48,9 @@ import org.modeshape.graph.property.PropertyType;
 @Entity
 @Table( name = "MODE_SIMPLE_LARGE_VALUES" )
 @NamedQuery( name = "LargeValueEntity.deleteAllUnused", query = "delete LargeValueEntity lve where lve.hash not in (select values.hash from NodeEntity node join node.largeValues values)" )
-public class LargeValueEntity {
+public class LargeValueEntity implements Serializable {
+
+    private static final long serialVersionUID = 1L;
 
     /**
      * The MySQL delete statement to remove all unused LargeValueEntity records.

--- a/extensions/modeshape-connector-store-jpa/src/main/java/org/modeshape/connector/store/jpa/model/simple/NodeEntity.java
+++ b/extensions/modeshape-connector-store-jpa/src/main/java/org/modeshape/connector/store/jpa/model/simple/NodeEntity.java
@@ -23,6 +23,7 @@
  */
 package org.modeshape.connector.store.jpa.model.simple;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
@@ -70,7 +71,9 @@ import org.modeshape.connector.store.jpa.util.Serializer;
     @NamedQuery( name = "NodeEntity.findByNodeUuid", query = "from NodeEntity as node where node.workspaceId = :workspaceId and node.nodeUuidString = :nodeUuidString" ),
     @NamedQuery( name = "NodeEntity.deleteAllInWorkspace", query = "delete from NodeEntity where workspaceId = :workspaceId" ),
     @NamedQuery( name = "NodeEntity.withLargeValues", query = "from NodeEntity as node where node.workspaceId = :workspaceId and size(node.largeValues) > 0" )} )
-public class NodeEntity {
+public class NodeEntity implements Serializable {
+
+    private static final long serialVersionUID = 1L;
 
     @Id
     @GeneratedValue( strategy = GenerationType.AUTO )

--- a/extensions/modeshape-connector-store-jpa/src/main/java/org/modeshape/connector/store/jpa/model/simple/SubgraphNodeEntity.java
+++ b/extensions/modeshape-connector-store-jpa/src/main/java/org/modeshape/connector/store/jpa/model/simple/SubgraphNodeEntity.java
@@ -23,6 +23,7 @@
  */
 package org.modeshape.connector.store.jpa.model.simple;
 
+import java.io.Serializable;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
@@ -62,7 +63,9 @@ import org.hibernate.annotations.Index;
     // "delete ReferenceEntity as ref where ref.id.workspaceId = :workspaceId and ref.id.fromUuidString in ( select node.nodeUuid from SubgraphNodeEntity node where node.queryId = :queryId )"
     // ),
     @NamedQuery( name = "SubgraphNodeEntity.deleteByQueryId", query = "delete SubgraphNodeEntity where queryId = :queryId" )} )
-public class SubgraphNodeEntity {
+public class SubgraphNodeEntity implements Serializable {
+
+    private static final long serialVersionUID = 1L;
 
     @Id
     @Column( name = "ID" )

--- a/extensions/modeshape-connector-store-jpa/src/main/java/org/modeshape/connector/store/jpa/model/simple/SubgraphQueryEntity.java
+++ b/extensions/modeshape-connector-store-jpa/src/main/java/org/modeshape/connector/store/jpa/model/simple/SubgraphQueryEntity.java
@@ -23,6 +23,7 @@
  */
 package org.modeshape.connector.store.jpa.model.simple;
 
+import java.io.Serializable;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
@@ -33,7 +34,9 @@ import javax.persistence.Id;
  * Represents a temporary working area for a query that retrieves the nodes in a subgraph.
  */
 @Entity( name = "MODE_SUBGRAPH_QUERIES" )
-public class SubgraphQueryEntity {
+public class SubgraphQueryEntity implements Serializable {
+
+    private static final long serialVersionUID = 1L;
 
     @Id
     @GeneratedValue( strategy = GenerationType.AUTO )

--- a/extensions/modeshape-connector-store-jpa/src/main/java/org/modeshape/connector/store/jpa/util/StoreOptionEntity.java
+++ b/extensions/modeshape-connector-store-jpa/src/main/java/org/modeshape/connector/store/jpa/util/StoreOptionEntity.java
@@ -23,6 +23,7 @@
  */
 package org.modeshape.connector.store.jpa.util;
 
+import java.io.Serializable;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.Id;
@@ -42,7 +43,9 @@ import org.modeshape.connector.store.jpa.Model;
  */
 @Entity( name = "MODE_OPTIONS" )
 @NamedQueries( {@NamedQuery( name = "StoreOptionEntity.findAll", query = "SELECT option FROM MODE_OPTIONS AS option" )} )
-public class StoreOptionEntity {
+public class StoreOptionEntity implements Serializable {
+
+    private static final long serialVersionUID = 1L;
 
     @Id
     @Column( name = "NAME", nullable = false, length = 128 )


### PR DESCRIPTION
Changed the JPA entities in the JPA connector to all be serializable. They should have been Serializable in the first place, as Hibernate clustered cache implementations require this.

All unit and integration tests pass.
