### PR TITLE
MODE-1328 Minor changes to the custom NodeTypeManager methods

### DIFF
--- a/docs/reference/src/main/docbook/en-US/content/jcr/jcr.xml
+++ b/docs/reference/src/main/docbook/en-US/content/jcr/jcr.xml
@@ -1091,11 +1091,11 @@ nodeTypeManager.unregisterNodeTypes(unusedNodeTypeNames);
                               session.getWorkspace().getNodeTypeManager();
 boolean allowUpdate = true;
 File file = ...  // or InputStream or URL
-nodeTypeMgr.registerNodeTypeDefinitions(file,allowUpdate);
+nodeTypeMgr.registerNodeTypes(file,allowUpdate);
 </programlisting>
 
       ModeShape's &ModeShapeNodeTypeManager; interface extends the standard <code>javax.jcr.nodetype.NodeTypeManager</code> interface
-      and provides <code>registerNodeTypeDefinitions(...)</code> methods overloaded to accept &File;, 
+      and provides <code>registerNodeTypes(...)</code> methods overloaded to accept &File;, 
       &URL;, and &InputStream; instances. The content of these files can be the standard CND file format or the non-standard
       XML format used by Jackrabbit.
       These methods are also functionally similar to the standard methods that register arrays of &NodeTypeDefinition; objects

