### PR TITLE
MODE-1313 Corrected wrapping of exception for invalid identifier

### DIFF
--- a/modeshape-common/src/main/java/org/modeshape/common/util/StringUtil.java
+++ b/modeshape-common/src/main/java/org/modeshape/common/util/StringUtil.java
@@ -37,8 +37,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import org.modeshape.common.annotation.Immutable;
 import org.modeshape.common.CommonI18n;
+import org.modeshape.common.annotation.Immutable;
 
 /**
  * Utilities for string processing and manipulation.
@@ -481,8 +481,11 @@ public class StringUtil {
 
     /**
      * Returns true if the given string is null or represents the empty string
+     * 
+     * @param str the string; may be null or empty
+     * @return true if the string is null or contains only whitespace
      */
-    public static boolean isBlank(String str) {
+    public static boolean isBlank( String str ) {
         return str == null || str.trim().isEmpty();
     }
 

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrSession.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrSession.java
@@ -872,7 +872,13 @@ class JcrSession implements Session {
                 return getNode(path);
             } catch (org.modeshape.graph.property.ValueFormatException e2) {
                 // It's not a path either ...
-                throw new RepositoryException(JcrI18n.identifierPathContainedUnsupportedIdentifierFormat.text(id));
+                throw new RepositoryException(JcrI18n.identifierPathContainedUnsupportedIdentifierFormat.text(id), e2);
+            } catch (org.modeshape.graph.property.InvalidPathException e2) {
+                // It's an invalid path either ...
+                throw new RepositoryException(JcrI18n.identifierPathContainedUnsupportedIdentifierFormat.text(id), e2);
+            } catch (RuntimeException e2) {
+                // Something unexpected happened ...
+                throw new RepositoryException(JcrI18n.identifierPathContainedUnsupportedIdentifierFormat.text(id), e2);
             }
         }
     }


### PR DESCRIPTION
When processing invalid identifiers, the Session.getNodeByIdentifier(String) method was throwing an internal exception that should be wrapped in a RepositoryException. This commit adds the check for this condition.

All unit and integration tests pass.

This should be merged onto the 'master' and '3.x' branches.
