### PR TITLE
MODE-1384 Changed JBoss AS7 kit assembly to use project version variable

### DIFF
--- a/deploy/jbossas/assembly/kit-as7.xml
+++ b/deploy/jbossas/assembly/kit-as7.xml
@@ -16,6 +16,7 @@
 		<fileSet>
 			<directory>kit/jboss-as7</directory>
 			<outputDirectory>/</outputDirectory>
+			<filtered>true</filtered>
 		</fileSet>
 
 		<fileSet>
@@ -49,7 +50,7 @@
 		<dependencySet>
 			<outputDirectory>modules/org/modeshape/main</outputDirectory>
 			<includes>
-				<include>org.modeshape:modeshape-jcr-redux</include>
+				<include>org.modeshape:modeshape-jcr</include>
 				<include>org.modeshape:modeshape-common</include>
 				<include>org.modeshape:modeshape-schematic</include>
 			</includes>

--- a/deploy/jbossas/kit/jboss-as7/modules/org/modeshape/jcr/api/main/module.xml
+++ b/deploy/jbossas/kit/jboss-as7/modules/org/modeshape/jcr/api/main/module.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <module xmlns="urn:jboss:module:1.0" name="org.modeshape.jcr.api">
     <resources>
-        <resource-root path="modeshape-jcr-api-3.0-SNAPSHOT.jar" />
+        <resource-root path="modeshape-jcr-api-${project.version}.jar" />
         <!-- Insert resources here -->
     </resources>
     

--- a/deploy/jbossas/kit/jboss-as7/modules/org/modeshape/jcr/main/module.xml
+++ b/deploy/jbossas/kit/jboss-as7/modules/org/modeshape/jcr/main/module.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <module xmlns="urn:jboss:module:1.0" name="org.modeshape">
     <resources>
-        <resource-root path="modeshape-jcr-redux-3.0-SNAPSHOT.jar" />
+        <resource-root path="modeshape-jcr-${project.version}.jar" />
         <resource-root path="conf" />
-        <resource-root path="modeshape-common-3.0-SNAPSHOT.jar" />
-        <resource-root path="modeshape-schematic-3.0-SNAPSHOT.jar" />  
-        <resource-root path="modeshape-subsystem-3.0-SNAPSHOT.jar" />
+        <resource-root path="modeshape-common-${project.version}.jar" />
+        <resource-root path="modeshape-schematic-${project.version}.jar" />  
+        <resource-root path="modeshape-subsystem-${project.version}.jar" />
     </resources>
 
    <dependencies>

--- a/deploy/jbossas/kit/jboss-as7/modules/org/modeshape/main/module.xml
+++ b/deploy/jbossas/kit/jboss-as7/modules/org/modeshape/main/module.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <module xmlns="urn:jboss:module:1.0" name="org.modeshape">
     <resources>
-        <resource-root path="modeshape-jcr-redux-3.0-SNAPSHOT.jar" />
+        <resource-root path="modeshape-jcr-${project.version}.jar" />
         <resource-root path="conf" />
-        <resource-root path="modeshape-common-3.0-SNAPSHOT.jar" />
-        <resource-root path="modeshape-schematic-3.0-SNAPSHOT.jar" />  
-        <resource-root path="modeshape-subsystem-3.0-SNAPSHOT.jar" />
+        <resource-root path="modeshape-common-${project.version}.jar" />
+        <resource-root path="modeshape-schematic-${project.version}.jar" />  
+        <resource-root path="modeshape-subsystem-${project.version}.jar" />
     </resources>
 
    <dependencies>

--- a/deploy/jbossas/modeshape-jbossas-subsystem/pom.xml
+++ b/deploy/jbossas/modeshape-jbossas-subsystem/pom.xml
@@ -21,7 +21,7 @@
 	<dependencies>
 	<dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>modeshape-jcr-redux</artifactId>
+      <artifactId>modeshape-jcr</artifactId>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/deploy/jbossas/pom.xml
+++ b/deploy/jbossas/pom.xml
@@ -22,7 +22,7 @@
 	<dependencies>
 		<dependency>
 			<groupId>org.modeshape</groupId>
-			<artifactId>modeshape-jcr-redux</artifactId>
+			<artifactId>modeshape-jcr</artifactId>
 			<version>${project.version}</version>
 		</dependency>
 		<!-- <dependency> <groupId>org.modeshape</groupId> <artifactId>modeshape-jdbc</artifactId> 

--- a/modeshape-parent/pom.xml
+++ b/modeshape-parent/pom.xml
@@ -914,7 +914,7 @@
 			</dependency>
 			<dependency>
 				<groupId>org.modeshape</groupId>
-				<artifactId>modeshape-jcr-redux</artifactId>
+				<artifactId>modeshape-jcr</artifactId>
 				<version>${project.version}</version>
 			</dependency>
 			<dependency>

--- a/modeshape-performance-tests/pom.xml
+++ b/modeshape-performance-tests/pom.xml
@@ -28,7 +28,7 @@
     <!-- ModeShape JCR -->
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>modeshape-jcr-redux</artifactId>
+      <artifactId>modeshape-jcr</artifactId>
     </dependency>
     <!-- This should eventually get refactored into this project -->
     <dependency>


### PR DESCRIPTION
Previously, the '3.0-SNAPSHOT' was hardcoded. Plus, some of the Maven modules were referencing `modeshape-jcr-redux`, which was just replaced by `modeshape-jcr`.

Even with a clean Maven repository, the build works well.
