### PR TITLE
MODE-1348 Export changed to limit memory consumption with large binary values

### DIFF
--- a/modeshape-graph/src/main/java/org/modeshape/graph/property/Binary.java
+++ b/modeshape-graph/src/main/java/org/modeshape/graph/property/Binary.java
@@ -88,4 +88,9 @@ public interface Binary extends Comparable<Binary>, Serializable {
      */
     public void release();
 
+    /**
+     * A method that signals that any data kept in memory should be purged as it is no longer needed.
+     */
+    public void purge();
+
 }

--- a/modeshape-graph/src/main/java/org/modeshape/graph/property/basic/FileSystemBinary.java
+++ b/modeshape-graph/src/main/java/org/modeshape/graph/property/basic/FileSystemBinary.java
@@ -133,6 +133,11 @@ public class FileSystemBinary extends AbstractBinary {
         // do nothing
     }
 
+    @Override
+    public void purge() {
+        // no need to do anything
+    }
+
     private void writeObject( ObjectOutputStream out ) throws IOException {
         out.writeUTF(this.file.getPath());
     }

--- a/modeshape-graph/src/main/java/org/modeshape/graph/property/basic/InMemoryBinary.java
+++ b/modeshape-graph/src/main/java/org/modeshape/graph/property/basic/InMemoryBinary.java
@@ -40,7 +40,7 @@ public class InMemoryBinary extends AbstractBinary {
      */
     private static final long serialVersionUID = 2L;
 
-    private final byte[] bytes;
+    private byte[] bytes;
     private byte[] sha1hash;
     private int hc;
 
@@ -48,6 +48,7 @@ public class InMemoryBinary extends AbstractBinary {
         super();
         CheckArg.isNotNull(bytes, "bytes");
         this.bytes = bytes;
+        assert this.bytes != null;
     }
 
     /**
@@ -59,6 +60,7 @@ public class InMemoryBinary extends AbstractBinary {
     public int hashCode() {
         if (sha1hash == null) {
             // Idempotent, so doesn't matter if we recompute in concurrent threads ...
+            assert this.bytes != null : "This Binary object was purged and has no content";
             sha1hash = computeHash(bytes);
             hc = sha1hash.hashCode();
         }
@@ -80,6 +82,7 @@ public class InMemoryBinary extends AbstractBinary {
     public byte[] getHash() {
         if (sha1hash == null) {
             // Idempotent, so doesn't matter if we recompute in concurrent threads ...
+            assert this.bytes != null : "This Binary object was purged and has no content";
             sha1hash = computeHash(bytes);
             hc = sha1hash.hashCode();
         }
@@ -90,6 +93,7 @@ public class InMemoryBinary extends AbstractBinary {
      * {@inheritDoc}
      */
     public byte[] getBytes() {
+        assert this.bytes != null : "This Binary object was purged and has no content";
         return this.bytes;
     }
 
@@ -97,6 +101,7 @@ public class InMemoryBinary extends AbstractBinary {
      * {@inheritDoc}
      */
     public InputStream getStream() {
+        assert this.bytes != null : "This Binary object was purged and has no content";
         return new ByteArrayInputStream(this.bytes);
     }
 
@@ -112,5 +117,10 @@ public class InMemoryBinary extends AbstractBinary {
      */
     public void release() {
         // do nothing
+    }
+
+    @Override
+    public void purge() {
+        this.bytes = null;
     }
 }

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/AbstractJcrExporter.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/AbstractJcrExporter.java
@@ -46,8 +46,10 @@ import org.xml.sax.SAXException;
 /**
  * Superclass of ModeShape JCR exporters, provides basic support for traversing through the nodes recursively (if needed),
  * exception wrapping (since {@link ItemVisitor} does not allow checked exceptions to be thrown from its visit* methods, and the
- * ability to wrap an {@link OutputStream} with a {@link ContentHandler}. <p /> Each exporter is only intended to be used once (by
- * calling <code>exportView</code>) and discarded. This class is <b>NOT</b> thread-safe.
+ * ability to wrap an {@link OutputStream} with a {@link ContentHandler}.
+ * <p />
+ * Each exporter is only intended to be used once (by calling <code>exportView</code>) and discarded. This class is <b>NOT</b>
+ * thread-safe.
  * 
  * @see JcrSystemViewExporter
  * @see JcrDocumentViewExporter
@@ -156,7 +158,13 @@ abstract class AbstractJcrExporter {
             }
         }
 
-        exportNode(exportRootNode, contentHandler, skipBinary, noRecurse);
+        try {
+            exportNode(exportRootNode, contentHandler, skipBinary, noRecurse);
+        } finally {
+            // Refresh the session to release all nodes that have been cached and any binary values that were purged,
+            // but keep any transient changes made within the session ...
+            exportRootNode.refresh(true);
+        }
 
         for (int i = 0; i < namespacePrefixes.length; i++) {
             if (!restrictedPrefixes.contains(namespacePrefixes[i])) {


### PR DESCRIPTION
Exporting a workspace that has a lot of large binary values can result in out-of-memory errors, since the binary values are held in memory. (See MODE-1346 for improvements within the 3.x codebase.) While it'd be very difficult to change how the binary values are handled in 2.x, it should still be possible to modify the export logic to prevent holding all workspace content in-memory.

Therefore, the following changes were made to the export process:

1) After every Binary value on an _unmodified_ property is exported, that binary value is purged from memory and allowed to be garbage collected. Note this makes the binary values unusable (see step 2).
2) At the end of the export, the node that was exported is refreshed while keeping any transient changes, throwing out of the session's cache all _unmodified_ property values (including the binary values that were purged in step 1).

Note that the above steps only apply to _unmodified_ properties. This is very often the case, as a new session is used to export persisted content from the workspace. However, sessions _with transient changes_ can be exported, which is why the two steps listed above only purge binary values on _unmodified_ properties.

All unit and integration tests pass with these changes.
