### PR TITLE
MODE-1358 Used buffered streams when copying file content in FileSystemBinaryStore

### DIFF
--- a/modeshape-jcr-redux/src/main/java/org/modeshape/jcr/value/binary/FileSystemBinaryStore.java
+++ b/modeshape-jcr-redux/src/main/java/org/modeshape/jcr/value/binary/FileSystemBinaryStore.java
@@ -23,6 +23,7 @@
  */
 package org.modeshape.jcr.value.binary;
 
+import java.io.BufferedInputStream;
 import java.io.BufferedOutputStream;
 import java.io.File;
 import java.io.FileOutputStream;
@@ -164,19 +165,25 @@ public class FileSystemBinaryStore extends AbstractBinaryStore {
             // The move/rename didn't work, so we have to copy from the original ...
 
             // Create the new file and obtain an exclusive lock on it ...
+            final int bufferSize = AbstractBinaryStore.bestBufferSize(destination.length());
             fileLock = FileLocks.get().writeLock(destination);
             try {
+                // Create a buffered output stream to the destination file ...
+                // (Note that the Channels.newOutputStream does not create a buffered stream)
                 RandomAccessFile destinationRaf = new RandomAccessFile(destination, "rw");
                 FileChannel destinationChannel = destinationRaf.getChannel();
                 OutputStream output = Channels.newOutputStream(destinationChannel);
+                output = new BufferedOutputStream(output, bufferSize);
 
                 // Create an input stream to the original file ...
+                // (Note that the Channels.newInputStream does not create a buffered stream)
                 RandomAccessFile originalRaf = new RandomAccessFile(destination, "r");
                 FileChannel originalChannel = originalRaf.getChannel();
                 InputStream input = Channels.newInputStream(originalChannel);
+                input = new BufferedInputStream(input, bufferSize);
 
                 // Copy the content ...
-                IoUtil.write(input, output, AbstractBinaryStore.bestBufferSize(destination.length()));
+                IoUtil.write(input, output, bufferSize);
             } finally {
                 fileLock.unlock();
             }


### PR DESCRIPTION
The `FileSystemBinaryStore` was not using buffered streams when copying the content; note that `Channel.newInputStream(...)` and `Channel.newOutputStream(...)` do not return buffered streams.

On OS X, using buffered streams makes a little difference. A new unit test (`FileSystemBinaryStoreTest.shouldCopyFilesUsingStreams()` copies a 17MB file repeatedly takes 0.05-0.10 seconds without buffered streams, but is somewhat faster at 0.02-0.07 seconds (repeatedly) with buffered stream. Some of this may be the file system caching access, but it appears the buffered stream do help. The test writes the time to write the file to the console.

Therefore, I changed the `FileSystemBinaryStore` to use buffered streams.

On Windows, storing that same 17MB file in the `FileSystemBinaryStore` takes about 30 seconds (without buffered streams). Hopefully with these changes the `FileSystemBinaryStore` performance does improve. Perhaps Horia can report the time of this new test on Windows.
