### PR TITLE
MODE-1424 Fixed indexing deadlocking

### DIFF
--- a/modeshape-graph/src/main/java/org/modeshape/graph/request/CompositeRequestChannel.java
+++ b/modeshape-graph/src/main/java/org/modeshape/graph/request/CompositeRequestChannel.java
@@ -93,10 +93,7 @@ public class CompositeRequestChannel {
      *        be null or empty
      */
     public CompositeRequestChannel( final String sourceName ) {
-        assert sourceName != null;
-        this.sourceName = sourceName;
-        this.composite = new ChannelCompositeRequest();
-        this.keepRequests = true;
+        this(sourceName, true, false);
     }
 
     /**
@@ -108,9 +105,21 @@ public class CompositeRequestChannel {
      */
     public CompositeRequestChannel( final String sourceName,
                                     boolean keepRequests ) {
+        this(sourceName, keepRequests, false);
+    }
+    
+    /**
+     * @see CompositeRequestChannel#CompositeRequestChannel(String, boolean)
+     * 
+     * @param readOnlyRequest a boolean which indicates whether the {@link ChannelCompositeRequest} is created as a read-only
+     * request or not.
+     */
+    public CompositeRequestChannel( final String sourceName,
+                                    boolean keepRequests,
+                                    boolean readOnlyRequest) {
         assert sourceName != null;
         this.sourceName = sourceName;
-        this.composite = new ChannelCompositeRequest();
+        this.composite = new ChannelCompositeRequest(readOnlyRequest);
         this.keepRequests = keepRequests;
     }
 
@@ -417,8 +426,8 @@ public class CompositeRequestChannel {
         private static final long serialVersionUID = 1L;
         private final LinkedList<Request> allRequests = CompositeRequestChannel.this.allRequests;
 
-        protected ChannelCompositeRequest() {
-            super(false);
+        protected ChannelCompositeRequest( boolean readOnly ) {
+            super(readOnly);
         }
 
         /**

--- a/modeshape-graph/src/main/java/org/modeshape/graph/search/SearchEngineIndexer.java
+++ b/modeshape-graph/src/main/java/org/modeshape/graph/search/SearchEngineIndexer.java
@@ -104,7 +104,7 @@ public class SearchEngineIndexer {
         this.searchEngine = searchEngine;
         this.sourceName = searchEngine.getSourceName();
         this.connectionFactory = connectionFactory;
-        this.channel = new CompositeRequestChannel(this.sourceName, false);
+        this.channel = new CompositeRequestChannel(this.sourceName, false, true);
         this.service = Executors.newSingleThreadExecutor(new NamedThreadFactory("search-" + sourceName));
         // Start the channel and search engine processor right away (this is why this object must be closed)
         this.channel.start(service, this.context, this.connectionFactory);
@@ -468,8 +468,8 @@ public class SearchEngineIndexer {
             channel.close();
         } finally {
             // And shut down the executor service ...
-            service.shutdown();
             try {
+                service.shutdown();
                 service.awaitTermination(5, TimeUnit.SECONDS);
             } catch (InterruptedException e) {
                 // Log this ...

--- a/modeshape-integration-tests/src/test/resources/federated/redhatMixin.cnd
+++ b/modeshape-integration-tests/src/test/resources/federated/redhatMixin.cnd
@@ -1,0 +1,1 @@
+[rh:product] mixin

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/RepositoryQueryManager.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/RepositoryQueryManager.java
@@ -444,10 +444,14 @@ abstract class RepositoryQueryManager {
                                     int maxRowCount,
                                     int offset ) {
             SearchEngineProcessor processor = searchEngine.createProcessor(context, null, true);
-            FullTextSearchRequest request = new FullTextSearchRequest(searchExpression, workspaceName, maxRowCount, offset);
-            processor.process(request);
-            return new org.modeshape.graph.query.process.QueryResults(request.getResultColumns(), request.getStatistics(),
-                                                                      request.getTuples());
+            try {
+                FullTextSearchRequest request = new FullTextSearchRequest(searchExpression, workspaceName, maxRowCount, offset);
+                processor.process(request);
+                return new org.modeshape.graph.query.process.QueryResults(request.getResultColumns(), request.getStatistics(),
+                                                                          request.getTuples());
+            } finally {
+                processor.close();
+            }
         }
 
         /**

--- a/modeshape-jcr/src/test/java/org/modeshape/jcr/ModeShapeTckTest.java
+++ b/modeshape-jcr/src/test/java/org/modeshape/jcr/ModeShapeTckTest.java
@@ -2514,6 +2514,7 @@ public class ModeShapeTckTest extends AbstractJCRTest {
             while (events.hasNext()) {
                 try {
                     latch.countDown();
+                    events.nextEvent();
                 } catch (Throwable e) {
                     latch.countDown();
                     fail(e.getMessage());


### PR DESCRIPTION
Based on the thread-dumps, a couple of things have been updated:
- the locking implementation around the Lucene IndexWriter was changed from a binary semaphore (which isn't reentrant) to a ReentrantLock
- to avoid write transactions (which do use write locks for the in-memory source) the requests which are sent out by the SearchEngineIndexer are marked as read-only (always)
