### PR TITLE
MODE-1349 Removed the JPA connector's caching of binary values

### DIFF
--- a/extensions/modeshape-connector-store-jpa/src/main/java/org/modeshape/connector/store/jpa/HibernateAdapter.java
+++ b/extensions/modeshape-connector-store-jpa/src/main/java/org/modeshape/connector/store/jpa/HibernateAdapter.java
@@ -117,9 +117,6 @@ public class HibernateAdapter implements JpaAdapter {
                         "hibernate.ejb.classcache.org.modeshape.connector.store.jpa.model.simple.NodeEntity",
                         cacheConcurrencyStrategy);
             setProperty(jpaProperties,
-                        "hibernate.ejb.classcache.org.modeshape.connector.store.jpa.model.simple.LargeValueEntity",
-                        cacheConcurrencyStrategy);
-            setProperty(jpaProperties,
                         "hibernate.ejb.collectioncache.org.modeshape.connector.store.jpa.model.simple.NodeEntity.children",
                         cacheConcurrencyStrategy);
             setProperty(jpaProperties,


### PR DESCRIPTION
Although the binary value content should not be put into the 2nd level cache because of the @Lob field, this change removes the LargeValueEntity class from the set of classes that should be put into Hibernate's 2nd level cache, thereby removing any concern of caching these potentially large values.

All unit and integration tests pass.
