### PR TITLE
MODE-1328 Added to public API methods to register the node types defined in CND & XML files

### DIFF
--- a/docs/reference/src/main/docbook/en-US/content/jcr/jcr.xml
+++ b/docs/reference/src/main/docbook/en-US/content/jcr/jcr.xml
@@ -1072,7 +1072,7 @@ nodeTypeManager.unregisterNodeTypes(unusedNodeTypeNames);
 			</para>
 		</sect3>
 		<sect3>
-				<title>Reading JCR CND files</title>
+				<title>Reading node type definition files</title>
 			<para>
 			Custom node types can be defined more succinctly through the CND file format defined by the JCR 2.0 specification.  In fact, this is how JBoss
 			ModeShape defines its built-in node types. An example CND file that declares the same node type as above would be:
@@ -1083,50 +1083,30 @@ nodeTypeManager.unregisterNodeTypes(unusedNodeTypeNames);
 </programlisting>	
 			This definition could then be registered as part of the repository configuration
 			(see the <link linkend="programmatically_configuring_repositories">previous chapter</link>).  Or, you can also
-			use a Session to programmatically register the node types in a CND file, but this requires ModeShape-specific class to read this file:
+			use a Session to programmatically register the node types in a CND file, but this requires casting the node type manager
+			to a ModeShape-specific interface in the
+			<code>modeshape-jcr-api</code> module:
 <programlisting>&Session; session = ...
-&CndNodeTypeReader; reader = new &CndNodeTypeReader;(session);
-reader.read(cndFile); // from file, file system path, classpath resource, URL, etc.
+&ModeShapeNodeTypeManager; nodeTypeMgr = (org.modeshape.jcr.nodetype.NodeTypeManager)
+                              session.getWorkspace().getNodeTypeManager();
+boolean allowUpdate = true;
+File file = ...  // or InputStream or URL
+nodeTypeMgr.registerNodeTypeDefinitions(file,allowUpdate);
+</programlisting>
 
