### PR TITLE
MODE-1377 Fixed webdav repository path parsing with trailing slash.

### DIFF
--- a/web/modeshape-web-jcr-webdav-war/pom.xml
+++ b/web/modeshape-web-jcr-webdav-war/pom.xml
@@ -25,6 +25,12 @@
 			<scope>runtime</scope>
 		</dependency>
 
+        <dependency>
+			<groupId>log4j</groupId>
+			<artifactId>log4j</artifactId>
+			<scope>runtime</scope>
+		</dependency>
+
 		<!--  TESTING DEPENDENCIES -->
 		<dependency>
 			<groupId>junit</groupId>
@@ -74,12 +80,12 @@
 							<cargo.jvmargs>-XX:PermSize=128m -XX:MaxPermSize=512 -XX:+UseConcMarkSweepGC -XX:+CMSPermGenSweepingEnabled -XX:+CMSClassUnloadingEnabled</cargo.jvmargs>
 							<cargo.logging>low</cargo.logging>
 							<cargo.servlet.users>dnauser:password:connect,readwrite|unauthorized:password:bogus</cargo.servlet.users>
-                                                        <cargo.servlet.port>8090</cargo.servlet.port>
+                            <cargo.servlet.port>8090</cargo.servlet.port>
 						</properties>
 						<home>${project.build.directory}/cargo</home>
 					</configuration>
 					<wait>false</wait>
-				</configuration>
+                </configuration>
 			</plugin>
 			<!--
 				Override the default Surefire behavior to run during

--- a/web/modeshape-web-jcr-webdav/src/main/java/org/modeshape/web/jcr/webdav/MultiRepositoryRequestResolver.java
+++ b/web/modeshape-web-jcr-webdav/src/main/java/org/modeshape/web/jcr/webdav/MultiRepositoryRequestResolver.java
@@ -40,7 +40,7 @@ public class MultiRepositoryRequestResolver implements RequestResolver {
     /**
      * The string representation of the Java version of the {@link #PATH_PATTERN} regular expression.
      */
-    protected static final String PATH_PATTERN_STRING = "/?(([^/]*)(/([^/]*)?(/(.*))?)?)?";
+    protected static final String PATH_PATTERN_STRING = "/*(([^/]*)(/+([^/]*)?(/+(.*))?)?)?";
 
     /**
      * The regular expression that is used to extract the repository name, workspace name, and node path. Group 2 will contain the
@@ -89,6 +89,7 @@ public class MultiRepositoryRequestResolver implements RequestResolver {
                     // There is a path, so make sure that the repository and workspace names exist ...
                     if (repositoryName == null) repositoryName = "";
                     else if (workspaceName == null) workspaceName = "";
+                    nodePath = nodePath.replaceAll("/{2,}+", "/");
                 }
                 return new ResolvedRequest(request, repositoryName, workspaceName, nodePath);
             }

--- a/web/modeshape-web-jcr-webdav/src/test/java/org/modeshape/web/jcr/webdav/MultiRepositoryRequestResolverTest.java
+++ b/web/modeshape-web-jcr-webdav/src/test/java/org/modeshape/web/jcr/webdav/MultiRepositoryRequestResolverTest.java
@@ -116,8 +116,24 @@ public class MultiRepositoryRequestResolverTest {
     }
 
     @Test
-    public void shouldResolveUrlPathWithSlashAndRepositoryAndBlankWorkspaceAndMultipleSegmentPath() {
-        assertResolved("/rep//a/b/c", "rep", "", "/a/b/c");
+    public void shouldResolveUrlPathWithSlashAndRepositoryAndMultipleSlashWorkspaceAndMultipleSegmentPath() {
+        assertResolved("/rep//a/b/c", "rep", "a", "/b/c");
+        assertResolved("/rep///a/b/c", "rep", "a", "/b/c");
+        assertResolved("/rep////a/b/c", "rep", "a", "/b/c");
+    }
+
+    @Test
+    public void shouldResolveUrlPathWithSlashAndRepositoryAndMultipleSlashWorkspaceAndMultipleSlashSegmentPath() {
+        assertResolved("/rep//a//b/c", "rep", "a", "/b/c");
+        assertResolved("/rep///a/b///c", "rep", "a", "/b/c");
+        assertResolved("/rep////a/b/c///", "rep", "a", "/b/c/");
+    }
+
+    @Test
+    public void shouldResolveUrlPathWithSlashAndRepositoryAndSlashWorkspaceAndMultipleSlashSegmentPath() {
+        assertResolved("/rep/a//b/c", "rep", "a", "/b/c");
+        assertResolved("/rep/a/b///c", "rep", "a", "/b/c");
+        assertResolved("/rep/a/b/c///", "rep", "a", "/b/c/");
     }
 
     @Test
@@ -127,16 +143,16 @@ public class MultiRepositoryRequestResolverTest {
 
     @Test
     public void shouldResolveUrlPathWithSlashAndBlankRepositoryAndBlankWorkspaceAndSlash() {
-        assertResolved("///", "", "", "/");
+        assertResolved("///", null, null, null);
     }
 
     @Test
     public void shouldResolveUrlPathWithSlashAndBlankRepositoryAndBlankWorkspaceAndSingleSegmentPath() {
-        assertResolved("///a", "", "", "/a");
+        assertResolved("///a", "a", null, null);
     }
 
     @Test
     public void shouldResolveUrlPathWithSlashAndBlankRepositoryAndBlankWorkspaceAndMultipleSegmentPath() {
-        assertResolved("///a/b/c", "", "", "/a/b/c");
+        assertResolved("///a/b/c", "a", "b", "/c");
     }
 }


### PR DESCRIPTION
- changed request path parsing so that multiple empty '/' characters are collapsed into one.
- updated pom.xml so that log4j dependency is runtime (this is not ideal, but until slf4j dependencies are changed, this should be there)
