### PR TITLE
MODE-1401 Corrections to behaviors when nodes are checked in

### DIFF
--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/AbstractJcrNode.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/AbstractJcrNode.java
@@ -1468,7 +1468,7 @@ abstract class AbstractJcrNode extends AbstractJcrItem implements javax.jcr.Node
         }
 
         // Create the child ...
-        return editor.createChild(childName, desiredUuid, childPrimaryTypeName);
+        return editor.createChild(childName, desiredUuid, childPrimaryTypeName, false);
     }
 
     /**

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrContentHandler.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrContentHandler.java
@@ -798,7 +798,7 @@ class JcrContentHandler extends DefaultHandler {
                     Name primaryTypeName = nameFor(typeName);
                     if (JcrNtLexicon.SHARE.equals(primaryTypeName) && uuid != null) {
                         // Per Section 14.7 and 14.8 of the JCR 2.0 specification, shared nodes are imported in a special way ...
-                        child = parent.editor().createChild(nodeName, UUID.randomUUID(), ModeShapeLexicon.SHARE);
+                        child = parent.editor().createChild(nodeName, UUID.randomUUID(), ModeShapeLexicon.SHARE, false);
                         SessionCache.NodeEditor newNodeEditor = child.editor();
                         JcrValue uuidValue = (JcrValue)valueFor(uuid.toString(), PropertyType.STRING);
                         newNodeEditor.setProperty(ModeShapeLexicon.SHARED_UUID, uuidValue, false, true);
@@ -806,7 +806,7 @@ class JcrContentHandler extends DefaultHandler {
                         return;
                     }
                     // Otherwise, it's just a regular node...
-                    child = parent.editor().createChild(nodeName, uuid, primaryTypeName);
+                    child = parent.editor().createChild(nodeName, uuid, primaryTypeName, false);
                 } else {
                     child = existingNode;
                 }

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrI18n.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrI18n.java
@@ -276,6 +276,8 @@ public final class JcrI18n {
 
     // Versioning messages
     public static I18n nodeIsCheckedIn;
+    public static I18n cannotCreateChildOnCheckedInNodeSinceOpvOfChildDefinitionIsNotIgnore;
+    public static I18n cannotRemoveChildOnCheckedInNodeSinceOpvOfChildDefinitionIsNotIgnore;
     public static I18n cannotRemoveFromProtectedNode;
     public static I18n cannotRemoveVersion;
     public static I18n pendingMergeConflicts;

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrVersionManager.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrVersionManager.java
@@ -702,7 +702,7 @@ final class JcrVersionManager implements VersionManager {
             AbstractJcrProperty uuidProp = sourceNode.getProperty(JcrLexicon.FROZEN_UUID);
             UUID desiredUuid = uuid(uuidProp.property().getFirstValue());
 
-            existingNode = parentNode.editor().createChild(path.getLastSegment().getName(), desiredUuid, primaryTypeName);
+            existingNode = parentNode.editor().createChild(path.getLastSegment().getName(), desiredUuid, primaryTypeName, true);
 
             nodeToCheckLock = parentNode;
         }
@@ -1127,7 +1127,7 @@ final class JcrVersionManager implements VersionManager {
                         PropertyInfo<JcrPropertyPayload> uuidProp = resolvedChild.getProperty(JcrLexicon.FROZEN_UUID);
                         UUID desiredUuid = uuid(uuidProp.getProperty().getFirstValue());
 
-                        targetChildNode = targetEditor.createChild(sourceChild.getName(), desiredUuid, primaryTypeName);
+                        targetChildNode = targetEditor.createChild(sourceChild.getName(), desiredUuid, primaryTypeName, true);
                     } else {
                         Name primaryTypeName = name(resolvedChild.getProperty(JcrLexicon.PRIMARY_TYPE)
                                                                  .getProperty()
@@ -1135,7 +1135,7 @@ final class JcrVersionManager implements VersionManager {
                         PropertyInfo<JcrPropertyPayload> uuidProp = resolvedChild.getProperty(JcrLexicon.UUID);
                         UUID desiredUuid = uuidProp == null ? null : uuid(uuidProp.getProperty().getFirstValue());
 
-                        targetChildNode = targetEditor.createChild(sourceChild.getName(), desiredUuid, primaryTypeName);
+                        targetChildNode = targetEditor.createChild(sourceChild.getName(), desiredUuid, primaryTypeName, true);
                     }
                     assert shouldRestore == true;
                 }

--- a/modeshape-jcr/src/main/resources/org/modeshape/jcr/JcrI18n.properties
+++ b/modeshape-jcr/src/main/resources/org/modeshape/jcr/JcrI18n.properties
@@ -263,6 +263,8 @@ sessionIsNotActive = The session with an ID of '{0}' has been closed and can no 
 
 # Versioning messages
 nodeIsCheckedIn = '{0}' (or its nearest versionable ancestor) is checked in, preventing this action
+cannotCreateChildOnCheckedInNodeSinceOpvOfChildDefinitionIsNotIgnore = Cannot add the child node named '{0}' under '{1}' because it is checked in and the child's node definition '{2}' has an on-parent-version attribute of '{3}' (must be 'ignore' to add child to checked-in parent)
+cannotRemoveChildOnCheckedInNodeSinceOpvOfChildDefinitionIsNotIgnore = Cannot remove the child at '{0}' because the parent node is checked in and the child's node definition '{1}' has an on-parent-version attribute of '{2}' (must be 'ignore' to remove child from checked-in parent)
 cannotRemoveFromProtectedNode = Mixins cannot be removed from the node at '{0}' because it has a protected node definition
 cannotRemoveVersion = This version cannot be removed as the property at '{0}' still references it.  Remove that reference and try again.
 pendingMergeConflicts = The node at '{0}' cannot be checked in due to existing merge conflicts stored in the 'jcr:mergeFailed property.

--- a/modeshape-jcr/src/test/resources/versioning.cnd
+++ b/modeshape-jcr/src/test/resources/versioning.cnd
@@ -1,0 +1,19 @@
+<ver='http://www.modeshape.org/test/nodetypes/versioning'>
+
+[ver:versionable] > mix:versionable
+  - versionProp (string) version
+  - copyProp (string) copy
+  - ignoreProp (string) ignore
+  + nonVersionedChild (ver:nonVersionableChild) multiple version
+  + versionedChild (ver:versionableChild) multiple version
+  + nonVersionedIgnoredChild (ver:nonVersionableChild) multiple ignore
+  + versionedIgnoredChild (ver:versionableChild) multiple ignore
+
+[ver:versionableChild] > mix:versionable
+  - copyProp (string) copy
+  - ignoreProp (string) ignore
+  
+[ver:nonVersionableChild]
+  - copyProp (string) copy
+  - ignoreProp (string) ignore
+  


### PR DESCRIPTION
Corrected several behaviors of what is allowed and not allowed for modifying nodes that are checked in, per Section 15.2.2 of the JCR specification. Several new unit tests were added that verify these behaviors. These new tests all failed prior to these fixes, but they all pass now. (Note this clearly shows the incomplete coverage of the TCK versioning tests.)

All unit and integration tests pass with these changes.
