### PR TITLE
MODE-1418 Corrected certain queries with full-text search criteria

### DIFF
--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/query/parse/BasicSqlQueryParser.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/query/parse/BasicSqlQueryParser.java
@@ -691,7 +691,7 @@ public class BasicSqlQueryParser implements QueryParser {
                     String msg = GraphI18n.functionIsAmbiguous.text("CONTAINS()", pos.getLine(), pos.getColumn());
                     throw new ParsingException(pos, msg);
                 }
-                selectorName = ((Selector)source).name();
+                selectorName = ((Selector)source).aliasOrName();
                 propertyName = removeBracketsAndQuotes(first);
             }
             tokens.consume(',');

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/query/plan/PlanUtil.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/query/plan/PlanUtil.java
@@ -680,6 +680,8 @@ public class PlanUtil {
                         node.getSelectors().clear();
                         node.addSelectors(Visitors.getSelectorsReferencedBy(newConstraint));
                         node.setProperty(Property.SELECT_CRITERIA, newConstraint);
+                    } else {
+                        node.addSelector(viewName);
                     }
                     break;
                 case SOURCE:

--- a/modeshape-jcr/src/test/java/org/modeshape/jcr/JcrQueryManagerTest.java
+++ b/modeshape-jcr/src/test/java/org/modeshape/jcr/JcrQueryManagerTest.java
@@ -158,7 +158,7 @@ public class JcrQueryManagerTest extends MultiUseAbstractTest {
                 a.setProperty("somethingElse", "value2");
                 a.setProperty("propA", "value1");
                 Node other2 = other.addNode("NodeA", "nt:unstructured");
-                other2.setProperty("something", "value2 quick brown cat");
+                other2.setProperty("something", "value2 quick brown cat wearing hat");
                 other2.setProperty("propB", "value1");
                 other2.setProperty("propC", "value2");
                 Node other3 = other.addNode("NodeA", "nt:unstructured");
@@ -1217,9 +1217,64 @@ public class JcrQueryManagerTest extends MultiUseAbstractTest {
         }
     }
 
+    @Ignore
+    @FixFor( "MODE-1418" )
+    @Test
+    public void shouldBeAbleToCreateAndExecuteJcrSql2QueryWithFullTextSearchWithSelectorAndOneProperty()
+        throws RepositoryException {
+        String sql = "select [jcr:path] from [nt:unstructured] as n where contains(n.something, 'cat wearing')";
+        Query query = session.getWorkspace().getQueryManager().createQuery(sql, Query.JCR_SQL2);
+        assertThat(query, is(notNullValue()));
+        // print = true;
+        QueryResult result = query.execute();
+        assertThat(result, is(notNullValue()));
+        assertResults(query, result, 1L);
+    }
+
+    @Ignore
+    @FixFor( "MODE-1418" )
+    @Test
+    public void shouldBeAbleToCreateAndExecuteJcrSql2QueryWithFullTextSearchWithSelectorAndAllProperties()
+        throws RepositoryException {
+        String sql = "select [jcr:path] from [nt:unstructured] as n where contains(n.*, 'cat wearing')";
+        Query query = session.getWorkspace().getQueryManager().createQuery(sql, Query.JCR_SQL2);
+        assertThat(query, is(notNullValue()));
+        // print = true;
+        QueryResult result = query.execute();
+        assertThat(result, is(notNullValue()));
+        assertResults(query, result, 1L);
+    }
+
+    @Ignore
+    @FixFor( "MODE-1418" )
+    @Test
+    public void shouldBeAbleToCreateAndExecuteJcrSql2QueryWithFullTextSearchWithNoSelectorAndOneProperty()
+        throws RepositoryException {
+        String sql = "select [jcr:path] from [nt:unstructured] as n where contains(something,'cat wearing')";
+        Query query = session.getWorkspace().getQueryManager().createQuery(sql, Query.JCR_SQL2);
+        assertThat(query, is(notNullValue()));
+        // print = true;
+        QueryResult result = query.execute();
+        assertThat(result, is(notNullValue()));
+        assertResults(query, result, 1L);
+    }
+
     // ----------------------------------------------------------------------------------------------------------------
     // Full-text Search Queries
     // ----------------------------------------------------------------------------------------------------------------
+
+    @Ignore
+    @FixFor( "MODE-1418" )
+    @Test
+    public void shouldBeAbleToCreateAndExecuteFullTextSearchQueryOfPhrase() throws RepositoryException {
+        Query query = session.getWorkspace().getQueryManager().createQuery("cat wearing", JcrRepository.QueryLanguage.SEARCH);
+        assertThat(query, is(notNullValue()));
+        QueryResult result = query.execute();
+        // print = true;
+        assertThat(result, is(notNullValue()));
+        assertResults(query, result, 1);
+        assertResultsHaveColumns(result, searchColumnNames());
+    }
 
     @Ignore
     @FixFor( "MODE-905" )


### PR DESCRIPTION
Certain JCR-SQL2 full-text search criteria were not being processed correctly. Any f.t.s. criteria that specified a single property resulted in an incorrect query plan.

Several changes were made to correct this behavior, and new unit tests were added.
