### PR TITLE
MODE-1380 Improve NodeTypeManager.registerNodeType methods

### DIFF
--- a/modeshape-jcr-api/src/main/java/org/modeshape/jcr/api/nodetype/NodeTypeManager.java
+++ b/modeshape-jcr-api/src/main/java/org/modeshape/jcr/api/nodetype/NodeTypeManager.java
@@ -31,6 +31,7 @@ import javax.jcr.RepositoryException;
 import javax.jcr.UnsupportedRepositoryOperationException;
 import javax.jcr.nodetype.InvalidNodeTypeDefinitionException;
 import javax.jcr.nodetype.NodeTypeExistsException;
+import javax.jcr.nodetype.NodeTypeIterator;
 
 /**
  * An extension of JCR 2.0's {@link javax.jcr.nodetype.NodeTypeManager} interface, with methods to support registering node type
@@ -39,52 +40,98 @@ import javax.jcr.nodetype.NodeTypeExistsException;
 public interface NodeTypeManager extends javax.jcr.nodetype.NodeTypeManager {
 
     /**
-     * Read the supplied stream containing node type definitions in the standard JCR 2.0 Compact Node Definition (CND) format or
-     * non-standard Jackrabbit XML format, and register the node types with this repository.
-     * 
+     * Registers or updates the node type definitions per the Compact Node Definition
+     * (CND) file given by the supplied stream. This method is used to register 
+     * or update a set of node types with mutual dependencies. Returns an iterator
+     * over the resulting <code>NodeType</code> objects.
+     * <p>
+     * The effect of the method is "all or nothing"; if an error occurs, no node
+     * types are registered or updated.
+     *
      * @param stream the stream containing the node type definitions in CND format
      * @param allowUpdate a boolean stating whether existing node type definitions should be modified/updated
+     * @return the registered node types.
      * @throws IOException if there is a problem reading from the supplied stream
-     * @throws InvalidNodeTypeDefinitionException if the <code>NodeTypeDefinition</code> is invalid.
-     * @throws NodeTypeExistsException if <code>allowUpdate</code> is <code>false</code> and the <code>NodeTypeDefinition</code>
-     *         specifies a node type name that is already registered.
-     * @throws UnsupportedRepositoryOperationException if this implementation does not support node type registration.
-     * @throws RepositoryException if another error occurs.
+     * @throws InvalidNodeTypeDefinitionException
+     *                                 if a <code>NodeTypeDefinition</code>
+     *                                 within the <code>Collection</code> is invalid or if the
+     *                                 <code>Collection</code> contains an object of a type other than
+     *                                 <code>NodeTypeDefinition</code>.
+     * @throws NodeTypeExistsException if <code>allowUpdate</code> is
+     *                                 <code>false</code> and a <code>NodeTypeDefinition</code> within the
+     *                                 <code>Collection</code> specifies a node type name that is already
+     *                                 registered.
+     * @throws UnsupportedRepositoryOperationException
+     *                                 if this implementation
+     *                                 does not support node type registration.
+     * @throws RepositoryException     if another error occurs.
      */
-    void registerNodeTypes( InputStream stream,
-                            boolean allowUpdate )
-        throws IOException, InvalidNodeTypeDefinitionException, NodeTypeExistsException, UnsupportedRepositoryOperationException,
-        RepositoryException;
+    NodeTypeIterator registerNodeTypes( InputStream stream,
+                                        boolean allowUpdate )
+        throws IOException, InvalidNodeTypeDefinitionException, NodeTypeExistsException, 
+        UnsupportedRepositoryOperationException, RepositoryException;
 
     /**
-     * Read the supplied file containing node type definitions in the standard JCR 2.0 Compact Node Definition (CND) format or
-     * non-standard Jackrabbit XML format, and register the node types with this repository.
-     * 
+     * Registers or updates the node type definitions per the Compact Node Definition
+     * (CND) file given by the supplied file. This method is used to register 
+     * or update a set of node types with mutual dependencies. Returns an iterator
+     * over the resulting <code>NodeType</code> objects.
+     * <p>
+     * The effect of the method is "all or nothing"; if an error occurs, no node
+     * types are registered or updated.
+     *
      * @param file the file containing the node types
      * @param allowUpdate a boolean stating whether existing node type definitions should be modified/updated
+     * @return the registered node types.
      * @throws IOException if there is a problem reading from the supplied stream
-     * @throws InvalidNodeTypeDefinitionException if the <code>NodeTypeDefinition</code> is invalid.
-     * @throws NodeTypeExistsException if <code>allowUpdate</code> is <code>false</code> and the <code>NodeTypeDefinition</code>
-     *         specifies a node type name that is already registered.
-     * @throws UnsupportedRepositoryOperationException if this implementation does not support node type registration.
-     * @throws RepositoryException if another error occurs.
+     * @throws InvalidNodeTypeDefinitionException
+     *                                 if a <code>NodeTypeDefinition</code>
+     *                                 within the <code>Collection</code> is invalid or if the
+     *                                 <code>Collection</code> contains an object of a type other than
+     *                                 <code>NodeTypeDefinition</code>.
+     * @throws NodeTypeExistsException if <code>allowUpdate</code> is
+     *                                 <code>false</code> and a <code>NodeTypeDefinition</code> within the
+     *                                 <code>Collection</code> specifies a node type name that is already
+     *                                 registered.
+     * @throws UnsupportedRepositoryOperationException
+     *                                 if this implementation
+     *                                 does not support node type registration.
+     * @throws RepositoryException     if another error occurs.
      */
