### PR TITLE
MODE-1391 Added ability to specify location for file-based binary store

### DIFF
--- a/demos/sequencers/src/main/resources/my-repository.json
+++ b/demos/sequencers/src/main/resources/my-repository.json
@@ -4,36 +4,36 @@
         "removeDerivedContentWithOriginal" : true,
         "sequencers" : [
             {
-                "name" : "MP3s",
+                "description" : "MP3s",
                 "type" : "mp3",
-                "pathExpression" : "//(*.mp3)/jcr:content[@jcr:data] => /audio"
+                "pathExpressions" : [ "//(*.mp3)/jcr:content[@jcr:data] => /audio" ]
             },
             {
-                "name" : "Images",
+                "description" : "Images",
                 "type" : "image",
-                "pathExpression" : "//(*.(gif|png|pict|jpg))/jcr:content[@jcr:data] => /images"
+                "pathExpressions" : [ "//(*.(gif|png|pict|jpg))/jcr:content[@jcr:data] => /images" ]
             },
             {
-                "name" : "Fixed width text sequencer",
-                "classname" : "org.modeshape.sequencer.text.FixedWidthTextSequencer",
-                "pathExpression" : "//(*.txt)/jcr:content[@jcr:data] => /text",
+                "description" : "Fixed width text sequencer",
+                "type" : "org.modeshape.sequencer.text.FixedWidthTextSequencer",
+                "pathExpressions" : [ "//(*.txt)/jcr:content[@jcr:data] => /text" ],
                 "columnStartPositions" : [3,6],
                 "commentMarker" : "#"
             },
             {
                 "type" : "delimitedtext",
-                "pathExpression" : "//(*.csv)/jcr:content[@jcr:data] => /text",
+                "pathExpressions" : [ "//(*.csv)/jcr:content[@jcr:data] => /text" ],
                 "commentMarker" : "#"
             },
             {
-                "name" : "Java Classes",
+                "description" : "Java Classes",
                 "type" : "class",
-                "pathExpression" : "//(*.class)/jcr:content[@jcr:data] => /java"
+                "pathExpressions" : [ "//(*.class)/jcr:content[@jcr:data] => /java" ]
             },
             {
-                "name" : "Java Source",
+                "description" : "Java Source",
                 "type" : "java",
-                "pathExpression" : "//(*.java)/jcr:content[@jcr:data] => /java"
+                "pathExpressions" : [ "//(*.java)/jcr:content[@jcr:data] => /java" ]
             }
         ]
     }

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/value/binary/AbstractBinaryStore.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/value/binary/AbstractBinaryStore.java
@@ -98,4 +98,13 @@ public abstract class AbstractBinaryStore implements BinaryStore {
     protected final MimeTypeDetector detector() {
         return detector;
     }
+
+    /**
+     * Initialize the store and get ready for use.
+     */
+    public void start() {
+    }
+
+    public void shutdown() {
+    }
 }

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/value/binary/InfinispanBinaryStore.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/value/binary/InfinispanBinaryStore.java
@@ -26,6 +26,8 @@ package org.modeshape.jcr.value.binary;
 import java.io.InputStream;
 import java.util.concurrent.TimeUnit;
 import org.infinispan.Cache;
+import org.infinispan.manager.CacheContainer;
+import org.infinispan.manager.EmbeddedCacheManager;
 import org.modeshape.common.annotation.ThreadSafe;
 import org.modeshape.jcr.value.Binary;
 import org.modeshape.jcr.value.BinaryKey;