--- a/modeshape-jcr-api/src/main/java/org/modeshape/jcr/api/nodetype/NodeTypeManager.java
+++ b/modeshape-jcr-api/src/main/java/org/modeshape/jcr/api/nodetype/NodeTypeManager.java
@@ -51,8 +51,8 @@ public interface NodeTypeManager extends javax.jcr.nodetype.NodeTypeManager {
      * @throws UnsupportedRepositoryOperationException if this implementation does not support node type registration.
      * @throws RepositoryException if another error occurs.
      */
-    void registerNodeTypeDefinitions( InputStream stream,
-                                      boolean allowUpdate )
+    void registerNodeTypes( InputStream stream,
+                            boolean allowUpdate )
         throws IOException, InvalidNodeTypeDefinitionException, NodeTypeExistsException, UnsupportedRepositoryOperationException,
         RepositoryException;
 
@@ -69,8 +69,8 @@ public interface NodeTypeManager extends javax.jcr.nodetype.NodeTypeManager {
      * @throws UnsupportedRepositoryOperationException if this implementation does not support node type registration.
      * @throws RepositoryException if another error occurs.
      */
-    void registerNodeTypeDefinitions( File file,
-                                      boolean allowUpdate ) throws IOException, RepositoryException;
+    void registerNodeTypes( File file,
+                            boolean allowUpdate ) throws IOException, RepositoryException;
 
     /**
      * Read the supplied stream containing node type definitions in the standard JCR 2.0 Compact Node Definition (CND) format, and
@@ -85,6 +85,6 @@ public interface NodeTypeManager extends javax.jcr.nodetype.NodeTypeManager {
      * @throws UnsupportedRepositoryOperationException if this implementation does not support node type registration.
      * @throws RepositoryException if another error occurs.
      */
-    void registerNodeTypeDefinitions( URL url,
-                                      boolean allowUpdate ) throws IOException, RepositoryException;
+    void registerNodeTypes( URL url,
+                            boolean allowUpdate ) throws IOException, RepositoryException;
 }

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/CndNodeTypeReader.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/CndNodeTypeReader.java
@@ -60,7 +60,7 @@ import org.modeshape.jcr.api.nodetype.NodeTypeManager;
  * 
  * </p>
  * 
- * @deprecated Use {@link NodeTypeManager#registerNodeTypeDefinitions} instead
+ * @deprecated Use {@link NodeTypeManager#registerNodeTypes} instead
  */
 @Deprecated
 public class CndNodeTypeReader extends GraphNodeTypeReader {

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/JackrabbitXmlNodeTypeReader.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/JackrabbitXmlNodeTypeReader.java
@@ -124,7 +124,7 @@ import org.xml.sax.SAXException;
  * 
  * </pre>
  * 
- * @deprecated Use {@link NodeTypeManager#registerNodeTypeDefinitions} instead
+ * @deprecated Use {@link NodeTypeManager#registerNodeTypes} instead
  */
 @Deprecated
 public class JackrabbitXmlNodeTypeReader extends GraphNodeTypeReader {

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrNodeTypeManager.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrNodeTypeManager.java
@@ -819,24 +819,10 @@ public class JcrNodeTypeManager implements NodeTypeManager {
         return false;
     }
 
-    protected List<NodeTypeDefinition> importFromXml( InputStream stream,
-                                                      String sourceName ) throws RepositoryException {
-        JackrabbitXmlNodeTypeReader reader = new JackrabbitXmlNodeTypeReader(session);
-        try {
-            reader.read(stream, sourceName);
-            return Arrays.asList(reader.getNodeTypeDefinitions());
-        } catch (IOException ioe) {
-            throw new RepositoryException(ioe);
-        } catch (RuntimeException t) {
-            throw t;
-        } catch (Throwable t) {
-            throw new RepositoryException(t);
-        }
-    }
-
+    @SuppressWarnings( "deprecation" )
     @Override
-    public void registerNodeTypeDefinitions( File file,
-                                             boolean allowUpdate ) throws IOException, RepositoryException {
+    public void registerNodeTypes( File file,
+                                   boolean allowUpdate ) throws IOException, RepositoryException {
         CheckArg.isNotNull(file, "file");
         String content = IoUtil.read(file);
         GraphNodeTypeReader reader = null;
@@ -859,9 +845,10 @@ public class JcrNodeTypeManager implements NodeTypeManager {
         }
     }
 
+    @SuppressWarnings( "deprecation" )
     @Override
-    public void registerNodeTypeDefinitions( InputStream stream,
-                                             boolean allowUpdate )
+    public void registerNodeTypes( InputStream stream,
+                                   boolean allowUpdate )
         throws IOException, javax.jcr.nodetype.InvalidNodeTypeDefinitionException, javax.jcr.nodetype.NodeTypeExistsException,
         UnsupportedRepositoryOperationException, RepositoryException {
         CheckArg.isNotNull(stream, "stream");
@@ -885,9 +872,10 @@ public class JcrNodeTypeManager implements NodeTypeManager {
         }
     }
 
+    @SuppressWarnings( "deprecation" )
     @Override
-    public void registerNodeTypeDefinitions( URL url,
-                                             boolean allowUpdate ) throws IOException, RepositoryException {
+    public void registerNodeTypes( URL url,
+                                   boolean allowUpdate ) throws IOException, RepositoryException {
         CheckArg.isNotNull(url, "url");
         InputStream stream = url.openStream();
         if (stream == null) {

--- a/modeshape-jcr/src/test/java/org/modeshape/jcr/NodeTypeRegistrationTest.java
+++ b/modeshape-jcr/src/test/java/org/modeshape/jcr/NodeTypeRegistrationTest.java
@@ -84,7 +84,7 @@ public class NodeTypeRegistrationTest extends AbstractJcrAccessTest {
     public void shouldFailIfResourceFileCouldNotBeFoundAsRelativeFile() throws Exception {
         File file = new File("/this/resource/file/does/not/exist");
         assertThat(file.exists(), is(false));
-        nodeTypeManager.registerNodeTypeDefinitions(file, true);
+        nodeTypeManager.registerNodeTypes(file, true);
     }
 
     @Test( expected = IOException.class )
@@ -92,12 +92,12 @@ public class NodeTypeRegistrationTest extends AbstractJcrAccessTest {
         File file = new File("/this/resource/file/does/not/exist");
         assertThat(file.exists(), is(false));
         URL url = file.toURI().toURL();
-        nodeTypeManager.registerNodeTypeDefinitions(url, true);
+        nodeTypeManager.registerNodeTypes(url, true);
     }
 
     @Test
     public void shouldLoadNodeTypesFromCndResourceFileFoundOnClasspath() throws Exception {
-        nodeTypeManager.registerNodeTypeDefinitions(resourceAsStream("cars.cnd"), true);
+        nodeTypeManager.registerNodeTypes(resourceAsStream("cars.cnd"), true);
         assertNodeType("car:Car");
     }
 
@@ -105,7 +105,7 @@ public class NodeTypeRegistrationTest extends AbstractJcrAccessTest {
     public void shouldLoadNodeTypesFromCndResourceFileFoundWithRelativePathOnFileSystem() throws Exception {
         File file = new File("src/test/resources/cnd/cars.cnd");
         if (file.exists()) {
-            nodeTypeManager.registerNodeTypeDefinitions(file, true);
+            nodeTypeManager.registerNodeTypes(file, true);
             assertNodeType("car:Car");
         }
     }
@@ -114,32 +114,32 @@ public class NodeTypeRegistrationTest extends AbstractJcrAccessTest {
     public void shouldLoadNodeTypesFromCndResourceFileFoundWithAbsolutePathOnFileSystem() throws Exception {
         File file = new File("src/test/resources/cnd/cars.cnd");
         if (file.exists()) {
-            nodeTypeManager.registerNodeTypeDefinitions(file.getAbsoluteFile(), true);
+            nodeTypeManager.registerNodeTypes(file.getAbsoluteFile(), true);
             assertNodeType("car:Car");
         }
     }
 
     @Test
     public void shouldLoadNodeTypesFromUrlToCndFile() throws Exception {
-        nodeTypeManager.registerNodeTypeDefinitions(resourceAsUrl("cars.cnd"), true);
+        nodeTypeManager.registerNodeTypes(resourceAsUrl("cars.cnd"), true);
         assertNodeType("car:Car");
     }
 
     @Test( expected = NodeTypeExistsException.class )
     public void shouldNotAllowRedefinitionOfExistingTypesFromCndFile() throws Exception {
-        nodeTypeManager.registerNodeTypeDefinitions(resourceAsUrl("cndNodeTypeRegistration/existingType.cnd"), false);
+        nodeTypeManager.registerNodeTypes(resourceAsUrl("cndNodeTypeRegistration/existingType.cnd"), false);
         // assertNodeType("nt:folder");
     }
 
     @Test
     public void shouldLoadMagnoliaTypesFromCndFile() throws Exception {
-        nodeTypeManager.registerNodeTypeDefinitions(resourceAsUrl("magnolia.cnd"), true);
+        nodeTypeManager.registerNodeTypes(resourceAsUrl("magnolia.cnd"), true);
         assertNodeType("mgnl:contentNode");
     }
 
     @Test
     public void shouldRegisterValidTypesFromCndFile() throws Exception {
-        nodeTypeManager.registerNodeTypeDefinitions(resourceAsUrl("cndNodeTypeRegistration/validType.cnd"), true);
+        nodeTypeManager.registerNodeTypes(resourceAsUrl("cndNodeTypeRegistration/validType.cnd"), true);
 
         NodeType nodeType = assertNodeType("modetest:testType");
         assertThat(nodeType, is(notNullValue()));
@@ -169,8 +169,7 @@ public class NodeTypeRegistrationTest extends AbstractJcrAccessTest {
 
     @Test
     public void shouldLoadNodeTypesFromXmlResourceFileFoundOnClasspath() throws Exception {
-        nodeTypeManager.registerNodeTypeDefinitions(resourceAsStream("xmlNodeTypeRegistration/magnolia_forum_nodetypes.xml"),
-                                                    true);
+        nodeTypeManager.registerNodeTypes(resourceAsStream("xmlNodeTypeRegistration/magnolia_forum_nodetypes.xml"), true);
         assertNodeType("mgnl:forum");
     }
 
@@ -178,7 +177,7 @@ public class NodeTypeRegistrationTest extends AbstractJcrAccessTest {
     public void shouldLoadNodeTypesFromXmlResourceFileFoundWithRelativePathOnFileSystem() throws Exception {
         File file = new File("src/test/resources/xmlNodeTypeRegistration/magnolia_forum_nodetypes.xml");
         if (file.exists()) {
-            nodeTypeManager.registerNodeTypeDefinitions(file, true);
+            nodeTypeManager.registerNodeTypes(file, true);
             assertNodeType("mgnl:forum");
         }
     }
@@ -187,33 +186,32 @@ public class NodeTypeRegistrationTest extends AbstractJcrAccessTest {
     public void shouldLoadNodeTypesFromXmlResourceFileFoundWithAbsolutePathOnFileSystem() throws Exception {
         File file = new File("src/test/resources/xmlNodeTypeRegistration/magnolia_forum_nodetypes.xml");
         if (file.exists()) {
-            nodeTypeManager.registerNodeTypeDefinitions(file.getAbsoluteFile(), true);
+            nodeTypeManager.registerNodeTypes(file.getAbsoluteFile(), true);
             assertNodeType("mgnl:forum");
         }
     }
 
     @Test
     public void shouldLoadNodeTypesFromUrl() throws Exception {
-        nodeTypeManager.registerNodeTypeDefinitions(resourceAsUrl("xmlNodeTypeRegistration/magnolia_forum_nodetypes.xml"), true);
+        nodeTypeManager.registerNodeTypes(resourceAsUrl("xmlNodeTypeRegistration/magnolia_forum_nodetypes.xml"), true);
         assertNodeType("mgnl:forum");
     }
 
     @Test
     public void shouldLoadMagnoliaNodeTypesFromXml() throws Exception {
-        nodeTypeManager.registerNodeTypeDefinitions(resourceAsStream("xmlNodeTypeRegistration/magnolia_forum_nodetypes.xml"),
-                                                    true);
+        nodeTypeManager.registerNodeTypes(resourceAsStream("xmlNodeTypeRegistration/magnolia_forum_nodetypes.xml"), true);
         assertNodeType("mgnl:forum");
     }
 
     @Test
     public void shouldLoadOwfeNodeTypesFromXml() throws Exception {
-        nodeTypeManager.registerNodeTypeDefinitions(resourceAsStream("xmlNodeTypeRegistration/owfe_nodetypes.xml"), true);
+        nodeTypeManager.registerNodeTypes(resourceAsStream("xmlNodeTypeRegistration/owfe_nodetypes.xml"), true);
         assertNodeType("expression");
     }
 
     @Test
     public void shouldLoadCustomNodeTypesFromXml() throws Exception {
-        nodeTypeManager.registerNodeTypeDefinitions(resourceAsStream("xmlNodeTypeRegistration/custom_nodetypes.xml"), true);
+        nodeTypeManager.registerNodeTypes(resourceAsStream("xmlNodeTypeRegistration/custom_nodetypes.xml"), true);
         assertNodeType("mgnl:reserve");
     }
 


### PR DESCRIPTION
The methods of the `org.modeshape.jcr.api.nodetype.NodeTypeManager` interface were renamed to `registerNodeTypes` to mirror the standard methods in the `javax.jcr.nodetype.NodeTypeManager` methods.
