### PR TITLE
MODE-1400 Added error/warning checks when registering node types via CND files

### DIFF
--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrI18n.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrI18n.java
@@ -253,6 +253,11 @@ public final class JcrI18n {
     public static I18n problemRefreshingNodeTypesFromSystem;
     public static I18n errorRefreshingNodeTypes;
 
+    public static I18n errorsParsingNodeTypeDefinitions;
+    public static I18n errorsParsingStreamOfNodeTypeDefinitions;
+    public static I18n warningsParsingNodeTypeDefinitions;
+    public static I18n warningsParsingStreamOfNodeTypeDefinitions;
+
     // Lock messages
     public static I18n nodeNotLockable;
     public static I18n cannotRemoveLockToken;

--- a/modeshape-jcr/src/main/resources/org/modeshape/jcr/JcrI18n.properties
+++ b/modeshape-jcr/src/main/resources/org/modeshape/jcr/JcrI18n.properties
@@ -240,6 +240,11 @@ errorRefreshingNodeTypesFromSystem = Encountered the following error(s) while re
 problemRefreshingNodeTypesFromSystem = Encountered following problems reading node types from system content: {0}
 errorRefreshingNodeTypes = Node types were read from the system content, and appear to be inconsistent or invalid: {0}
 
+errorsParsingNodeTypeDefinitions = Reading the node definitions from '{0}' resulted in problems(s): {1}
+errorsParsingStreamOfNodeTypeDefinitions = Reading the node definitions from the supplied stream resulted in problems(s): {0}
+warningsParsingNodeTypeDefinitions = Reading the node definitions from '{0}' resulted in warnings(s): {1}
+warningsParsingStreamOfNodeTypeDefinitions = Reading the node definitions from the supplied stream resulted in warnings(s): {0}
+
 # Lock messages
 nodeNotLockable = The node at '{0}' is not lockable.  Add the 'mix:lockable' mixin type to make it lockable.
 cannotRemoveLockToken = The lock token '{0}' is a session-scoped lock


### PR DESCRIPTION
Previously, the CND files were being read but any problems during the reading were not reported and were simply ignored. Some errors cause the reader to abort reading and to have successfully read in no node types, so registration appeared to do nothing while hiding the errors. With these changes, the errors and warnings are included in a thrown exception; if there are no errors and only warnings, the warnings are simply logged.

All unit and integration tests pass.