@@ -36,8 +38,73 @@ import org.modeshape.jcr.value.BinaryKey;
 @ThreadSafe
 public class InfinispanBinaryStore extends AbstractBinaryStore {
 
+    private String contentCacheName;
+    private CacheContainer contentCacheContainer;
+    private String cacheName;
+    private CacheContainer cacheContainer;
+    private Cache<?, ?> cache;
+    private boolean ownCacheContainer;
+
+    public InfinispanBinaryStore( String cacheName,
+                                  CacheContainer cacheContainer ) {
+        this.cacheName = cacheName;
+        this.cacheContainer = cacheContainer;
+    }
+
+    /**
+     * Set the name of the content cache. This will be called before {@link #start()}.
+     * 
+     * @param cacheName the name of the cache this repository uses to store content; never null
+     */
+    public void setContentCacheName( String cacheName ) {
+        this.contentCacheName = cacheName;
+    }
+
+    /**
+     * Set the {@link CacheContainer} this repository uses for content. This will be called before {@link #start()}.
+     * 
+     * @param cacheContainer the cache container this repository uses to store content; never null
+     */
+    public void setContentCacheContainer( CacheContainer cacheContainer ) {
+        this.contentCacheContainer = cacheContainer;
+    }
+
+    /**
+     * Initialize the store with the name of the cache and the {@link CacheContainer} used for the content cache.
+     */
+    @Override
+    public void start() {
+        if (cache != null) {
+            if (this.cacheName == null) {
+                this.cacheName = contentCacheName;
+            }
+            if (this.cacheContainer == null) {
+                this.cacheContainer = contentCacheContainer;
+                this.ownCacheContainer = false;
+            } else {
+                this.ownCacheContainer = true;
+            }
+            // find the cache instance ...
+            cache = this.cacheContainer.getCache(this.cacheName);
+        }
+    }
+
+    @Override
+    public void shutdown() {
+        try {
+            if (this.ownCacheContainer) {
+                if (cacheContainer instanceof EmbeddedCacheManager) {
+                    ((EmbeddedCacheManager)this.cacheContainer).stop();
+                }
+            }
+        } finally {
+            this.cacheContainer = null;
+            this.cacheName = null;
+        }
+    }
+
     public Cache<?, ?> getCache() {
-        return null;
+        return cache;
     }
 
     @Override

--- a/modeshape-jcr/src/main/resources/org/modeshape/jcr/repository-config-schema.json
+++ b/modeshape-jcr/src/main/resources/org/modeshape/jcr/repository-config-schema.json
@@ -45,20 +45,86 @@
                     "description" : "The name of the Infinispan class that should be used to find the JTA transaction manager instance. It defaults to 'org.infinispan.transaction.lookup.GenericTransactionManagerLookup'"
                 },
                 "binaryStorage" : {
-                    "type" : "object",
-                    "additionalProperties" : true,
-                    "properties" : {
-                        "minimumBinarySizeInBytes" : {
-                            "type" : "integer",
-                            "default" : 4096,
-                            "description" : "The size threshold that dictates whether String and binary values should be stored in the binary store. String and binary values smaller than this value are stored with the node, whereas string and binary values with a size equal to or greater than this limit will be stored separately from the node and in the binary store, keyed by the SHA-1 hash of the value. This is a space and performance optimization that stores each unique large value only once. The default value is '4096' bytes, or 4 kilobytes."
+                    "type" : [
+                        {
+                            "type" : "object",
+                            "additionalProperties" : false,
+                            "properties" : {
+                                "type" : {
+                                    "type" : "string",
+                                    "description" : "The specification of the transient binary store, which keeps BINARY values on disk in the temp directory.",
+                                    "enum" : [ "transient" ]
+                                },
+                                "minimumBinarySizeInBytes" : {
+                                    "type" : "integer",
+                                    "default" : 4096,
+                                    "description" : "The size threshold that dictates whether String and binary values should be stored in the binary store. String and binary values smaller than this value are stored with the node, whereas string and binary values with a size equal to or greater than this limit will be stored separately from the node and in the binary store, keyed by the SHA-1 hash of the value. This is a space and performance optimization that stores each unique large value only once. The default value is '4096' bytes, or 4 kilobytes."
+                                },
+                            }
                         },
-                        "type" : {
-                            "type" : "string",
-                            "description" : "A shortcut for 'classname' of built-in providers, where the package name is not required. Values are matched against the names of built-in provider implementation classes. The value of this field will also determine whether any additional fields are required or optional.",
-                            "enum" : [ "transient", "file", "database","cache"]
+                        {
+                            "type" : "object",
+                            "additionalProperties" : false,
+                            "properties" : {
+                                "type" : {
+                                    "type" : "string",
+                                    "description" : "The specification of the file-based binary store, which keeps BINARY values on disk in the specified directory.",
+                                    "enum" : [ "file" ]
+                                },
+                                "directory" : {
+                                    "type" : "string",
+                                    "required" : true,
+                                    "description" : "The location of the directory the file system under which the BINARY values should be stored. The value can be an absolute or relative path."
+                                },
+                                "minimumBinarySizeInBytes" : {
+                                    "type" : "integer",
+                                    "default" : 4096,
+                                    "description" : "The size threshold that dictates whether String and binary values should be stored in the binary store. String and binary values smaller than this value are stored with the node, whereas string and binary values with a size equal to or greater than this limit will be stored separately from the node and in the binary store, keyed by the SHA-1 hash of the value. This is a space and performance optimization that stores each unique large value only once. The default value is '4096' bytes, or 4 kilobytes."
+                                },
+                            }
                         },
-                    }
+                        {
+                            "type" : "object",
+                            "additionalProperties" : false,
+                            "properties" : {
+                                "type" : {
+                                    "type" : "string",
+                                    "description" : "The specification of the database binary store, which stores BINARY values in a JDBC-compatible database.",
+                                    "enum" : [ "database" ]
+                                },
+                                "minimumBinarySizeInBytes" : {
+                                    "type" : "integer",
+                                    "default" : 4096,
+                                    "description" : "The size threshold that dictates whether String and binary values should be stored in the binary store. String and binary values smaller than this value are stored with the node, whereas string and binary values with a size equal to or greater than this limit will be stored separately from the node and in the binary store, keyed by the SHA-1 hash of the value. This is a space and performance optimization that stores each unique large value only once. The default value is '4096' bytes, or 4 kilobytes."
+                                },
+                            }
+                        },
+                        {
+                            "type" : "object",
+                            "additionalProperties" : false,
+                            "properties" : {
+                                "type" : {
+                                    "type" : "string",
+                                    "description" : "The specification of the database binary store, which stores BINARY values in a JDBC-compatible database.",
+                                    "enum" : [ "cache" ]
+                                },
+                                "cacheName" : {
+                                    "type" : "string",
+                                    "required" : true,
+                                    "description" : "The name of the Infinispan cache where BINARY values should be stored."
+                                },
+                                "cacheConfiguration" : {
+                                    "type" : "string",
+                                    "description" : "The name of the Infinispan configuration file for creating a new cache manager. If a file could not be found (on the thread context classloader, on the application's classpath, or on the system classpath), then the name is assumed to reference an existing Infinispan CacheContainer instance via a valid JNDI name or as the name of a service as defined by the local environment. If not specified or no such container is found, then the same cache manager used for the content storage will be used."
+                                },
+                                "minimumBinarySizeInBytes" : {
+                                    "type" : "integer",
+                                    "default" : 4096,
+                                    "description" : "The size threshold that dictates whether String and binary values should be stored in the binary store. String and binary values smaller than this value are stored with the node, whereas string and binary values with a size equal to or greater than this limit will be stored separately from the node and in the binary store, keyed by the SHA-1 hash of the value. This is a space and performance optimization that stores each unique large value only once. The default value is '4096' bytes, or 4 kilobytes."
+                                },
+                            }
+                        },
+                    ]
                 },
             }
         },


### PR DESCRIPTION
Changed the repository configuration JSON Schema to have different structures for the 'transient', 'file', 'database', and 'cache' binary storage nested document. This allows each type to dictate its own properties.

All unit and integration tests pass.
