### PR TITLE
MODE-1374 Corrected node type init errors in concurrent environment

### DIFF
--- a/modeshape-jcr-redux/src/main/java/org/modeshape/jcr/RepositoryNodeTypeManager.java
+++ b/modeshape-jcr-redux/src/main/java/org/modeshape/jcr/RepositoryNodeTypeManager.java
@@ -492,16 +492,17 @@ class RepositoryNodeTypeManager implements ChangeSetListener {
                 // Make sure the nodes have primary types that are either already registered, or pending registration ...
                 for (JcrNodeType nodeType : typesPendingRegistration) {
                     for (JcrNodeDefinition nodeDef : nodeType.getDeclaredChildNodeDefinitions()) {
-                        JcrNodeType[] requiredPrimaryTypes = new JcrNodeType[nodeDef.requiredPrimaryTypeNames().length];
+                        Name[] requiredPrimaryTypeNames = nodeDef.requiredPrimaryTypeNames();
+                        JcrNodeType[] requiredPrimaryTypes = new JcrNodeType[requiredPrimaryTypeNames.length];
                         int i = 0;
-                        for (Name primaryTypeName : nodeDef.requiredPrimaryTypeNames()) {
-                            requiredPrimaryTypes[i] = nodeTypes.findTypeInMapOrList(primaryTypeName, typesPendingRegistration);
-
-                            if (requiredPrimaryTypes[i] == null) {
-                                throw new RepositoryException(JcrI18n.invalidPrimaryTypeName.text(primaryTypeName,
-                                                                                                  nodeType.getName()));
+                        for (Name primaryTypeName : requiredPrimaryTypeNames) {
+                            JcrNodeType requiredPrimaryType = nodeTypes.findTypeInMapOrList(primaryTypeName,
+                                                                                            typesPendingRegistration);
+                            if (requiredPrimaryType == null) {
+                                String msg = JcrI18n.invalidPrimaryTypeName.text(primaryTypeName, nodeType.getName());
+                                throw new RepositoryException(msg);
                             }
-                            i++;
+                            requiredPrimaryTypes[i++] = requiredPrimaryType;
                         }
                     }
                 }


### PR DESCRIPTION
The JcrNodeDefinition is intended to be immutable and thread-safe, and although it is publicly immutable, internally it delays loading the references to the required primary types until needed. The `ensureRequiredPrimaryTypesLoaded()` method lazily initializes the references, and this method is properly called in the right spots within JcrNodeDefinition. However, in a highly-concurrent environment a node type definition may be needed by multiple threads, and this can result in this method being called concurrently. Unfortunately this method is not thread-safe, and can cause a NullPointerException when used concurrently.

Unlike the fix in the 2.x codebase, the fix for 3.x simply removes the cached JcrNodeType references (both the array and the map keyed by Name) from JcrNodeDefinition. This simplifies the JcrNodeDefinition class by making it fully immutable (not just publicly immutable), and it also ensures that when node types are updated, they are accurately reflected in all child node definitions.

With this change, all unit and integration tests pass.