-if (!reader.getProblems().isEmpty()) {
-  for (&Problem; problem : nodeTypeSource.getProblems()) {
-    // report or record problem
-  }
-} else {
-  boolean allowUpdate = ...
-  &NodeTypeManager; nodeTypeManager = session.getWorkspace().getNodeTypeManager();
-  nodeTypeManager.registerNodeTypes(reader.getNodeTypeDefinitions(), allowUpdate);
-}</programlisting>
-
-      The &CndNodeTypeReader; class provides a number of <code>read(...)</code> methods that accept &File;s, paths to files on the file system,
-      the names of resources on the classpath, &URLs;, and &InputStream;s. And &CndNodeTypeReader; will also register any namespace mappings
-      defined in the CND file but not yet registered in the session or workspace. For details, see the JavaDoc for &CndNodeTypeReader;.
-			If you have multiple CND files, you can either call <code>read(...)</code> multiple times before
-      registering (as long as the CND files don't contain duplicate node type definitions), or you can simply create and use a new reader
-      for each CND file. The choice is yours.
+      ModeShape's &ModeShapeNodeTypeManager; interface extends the standard <code>javax.jcr.nodetype.NodeTypeManager</code> interface
+      and provides <code>registerNodeTypeDefinitions(...)</code> methods overloaded to accept &File;, 
+      &URL;, and &InputStream; instances. The content of these files can be the standard CND file format or the non-standard
+      XML format used by Jackrabbit.
+      These methods are also functionally similar to the standard methods that register arrays of &NodeTypeDefinition; objects
+      in that they have a second <code>allowUpdates</code> parameter specifying whether existing node types can be updated.
+      However, note that these methods will automatically register any namespaces declared in the files but not yet registered with the workspace.
 	  </para>
+	  <note>
+	    <para>This technique was added to ModeShape 2.7, and replaces the now-deprecated &CndNodeTypeReader; and &JackrabbitXmlNodeTypeReader; classes,
+	      which will be removed in ModeShape 3.0.</para>
+	  </note>
 	</sect3>
-	<sect3>
-			<title>Reading Jackrabbit XML Node Type Files</title>
-  	<para>
-			ModeShape also provides a class that reads the node types defined in a Jackrabbit XML format. This is useful if you've been using Jackrabbit,
-			have defined your custom node types in the Jackrabbit-specific format, but want to switch to ModeShape and don't want to have to manually
-			convert your node types in the standard CND format. This class is used almost identically to the &CndNodeTypeReader; class described above:
-<programlisting>&Session; session = ...
-&JackrabbitXmlNodeTypeReader; reader = new &JackrabbitXmlNodeTypeReader;(session);
-reader.read(cndFile); // from file, file system path, classpath resource, URL, etc.
-
-if (!reader.getProblems().isEmpty()) {
-  for (&Problem; problem : nodeTypeSource.getProblems()) {
-    // report or record problem
-  }
-} else {
-  boolean allowUpdate = ...
-  &NodeTypeManager; nodeTypeManager = session.getWorkspace().getNodeTypeManager();
-  nodeTypeManager.registerNodeTypes(reader.getNodeTypeDefinitions(), allowUpdate);
-}</programlisting>
-			</para>
-		</sect3>
 	</sect2>
 	</sect1>
 	<sect1>

--- a/docs/reference/src/main/docbook/en-US/custom.dtd
+++ b/docs/reference/src/main/docbook/en-US/custom.dtd
@@ -268,6 +268,7 @@
 <!ENTITY JaasCredentials				  		"<ulink url='&API;jcr/api/JaasCredentials.html'><classname>JaasCredentials</classname></ulink>">
 <!ENTITY Repositories				  		    "<ulink url='&API;jcr/api/Repositories.html'><classname>Repositories</classname></ulink>">
 <!ENTITY ServletCredentials				  	"<ulink url='&API;jcr/api/ServletCredentials.html'><classname>ServletCredentials</classname></ulink>">
+<!ENTITY ModeShapeNodeTypeManager		  "<ulink url='&API;jcr/nodetype/NodeTypeManager.html'><interface>NodeTypeManager</interface></ulink>">
 
 <!-- Types in extensions/ -->
 

--- a/modeshape-jcr-api/src/main/java/org/modeshape/jcr/api/nodetype/NodeTypeManager.java
+++ b/modeshape-jcr-api/src/main/java/org/modeshape/jcr/api/nodetype/NodeTypeManager.java
@@ -1,0 +1,90 @@
+/*
+ * ModeShape (http://www.modeshape.org)
+ * See the COPYRIGHT.txt file distributed with this work for information
+ * regarding copyright ownership.  Some portions may be licensed
+ * to Red Hat, Inc. under one or more contributor license agreements.
+ * See the AUTHORS.txt file in the distribution for a full listing of 
+ * individual contributors.
+ *
+ * ModeShape is free software. Unless otherwise indicated, all code in ModeShape
+ * is licensed to you under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ * 
+ * ModeShape is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.modeshape.jcr.api.nodetype;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import javax.jcr.RepositoryException;
+import javax.jcr.UnsupportedRepositoryOperationException;
+import javax.jcr.nodetype.InvalidNodeTypeDefinitionException;
+import javax.jcr.nodetype.NodeTypeExistsException;
+
+/**
+ * An extension of JCR 2.0's {@link javax.jcr.nodetype.NodeTypeManager} interface, with methods to support registering node type
+ * definitions from CND files.
+ */
+public interface NodeTypeManager extends javax.jcr.nodetype.NodeTypeManager {
+
+    /**
+     * Read the supplied stream containing node type definitions in the standard JCR 2.0 Compact Node Definition (CND) format, and
+     * register the node types with this repository.
+     * 
+     * @param stream the stream containing the node type definitions in CND format
+     * @param allowUpdate a boolean stating whether existing node type definitions should be modified/updated
+     * @throws IOException if there is a problem reading from the supplied stream
+     * @throws InvalidNodeTypeDefinitionException if the <code>NodeTypeDefinition</code> is invalid.
+     * @throws NodeTypeExistsException if <code>allowUpdate</code> is <code>false</code> and the <code>NodeTypeDefinition</code>
+     *         specifies a node type name that is already registered.
+     * @throws UnsupportedRepositoryOperationException if this implementation does not support node type registration.
+     * @throws RepositoryException if another error occurs.
+     */
+    void registerNodeTypeDefinitions( InputStream stream,
+                                      boolean allowUpdate )
+        throws IOException, InvalidNodeTypeDefinitionException, NodeTypeExistsException, UnsupportedRepositoryOperationException,
+        RepositoryException;
+
+    /**
+     * Read the supplied file containing node type definitions in the standard JCR 2.0 Compact Node Definition (CND) format, and
+     * register the node types with this repository.
+     * 
+     * @param file the file containing the node types
+     * @param allowUpdate a boolean stating whether existing node type definitions should be modified/updated
+     * @throws IOException if there is a problem reading from the supplied stream
+     * @throws InvalidNodeTypeDefinitionException if the <code>NodeTypeDefinition</code> is invalid.
+     * @throws NodeTypeExistsException if <code>allowUpdate</code> is <code>false</code> and the <code>NodeTypeDefinition</code>
+     *         specifies a node type name that is already registered.
+     * @throws UnsupportedRepositoryOperationException if this implementation does not support node type registration.
+     * @throws RepositoryException if another error occurs.
+     */
+    void registerNodeTypeDefinitions( File file,
+                                      boolean allowUpdate ) throws IOException, RepositoryException;
+
+    /**
+     * Read the supplied stream containing node type definitions in the standard JCR 2.0 Compact Node Definition (CND) format, and
+     * register the node types with this repository.
+     * 
+     * @param url the URL that can be resolved to the file containing the node type definitions in CND format
+     * @param allowUpdate a boolean stating whether existing node type definitions should be modified/updated
+     * @throws IOException if there is a problem reading from the supplied stream
+     * @throws InvalidNodeTypeDefinitionException if the <code>NodeTypeDefinition</code> is invalid.
+     * @throws NodeTypeExistsException if <code>allowUpdate</code> is <code>false</code> and the <code>NodeTypeDefinition</code>
+     *         specifies a node type name that is already registered.
+     * @throws UnsupportedRepositoryOperationException if this implementation does not support node type registration.
+     * @throws RepositoryException if another error occurs.
+     */
+    void registerNodeTypeDefinitions( URL url,
+                                      boolean allowUpdate ) throws IOException, RepositoryException;
+}

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/CndNodeTypeReader.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/CndNodeTypeReader.java
@@ -38,6 +38,7 @@ import org.modeshape.graph.Location;
 import org.modeshape.graph.Subgraph;
 import org.modeshape.graph.io.Destination;
 import org.modeshape.graph.property.Path;
+import org.modeshape.jcr.api.nodetype.NodeTypeManager;
 
 /**
  * A class that reads files in the standard CND format defined by the JCR 2.0 specification.
@@ -58,7 +59,10 @@ import org.modeshape.graph.property.Path;
  * </pre>
  * 
  * </p>
+ * 
+ * @deprecated Use {@link NodeTypeManager#registerNodeTypeDefinitions} instead
  */
+@Deprecated
 public class CndNodeTypeReader extends GraphNodeTypeReader {
 
     /**

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/JackrabbitXmlNodeTypeReader.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/JackrabbitXmlNodeTypeReader.java
@@ -54,6 +54,7 @@ import org.modeshape.graph.property.PathNotFoundException;
 import org.modeshape.graph.property.Property;
 import org.modeshape.graph.property.PropertyFactory;
 import org.modeshape.graph.property.ValueFactories;
+import org.modeshape.jcr.api.nodetype.NodeTypeManager;
 import org.xml.sax.SAXException;
 
 /**
@@ -122,7 +123,10 @@ import org.xml.sax.SAXException;
  *     &lt;!ELEMENT requiredPrimaryType (CDATA)>
  * 
  * </pre>
+ * 
+ * @deprecated Use {@link NodeTypeManager#registerNodeTypeDefinitions} instead
  */
+@Deprecated
 public class JackrabbitXmlNodeTypeReader extends GraphNodeTypeReader {
 
     /**

--- a/modeshape-jcr/src/test/java/org/modeshape/jcr/NodeTypeRegistrationTest.java
+++ b/modeshape-jcr/src/test/java/org/modeshape/jcr/NodeTypeRegistrationTest.java
@@ -1,0 +1,220 @@
+/*
+ * ModeShape (http://www.modeshape.org)
+ * See the COPYRIGHT.txt file distributed with this work for information
+ * regarding copyright ownership.  Some portions may be licensed
+ * to Red Hat, Inc. under one or more contributor license agreements.
+ * See the AUTHORS.txt file in the distribution for a full listing of 
+ * individual contributors.
+ *
+ * ModeShape is free software. Unless otherwise indicated, all code in ModeShape
+ * is licensed to you under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ * 
+ * ModeShape is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.modeshape.jcr;
+
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsNull.notNullValue;
+import static org.junit.Assert.assertThat;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import javax.jcr.PropertyType;
+import javax.jcr.RepositoryException;
+import javax.jcr.nodetype.NodeType;
+import javax.jcr.nodetype.NodeTypeExistsException;
+import org.junit.Before;
+import org.junit.Test;
+import org.modeshape.jcr.api.nodetype.NodeTypeManager;
+
+/**
+ * Test of CND-based type definitions. These test cases focus on ensuring that an import of a type from a CND file registers the
+ * expected type rather than attempting to validate all of the type registration functionality already tested in
+ * {@link TypeRegistrationTest}.
+ */
+public class NodeTypeRegistrationTest extends AbstractJcrAccessTest {
+
+    private NodeTypeManager nodeTypeManager;
+
+    @Override
+    @Before
+    public void beforeEach() throws Exception {
+        super.beforeEach();
+        this.nodeTypeManager = (NodeTypeManager)session().getWorkspace().getNodeTypeManager();
+    }
+
+    protected InputStream resourceAsStream( String path ) {
+        return getClass().getClassLoader().getResourceAsStream(path);
+    }
+
+    protected URL resourceAsUrl( String path ) {
+        return getClass().getClassLoader().getResource(path);
+    }
+
+    protected NodeType assertNodeType( String name ) throws RepositoryException {
+        NodeType type = nodeTypeManager.getNodeType(name);
+        assertThat(type, is(notNullValue()));
+        return type;
+    }
+
+    @Test
+    public void shouldAccessCustomNodeTypeManagerViaCasting() throws Exception {
+        NodeTypeManager nodeTypeMgr = (NodeTypeManager)session().getWorkspace().getNodeTypeManager();
+        assertThat(nodeTypeMgr, is(notNullValue()));
+    }
+
+    @Test
+    public void shouldAccessCustomNodeTypeManagerViaProtectedMethods() throws Exception {
+        NodeTypeManager nodeTypeMgr = session().workspace().nodeTypeManager();
+        assertThat(nodeTypeMgr, is(notNullValue()));
+    }
+
+    @Test( expected = IOException.class )
+    public void shouldFailIfResourceFileCouldNotBeFoundAsRelativeFile() throws Exception {
+        File file = new File("/this/resource/file/does/not/exist");
+        assertThat(file.exists(), is(false));
+        nodeTypeManager.registerNodeTypeDefinitions(file, true);
+    }
+
+    @Test( expected = IOException.class )
+    public void shouldFailIfResourceFileCouldNotBeFoundAsUrl() throws Exception {
+        File file = new File("/this/resource/file/does/not/exist");
+        assertThat(file.exists(), is(false));
+        URL url = file.toURI().toURL();
+        nodeTypeManager.registerNodeTypeDefinitions(url, true);
+    }
+
+    @Test
+    public void shouldLoadNodeTypesFromCndResourceFileFoundOnClasspath() throws Exception {
+        nodeTypeManager.registerNodeTypeDefinitions(resourceAsStream("cars.cnd"), true);
+        assertNodeType("car:Car");
+    }
+
+    @Test
+    public void shouldLoadNodeTypesFromCndResourceFileFoundWithRelativePathOnFileSystem() throws Exception {
+        File file = new File("src/test/resources/cnd/cars.cnd");
+        if (file.exists()) {
+            nodeTypeManager.registerNodeTypeDefinitions(file, true);
+            assertNodeType("car:Car");
+        }
+    }
+
+    @Test
+    public void shouldLoadNodeTypesFromCndResourceFileFoundWithAbsolutePathOnFileSystem() throws Exception {
+        File file = new File("src/test/resources/cnd/cars.cnd");
+        if (file.exists()) {
+            nodeTypeManager.registerNodeTypeDefinitions(file.getAbsoluteFile(), true);
+            assertNodeType("car:Car");
+        }
+    }
+
+    @Test
+    public void shouldLoadNodeTypesFromUrlToCndFile() throws Exception {
+        nodeTypeManager.registerNodeTypeDefinitions(resourceAsUrl("cars.cnd"), true);
+        assertNodeType("car:Car");
+    }
+
+    @Test( expected = NodeTypeExistsException.class )
+    public void shouldNotAllowRedefinitionOfExistingTypesFromCndFile() throws Exception {
+        nodeTypeManager.registerNodeTypeDefinitions(resourceAsUrl("cndNodeTypeRegistration/existingType.cnd"), false);
+        // assertNodeType("nt:folder");
+    }
+
+    @Test
+    public void shouldLoadMagnoliaTypesFromCndFile() throws Exception {
+        nodeTypeManager.registerNodeTypeDefinitions(resourceAsUrl("magnolia.cnd"), true);
+        assertNodeType("mgnl:contentNode");
+    }
+
+    @Test
+    public void shouldRegisterValidTypesFromCndFile() throws Exception {
+        nodeTypeManager.registerNodeTypeDefinitions(resourceAsUrl("cndNodeTypeRegistration/validType.cnd"), true);
+
+        NodeType nodeType = assertNodeType("modetest:testType");
+        assertThat(nodeType, is(notNullValue()));
+        assertThat(nodeType.isMixin(), is(true));
+        assertThat(nodeType.hasOrderableChildNodes(), is(true));
+        assertThat(nodeType.getDeclaredSupertypes().length, is(2));
+        assertThat(nodeType.getDeclaredChildNodeDefinitions().length, is(1));
+        JcrNodeDefinition childNode = (JcrNodeDefinition)nodeType.getDeclaredChildNodeDefinitions()[0];
+        assertThat(childNode.getName(), is("modetest:namespace"));
+        assertThat(childNode.getDefaultPrimaryType().getName(), is("mode:namespace"));
+        assertThat(childNode.getRequiredPrimaryTypes().length, is(1));
+        assertThat(childNode.getRequiredPrimaryTypes()[0].getName(), is("mode:namespace"));
+        assertThat(childNode.allowsSameNameSiblings(), is(false));
+        assertThat(childNode.isMandatory(), is(false));
+
+        assertThat(nodeType.getDeclaredPropertyDefinitions().length, is(1));
+        JcrPropertyDefinition property = (JcrPropertyDefinition)nodeType.getDeclaredPropertyDefinitions()[0];
+        assertThat(property.getName(), is("*"));
+        assertThat(property.getRequiredType(), is(PropertyType.STRING));
+        assertThat(property.getValueConstraints().length, is(3));
+        assertThat(property.getValueConstraints()[0], is("foo"));
+        assertThat(property.getValueConstraints()[1], is("bar"));
+        assertThat(property.getValueConstraints()[2], is("baz"));
+        assertThat(property.getDefaultValues().length, is(1));
+        assertThat(property.getDefaultValues()[0].getString(), is("foo"));
+    }
+
+    @Test
+    public void shouldLoadNodeTypesFromXmlResourceFileFoundOnClasspath() throws Exception {
+        nodeTypeManager.registerNodeTypeDefinitions(resourceAsStream("xmlNodeTypeRegistration/magnolia_forum_nodetypes.xml"),
+                                                    true);
+        assertNodeType("mgnl:forum");
+    }
+
+    @Test
+    public void shouldLoadNodeTypesFromXmlResourceFileFoundWithRelativePathOnFileSystem() throws Exception {
+        File file = new File("src/test/resources/xmlNodeTypeRegistration/magnolia_forum_nodetypes.xml");
+        if (file.exists()) {
+            nodeTypeManager.registerNodeTypeDefinitions(file, true);
+            assertNodeType("mgnl:forum");
+        }
+    }
+
+    @Test
+    public void shouldLoadNodeTypesFromXmlResourceFileFoundWithAbsolutePathOnFileSystem() throws Exception {
+        File file = new File("src/test/resources/xmlNodeTypeRegistration/magnolia_forum_nodetypes.xml");
+        if (file.exists()) {
+            nodeTypeManager.registerNodeTypeDefinitions(file.getAbsoluteFile(), true);
+            assertNodeType("mgnl:forum");
+        }
+    }
+
+    @Test
+    public void shouldLoadNodeTypesFromUrl() throws Exception {
+        nodeTypeManager.registerNodeTypeDefinitions(resourceAsUrl("xmlNodeTypeRegistration/magnolia_forum_nodetypes.xml"), true);
+        assertNodeType("mgnl:forum");
+    }
+
+    @Test
+    public void shouldLoadMagnoliaNodeTypesFromXml() throws Exception {
+        nodeTypeManager.registerNodeTypeDefinitions(resourceAsStream("xmlNodeTypeRegistration/magnolia_forum_nodetypes.xml"),
+                                                    true);
+        assertNodeType("mgnl:forum");
+    }
+
+    @Test
+    public void shouldLoadOwfeNodeTypesFromXml() throws Exception {
+        nodeTypeManager.registerNodeTypeDefinitions(resourceAsStream("xmlNodeTypeRegistration/owfe_nodetypes.xml"), true);
+        assertNodeType("expression");
+    }
+
+    @Test
+    public void shouldLoadCustomNodeTypesFromXml() throws Exception {
+        nodeTypeManager.registerNodeTypeDefinitions(resourceAsStream("xmlNodeTypeRegistration/custom_nodetypes.xml"), true);
+        assertNodeType("mgnl:reserve");
+    }
+
+}


### PR DESCRIPTION
Added the `org.modeshape.jcr.api.nodetype.NodeTypeManager` interface that extends the `javax.jcr.nodetype.NodeTypeManager` interface with new `registerNodeTypeDefinitions(...)` methods that accept File, URL, or InputStream objects.

A new test class was added to verify the behavior. Also, the `CndNodeTypeReader` and `JackrabbitXmlNodeTypeReader` classes have been deprecated. The Reference Guide was also updated.

All unit and integration tests pass.
