### PR TITLE
MODE-1420 Fixed unwanted Hibernate Search warning messages

### DIFF
--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/RepositoryConfiguration.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/RepositoryConfiguration.java
@@ -372,7 +372,7 @@ public class RepositoryConfiguration {
         public static final String INDEXING_BACKEND_JMS_QUEUE_JNDI_NAME = "queueJndiName";
         public static final String INDEXING_BACKEND_JGROUPS_CHANNEL_NAME = "channelName";
         public static final String INDEXING_BACKEND_JGROUPS_CHANNEL_CONFIGURATION = "channelConfiguration";
-    
+
         /**
          * The name of the clustering top-level configuration document
          */
@@ -384,7 +384,8 @@ public class RepositoryConfiguration {
         private static final String CLUSTER_NAME = "clusterName";
 
         /**
-         * The fully qualified name of the {@link org.modeshape.jcr.clustering.ChannelProvider} implementation which will provide the JChannel instance
+         * The fully qualified name of the {@link org.modeshape.jcr.clustering.ChannelProvider} implementation which will provide
+         * the JChannel instance
          */
         private static final String CHANNEL_PROVIDER = "channelProvider";
 
@@ -809,7 +810,7 @@ public class RepositoryConfiguration {
         }
         return new BinaryStorage(storage.getDocument(FieldName.BINARY_STORAGE));
     }
-    
+
     public Clustering getClustering() {
         return new Clustering(doc.getDocument(FieldName.CLUSTERING));
     }
@@ -1369,8 +1370,10 @@ public class RepositoryConfiguration {
         }
 
         /**
-         * Checks whether clustering is enabled or not, based on a) JGroups being in the classpath and b) a clustering configuration
-         * having been provided
+         * Checks whether clustering is enabled or not, based on a) JGroups being in the classpath and b) a clustering
+         * configuration having been provided.
+         * 
+         * @return true if clustering is enabled, or false otherwise
          */
         public boolean isEnabled() {
             return this.clusteringDoc != EMPTY;

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/query/lucene/LuceneSearchConfiguration.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/query/lucene/LuceneSearchConfiguration.java
@@ -107,7 +107,9 @@ public abstract class LuceneSearchConfiguration implements SearchConfiguration {
 
     @Override
     public boolean isTransactionManagerExpected() {
-        return true;
+        // See MODE-1420; we use a transaction manager when updating indexes with changes made by sessions,
+        // but a transaction is not used when manually re-indexing
+        return false;
     }
 
     @Override

--- a/modeshape-jcr/src/test/java/org/modeshape/jcr/JcrQueryManagerTest.java
+++ b/modeshape-jcr/src/test/java/org/modeshape/jcr/JcrQueryManagerTest.java
@@ -1198,7 +1198,7 @@ public class JcrQueryManagerTest extends MultiUseAbstractTest {
                      + " WHERE ISDESCENDANTNODE( mythirdnodetypes, '/') OR " + "myfirstnodetypes.[jcr:primaryType] IS NOT NULL";
         Query query = session.getWorkspace().getQueryManager().createQuery(sql, Query.JCR_SQL2);
         assertThat(query, is(notNullValue()));
-        print = true;
+        // print = true;
         QueryResult result = query.execute();
         assertThat(result, is(notNullValue()));
         assertResults(query, result, 310L);


### PR DESCRIPTION
Hibernate Search's `SearchConfiguration` class defines a `isTransactionManagerExpected()` method that dictates whether the warning messages should be logged (and that appears to be the only way in which this method is used). 

So far, ModeShape's `org.modeshape.jcr.query.lucene.LuceneSearchConfiguration` implementation has returned `true`. But this method should return `false`, since the re-indexing operations are not performed within a transaction, so Hibernate Search shouldn't always expect a transaction. Simply making this change makes the problematic log messages disappear, but doesn't otherwise affect any functionality.

All unit and integration tests pass with these changes.
