### PR TITLE
MODE-1402 Changed repository configuration format to simplify sequencer configuration 

### DIFF
--- a/modeshape-jcr-api/src/main/java/org/modeshape/jcr/api/sequencer/Sequencer.java
+++ b/modeshape-jcr-api/src/main/java/org/modeshape/jcr/api/sequencer/Sequencer.java
@@ -28,6 +28,7 @@ import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.List;
+import java.util.UUID;
 import javax.jcr.NamespaceException;
 import javax.jcr.NamespaceRegistry;
 import javax.jcr.Node;
@@ -49,19 +50,19 @@ import org.modeshape.jcr.api.nodetype.NodeTypeManager;
  */
 public abstract class Sequencer {
 
-    private String name;
+    private final UUID uuid = UUID.randomUUID();
     private String description;
     private String repositoryName;
     private Object[] pathExpressions;
     private String pathExpression;
 
     /**
-     * Get the name of this sequencer.
+     * Return the unique identifier for this sequencer.
      * 
-     * @return the sequencer name; null only if not {@link #initialize initialized}
+     * @return the unique identifier; never null
      */
-    public final String getName() {
-        return name;
+    public final UUID getUniqueId() {
+        return uuid;
     }
 
     /**
@@ -164,7 +165,8 @@ public abstract class Sequencer {
 
     @Override
     public String toString() {
-        return repositoryName + " -> " + name + (description != null ? (" : " + description) : "");
+        return repositoryName + " -> " + getClass().getName() + " uuid=" + uuid
+               + (description != null ? (" : " + description) : "");
     }
 
     /**

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrI18n.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrI18n.java
@@ -177,7 +177,7 @@ public final class JcrI18n {
     public static I18n invalidAliasForComponent;
     public static I18n unableToSetFieldOnInstance;
     public static I18n missingFieldOnInstance;
-    public static I18n missingComponentClassnameOrAlias;
+    public static I18n missingComponentType;
 
     public static I18n typeMissingWhenRegisteringEngineInJndi;
     public static I18n repositoryNameNotProvidedWhenRegisteringRepositoryInJndi;

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrRepository.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrRepository.java
@@ -1235,11 +1235,7 @@ public class JcrRepository implements org.modeshape.jcr.api.Repository {
                         }
                     }
                 } catch (Throwable t) {
-                    logger.error(t,
-                                 JcrI18n.unableToInitializeAuthenticationProvider,
-                                 component.getName(),
-                                 repositoryName(),
-                                 t.getMessage());
+                    logger.error(t, JcrI18n.unableToInitializeAuthenticationProvider, component, repositoryName(), t.getMessage());
                 }
             }
 

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/TextExtractors.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/TextExtractors.java
@@ -23,16 +23,16 @@
  */
 package org.modeshape.jcr;
 
-import org.modeshape.common.annotation.Immutable;
-import org.modeshape.common.util.Logger;
-import org.modeshape.jcr.RepositoryConfiguration.Component;
-import org.modeshape.jcr.api.text.TextExtractor;
-import org.modeshape.jcr.api.text.TextExtractorOutput;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import org.modeshape.common.annotation.Immutable;
+import org.modeshape.common.util.Logger;
+import org.modeshape.jcr.RepositoryConfiguration.Component;
+import org.modeshape.jcr.api.text.TextExtractor;
+import org.modeshape.jcr.api.text.TextExtractorOutput;
 
 /**
  * Facility for managing {@link TextExtractor} instances.
@@ -58,9 +58,9 @@ public final class TextExtractors implements TextExtractor {
                 TextExtractor extractor = component.createInstance(cl);
                 this.extractors.add(extractor);
             } catch (Throwable t) {
-                String name = component.getName();
+                String desc = component.getDescription();
                 String repoName = repository.name();
-                Logger.getLogger(getClass()).error(t, JcrI18n.unableToInitializeTextExtractor, name, repoName, t.getMessage());
+                Logger.getLogger(getClass()).error(t, JcrI18n.unableToInitializeTextExtractor, desc, repoName, t.getMessage());
             }
         }
     }

--- a/modeshape-jcr/src/main/resources/org/modeshape/jcr/JcrI18n.properties
+++ b/modeshape-jcr/src/main/resources/org/modeshape/jcr/JcrI18n.properties
@@ -174,7 +174,7 @@ errorUpdatingQueryIndexes = Error updating the query indexes: {0}
 invalidAliasForComponent = The '{0}' value "{1}" is not recognized; allowed values are: {2}
 unableToSetFieldOnInstance = Unable to set the '{0}' field on an instance of '{2}' to '{1}' 
 missingFieldOnInstance = The field {0} is not present on {1} or any of its super types
-missingComponentClassnameOrAlias = Must specify a classname or one of the aliases: {0}
+missingComponentType = The component type is required, and must be either a classname or a valid alias: {0}
 
 typeMissingWhenRegisteringEngineInJndi = JNDI registration of engine at "{0}": the 'type' parameter should be specified with a value of '{1}'
 repositoryNameNotProvidedWhenRegisteringRepositoryInJndi = JNDI registration failed: unable to register in JNDI a repository at "{0}" because a 'repositoryName' parameter was not provided

--- a/modeshape-jcr/src/main/resources/org/modeshape/jcr/repository-config-schema.json
+++ b/modeshape-jcr/src/main/resources/org/modeshape/jcr/repository-config-schema.json
@@ -130,26 +130,18 @@
                         "description" : "Specification of a security provider configuration.",
                         "additionalProperties" : true,
                         "properties" : {
-                            "name" : {
-                                "type" : "string",
-                                "description" : "The optional user-defined name of the security provider configuration."
-                            },
-                            "description" : {
-                                "type" : "string",
-                                "description" : "The optional description of the security provider configuration."
-                            },
                             "type" : {
                                 "type" : "string",
-                                "description" : "A shortcut for 'classname' of built-in providers, where the package name is not required. Values are matched against the names of built-in provider implementation classes.",
-                                "enum" : [ "jaas", "servlet"]
-                            },
-                            "classname" : {
-                                "type" : "string",
-                                "description" : "The fully-qualified name of the org.modeshape.graph.text.TextExtractor implementation class."
+                                "required" : true,
+                                "description" : "The fully-qualified name of the 'org.modeshape.jcr.security.AuthenticationProvider' implementation class. Aliases can be used for the built-in providers: 'jaas' for the JAAS provider, and 'servlet' for the Servlet provider."
                             },
                             "classloader" : {
                                 "type" : "string",
-                                "description" : "The optional name of the classloader that should be used to load the sequencer class. If empty or not provided, the classpath accessible to ModeShape will be used."
+                                "description" : "The optional name of the classloader that should be used to load the AuthenicationProvider implementation class. If empty or not provided, the classpath accessible to ModeShape will be used."
+                            },
+                            "description" : {
+                                "type" : "string",
+                                "description" : "The optional description of the security provider configuration, used for administration and reporting. If not specified, the classname will be used."
                             }
                         }
                     }
@@ -180,25 +172,18 @@
                         "description" : "Specification of a text extractor configuration.",
                         "additionalProperties" : true,
                         "properties" : {
-                            "name" : {
-                                "type" : "string",
-                                "description" : "The optional user-defined name of the extractor configuration."
-                            },
-                            "description" : {
-                                "type" : "string",
-                                "description" : "The optional description of the extractor configuration."
-                            },
                             "type" : {
                                 "type" : "string",
-                                "description" : "A shortcut for 'classname' of built-in extractors, where the package name is not required. Values are matched against the names of built-in TextExtractor implementation classes."
-                            },
-                            "classname" : {
-                                "type" : "string",
-                                "description" : "The fully-qualified name of the org.modeshape.jcr.text.TextExtractor implementation class."
+                                "required" : true,
+                                "description" : "The fully-qualified name of the 'org.modeshape.jcr.text.TextExtractor' implementation class. A shortcut for built-in extractors is to just specify the name of the class (without the package specifciation)."
                             },
                             "classloader" : {
                                 "type" : "string",
                                 "description" : "The optional name of the classloader that should be used to load the sequencer class. If empty or not provided, the classpath accessible to ModeShape will be used."
+                            },
+                            "description" : {
+                                "type" : "string",
+                                "description" : "The optional description of the extractor configuration, used for administration and reporting purposes. If not specified, the extractor's classname will be used."
                             }
                         }
                     }
@@ -625,41 +610,32 @@
                 "sequencers" : {
                     "type" : "array",
                     "description" : "The named set of sequencer configurations",
+                    "required" : true,
                     "items" : {
                         "type" : "object",
                         "additionalProperties" : true,
                         "description" : "Specification of a sequencer configuration.",
                         "properties" : {
-                            "name" : {
-                                "type" : "string",
-                                "description" : "The optional user-defined name of the sequencer configuration."
-                            },
-                            "description" : {
-                                "type" : "string",
-                                "description" : "The optional description of the sequencer configuration."
-                            },
                             "type" : {
                                 "type" : "string",
-                                "description" : "A shortcut for 'classname' of built-in sequencers, where the package name is not required. Values are matched against the names of built-in sequencer implementation classes."
-                            },
-                            "classname" : {
-                                "type" : "string",
-                                "description" : "The fully-qualified name of the org.modeshape.jcr.sequencer.Sequencer implementation class."
+                                "required" : true,
+                                "description" : "The fully-qualified name of the 'org.modeshape.jcr.api.sequencer.Sequencer' subclass. A shortcut for built-in sequencers is to just use the name of the class (without the package specification)."
                             },
                             "classloader" : {
                                 "type" : "string",
                                 "description" : "The optional name of the classloader that should be used to load the sequencer class. If empty or not provided, the classpath accessible to ModeShape will be used."
                             },
-                            "pathExpression" : {
-                                "type" : "string",
-                                "description" : "The expression that describes the paths upon which this sequencer operates and the paths where the sequencer output is written."
-                            },
                             "pathExpressions" : {
                                 "type" : "array",
+                                "required" : true,
                                 "items" : {
                                     "type" : "string"
                                 },
                                 "description" : "The expressions that describes the paths upon which this sequencer operates and the paths where the sequencer output is written."
+                            },
+                            "description" : {
+                                "type" : "string",
+                                "description" : "The optional description of the sequencer configuration, used for administration and reporting purposes. If not specified, the description will be a combination of the type and path expressions."
                             }
                         }
                     }

--- a/modeshape-jcr/src/test/java/org/modeshape/jcr/RepositoryConfigurationTest.java
+++ b/modeshape-jcr/src/test/java/org/modeshape/jcr/RepositoryConfigurationTest.java
@@ -73,7 +73,7 @@ public class RepositoryConfigurationTest {
 
     @Test
     public void shouldReportErrorWithExtraSequencingProperties() {
-        assertNotValid(1, "{ 'name' = 'nm', \"sequencing\" : { \"notValid\" : false } }");
+        assertNotValid(1, "{ 'name' = 'nm', \"sequencing\" : { \"notValid\" : false, 'sequencers' : [] } }");
     }
 
     @Test

--- a/modeshape-jcr/src/test/resources/config/repo-config-property-types.json
+++ b/modeshape-jcr/src/test/resources/config/repo-config-property-types.json
@@ -4,8 +4,8 @@
         "removeDerivedContentWithOriginal":true,
         "sequencers":[
             {
-                "name":"Test sequencer",
-                "classname":"org.modeshape.jcr.TestSequencersHolder$SequencerWithProperties",
+                "description":"Test sequencer",
+                "type":"org.modeshape.jcr.TestSequencersHolder$SequencerWithProperties",
                 "pathExpression":"default://",
                 "intList":[1, 1, 2, 3],
                 "intSet":[1, 2, 3],
@@ -25,15 +25,15 @@
                 "doubleProp" : 1.2,
                 "doubleArray" : [1.2, 3.4],
                 "subSequencer" : {
-                    "name" : "SubSequencer",
+                    "description" : "SubSequencer",
                     "intSet":[4,5]
                 },
                 "subSequencerList" : [
                     {
-                        "name" : "subSequencer1"
+                        "description" : "subSequencer1"
                     },
                     {
-                        "name" : "subSequencer2"
+                        "description" : "subSequencer2"
                     }
                 ]
             }

--- a/modeshape-jcr/src/test/resources/config/repo-config.json
+++ b/modeshape-jcr/src/test/resources/config/repo-config.json
@@ -6,7 +6,9 @@
             {
                 "name" : "CND sequencer",
                 "type" : "cnd",
-                "pathExpression" : "default://(*.cnd)/jcr:content[@jcr:data]"
+                "pathExpressions" : [ 
+                    "default://(*.cnd)/jcr:content[@jcr:data]" 
+                ]
             }
         ]
     }

--- a/modeshape-jcr/src/test/resources/sample-repo-config.json
+++ b/modeshape-jcr/src/test/resources/sample-repo-config.json
@@ -24,7 +24,7 @@
         "providers" : [
             {
                 "name" : "My Custom Security Provider",
-                "classname" : "com.example.MyAuthenticationProvider",
+                "type" : "com.example.MyAuthenticationProvider",
                 "description" : "A custom security provider used for authentication and authorization."
             },
             {
@@ -63,12 +63,12 @@
             {
                 "name" : "ZIP Files",
                 "type" : "ZipSequencer",
-                "pathExpression" : "default:/files(//)(*.zip[*])/jcr:content[@jcr:data] => default:/sequenced/zip/$1",
+                "pathExpressions" : ["default:/files(//)(*.zip[*])/jcr:content[@jcr:data] => default:/sequenced/zip/$1"],
                 "description" : "Sequences ZIP files loaded under '/files' and extracting into '/sequenced/zip/$1'",
             },
             {
                 "name" : "Delimited Text File Sequencer",
-                "classname" : "org.modeshape.sequencer.text.DelimitedTextSequencer",
+                "type" : "org.modeshape.sequencer.text.DelimitedTextSequencer",
                 "pathExpressions" : [ 
                     "default:/files//(*.csv[*])/jcr:content[@jcr:data] => default:/sequenced/text/delimited/$1"
                 ],

--- a/modeshape-schematic/src/main/java/org/infinispan/schematic/internal/schema/JsonSchemaValidatorFactory.java
+++ b/modeshape-schematic/src/main/java/org/infinispan/schematic/internal/schema/JsonSchemaValidatorFactory.java
@@ -596,7 +596,7 @@ public class JsonSchemaValidatorFactory implements Validator.Factory {
                               Path pathToParent,
                               Problems problems,
                               SchemaDocumentResolver resolver ) {
-            if (Null.matches(fieldValue)) {
+            if (Null.matches(fieldValue) && fieldName != null) {
                 if (pathToParent.size() == 0) {
                     problems.recordError(pathToParent.with(fieldName), "The top-level '" + fieldName + "' field is required");
                 } else {

--- a/sequencers/modeshape-sequencer-ddl/src/test/resources/config/repo-config.json
+++ b/sequencers/modeshape-sequencer-ddl/src/test/resources/config/repo-config.json
@@ -4,9 +4,9 @@
         "removeDerivedContentWithOriginal" : true,
         "sequencers" : [
             {
-                "name" : "Ddl sequencer test",
+                "description" : "Ddl sequencer test",
                 "type" : "DdlSequencer",
-                "pathExpression" : "default://(*.ddl)/jcr:content[@jcr:data] => default:/ddl"
+                "pathExpressions" : [ "default://(*.ddl)/jcr:content[@jcr:data] => default:/ddl" ]
             }
         ]
     }

--- a/sequencers/modeshape-sequencer-images/src/test/resources/config/repo-config.json
+++ b/sequencers/modeshape-sequencer-images/src/test/resources/config/repo-config.json
@@ -4,14 +4,14 @@
         "removeDerivedContentWithOriginal" : true,
         "sequencers" : [
             {
-                "name" : "Images in separate location",
+                "description" : "Images in separate location",
                 "type" : "ImageSequencer",
                 "pathExpression" : "default://(*.(gif|png|pict|jpg))/jcr:content[@jcr:data] => default:/sequenced/images"
             },
             {
-                "name" : "Images in the same location",
-                "classname" : "org.modeshape.sequencer.image.ImageMetadataSequencer",
-                "pathExpression" : "default://(*.(gif|png|pict|jpg))/jcr:content[@jcr:data]"
+                "description" : "Images in the same location",
+                "type" : "org.modeshape.sequencer.image.ImageMetadataSequencer",
+                "pathExpressions" : [ "default://(*.(gif|png|pict|jpg))/jcr:content[@jcr:data]" ]
             }
         ]
     }

--- a/sequencers/modeshape-sequencer-java/src/test/resources/config/repo-config.json
+++ b/sequencers/modeshape-sequencer-java/src/test/resources/config/repo-config.json
@@ -4,19 +4,19 @@
         "removeDerivedContentWithOriginal" : true,
         "sequencers" : [
             {
-                "name" : "Classes in the same location",
+                "description" : "Classes in the same location",
                 "type" : "ClassSequencer",
-                "pathExpression" : "default://(*.class)/jcr:content[@jcr:data]"
+                "pathExpressions" : [ "default://(*.class)/jcr:content[@jcr:data]" ]
             },
             {
-                "name" : "Classes in different location",
-                "classname" : "org.modeshape.sequencer.classfile.ClassFileSequencer",
-                "pathExpression" : "default://(*.class)/jcr:content[@jcr:data] => /classes"
+                "description" : "Classes in different location",
+                "type" : "org.modeshape.sequencer.classfile.ClassFileSequencer",
+                "pathExpressions" : [ "default://(*.class)/jcr:content[@jcr:data] => /classes" ]
             } ,
             {
-                "name" : "Java Sequencer in different location",
+                "description" : "Java Sequencer in different location",
                 "type" : "javasourcesequencer",
-                "pathExpression" : "default://(*.java)/jcr:content[@jcr:data] => /java"
+                "pathExpressions" : [ "default://(*.java)/jcr:content[@jcr:data] => /java" ]
             }
         ]
     }

--- a/sequencers/modeshape-sequencer-mp3/src/test/resources/config/repo-config.json
+++ b/sequencers/modeshape-sequencer-mp3/src/test/resources/config/repo-config.json
@@ -4,14 +4,14 @@
         "removeDerivedContentWithOriginal" : true,
         "sequencers" : [
             {
-                "name" : "Mp3s in the same location",
+                "description" : "Mp3s in the same location",
                 "type" : "mp3",
-                "pathExpression" : "default://(*.mp3)/jcr:content[@jcr:data]"
+                "pathExpressions" : [ "default://(*.mp3)/jcr:content[@jcr:data]" ]
             },
             {
-                "name" : "Mp3s in different location",
-                "classname" : "org.modeshape.sequencer.mp3.Mp3MetadataSequencer",
-                "pathExpression" : "default://(*.mp3)/jcr:content[@jcr:data] => /mp3s"
+                "description" : "Mp3s in different location",
+                "type" : "org.modeshape.sequencer.mp3.Mp3MetadataSequencer",
+                "pathExpressions" : [ "default://(*.mp3)/jcr:content[@jcr:data] => /mp3s" ]
             }
         ]
     }

--- a/sequencers/modeshape-sequencer-msoffice/src/test/resources/config/repo-config.json
+++ b/sequencers/modeshape-sequencer-msoffice/src/test/resources/config/repo-config.json
@@ -4,9 +4,9 @@
         "removeDerivedContentWithOriginal" : true,
         "sequencers" : [
             {
-                "name" : "Office sequencer",
+                "description" : "Office sequencer",
                 "type" : "msoffice",
-                "pathExpression" : "default://(*.(xls|doc|ppt))/jcr:content[@jcr:data]"
+                "pathExpressions" : [ "default://(*.(xls|doc|ppt))/jcr:content[@jcr:data]" ]
             }
         ]
     }

--- a/sequencers/modeshape-sequencer-text/src/test/resources/config/repo-config.json
+++ b/sequencers/modeshape-sequencer-text/src/test/resources/config/repo-config.json
@@ -4,49 +4,49 @@
         "removeDerivedContentWithOriginal" : true,
         "sequencers" : [
             {
-                "name" : "Delimited text sequencer",
+                "description" : "Delimited text sequencer",
                 "type" : "delimitedtext",
-                "pathExpression" : "default:/(*.csv)/jcr:content[@jcr:data] => /delimited",
+                "pathExpressions" : [ "default:/(*.csv)/jcr:content[@jcr:data] => /delimited" ],
                 "commentMarker" : "#"
             },
             {
-                "name" : "Delimited text sequencer with max lines to read",
-                "classname" : "org.modeshape.sequencer.text.DelimitedTextSequencer",
+                "description" : "Delimited text sequencer with max lines to read",
+                "type" : "org.modeshape.sequencer.text.DelimitedTextSequencer",
                 "maximumLinesToRead" : 3,
-                "pathExpression" : "default://maxlines/(*.csv)/jcr:content[@jcr:data] => /delimited/maxlines"
+                "pathExpressions" : [ "default://maxlines/(*.csv)/jcr:content[@jcr:data] => /delimited/maxlines" ]
             },
             {
-                "name" : "Delimited text sequencer with custom row factory",
-                "classname" : "org.modeshape.sequencer.text.DelimitedTextSequencer",
+                "description" : "Delimited text sequencer with custom row factory",
+                "type" : "org.modeshape.sequencer.text.DelimitedTextSequencer",
                 "rowFactoryClassName" : "org.modeshape.sequencer.text.CustomRowFactory",
-                "pathExpression" : "default://customrowfactory/(*.csv)/jcr:content[@jcr:data] => /delimited/customrowfactory"
+                "pathExpressions" : [ "default://customrowfactory/(*.csv)/jcr:content[@jcr:data] => /delimited/customrowfactory" ]
             },
             {
-                "name" : "Delimited text sequencer with custom split pattern",
-                "classname" : "org.modeshape.sequencer.text.DelimitedTextSequencer",
+                "description" : "Delimited text sequencer with custom split pattern",
+                "type" : "org.modeshape.sequencer.text.DelimitedTextSequencer",
                 "splitPattern" : "\\|",
-                "pathExpression" : "default://customsplitpattern/(*.csv)/jcr:content[@jcr:data] => /delimited/customsplitpattern"
+                "pathExpressions" : [ "default://customsplitpattern/(*.csv)/jcr:content[@jcr:data] => /delimited/customsplitpattern" ]
             },
             {
-                "name" : "Fixed width text sequencer",
+                "description" : "Fixed width text sequencer",
                 "type" : "fixedwidthtext",
-                "pathExpression" : "default:/(*.txt)/jcr:content[@jcr:data] => /fixed",
+                "pathExpressions" : [ "default:/(*.txt)/jcr:content[@jcr:data] => /fixed"] ,
                 "columnStartPositions" : [3,6],
                 "commentMarker" : "#"
             },
             {
-                "name" : "Fixed width text sequencer with custom row factory",
-                "classname" : "org.modeshape.sequencer.text.FixedWidthTextSequencer",
+                "description" : "Fixed width text sequencer with custom row factory",
+                "type" : "org.modeshape.sequencer.text.FixedWidthTextSequencer",
                 "rowFactoryClassName" : "org.modeshape.sequencer.text.CustomRowFactory",
                 "columnStartPositions" : [3,6],
-                "pathExpression" : "default://customrowfactory/(*.txt)/jcr:content[@jcr:data] => /fixed/customrowfactory"
+                "pathExpressions" : [ "default://customrowfactory/(*.txt)/jcr:content[@jcr:data] => /fixed/customrowfactory" ]
             },
             {
-                "name" : "Fixed width text sequencer with max lines to read",
-                "classname" : "org.modeshape.sequencer.text.FixedWidthTextSequencer",
+                "description" : "Fixed width text sequencer with max lines to read",
+                "type" : "org.modeshape.sequencer.text.FixedWidthTextSequencer",
                 "maximumLinesToRead" : 3,
                 "columnStartPositions" : [3,6],
-                "pathExpression" : "default://maxline/(*.txt)/jcr:content[@jcr:data] => /delimited/maxlines"
+                "pathExpressions" : [ "default://maxline/(*.txt)/jcr:content[@jcr:data] => /delimited/maxlines" ]
             }
         ]
     }

--- a/sequencers/modeshape-sequencer-wsdl/src/test/resources/config/repo-config.json
+++ b/sequencers/modeshape-sequencer-wsdl/src/test/resources/config/repo-config.json
@@ -4,9 +4,9 @@
         "removeDerivedContentWithOriginal" : true,
         "sequencers" : [
             {
-                "name" : "WSDL sequencer",
+                "description" : "WSDL sequencer",
                 "type" : "wsdlsequencer",
-                "pathExpression" : "default:/(*.wsdl)/jcr:content[@jcr:data] => /wsdl"
+                "pathExpressions" : [ "default:/(*.wsdl)/jcr:content[@jcr:data] => /wsdl" ]
             }
         ]
     }

--- a/sequencers/modeshape-sequencer-xml/src/test/resources/config/repo-config.json
+++ b/sequencers/modeshape-sequencer-xml/src/test/resources/config/repo-config.json
@@ -4,14 +4,14 @@
         "removeDerivedContentWithOriginal" : true,
         "sequencers" : [
             {
-                "name" : "XML sequencer",
+                "description" : "XML sequencer",
                 "type" : "xmlsequencer",
-                "pathExpression" : "default:/(*.xml)/jcr:content[@jcr:data] => /xml"
+                "pathExpressions" : [ "default:/(*.xml)/jcr:content[@jcr:data] => /xml" ]
             },
             {
-                "name" : "Inheriting XML sequencer",
-                "classname" : "org.modeshape.sequencer.xml.InheritingXmlSequencer",
-                "pathExpression" : "default:/(*.xsd)/jcr:content[@jcr:data] => /xml"
+                "description" : "Inheriting XML sequencer",
+                "type" : "org.modeshape.sequencer.xml.InheritingXmlSequencer",
+                "pathExpressions" : [ "default:/(*.xsd)/jcr:content[@jcr:data] => /xml" ]
             }
         ]
     }

--- a/sequencers/modeshape-sequencer-xsd/src/test/resources/config/repo-config.json
+++ b/sequencers/modeshape-sequencer-xsd/src/test/resources/config/repo-config.json
@@ -4,9 +4,9 @@
         "removeDerivedContentWithOriginal" : true,
         "sequencers" : [
             {
-                "name" : "XSD sequencer",
+                "description" : "XSD sequencer",
                 "type" : "xsdsequencer",
-                "pathExpression" : "default:/(*.xsd)/jcr:content[@jcr:data]"
+                "pathExpressions" : [ "default:/(*.xsd)/jcr:content[@jcr:data]" ]
             }
         ]
     }

--- a/sequencers/modeshape-sequencer-zip/src/test/resources/config/repo-config.json
+++ b/sequencers/modeshape-sequencer-zip/src/test/resources/config/repo-config.json
@@ -4,9 +4,9 @@
         "removeDerivedContentWithOriginal" : true,
         "sequencers" : [
             {
-                "name" : "ZIP sequencer",
+                "description" : "ZIP sequencer",
                 "type" : "zipsequencer",
-                "pathExpression" : "default:/(*.zip)/jcr:content[@jcr:data] => /zip"
+                "pathExpressions" : [ "default:/(*.zip)/jcr:content[@jcr:data] => /zip" ]
             }
         ]
     }


### PR DESCRIPTION
Made a couple of changes to the repository configuration JSON Schema to simplify things and remove unused or ancillary items:
- The sequencer, text extractor, and authentication provider components no longer have a "name" field, since it was not much different than "description"
- The sequencer, text extractor, and authentication provider components have a "type" field that is a superset of the older "type" and "classname" fields. The "type" field is now required.
- The sequencer components no longer have a "pathExpression" and "pathExpressions" fields; instead, there's just "pathExpressions" whose values are always arrays. Note that "pathExpressions" is now a required field.

Lots of configuration files for the sequencer modules were changed (as was the online documentation). Quite a few other classes needed to be changed to support the removal of the "name" field from Component and Sequencers.

All unit and integration tests pass.
