### PR TITLE
MODE-1359 Corrected NPE during join evaluation

### DIFF
--- a/modeshape-graph/src/main/java/org/modeshape/graph/query/process/JoinComponent.java
+++ b/modeshape-graph/src/main/java/org/modeshape/graph/query/process/JoinComponent.java
@@ -349,14 +349,14 @@ public abstract class JoinComponent extends ProcessingComponent {
                                          Object locationB ) {
                     Location location1 = (Location)locationA;
                     Location location2 = (Location)locationB;
-                    return location1.isSame(location2);
+                    return location1 == null ? location2 == null : location1.isSame(location2);
                 }
             };
         } else if (condition instanceof EquiJoinCondition) {
             return new Joinable() {
                 public boolean evaluate( Object leftValue,
                                          Object rightValue ) {
-                    return leftValue.equals(rightValue);
+                    return leftValue == null ? rightValue == null : leftValue.equals(rightValue);
                 }
             };
         } else if (condition instanceof ChildNodeJoinCondition) {
@@ -367,6 +367,7 @@ public abstract class JoinComponent extends ProcessingComponent {
                 return new Joinable() {
                     public boolean evaluate( Object childLocation,
                                              Object parentLocation ) {
+                        if (childLocation == null || parentLocation == null) return false;
                         Path childPath = ((Location)childLocation).getPath();
                         Path parentPath = ((Location)parentLocation).getPath();
                         if (childPath.isRoot()) return false;
@@ -378,6 +379,7 @@ public abstract class JoinComponent extends ProcessingComponent {
             return new Joinable() {
                 public boolean evaluate( Object parentLocation,
                                          Object childLocation ) {
+                    if (childLocation == null || parentLocation == null) return false;
                     Path childPath = ((Location)childLocation).getPath();
                     Path parentPath = ((Location)parentLocation).getPath();
                     if (childPath.isRoot()) return false;
@@ -392,6 +394,7 @@ public abstract class JoinComponent extends ProcessingComponent {
                 return new Joinable() {
                     public boolean evaluate( Object ancestorLocation,
                                              Object descendantLocation ) {
+                        if (ancestorLocation == null || descendantLocation == null) return false;
                         Path ancestorPath = ((Location)ancestorLocation).getPath();
                         Path descendantPath = ((Location)descendantLocation).getPath();
                         return ancestorPath.isAncestorOf(descendantPath);
@@ -402,6 +405,7 @@ public abstract class JoinComponent extends ProcessingComponent {
             return new Joinable() {
                 public boolean evaluate( Object descendantLocation,
                                          Object ancestorLocation ) {
+                    if (ancestorLocation == null || descendantLocation == null) return false;
                     Path ancestorPath = ((Location)ancestorLocation).getPath();
                     Path descendantPath = ((Location)descendantLocation).getPath();
                     return ancestorPath.isAncestorOf(descendantPath);
@@ -430,6 +434,8 @@ public abstract class JoinComponent extends ProcessingComponent {
             return new Comparator<Object>() {
                 public int compare( Object location1,
                                     Object location2 ) {
+                    if (location1 == null) return location2 == null ? 0 : -1;
+                    else if (location2 == null) return 1;
                     Path path1 = ((Location)location1).getPath();
                     Path path2 = ((Location)location2).getPath();
                     return pathComparator.compare(path1, path2);
@@ -444,6 +450,8 @@ public abstract class JoinComponent extends ProcessingComponent {
                 return new Comparator<Object>() {
                     public int compare( Object childLocation,
                                         Object parentLocation ) {
+                        if (childLocation == null) return parentLocation == null ? 0 : -1;
+                        else if (parentLocation == null) return 1;
                         Path childPath = ((Location)childLocation).getPath();
                         Path parentPath = ((Location)parentLocation).getPath();
                         if (childPath.isRoot()) return parentPath.isRoot() ? 0 : -1;
@@ -456,6 +464,8 @@ public abstract class JoinComponent extends ProcessingComponent {
             return new Comparator<Object>() {
                 public int compare( Object parentLocation,
                                     Object childLocation ) {
+                    if (parentLocation == null) return parentLocation == null ? 0 : -1;
+                    else if (parentLocation == null) return 1;
                     Path childPath = ((Location)childLocation).getPath();
                     Path parentPath = ((Location)parentLocation).getPath();
                     if (childPath.isRoot()) return parentPath.isRoot() ? 0 : -1;

--- a/modeshape-jcr/src/test/java/org/modeshape/jcr/ModeShapeTckTest.java
+++ b/modeshape-jcr/src/test/java/org/modeshape/jcr/ModeShapeTckTest.java
@@ -15,6 +15,7 @@ import javax.jcr.Credentials;
 import javax.jcr.ImportUUIDBehavior;
 import javax.jcr.InvalidItemStateException;
 import javax.jcr.LoginException;
+import javax.jcr.NamespaceRegistry;
 import javax.jcr.Node;
 import javax.jcr.NodeIterator;
 import javax.jcr.PathNotFoundException;
@@ -36,7 +37,9 @@ import javax.jcr.observation.Event;
 import javax.jcr.observation.EventIterator;
 import javax.jcr.observation.EventListener;
 import javax.jcr.query.Query;
+import javax.jcr.query.QueryManager;
 import javax.jcr.query.QueryResult;
+import javax.jcr.version.OnParentVersionAction;
 import javax.jcr.version.Version;
 import javax.jcr.version.VersionException;
 import javax.jcr.version.VersionHistory;
@@ -1126,6 +1129,56 @@ public class ModeShapeTckTest extends AbstractJCRTest {
         assertThat(belowCopyNode2.getProperty("computeProp").getString(), is("computePropValue"));
         assertThat(belowCopyNode2.getProperty("versionProp").getString(), is("versionPropValue"));
         assertThat(belowCopyNode2.getMixinNodeTypes()[0].getName(), is("mix:referenceable"));
+    }
+
+    @SuppressWarnings( "unchecked" )
+    @FixFor( "MODE-1359" )
+    public void testShouldQueryUsingJoinWithLeftHandSideOfJoinConditionBeingNullable() throws Exception {
+        session = getHelper().getSuperuserSession();
+        final NamespaceRegistry registry = session.getWorkspace().getNamespaceRegistry();
+
+        final String NAMESPACE_PREFIX = "tt";
+        final String NAMESPACE_URI = "http://test.com/tt";
+        final String FRIENDLY = "tt:friendly";
+        final String FRIEND = "tt:friend";
+
+        registry.registerNamespace(NAMESPACE_PREFIX, NAMESPACE_URI);
+
+        NodeTypeManager manager = session.getWorkspace().getNodeTypeManager();
+        NodeTypeTemplate nodeType = manager.createNodeTypeTemplate();
+        nodeType.setMixin(true);
+        nodeType.setName(FRIENDLY);
+        nodeType.setQueryable(true);
+        nodeType.setDeclaredSuperTypeNames(new String[] {"mix:referenceable"});
+
+        PropertyDefinitionTemplate propertyDef = manager.createPropertyDefinitionTemplate();
+        propertyDef.setName(FRIEND);
+        propertyDef.setMultiple(true);
+        propertyDef.setRequiredType(PropertyType.REFERENCE);
+        propertyDef.setOnParentVersion(OnParentVersionAction.COPY);
+        propertyDef.setProtected(false);
+
+        nodeType.getPropertyDefinitionTemplates().add(propertyDef);
+        manager.registerNodeType(nodeType, true);
+
+        final String USER_NAME = "Paul";
+        final Node userNode = session.getRootNode().addNode(USER_NAME, "nt:folder");
+        userNode.addMixin(FRIENDLY);
+
+        session.save();
+
+        final QueryManager queryManager = session.getWorkspace().getQueryManager();
+        String expression = "SELECT grantee.* FROM [tt:friendly] as grantee "
+                            + "INNER JOIN [tt:friendly] as grantor ON grantee.[jcr:uuid] = grantor.[tt:friend]";
+
+        QueryResult queryResult = queryManager.createQuery(expression, "JCR-SQL2").execute();
+        assertThat(queryResult, is(notNullValue()));
+
+        expression = "SELECT grantee.* FROM [tt:friendly] as grantor "
+                     + "INNER JOIN [tt:friendly] as grantee ON grantor.[tt:friend] = grantee.[jcr:uuid]";
+
+        queryResult = queryManager.createQuery(expression, "JCR-SQL2").execute();
+        assertThat(queryResult, is(notNullValue()));
     }
 
     @FixFor( "MODE-693" )


### PR DESCRIPTION
Added an integration test that verifies the above test code does indeed fail. After fixing the various `Joinable` and `Comparable` implementations in `JoinComponent` (used by both the nested loop join and merge join algorithms, the test code passes. Additionally, all other unit and integration tests pass.

This code will need to be merged into 'master' (for inclusion in 2.7.0.Final) and '3.x' (for inclusion in the 3.0 codebase).