-    void registerNodeTypes( File file,
-                            boolean allowUpdate ) throws IOException, RepositoryException;
+    NodeTypeIterator registerNodeTypes( File file,
+                                        boolean allowUpdate ) 
+        throws IOException, InvalidNodeTypeDefinitionException, NodeTypeExistsException, 
+        UnsupportedRepositoryOperationException, RepositoryException;
 
     /**
-     * Read the supplied stream containing node type definitions in the standard JCR 2.0 Compact Node Definition (CND) format or
-     * non-standard Jackrabbit XML format, and register the node types with this repository.
-     * 
+     * Registers or updates the node type definitions per the Compact Node Definition
+     * (CND) file given by the supplied URL. This method is used to register 
+     * or update a set of node types with mutual dependencies. Returns an iterator
+     * over the resulting <code>NodeType</code> objects.
+     * <p>
+     * The effect of the method is "all or nothing"; if an error occurs, no node
+     * types are registered or updated.
+     *
      * @param url the URL that can be resolved to the file containing the node type definitions in CND format
      * @param allowUpdate a boolean stating whether existing node type definitions should be modified/updated
+     * @return the registered node types.
      * @throws IOException if there is a problem reading from the supplied stream
-     * @throws InvalidNodeTypeDefinitionException if the <code>NodeTypeDefinition</code> is invalid.
-     * @throws NodeTypeExistsException if <code>allowUpdate</code> is <code>false</code> and the <code>NodeTypeDefinition</code>
-     *         specifies a node type name that is already registered.
-     * @throws UnsupportedRepositoryOperationException if this implementation does not support node type registration.
-     * @throws RepositoryException if another error occurs.
+     * @throws InvalidNodeTypeDefinitionException
+     *                                 if a <code>NodeTypeDefinition</code>
+     *                                 within the <code>Collection</code> is invalid or if the
+     *                                 <code>Collection</code> contains an object of a type other than
+     *                                 <code>NodeTypeDefinition</code>.
+     * @throws NodeTypeExistsException if <code>allowUpdate</code> is
+     *                                 <code>false</code> and a <code>NodeTypeDefinition</code> within the
+     *                                 <code>Collection</code> specifies a node type name that is already
+     *                                 registered.
+     * @throws UnsupportedRepositoryOperationException
+     *                                 if this implementation
+     *                                 does not support node type registration.
+     * @throws RepositoryException     if another error occurs.
      */
-    void registerNodeTypes( URL url,
-                            boolean allowUpdate ) throws IOException, RepositoryException;
+    NodeTypeIterator registerNodeTypes( URL url,
+                                        boolean allowUpdate ) 
+        throws IOException, InvalidNodeTypeDefinitionException, NodeTypeExistsException, 
+        UnsupportedRepositoryOperationException, RepositoryException;
 }

--- a/modeshape-jcr-redux/src/main/java/org/modeshape/jcr/JcrNodeTypeManager.java
+++ b/modeshape-jcr-redux/src/main/java/org/modeshape/jcr/JcrNodeTypeManager.java
@@ -845,62 +845,65 @@ public class JcrNodeTypeManager implements NodeTypeManager {
     }
 
     @Override
