### PR TITLE
MODE-1252 Added repository name constant in RepositoryFactory

### DIFF
--- a/modeshape-jcr-api/src/main/java/org/modeshape/jcr/api/RepositoryFactory.java
+++ b/modeshape-jcr-api/src/main/java/org/modeshape/jcr/api/RepositoryFactory.java
@@ -25,8 +25,139 @@ package org.modeshape.jcr.api;
 
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
+import javax.jcr.Repository;
 
+/**
+ * An extension to the standard {@link javax.jcr.RepositoryFactory} interface, with ModeShape-specific constants and additional
+ * {@link #shutdown()} methods.
+ * <p>
+ * ModeShape's RepositoryFactory implementation looks for two parameters:
+ * <ul>
+ * <li><code><b>org.modeshape.jcr.URL</b></code> - This parameter specifies the URL of the configuration file for the ModeShape
+ * engine with an optional "<code>repositoryName</code>" URL parameter specifying which of the repository defined in the
+ * configuration file should be used. Alternatively, if the URL begins with "<code>jndi:</code>", the object in the JNDI name will
+ * be looked up, and returned if it is a {@link Repository} instance or used to find the Repository instance if the JNDI object is
+ * the ModeShape engine.
+ * <li><code><b>org.modeshape.jcr.RepositoryName</b></code> - This parameter specifies the name of the repository that is to be
+ * used, and that is an alternative to the "<code>repositoryName</code> URL parameter.
+ * </ul>
+ * Often, both properties will be used, resulting in ModeShape's factory using this logic:
+ * <ol>
+ * <li>Look for an already-deployed repository with the name given by <code>org.modeshape.jcr.RepositoryName</code>. If one is
+ * found, then return that Repository instance.</li>
+ * <li>Look for the repository's configuration file at the URL given by <code>org.modeshape.jcr.URL</code>. If the file had
+ * already been loaded, find the repository and return it; otherwise attempt to load the file, start the engine, and find the
+ * Repository instance with the given name.</li>
+ * </ol>
+ * <h2>Use the Standard JCR API</h2>
+ * <p>
+ * The best way for your application to use the RepositoryFactory is to use only the JCR API, and load the properties from a file.
+ * This way, only the file has implementation-specific information, while your application uses only the standard JCR API:
+ * 
+ * <pre>
+ * Properties parameters = new Properties();
+ * parameters.load(...); // Load from a stream or reader
+ * 
+ * Repository repository = null;
+ * for (RepositoryFactory factory : ServiceLoader.load(RepositoryFactory.class)) {
+ *     repository = factory.getRepository(parameters);
+ *     if (repository != null) break;
+ * }
+ * </pre>
+ * 
+ * </p>
+ * <h2>Use the ModeShape constants</h2>
+ * <p>
+ * If you'd rather your application programmatically create the parameters to pass to JCR's RepositoryFactory, and your
+ * application is already dependent upon the ModeShape public API, you can use the constants in this interface to build your
+ * parameter.
+ * </p>
+ * <p>
+ * The preferred approach is to specify the location of the ModeShape configuration file and the name of the repository using
+ * separate parameters:
+ * 
+ * <pre>
+ * String configUrl = &quot;file://path/to/configFile.xml&quot;; // URL that points to ModeShape's configuration file
+ * String repoName = &quot;MyRepository&quot;; // Name of the repository
+ * 
+ * Map&lt;String, String&gt; parameters = new HashMap&lt;String, String&gt;();
+ * parameters.put(org.modeshape.jcr.api.RepositoryFactory.URL, configUrl);
+ * parameters.put(org.modeshape.jcr.api.RepositoryFactory.RepositoryName, repoName);
+ * 
+ * Repository repository = null;
+ * for (RepositoryFactory factory : ServiceLoader.load(RepositoryFactory.class)) {
+ *     repository = factory.getRepository(parameters);
+ *     if (repository != null) break;
+ * }
+ * </pre>
+ * 
+ * </p>
+ * <p>
+ * Note, however, that the repository name could have been specified with a URL parameter:
+ * 
+ * <pre>
+ * String configUrl = &quot;file://path/to/configFile.xml?repositoryName=MyRepository&quot;;
+ * 
+ * Map&lt;String, String&gt; parameters = new HashMap&lt;String, String&gt;();
+ * parameters.put(org.modeshape.jcr.api.RepositoryFactory.URL, configUrl);
+ * 
+ * Repository repository = null;
+ * for (RepositoryFactory factory : ServiceLoader.load(RepositoryFactory.class)) {
+ *     repository = factory.getRepository(parameters);
+ *     if (repository != null) break;
+ * }
+ * </pre>
+ * 
+ * </p>
+ */
 public interface RepositoryFactory extends javax.jcr.RepositoryFactory {
+
+    /**
+     * The name of the key for the ModeShape JCR URL in the parameter map.
+     * <p>
+     * For example:
+     * 
+     * <pre>
+     * String configUrl = &quot;file://path/to/configFile.xml?repositoryName=myRepository&quot;; // URL that points to your configuration file
+     * 
+     * Map&lt;String, String&gt; parameters = new HashMap&lt;String, String&gt;();
+     * parameters.put(org.modeshape.jcr.api.RepositoryFactory.URL, configUrl);
+     * 
+     * Repository repository = null;
+     * for (RepositoryFactory factory : ServiceLoader.load(RepositoryFactory.class)) {
+     *     repository = factory.getRepository(parameters);
+     *     if (repository != null) break;
+     * }
+     * </pre>
+     * 
+     * </p>
+     */
+    public static final String URL = "org.modeshape.jcr.URL";
+
+    /**
+     * The name of the key for the ModeShape JCR repository name in the parameter map. This can be used as an alternative to
+     * specifying the repository name as a URL parameter within the {@link #URL URL}.
+     * <p>
+     * For example:
+     * 
+     * <pre>
+     * String configUrl = &quot;file://path/to/configFile.xml&quot;; // URL that points to your configuration file
+     * String repoName = &quot;myRepository&quot;; // Name of your repository defined within the configuration file
+     * 
+     * Map&lt;String, String&gt; parameters = new HashMap&lt;String, String&gt;();
+     * parameters.put(org.modeshape.jcr.api.RepositoryFactory.URL, configUrl);
+     * parameters.put(org.modeshape.jcr.api.RepositoryFactory.REPOSITORY_NAME, repoName);
+     * 
+     * Repository repository = null;
+     * for (RepositoryFactory factory : ServiceLoader.load(RepositoryFactory.class)) {
+     *     repository = factory.getRepository(parameters);
+     *     if (repository != null) break;
+     * }
+     * </pre>
+     * 
+     * </p>
+     */
+    public static final String REPOSITORY_NAME = "org.modeshape.jcr.RepositoryName";
 
     /**
      * Begin the shutdown process for all the {@code JcrEngine JcrEngines} created by calls to {@link #getRepository(Map)}.
@@ -75,7 +206,6 @@ public interface RepositoryFactory extends javax.jcr.RepositoryFactory {
      */
     public boolean shutdown( long timeout,
                              TimeUnit unit ) throws InterruptedException;
-
 
     /**
      * Returns the {@link Repositories} instance referenced by the {@code jcrUrl} parameter.

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrRepositoryFactory.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrRepositoryFactory.java
@@ -93,10 +93,21 @@ public class JcrRepositoryFactory implements RepositoryFactory {
      */
     private static final Map<String, JcrEngine> ENGINES = new HashMap<String, JcrEngine>();
 
-    /** The name of the key for the ModeShape JCR URL in the parameter map */
-    public static final String URL = "org.modeshape.jcr.URL";
+    /**
+     * @deprecated Use {@link RepositoryFactory#URL} instead
+     */
+    @Deprecated
+    public static final String URL = RepositoryFactory.URL;
 
-    /** The name of the URL parameter that specifies the repository name. */
+    /**
+     * @deprecated Use {@link RepositoryFactory#REPOSITORY_NAME} instead
+     */
+    @Deprecated
+    public static final String REPOSITORY_NAME = RepositoryFactory.REPOSITORY_NAME;
+
+    /**
+     * The name of the URL parameter that specifies the repository name.
+     */
     public static final String REPOSITORY_NAME_PARAM = "repositoryName";
 
     /**
@@ -127,9 +138,9 @@ public class JcrRepositoryFactory implements RepositoryFactory {
         LOG.debug("Trying to load ModeShape JCR Repository with parameters: " + parameters);
         if (parameters == null) return null;
 
-        Object rawUrl = parameters.get(URL);
+        Object rawUrl = parameters.get(RepositoryFactory.URL);
         if (rawUrl == null) {
-            LOG.debug("No parameter found with key: " + URL);
+            LOG.debug("No parameter found with key: " + RepositoryFactory.URL);
             return null;
         }
 
@@ -153,8 +164,12 @@ public class JcrRepositoryFactory implements RepositoryFactory {
         Repositories repositories = repositoriesFor(url, parameters);
         if (repositories == null) return null;
 
-        String repositoryName = repositoryNameFor(repositories, url);
-        if (repositoryName == null) return null;
+        Object repositoryNameValue = parameters.get(RepositoryFactory.REPOSITORY_NAME);
+        String repositoryName = repositoryNameValue != null ? repositoryNameValue.toString() : null;
+        if (repositoryName == null) {
+            repositoryName = repositoryNameFor(repositories, url);
+            if (repositoryName == null) return null;
+        }
 
         try {
             LOG.debug("Trying to access repository: " + repositoryName);
@@ -312,6 +327,15 @@ public class JcrRepositoryFactory implements RepositoryFactory {
             if (ob instanceof Repository) {
                 return (Repository)ob;
             }
+            if (ob instanceof Repositories) {
+                Object repositoryNameValue = parameters.get(RepositoryFactory.REPOSITORY_NAME);
+                String repositoryName = repositoryNameValue != null ? repositoryNameValue.toString() : null;
+                if (repositoryName != null) {
+                    return ((Repositories)ob).getRepository(repositoryName);
+                }
+            }
+            return null;
+        } catch (RepositoryException e) {
             return null;
         } catch (NamingException ne) {
             return null;


### PR DESCRIPTION
Moved the URL an REPOSITORY_NAME constants from the JcrRepositoryFactory implementation class into the existing org.modeshape.jcr.api.RepositoryFactory interface. These constants can be used when programmatically defining the parameters to pass to the RepositoryFactory.getRepository(Map) method.

Also added more JavaDoc, and deprecated the constants in the JcrRepositoryFactory class.

All unit and integration tests pass with these changes.
