### PR TITLE
MODE-1366 Error parsing JCR-SQL2 queries using square brackets for quoting

### DIFF
--- a/modeshape-graph/src/test/java/org/modeshape/graph/query/parse/SqlTokenizerTest.java
+++ b/modeshape-graph/src/test/java/org/modeshape/graph/query/parse/SqlTokenizerTest.java
@@ -26,13 +26,13 @@ package org.modeshape.graph.query.parse;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
 import java.util.LinkedList;
+import org.junit.Before;
+import org.junit.Test;
 import org.modeshape.common.text.ParsingException;
 import org.modeshape.common.text.Position;
 import org.modeshape.common.text.TokenStream.CharacterArrayStream;
 import org.modeshape.common.text.TokenStream.Tokens;
 import org.modeshape.graph.query.parse.SqlQueryParser.SqlTokenizer;
-import org.junit.Before;
-import org.junit.Test;
 
 public class SqlTokenizerTest {
 
@@ -258,6 +258,30 @@ public class SqlTokenizerTest {
     public void shouldCreateTokenForDoubleQuotedStringWithoutClosingQuote() {
         String content = "==\"this is a double-quoted \n string";
         tokenize(content);
+    }
+
+    @Test
+    public void shouldCreateTokenForSquareBracketQuotedString() {
+        String content = "[/foo/bar/baz]";
+        tokenize(content);
+        assertNextTokenIs(0, content.length(), SqlTokenizer.QUOTED_STRING);
+        assertNoMoreTokens();
+    }
+
+    @Test
+    public void shouldCreateTokenForSquareBracketQuotedStringWithEmbeddedUnquotedSquareBrackets() {
+        String content = "[/foo/bar[12]/baz[3]]";
+        tokenize(content);
+        assertNextTokenIs(0, content.length(), SqlTokenizer.QUOTED_STRING);
+        assertNoMoreTokens();
+    }
+
+    @Test
+    public void shouldCreateTokenForSquareBracketQuotedStringWithUnrealisticEmbeddedUnquotedSquareBrackets() {
+        String content = "[/foo/bar[12]/baz[[[3]]]]";
+        tokenize(content);
+        assertNextTokenIs(0, content.length(), SqlTokenizer.QUOTED_STRING);
+        assertNoMoreTokens();
     }
 
     @Test


### PR DESCRIPTION
The JCR-SQL2 grammar uses square brackets for quoting identifiers, node names and node paths. However, path literals may also have square brackets around the same-name-siblings. The JCR-SQL2 parser was not able to properly parse quoted paths with SNS indexes.

The fix is to adjust the tokenizer to count the number of open and close square brackets, and to stop the quoted string token when the all of the opened square brackets were closed. Additional unit tests were added to verify the tokenizer and JCR-SQL2 parser behavior.

All unit and integration tests pass with these changes.
