### PR TITLE
MODE-1327 Corrected JPA Source's use of RepositorySourceCapabilities

### DIFF
--- a/extensions/modeshape-connector-store-jpa/src/main/java/org/modeshape/connector/store/jpa/JpaSource.java
+++ b/extensions/modeshape-connector-store-jpa/src/main/java/org/modeshape/connector/store/jpa/JpaSource.java
@@ -447,9 +447,7 @@ public class JpaSource implements RepositorySource, ObjectFactory {
      * @param allowsUpdates true if this source allows updating content, or false if this source only allows reading content.
      */
     public synchronized void setAllowsUpdates( boolean allowsUpdates ) {
-        capabilities = new RepositorySourceCapabilities(capabilities.supportsSameNameSiblings(), allowsUpdates,
-                                                        capabilities.supportsEvents(), capabilities.supportsCreatingWorkspaces(),
-                                                        capabilities.supportsReferences());
+        capabilities = capabilities.withUpdates(allowsUpdates);
     }
 
     /**
@@ -763,9 +761,7 @@ public class JpaSource implements RepositorySource, ObjectFactory {
      * @see #isCreatingWorkspacesAllowed()
      */
     public synchronized void setCreatingWorkspacesAllowed( boolean allowWorkspaceCreation ) {
-        capabilities = new RepositorySourceCapabilities(capabilities.supportsSameNameSiblings(), capabilities.supportsUpdates(),
-                                                        capabilities.supportsEvents(), allowWorkspaceCreation,
-                                                        capabilities.supportsReferences());
+        capabilities = capabilities.withCreatingWorkspaces(allowWorkspaceCreation);
     }
 
     /**


### PR DESCRIPTION
There were two places where `RepositorySourceCapabilities` objects were being constructed to replace the existing instance. These were removed and replaced with calls to the `capabilities.withCreatingWorkspaces(boolean)` and `capabilities.withUpdates(boolean)` methods (which properly construct and return a new instance).

All unit and integration tests pass with these changes.

Note that these changes should be applied to the 'master' and '3.x' branches.