-    public void registerNodeTypes( File file,
-                                   boolean allowUpdate ) throws IOException, RepositoryException {
+    public NodeTypeIterator registerNodeTypes( File file,
+                                               boolean allowUpdate ) throws IOException, RepositoryException {
         String content = IoUtil.read(file);
         if (content.startsWith("<?xml")) {
-            registerNodeTypes(importFromXml(new InputSource(new FileInputStream(file))), allowUpdate);
-        } else {
-            CndImporter importer = new CndImporter(context(), true);
-            Problems problems = new SimpleProblems();
-            importer.importFrom(content, problems, file.getAbsolutePath());
-            if (problems.hasErrors()) {
-                // There are problems, so report the original problems ...
-                String msg = JcrI18n.errorsParsingNodeTypeDefinitions.text(file.getAbsolutePath());
-                throw new RepositoryException(messageFrom(problems, msg));
-            }
-            registerNodeTypes(importer.getNodeTypeDefinitions(), allowUpdate);
+            // This is Jackrabbit XML format ...
+            return registerNodeTypes(importFromXml(new InputSource(new FileInputStream(file))), allowUpdate);
         }
+        // Assume this is CND format ...
+        CndImporter importer = new CndImporter(context(), true);
+        Problems problems = new SimpleProblems();
+        importer.importFrom(content, problems, file.getAbsolutePath());
+        if (problems.hasErrors()) {
+            // There are problems, so report the original problems ...
+            String msg = JcrI18n.errorsParsingNodeTypeDefinitions.text(file.getAbsolutePath());
+            throw new RepositoryException(messageFrom(problems, msg));
+        }
+        return registerNodeTypes(importer.getNodeTypeDefinitions(), allowUpdate);
     }
 
     @Override
-    public void registerNodeTypes( InputStream stream,
-                                   boolean allowUpdate )
+    public NodeTypeIterator registerNodeTypes( InputStream stream,
+                                               boolean allowUpdate )
         throws IOException, javax.jcr.nodetype.InvalidNodeTypeDefinitionException, javax.jcr.nodetype.NodeTypeExistsException,
         UnsupportedRepositoryOperationException, RepositoryException {
 
         String content = IoUtil.read(stream);
         if (content.startsWith("<?xml")) {
-            registerNodeTypes(importFromXml(new InputSource(new StringReader(content))), allowUpdate);
-        } else {
-            CndImporter importer = new CndImporter(context(), true);
-            Problems problems = new SimpleProblems();
-            importer.importFrom(content, problems, "stream");
-            if (problems.hasErrors()) {
-                // There are problems, so report the original problems ...
-                String msg = JcrI18n.errorsParsingStreamOfNodeTypeDefinitions.text();
-                throw new RepositoryException(messageFrom(problems, msg));
-            }
-            registerNodeTypes(importer.getNodeTypeDefinitions(), allowUpdate);
+            // This is Jackrabbit XML format ...
+            return registerNodeTypes(importFromXml(new InputSource(new StringReader(content))), allowUpdate);
         }
+        // Assume this is CND format ...
+        CndImporter importer = new CndImporter(context(), true);
+        Problems problems = new SimpleProblems();
+        importer.importFrom(content, problems, "stream");
+        if (problems.hasErrors()) {
+            // There are problems, so report the original problems ...
+            String msg = JcrI18n.errorsParsingStreamOfNodeTypeDefinitions.text();
+            throw new RepositoryException(messageFrom(problems, msg));
+        }
+        return registerNodeTypes(importer.getNodeTypeDefinitions(), allowUpdate);
     }
 
     @Override
-    public void registerNodeTypes( URL url,
-                                   boolean allowUpdate ) throws IOException, RepositoryException {
+    public NodeTypeIterator registerNodeTypes( URL url,
+                                               boolean allowUpdate ) throws IOException, RepositoryException {
         String content = IoUtil.read(url.openStream());
         if (content.startsWith("<?xml")) {
-            registerNodeTypes(importFromXml(new InputSource(new StringReader(content))), allowUpdate);
-        } else {
-            CndImporter importer = new CndImporter(context(), true);
-            Problems problems = new SimpleProblems();
-            importer.importFrom(content, problems, url.toExternalForm());
-            if (problems.hasErrors()) {
-                // There are problems, so report the original problems ...
-                String msg = JcrI18n.errorsParsingNodeTypeDefinitions.text(url.toExternalForm());
-                throw new RepositoryException(messageFrom(problems, msg));
-            }
-            registerNodeTypes(importer.getNodeTypeDefinitions(), allowUpdate);
+            // This is Jackrabbit XML format ...
+            return registerNodeTypes(importFromXml(new InputSource(new StringReader(content))), allowUpdate);
         }
+        // Assume this is CND format ...
+        CndImporter importer = new CndImporter(context(), true);
+        Problems problems = new SimpleProblems();
+        importer.importFrom(content, problems, url.toExternalForm());
+        if (problems.hasErrors()) {
+            // There are problems, so report the original problems ...
+            String msg = JcrI18n.errorsParsingNodeTypeDefinitions.text(url.toExternalForm());
+            throw new RepositoryException(messageFrom(problems, msg));
+        }
+        return registerNodeTypes(importer.getNodeTypeDefinitions(), allowUpdate);
     }
 }

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrNodeTypeManager.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrNodeTypeManager.java
@@ -821,8 +821,8 @@ public class JcrNodeTypeManager implements NodeTypeManager {
 
     @SuppressWarnings( "deprecation" )
     @Override
-    public void registerNodeTypes( File file,
-                                   boolean allowUpdate ) throws IOException, RepositoryException {
+    public NodeTypeIterator registerNodeTypes( File file,
+                                               boolean allowUpdate ) throws IOException, RepositoryException {
         CheckArg.isNotNull(file, "file");
         String content = IoUtil.read(file);
         GraphNodeTypeReader reader = null;
@@ -833,7 +833,7 @@ public class JcrNodeTypeManager implements NodeTypeManager {
         }
         try {
             reader.read(file);
-            registerNodeTypes(reader.getNodeTypeDefinitions(), allowUpdate);
+            return registerNodeTypes(reader.getNodeTypeDefinitions(), allowUpdate);
         } catch (IOException ioe) {
             throw new RepositoryException(ioe);
         } catch (RepositoryException t) {
@@ -847,8 +847,8 @@ public class JcrNodeTypeManager implements NodeTypeManager {
 
     @SuppressWarnings( "deprecation" )
     @Override
-    public void registerNodeTypes( InputStream stream,
-                                   boolean allowUpdate )
+    public NodeTypeIterator registerNodeTypes( InputStream stream,
+                                               boolean allowUpdate )
         throws IOException, javax.jcr.nodetype.InvalidNodeTypeDefinitionException, javax.jcr.nodetype.NodeTypeExistsException,
         UnsupportedRepositoryOperationException, RepositoryException {
         CheckArg.isNotNull(stream, "stream");
@@ -862,7 +862,7 @@ public class JcrNodeTypeManager implements NodeTypeManager {
         }
         try {
             reader.read(content, "Node type definitions");
-            registerNodeTypes(reader.getNodeTypeDefinitions(), allowUpdate);
+            return registerNodeTypes(reader.getNodeTypeDefinitions(), allowUpdate);
         } catch (RepositoryException t) {
             throw t;
         } catch (RuntimeException t) {
@@ -874,8 +874,8 @@ public class JcrNodeTypeManager implements NodeTypeManager {
 
     @SuppressWarnings( "deprecation" )
     @Override
-    public void registerNodeTypes( URL url,
-                                   boolean allowUpdate ) throws IOException, RepositoryException {
+    public NodeTypeIterator registerNodeTypes( URL url,
+                                               boolean allowUpdate ) throws IOException, RepositoryException {
         CheckArg.isNotNull(url, "url");
         InputStream stream = url.openStream();
         if (stream == null) {
@@ -890,7 +890,7 @@ public class JcrNodeTypeManager implements NodeTypeManager {
         }
         try {
             reader.read(url);
-            registerNodeTypes(reader.getNodeTypeDefinitions(), allowUpdate);
+            return registerNodeTypes(reader.getNodeTypeDefinitions(), allowUpdate);
         } catch (IOException ioe) {
             throw new RepositoryException(ioe);
         } catch (RepositoryException t) {


### PR DESCRIPTION
Make the ModeShape-specific `NodeTypeManager.registerNodeTypes(...)` methods more like the standard `javax.jcr.nodetype.NodeTypeManager.registerNodeTypes(...)` method. In particular, update the JavaDoc and change the return type from void to `NodeTypeIterator`.

These changes are backward compatible with the changes in the API added to ModeShape 2.7. They are also what I've proposed to JSR-333 with the [JSR-333-46|http://java.net/jira/browse/JSR_333-46] feature request.

All tests pass.
