### PR TITLE
MODE-1238 Fixed indexing for federated connectors

### DIFF
--- a/modeshape-graph/src/main/java/org/modeshape/graph/connector/federation/JoinRequestProcessor.java
+++ b/modeshape-graph/src/main/java/org/modeshape/graph/connector/federation/JoinRequestProcessor.java
@@ -192,13 +192,13 @@ class JoinRequestProcessor extends RequestProcessor {
             }
             mirrorProcessor.setFederatedRequest(forked);
             mirrorProcessor.process(original);
-            // If this is a change request, record it on this processor so it goes to the observer ...
-            if (original instanceof ChangeRequest && !original.hasError() && !original.isCancelled()) {
-                recordChange((ChangeRequest)original);
-            }
         } else {
             this.federatedRequest = forked;
             process(original);
+        }
+        // If this is a change request, record it on this processor so it goes to the observer ...
+        if (original instanceof ChangeRequest && !original.hasError() && !original.isCancelled()) {
+            recordChange((ChangeRequest)original);
         }
     }
 

--- a/modeshape-integration-tests/src/test/java/org/modeshape/test/integration/DiskRepositoryTest.java
+++ b/modeshape-integration-tests/src/test/java/org/modeshape/test/integration/DiskRepositoryTest.java
@@ -51,7 +51,7 @@ public class DiskRepositoryTest extends ModeShapeSingleUseTest {
 
     @Override
     public void beforeEach() throws Exception {
-        File repositoryFolder = new File("target/database");
+        File repositoryFolder = new File("target/database/ConfigurationTest/files");
         if (repositoryFolder.exists()) {
             assertTrue(FileUtil.delete(repositoryFolder));
         }

--- a/modeshape-integration-tests/src/test/java/org/modeshape/test/integration/federation/FederationConnectorQueryTest.java
+++ b/modeshape-integration-tests/src/test/java/org/modeshape/test/integration/federation/FederationConnectorQueryTest.java
@@ -1,0 +1,87 @@
+package org.modeshape.test.integration.federation;
+
+import javax.jcr.Credentials;
+import javax.jcr.Node;
+import javax.jcr.NodeIterator;
+import javax.jcr.Session;
+import javax.jcr.SimpleCredentials;
+import javax.jcr.nodetype.NodeType;
+import javax.jcr.query.Query;
+import javax.jcr.query.QueryManager;
+import javax.jcr.query.QueryResult;
+import static junit.framework.Assert.assertEquals;
+import org.junit.AfterClass;
+import static org.junit.Assert.assertNotNull;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.modeshape.common.FixFor;
+import org.modeshape.jcr.JaasTestUtil;
+import org.modeshape.test.ModeShapeSingleUseTest;
+
+/**
+ * Uni test for searching a federated repository
+ *
+ * @author Horia Chiorean
+ */
+public class FederationConnectorQueryTest extends ModeShapeSingleUseTest {
+    /**
+     * defined in security/jaas.conf.xml
+     */
+    private static final Credentials SUPERUSER_CREDENTIALS = new SimpleCredentials("superuser", "superuser".toCharArray());
+
+    private Session session;
+
+    @Override
+    public void beforeEach() throws Exception {
+        super.beforeEach();
+        session = sessionTo("My repository", "default", SUPERUSER_CREDENTIALS);
+    }
+
+    @Override
+    public void afterEach() throws Exception {
+        super.afterEach();
+    }
+
+    @BeforeClass
+    public static void beforeAll() {
+        JaasTestUtil.initJaas("security/jaas.conf.xml");
+    }
+
+    @AfterClass
+    public static void afterAll() {
+        JaasTestUtil.releaseJaas();
+    }
+
+    @Override
+    protected String getPathToDefaultConfiguration() {
+        return "config/configRepositoryForFederatedSearch.xml";
+    }
+
+    @FixFor("MODE-1238")
+    @Test
+    public void shouldUpdateQueryIndex() throws Exception {
+        // Get the root node ...
+        Node root = session.getRootNode();
+        assertNotNull(root);
+
+        Node testNode;
+        if (session.itemExists("/inmemory1")) {
+            testNode = session.getNode("/inmemory1").addNode("testNode", NodeType.NT_UNSTRUCTURED);
+        }
+        else {
+            testNode = root.addNode("/inmemory1", NodeType.NT_UNSTRUCTURED).addNode("testNode", NodeType.NT_UNSTRUCTURED);
+        }
+
+        testNode.setProperty("prop", "Hello World");
+        session.save();
+
+        QueryManager qm = session.getWorkspace().getQueryManager();
+        Query query = qm.createQuery("select * from [nt:unstructured] where prop = 'Hello World'", Query.JCR_SQL2);
+        QueryResult queryResult = query.execute();
+
+        NodeIterator iter = queryResult.getNodes();
+        assertEquals(1, iter.getSize());
+        Node foundNode = iter.nextNode();
+        assertEquals(testNode.getPath(), foundNode.getPath());        
+    }        
+}

--- a/modeshape-integration-tests/src/test/resources/config/configRepositoryForFederatedSearch.xml
+++ b/modeshape-integration-tests/src/test/resources/config/configRepositoryForFederatedSearch.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration xmlns:mode="http://www.modeshape.org/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0">
+    <!--
+      Define the JCR repositories
+    -->
+    <mode:repositories>
+        <mode:repository jcr:name="My repository" mode:source="federated">
+            <mode:options jcr:primaryType="mode:options">
+                <mode:option jcr:name="systemSourceName" mode:value="system@inmemory1"/>
+                <mode:option jcr:name="jaasLoginConfigName" mode:value="modeshape-jcr"/>
+                <mode:option jcr:name="queryIndexDirectory" mode:value="target/lucene/indexes"/>
+            </mode:options>
+        </mode:repository>
+    </mode:repositories>
+    <!--
+    Define the sources for the content.  These sources are directly accessible using the ModeShape-specific
+    Graph API.
+    -->
+    <mode:sources>
+        <mode:source jcr:name="inmemory1" mode:classname="org.modeshape.graph.connector.inmemory.InMemoryRepositorySource" mode:retryLimit="3" mode:defaultWorkspaceName="default">
+            <predefinedWorkspaceNames>system</predefinedWorkspaceNames>
+            <predefinedWorkspaceNames>default</predefinedWorkspaceNames>
+        </mode:source>
+        <mode:source jcr:name="inmemory2" mode:classname="org.modeshape.graph.connector.inmemory.InMemoryRepositorySource" mode:retryLimit="3" mode:defaultWorkspaceName="default">
+            <predefinedWorkspaceNames>default</predefinedWorkspaceNames>
+        </mode:source>
+        <mode:source jcr:name="federated">
+            <mode:classname>org.modeshape.graph.connector.federation.FederatedRepositorySource</mode:classname>
+            <mode:workspaces>
+                <mode:workspace jcr:name="default">
+                    <mode:projections>
+                        <mode:projection jcr:name="projection1" mode:source="inmemory1" mode:workspaceName="default">
+                            <mode:projectionRules>/inmemory1 => /</mode:projectionRules>
+                        </mode:projection>
+                        <mode:projection jcr:name="projection2" mode:source="inmemory2" mode:workspaceName="default">
+                            <mode:projectionRules>/inmemory2 => /</mode:projectionRules>
+                        </mode:projection>
+                    </mode:projections>
+                </mode:workspace>
+            </mode:workspaces>
+        </mode:source>
+    </mode:sources>
+</configuration>


### PR DESCRIPTION
The bug was caused by the fact that changes were not dispatched when the source and target space of the projection did not match. The fix allows changes to be recorded & dispatched always (not only when the source and target of the projection are the same)
