### PR TITLE
MODE-1314 Corrected JPA 2nd-level cache configuration for Hiberante 3.3+

### DIFF
--- a/extensions/modeshape-connector-store-jpa/src/main/java/org/modeshape/connector/store/jpa/JpaConnectorI18n.java
+++ b/extensions/modeshape-connector-store-jpa/src/main/java/org/modeshape/connector/store/jpa/JpaConnectorI18n.java
@@ -149,6 +149,9 @@ public final class JpaConnectorI18n {
     public static I18n cacheProviderClassNamePropertyDescription;
     public static I18n cacheProviderClassNamePropertyLabel;
     public static I18n cacheProviderClassNamePropertyCategory;
+    public static I18n cacheManagerLookupPropertyDescription;
+    public static I18n cacheManagerLookupPropertyLabel;
+    public static I18n cacheManagerLookupPropertyCategory;
     public static I18n cacheConcurrencyStrategyPropertyDescription;
     public static I18n cacheConcurrencyStrategyPropertyLabel;
     public static I18n cacheConcurrencyStrategyPropertyCategory;

--- a/extensions/modeshape-connector-store-jpa/src/main/resources/org/modeshape/connector/store/jpa/JpaConnectorI18n.properties
+++ b/extensions/modeshape-connector-store-jpa/src/main/resources/org/modeshape/connector/store/jpa/JpaConnectorI18n.properties
@@ -162,6 +162,10 @@ cacheProviderClassNamePropertyDescription = Specifies the class name of the cach
 cacheProviderClassNamePropertyLabel = Cache Provider Class Name
 cacheProviderClassNamePropertyCategory = Advanced
 
+cacheManagerLookupPropertyDescription = Specifies the location of the existing Infinispan cache manager in JBoss AS 6 or 7.  The default value of "null" should be used in all other cases. Changes made to this value at runtime will be ignored.
+cacheManagerLookupPropertyLabel = Cache Manager
+cacheManagerLookupPropertyCategory = Advanced
+
 cacheConcurrencyStrategyPropertyDescription = Specifies the cache concurrency strategy to use.  When Hibernate is used as the JPA provider, valid values are "read-only", "transactional", "nonstrict-read-write", and "read-write".  Changes made to this value at runtime will be ignored.
 cacheConcurrencyStrategyPropertyLabel = Cache Concurrency Strategy
 cacheConcurrencyStrategyPropertyCategory = Advanced


### PR DESCRIPTION
The `cacheProviderClassName` can now safely be set to a `RegionFactory` implementation class, and the JPA connector does the appropriate thing. Note that when using a version of Hibernate earlier than 3.3, the class name of the `ProviderClass` implementation should be used for the value.

Also, a new property was added to the JPA connector in ModeShape 2.7. The `cacheManagerLookup` connector property can now be used when configuring Infinispan 2nd level cache to specify where in JNDI the Infinispan cache manager can be found.

All unit and integration tests pass.
