### PR TITLE
MODE-1357 Eliminated NPE and blocking on binary garbage collection

### DIFF
--- a/modeshape-jcr-redux/src/main/java/org/modeshape/jcr/value/binary/BinaryStore.java
+++ b/modeshape-jcr-redux/src/main/java/org/modeshape/jcr/value/binary/BinaryStore.java
@@ -79,6 +79,9 @@ public interface BinaryStore {
      * Mark the supplied binary keys as unused, but key them in quarantine until needed again (at which point they're removed from
      * quarantine) or until {@link #removeValuesUnusedLongerThan(long, TimeUnit)} is called. This method ignores any keys for
      * values not stored within this store.
+     * <p>
+     * Note that the implementation must <i>never</i> block.
+     * </p>
      * 
      * @param keys the keys for the binary values that are no longer needed
      * @throws BinaryStoreException if there is a problem marking any of the supplied binary values as unused
@@ -87,6 +90,9 @@ public interface BinaryStore {
 
     /**
      * Remove binary values that have been {@link #markAsUnused(Iterable) unused} for at least the specified amount of time.
+     * <p>
+     * Note that the implementation must <i>never</i> block.
+     * </p>
      * 
      * @param minimumAge the minimum time that a binary value has been {@link #markAsUnused(Iterable) unused} before it can be
      *        removed; must be non-negative

--- a/modeshape-jcr-redux/src/test/java/org/modeshape/jcr/value/binary/FileSystemBinaryStoreTest.java
+++ b/modeshape-jcr-redux/src/test/java/org/modeshape/jcr/value/binary/FileSystemBinaryStoreTest.java
@@ -47,7 +47,6 @@ import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.modeshape.common.FixFor;
 import org.modeshape.common.statistic.Stopwatch;
@@ -74,7 +73,7 @@ public class FileSystemBinaryStoreTest {
 
     public static final String[] CONTENT_HASHES;
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(FileSystemBinaryStoreTest.class); 
+    private static final Logger LOGGER = LoggerFactory.getLogger(FileSystemBinaryStoreTest.class);
     static {
         String[] sha1s = new String[CONTENT.length];
         int index = 0;


### PR DESCRIPTION
Changed a couple of things. First, modified the JavaDoc on the two BinaryStore methods related to garbage collection to state that the methods may never block. Then, the FileSystemBinaryStore implementation was changed to correct the NPE and to also try to obtain a write lock on the temporary file that is being deleted; if the write lock cannot immediately be obtained, then that file is skipped and will be removed during the next pass (assuming it will be unlocked shortly). Finally, the FileLocks class was modified to add two methods for trying to obtain locks.

Verified that the behavior works (at least on OS X; we'll see about Windows). Note that FileSystemBinaryStore has a new private static variable that defines whether it should use a lock. If needed (and Windows doesn't like deleting a file that is locked), this constant could be set based upon the operating system.

All unit and integration tests pass on the 3.0 codebase with these changes.
