### PR TITLE
MODE-1324 Added methods to obtain SHA-1 has for a Binary value

### DIFF
--- a/modeshape-jcr-api/src/main/java/org/modeshape/jcr/api/Binary.java
+++ b/modeshape-jcr-api/src/main/java/org/modeshape/jcr/api/Binary.java
@@ -23,11 +23,39 @@
  */
 package org.modeshape.jcr.api;
 
+import java.security.MessageDigest;
+
 /**
- * Replicates JCR 2.0's javax.jcr.Binary interface.
- *
- * @deprecated use <code>javax.jcr.Binary</code> interface directly.
+ * An extension of the standard {@link javax.jcr.Binary} interface, with methods to obtain the SHA-1 hash of the binary value.
  */
-@Deprecated
-public interface Binary {
+public interface Binary extends javax.jcr.Binary {
+
+    /**
+     * Get the SHA-1 hash of the contents. This hash can be used to determine whether two Binary instances contain the same
+     * content.
+     * <p>
+     * Repeatedly calling this method should generally be efficient, as it most implementations will compute the hash only once.
+     * </p>
+     * 
+     * @return the hash of the contents as a byte array, or an empty array if the hash could not be computed.
+     * @see MessageDigest#digest(byte[])
+     * @see MessageDigest#getInstance(String)
+     * @see #getHexHash()
+     */
+    public byte[] getHash();
+
+    /**
+     * Get the hexadecimal form of the SHA-1 hash of the contents. This hash can be used to determine whether two Binary instances
+     * contain the same content.
+     * <p>
+     * Repeatedly calling this method should generally be efficient, as it most implementations will compute the hash only once.
+     * </p>
+     * 
+     * @return the hexadecimal form of the {@link #getHash()}, or a null string if the hash could not be computed or is not known
+     * @see MessageDigest#digest(byte[])
+     * @see MessageDigest#getInstance(String)
+     * @see #getHash()
+     */
+    public String getHexHash();
+
 }

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrBinary.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrBinary.java
@@ -25,6 +25,7 @@ package org.modeshape.jcr;
 
 import java.io.IOException;
 import java.io.InputStream;
+import org.modeshape.common.util.StringUtil;
 import org.modeshape.graph.property.Binary;
 
 /**
@@ -41,6 +42,14 @@ class JcrBinary implements javax.jcr.Binary, org.modeshape.jcr.api.Binary {
 
     Binary binary() {
         return this.binary;
+    }
+
+    public byte[] getHash() {
+        return this.binary.getHash();
+    }
+
+    public String getHexHash() {
+        return StringUtil.getHexString(getHash());
     }
 
     /**


### PR DESCRIPTION
Made the `org.modeshape.jcr.api.Binary` interface no longer deprecated (we're not using it again in ModeShape 3.x, too), and added two methods for obtaining the SHA-1 hash of the value's content. One of the methods returns the byte[] form of the hash, while the other returns the hexadecimal string form of the same hash.

All unit and integration tests pass.

Note this change only needs to be made to the 2.x codebase in 'master', since these changes reflect existing code in the 3.x branch.
