### PR TITLE
MODE-1309 Corrected query behavior when using residual properties in join criteria

### DIFF
--- a/modeshape-graph/src/main/java/org/modeshape/graph/query/QueryResults.java
+++ b/modeshape-graph/src/main/java/org/modeshape/graph/query/QueryResults.java
@@ -282,6 +282,14 @@ public interface QueryResults extends Serializable {
         public String getPropertyNameForColumn( int columnIndex );
 
         /**
+         * Get the name of the property that corresponds to the named column in each tuple.
+         * 
+         * @param columnName the column name
+         * @return the property name, or the supplied column name if there is no property for it
+         */
+        public String getPropertyNameForColumnName( String columnName );
+
+        /**
          * Get the index of the column given the column name.
          * 
          * @param columnName the column name

--- a/modeshape-graph/src/main/java/org/modeshape/graph/query/optimize/RewriteIdentityJoins.java
+++ b/modeshape-graph/src/main/java/org/modeshape/graph/query/optimize/RewriteIdentityJoins.java
@@ -36,9 +36,9 @@ import org.modeshape.graph.query.model.JoinCondition;
 import org.modeshape.graph.query.model.SameNodeJoinCondition;
 import org.modeshape.graph.query.model.SelectorName;
 import org.modeshape.graph.query.plan.PlanNode;
-import org.modeshape.graph.query.plan.PlanUtil;
 import org.modeshape.graph.query.plan.PlanNode.Property;
 import org.modeshape.graph.query.plan.PlanNode.Type;
+import org.modeshape.graph.query.plan.PlanUtil;
 import org.modeshape.graph.query.validate.Schemata;
 import org.modeshape.graph.query.validate.Schemata.Table;
 
@@ -121,20 +121,24 @@ public class RewriteIdentityJoins implements OptimizerRule {
                 String rightColumnName = equiJoin.property2Name();
                 Schemata.Column leftColumn = table.getColumn(leftColumnName);
                 Schemata.Column rightColumn = table.getColumn(rightColumnName);
-                if (leftColumn == null) {
-                    context.getProblems().addError(GraphI18n.columnDoesNotExistOnTable, leftColumnName, leftTableName);
-                    continue;
-                }
-                if (rightColumn == null) {
-                    context.getProblems().addError(GraphI18n.columnDoesNotExistOnTable, rightColumnName, leftTableName);
-                    continue;
-                }
-                // Are the join columns (on both sides) keys?
-                if (table.hasKey(leftColumn) && (rightColumn == leftColumn || table.hasKey(rightColumn))) {
-                    // It meets all the criteria, so rewrite this join node ...
-                    if (rewrittenSelectors == null) rewrittenSelectors = new HashMap<SelectorName, SelectorName>();
-                    rewriteJoinNode(context, joinNode, rewrittenSelectors);
-                    ++rewrittenJoins;
+                if (leftColumn != null && rightColumn != null) {
+                    // Are the join columns (on both sides) keys?
+                    if (table.hasKey(leftColumn) && (rightColumn == leftColumn || table.hasKey(rightColumn))) {
+                        // It meets all the criteria, so rewrite this join node ...
+                        if (rewrittenSelectors == null) rewrittenSelectors = new HashMap<SelectorName, SelectorName>();
+                        rewriteJoinNode(context, joinNode, rewrittenSelectors);
+                        ++rewrittenJoins;
+                    }
+                } else {
+                    // one or both of the columns must be residual properties ...
+                    // if (leftColumn == null) {
+                    // context.getProblems().addError(GraphI18n.columnDoesNotExistOnTable, leftColumnName, leftTableName);
+                    // continue;
+                    // }
+                    // if (rightColumn == null) {
+                    // context.getProblems().addError(GraphI18n.columnDoesNotExistOnTable, rightColumnName, leftTableName);
+                    // continue;
+                    // }
                 }
             } else if (condition instanceof SameNodeJoinCondition) {
                 SameNodeJoinCondition sameNodeCondition = (SameNodeJoinCondition)condition;

--- a/modeshape-jcr/src/test/java/org/modeshape/jcr/JcrQueryManagerTest.java
+++ b/modeshape-jcr/src/test/java/org/modeshape/jcr/JcrQueryManagerTest.java
@@ -158,12 +158,23 @@ public class JcrQueryManagerTest {
 
                 // Create a branch that contains some same-name-siblings ...
                 Node other = session.getRootNode().addNode("Other", "nt:unstructured");
-                other.addNode("NodeA", "nt:unstructured").setProperty("something", "value3 quick brown fox");
-                other.addNode("NodeA", "nt:unstructured").setProperty("something", "value2 quick brown cat");
-                other.addNode("NodeA", "nt:unstructured").setProperty("something", "value1 quick black dog");
+                Node a = other.addNode("NodeA", "nt:unstructured");
+                a.setProperty("something", "value3 quick brown fox");
+                a.setProperty("somethingElse", "value2");
+                a.setProperty("propA", "value1");
+                Node other2 = other.addNode("NodeA", "nt:unstructured");
+                other2.setProperty("something", "value2 quick brown cat");
+                other2.setProperty("propB", "value1");
+                other2.setProperty("propC", "value2");
+                Node other3 = other.addNode("NodeA", "nt:unstructured");
+                other3.setProperty("something", new String[] {"black dog", "white dog"});
+                other3.setProperty("propB", "value1");
+                other3.setProperty("propC", "value3");
                 Node c = other.addNode("NodeC", "notion:typed");
                 c.setProperty("notion:booleanProperty", true);
                 c.setProperty("notion:booleanProperty2", false);
+                c.setProperty("propD", "value4");
+                c.setProperty("propC", "value1");
                 session.getRootNode().addNode("NodeB", "nt:unstructured").setProperty("myUrl", "http://www.acme.com/foo/bar");
                 session.save();
 
@@ -562,6 +573,102 @@ public class JcrQueryManagerTest {
         QueryResult result = query.execute();
         assertThat(result, is(notNullValue()));
         assertResults(query, result, 24);
+        assertResultsHaveColumns(result, minimumColumnNames());
+    }
+
+    @FixFor( "MODE-1309" )
+    @Test
+    public void shouldBeAbleToCreateAndExecuteJcrSql2QueryUsingResidualPropertiesForJoinCriteria() throws RepositoryException {
+        String sql = "SELECT x.propA AS pa, y.propB as pb FROM [nt:unstructured] AS x INNER JOIN [nt:unstructured] AS y ON x.propA = y.propB WHERE x.propA = 'value1'";
+        Query query = session.getWorkspace().getQueryManager().createQuery(sql, Query.JCR_SQL2);
+        assertThat(query, is(notNullValue()));
+        // print = true;
+        QueryResult result = query.execute();
+        assertThat(result, is(notNullValue()));
+        assertResults(query, result, 2);
+        assertResultsHaveColumns(result, "pa", "pb");
+        RowIterator rows = result.getRows();
+        Row row1 = rows.nextRow();
+        Set<String> expectedPaths = new HashSet<String>();
+        expectedPaths.add("/Other/NodeA[2]");
+        expectedPaths.add("/Other/NodeA[3]");
+        assertThat(row1.getValue("pa").getString(), is("value1")); // same value from either row
+        assertThat(row1.getValue("pb").getString(), is("value1")); // same value from either row
+        assertThat(row1.getNode("x").getPath(), is("/Other/NodeA"));
+        assertThat(expectedPaths.remove(row1.getNode("y").getPath()), is(true));
+        Row row2 = rows.nextRow();
+        assertThat(row2.getValue("pa").getString(), is("value1")); // same value from either row
+        assertThat(row2.getValue("pb").getString(), is("value1")); // same value from either row
+        assertThat(row2.getNode("x").getPath(), is("/Other/NodeA"));
+        assertThat(expectedPaths.remove(row2.getNode("y").getPath()), is(true));
+    }
+
+    @FixFor( "MODE-1309" )
+    @Test
+    public void shouldBeAbleToCreateAndExecuteJcrSql2QuerySelectingResidualProperty() throws RepositoryException {
+        String sql = "SELECT a.propB FROM [nt:unstructured] AS a WHERE a.propB = 'value1'";
+        Query query = session.getWorkspace().getQueryManager().createQuery(sql, Query.JCR_SQL2);
+        assertThat(query, is(notNullValue()));
+        QueryResult result = query.execute();
+        assertThat(result, is(notNullValue()));
+        assertResults(query, result, 2);
+        assertResultsHaveColumns(result, "propB");
+        Row row1 = result.getRows().nextRow();
+        assertThat(row1.getValue("propB").getString(), is("value1")); // same value from either row
+    }
+
+    @FixFor( "MODE-1309" )
+    @Test
+    public void shouldBeAbleToCreateAndExecuteJcrSql2QuerySelectingResidualPropertyWithAlias() throws RepositoryException {
+        String sql = "SELECT a.propB AS foo FROM [nt:unstructured] AS a WHERE a.propB = 'value1'";
+        Query query = session.getWorkspace().getQueryManager().createQuery(sql, Query.JCR_SQL2);
+        assertThat(query, is(notNullValue()));
+        QueryResult result = query.execute();
+        assertThat(result, is(notNullValue()));
+        assertResults(query, result, 2);
+        assertResultsHaveColumns(result, "foo");
+        Row row1 = result.getRows().nextRow();
+        assertThat(row1.getValue("foo").getString(), is("value1")); // same value from either row
+    }
+
+    @FixFor( "MODE-1309" )
+    @Test
+    public void shouldBeAbleToCreateAndExecuteJcrSql2QuerySelectingResidualPropertyWithAliasUsingAliasInConstraint()
+        throws RepositoryException {
+        String sql = "SELECT a.propB AS foo FROM [nt:unstructured] AS a WHERE a.foo = 'value1'";
+        Query query = session.getWorkspace().getQueryManager().createQuery(sql, Query.JCR_SQL2);
+        assertThat(query, is(notNullValue()));
+        QueryResult result = query.execute();
+        assertThat(result, is(notNullValue()));
+        assertResults(query, result, 2);
+        assertResultsHaveColumns(result, "foo");
+        Row row1 = result.getRows().nextRow();
+        assertThat(row1.getValue("foo").getString(), is("value1")); // same value from either row
+    }
+
+    @Test
+    public void shouldBeAbleToCreateAndExecuteJcrSql2QueryToFindAllUnstructuredNodesWithCriteriaOnMultiValuedProperty()
+        throws RepositoryException {
+        String sql = "SELECT * FROM [nt:unstructured] WHERE something = 'white dog' and something = 'black dog'";
+        Query query = session.getWorkspace().getQueryManager().createQuery(sql, Query.JCR_SQL2);
+        assertThat(query, is(notNullValue()));
+        // print = true;
+        QueryResult result = query.execute();
+        assertThat(result, is(notNullValue()));
+        assertResults(query, result, 1);
+        assertResultsHaveColumns(result, minimumColumnNames());
+    }
+
+    @Test
+    public void shouldBeAbleToCreateAndExecuteJcrSql2QueryToFindAllUnstructuredNodesWithLikeCriteriaOnMultiValuedProperty()
+        throws RepositoryException {
+        String sql = "SELECT * FROM [nt:unstructured] WHERE something LIKE 'white%' and something LIKE 'black%'";
+        Query query = session.getWorkspace().getQueryManager().createQuery(sql, Query.JCR_SQL2);
+        assertThat(query, is(notNullValue()));
+        // print = true;
+        QueryResult result = query.execute();
+        assertThat(result, is(notNullValue()));
+        assertResults(query, result, 1);
         assertResultsHaveColumns(result, minimumColumnNames());
     }
 
@@ -1845,7 +1952,8 @@ public class JcrQueryManagerTest {
     public void shouldBeAbleToExecuteXPathQueryWithRangeCriteria() throws RepositoryException {
         Query query = session.getWorkspace()
                              .getQueryManager()
-                             .createQuery("/jcr:root/Other/*[@something <= 'value2' and @something > 'value1']", Query.XPATH);
+                             .createQuery("/jcr:root/Other/*[@somethingElse <= 'value2' and @somethingElse > 'value1']",
+                                          Query.XPATH);
         assertThat(query, is(notNullValue()));
         QueryResult result = query.execute();
         assertThat(result, is(notNullValue()));
@@ -1948,7 +2056,7 @@ public class JcrQueryManagerTest {
         Query query = session.getWorkspace().getQueryManager().createQuery(sql, Query.JCR_SQL2);
         assertThat(query, is(notNullValue()));
         QueryResult result = query.execute();
-        assertThat(result.getRows().getSize(), is(3L));
+        assertThat(result.getRows().getSize(), is(2L));
         for (NodeIterator iter = result.getNodes(); iter.hasNext();) {
             assertThat(iter.nextNode().hasProperty("something"), is(true));
         }


### PR DESCRIPTION
Found and fixed a couple of problems. First, aliases were not being treated properly, so any projected column with an alias was not actually connected to the underlying property in the Lucene document. Secondly, the exception reported above was due to an unnecessary check, which failed when the column corresponded to a residual property (since the residual properties are not in the schema).

Added a number of new unit tests to verify that such queries (including variations) are handled correctly. For example, the new tests verify that the criteria can reference the aliased columns, even though neither of the supplied queries use the aliases in the criteria.

All unit and integration tests pass with these changes.
