### PR TITLE
MODE-1417 Corrected versioning of files uploaded through REST client

### DIFF
--- a/web/modeshape-web-jcr-rest-client/src/main/java/org/modeshape/web/jcr/rest/client/json/FileNode.java
+++ b/web/modeshape-web-jcr-rest-client/src/main/java/org/modeshape/web/jcr/rest/client/json/FileNode.java
@@ -101,6 +101,9 @@ public final class FileNode extends JsonNode {
         JSONObject properties = new JSONObject();
         put(IJsonConstants.PROPERTIES_KEY, properties);
         properties.put(IJcrConstants.PRIMARY_TYPE_PROPERTY, IJcrConstants.FILE_NODE_TYPE);
+        if (versionable) {
+            properties.put(IJcrConstants.MIXIN_TYPES_PROPERTY, IJcrConstants.VERSIONABLE_NODE_TYPE);
+        }
 
         // add children
         JSONObject children = new JSONObject();
@@ -114,9 +117,6 @@ public final class FileNode extends JsonNode {
         properties = new JSONObject();
         kid.put(IJsonConstants.PROPERTIES_KEY, properties);
         properties.put(IJcrConstants.PRIMARY_TYPE_PROPERTY, IJcrConstants.RESOURCE_NODE_TYPE);
-        if (versionable) {
-            properties.put(IJcrConstants.MIXIN_TYPES_PROPERTY, IJcrConstants.VERSIONABLE_NODE_TYPE);
-        }
 
         // add required jcr:lastModified property
         Calendar lastModified = Calendar.getInstance();


### PR DESCRIPTION
The REST client library was versioning only the 'jcr:content' child node of an 'nt:file' node. While that's acceptable (since it's where the file's content is actually stored), it's better if the 'nt:file' node itself was versioned.

This change simply changes the node where the 'mix:versionable' mixin is applied. When a new 'nt:file' node is uploaded, that node is now made versionable instead of the 'jcr:content' child. All existing content is still handled and versioned correctly (as it was), and this change only affects content added using a RESTful client that contains the fix.

This change only affects the RESTful client, which is never used within the server-side installation of ModeShape.

All unit and integration tests pass with these changes.

_Note: this commit should be merged onto '2.8.x' and cherry-picked onto '2.x' and 'master'._
