### PR TITLE
MODE-1405 Corrected how JCR import handles protected content

### DIFF
--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/AbstractJcrNode.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/AbstractJcrNode.java
@@ -1265,7 +1265,8 @@ abstract class AbstractJcrNode extends AbstractJcrItem implements Node {
         if (jcrValue.value() == null) {
             throw new ValueFormatException(JcrI18n.valueMayNotContainNull.text(name));
         }
-        return setProperty(nameFrom(name), jcrValue, false);
+        return setProperty(nameFrom(name), jcrValue, false, false); // don't skip constraint checks or protected checks
+
     }
 
     @Override
@@ -1280,7 +1281,8 @@ abstract class AbstractJcrNode extends AbstractJcrItem implements Node {
         if (jcrValue.value() == null) {
             throw new ValueFormatException(JcrI18n.valueMayNotContainNull.text(name));
         }
-        return setProperty(nameFrom(name), jcrValue.asType(type), false);
+        // don't skip constraint checks or protected checks
+        return setProperty(nameFrom(name), jcrValue.asType(type), false, false);
     }
 
     @Override
@@ -1359,7 +1361,8 @@ abstract class AbstractJcrNode extends AbstractJcrItem implements Node {
         CheckArg.isNotNull(name, "name");
         checkSession();
         if (value == null) return removeExistingProperty(nameFrom(name));
-        return setProperty(nameFrom(name), valueFrom(PropertyType.STRING, value), false);
+        // don't skip constraint checks or protected checks
+        return setProperty(nameFrom(name), valueFrom(PropertyType.STRING, value), false, false);
     }
 
     @Override
@@ -1370,7 +1373,8 @@ abstract class AbstractJcrNode extends AbstractJcrItem implements Node {
         CheckArg.isNotNull(name, "name");
         checkSession();
         if (value == null) return removeExistingProperty(nameFrom(name));
-        return setProperty(nameFrom(name), valueFrom(type, value), false);
+        // don't skip constraint checks or protected checks
+        return setProperty(nameFrom(name), valueFrom(type, value), false, false);
     }
 
     @Override
@@ -1380,7 +1384,8 @@ abstract class AbstractJcrNode extends AbstractJcrItem implements Node {
         CheckArg.isNotNull(name, "name");
         checkSession();
         if (value == null) return removeExistingProperty(nameFrom(name));
-        return setProperty(nameFrom(name), valueFrom(value), false);
+        // don't skip constraint checks or protected checks
+        return setProperty(nameFrom(name), valueFrom(value), false, false);
     }
 
     @Override
@@ -1389,7 +1394,8 @@ abstract class AbstractJcrNode extends AbstractJcrItem implements Node {
         throws ValueFormatException, VersionException, LockException, ConstraintViolationException, RepositoryException {
         CheckArg.isNotNull(name, "name");
         checkSession();
-        return setProperty(nameFrom(name), valueFrom(PropertyType.BINARY, value), false);
+        // don't skip constraint checks or protected checks
+        return setProperty(nameFrom(name), valueFrom(PropertyType.BINARY, value), false, false);
     }
 
     @Override
@@ -1398,7 +1404,8 @@ abstract class AbstractJcrNode extends AbstractJcrItem implements Node {
         throws ValueFormatException, VersionException, LockException, ConstraintViolationException, RepositoryException {
         CheckArg.isNotNull(name, "name");
         checkSession();
-        return setProperty(nameFrom(name), valueFrom(PropertyType.BOOLEAN, value), false);
+        // don't skip constraint checks or protected checks
+        return setProperty(nameFrom(name), valueFrom(PropertyType.BOOLEAN, value), false, false);
     }
 
     @Override
@@ -1407,7 +1414,8 @@ abstract class AbstractJcrNode extends AbstractJcrItem implements Node {
         throws ValueFormatException, VersionException, LockException, ConstraintViolationException, RepositoryException {
         CheckArg.isNotNull(name, "name");
         checkSession();
-        return setProperty(nameFrom(name), valueFrom(PropertyType.DOUBLE, value), false);
+        // don't skip constraint checks or protected checks
+        return setProperty(nameFrom(name), valueFrom(PropertyType.DOUBLE, value), false, false);
     }
 
     @Override
@@ -1416,7 +1424,8 @@ abstract class AbstractJcrNode extends AbstractJcrItem implements Node {
         throws ValueFormatException, VersionException, LockException, ConstraintViolationException, RepositoryException {
         CheckArg.isNotNull(name, "name");
         checkSession();
-        return setProperty(nameFrom(name), valueFrom(PropertyType.DECIMAL, value), false);
+        // don't skip constraint checks or protected checks
+        return setProperty(nameFrom(name), valueFrom(PropertyType.DECIMAL, value), false, false);
     }
 
     @Override
@@ -1425,7 +1434,8 @@ abstract class AbstractJcrNode extends AbstractJcrItem implements Node {
         throws ValueFormatException, VersionException, LockException, ConstraintViolationException, RepositoryException {
         CheckArg.isNotNull(name, "name");
         checkSession();
-        return setProperty(nameFrom(name), valueFrom(PropertyType.LONG, value), false);
+        // don't skip constraint checks or protected checks
+        return setProperty(nameFrom(name), valueFrom(PropertyType.LONG, value), false, false);
     }
 
     @Override
@@ -1435,7 +1445,8 @@ abstract class AbstractJcrNode extends AbstractJcrItem implements Node {
         CheckArg.isNotNull(name, "name");
         checkSession();
         if (value == null) return removeExistingProperty(nameFrom(name));
-        return setProperty(nameFrom(name), valueFrom(value), false);
+        // don't skip constraint checks or protected checks
+        return setProperty(nameFrom(name), valueFrom(value), false, false);
     }
 
     @Override
@@ -1445,7 +1456,8 @@ abstract class AbstractJcrNode extends AbstractJcrItem implements Node {
         CheckArg.isNotNull(name, "name");
         checkSession();
         if (value == null) return removeExistingProperty(nameFrom(name));
-        return setProperty(nameFrom(name), valueFrom(value), false);
+        // don't skip constraint checks or protected checks
+        return setProperty(nameFrom(name), valueFrom(value), false, false);
     }
 
     /**
@@ -1473,6 +1485,8 @@ abstract class AbstractJcrNode extends AbstractJcrItem implements Node {
      * @param name the name of the property; may not be null
      * @param value the value of the property; may not be null
      * @param skipReferenceValidation indicates whether constraints on REFERENCE properties should be enforced
+     * @param skipProtectedValidation true if protected properties can be set by the caller of this method, or false if the method
+     *        should validate that protected methods are not being called
      * @return the new JCR property object
      * @throws VersionException if the node is checked out
      * @throws LockException if the node is locked
@@ -1481,7 +1495,8 @@ abstract class AbstractJcrNode extends AbstractJcrItem implements Node {
      */
     final AbstractJcrProperty setProperty( Name name,
                                            JcrValue value,
-                                           boolean skipReferenceValidation )
+                                           boolean skipReferenceValidation,
+                                           boolean skipProtectedValidation )
         throws VersionException, LockException, ConstraintViolationException, RepositoryException {
         assert value != null;
         assert value.value() != null;
@@ -1511,12 +1526,13 @@ abstract class AbstractJcrNode extends AbstractJcrItem implements Node {
         Set<Name> mixinTypes = node.getMixinTypes(cache);
         NodeTypes nodeTypes = session.nodeTypes();
         JcrPropertyDefinition defn = null;
-        defn = nodeTypes.findPropertyDefinition(session, primaryType, mixinTypes, name, value, true, true, true);
+        final boolean skipProtected = !skipProtectedValidation;
+        defn = nodeTypes.findPropertyDefinition(session, primaryType, mixinTypes, name, value, true, skipProtected, true);
 
         if (defn == null) {
             // Failed to find a valid property definition,
             // so figure out if there's a definition that would work if it had no constraints ...
-            defn = nodeTypes.findPropertyDefinition(session, primaryType, mixinTypes, name, value, true, true, false);
+            defn = nodeTypes.findPropertyDefinition(session, primaryType, mixinTypes, name, value, true, skipProtected, false);
 
             String propName = readable(name);
             if (defn != null) {
@@ -2049,7 +2065,8 @@ abstract class AbstractJcrNode extends AbstractJcrItem implements Node {
                             setProperty(propDefn.getInternalName(), defaultValues, propDefn.getRequiredType(), true);
                         } else {
                             assert propDefn.getDefaultValues().length == 1;
-                            setProperty(propDefn.getInternalName(), defaultValues[0], false); // don't skip constraint checks
+                            // don't skip constraint checks or protected checks
+                            setProperty(propDefn.getInternalName(), defaultValues[0], false, false);
                         }
                     }
                     // otherwise, we don't care

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrContentHandler.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrContentHandler.java
@@ -591,7 +591,7 @@ class JcrContentHandler extends DefaultHandler {
                     if (JcrLexicon.UUID.equals(name)) return;
 
                     // The node was already created, so set the property using the editor ...
-                    node.setProperty(name, (JcrValue)valueFor(value, propertyType), false);
+                    node.setProperty(name, (JcrValue)valueFor(value, propertyType), true, true);
                 } else {
                     // The node hasn't been created yet, so just enqueue the property value into the map ...
                     List<Value> values = properties.get(name);
@@ -729,7 +729,8 @@ class JcrContentHandler extends DefaultHandler {
                     AbstractJcrProperty prop;
 
                     if (values.size() == 1 && !this.multiValuedPropertyNames.contains(propertyName)) {
-                        prop = child.setProperty(propertyName, (JcrValue)values.get(0), true);
+                        // Don't check references or the protected status ...
+                        prop = child.setProperty(propertyName, (JcrValue)values.get(0), true, true);
                     } else {
                         prop = child.setProperty(propertyName,
                                                  values.toArray(new JcrValue[values.size()]),

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrSession.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrSession.java
@@ -1435,7 +1435,8 @@ public class JcrSession implements Session {
                             if (defn.isMultiple()) {
                                 jcrNode.setProperty(propName, defaultValues, defn.getRequiredType(), false);
                             } else {
-                                jcrNode.setProperty(propName, defaultValues[0], false);
+                                // don't skip constraint checks or protected checks
+                                jcrNode.setProperty(propName, defaultValues[0], false,false);
                             }
                         } else {
                             // There is no default for this mandatory property, so this is a constraint violation ...

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrVersionManager.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrVersionManager.java
@@ -1671,7 +1671,7 @@ final class JcrVersionManager implements VersionManager {
                 }
 
             } else {
-                targetNode.setProperty(JcrLexicon.MERGE_FAILED, targetNode.valueFrom(sourceVersion), false);
+                targetNode.setProperty(JcrLexicon.MERGE_FAILED, targetNode.valueFrom(sourceVersion), false, false);
             }
             failures.add(targetNode);
 

--- a/modeshape-jcr/src/test/java/org/modeshape/jcr/ImportExportTest.java
+++ b/modeshape-jcr/src/test/java/org/modeshape/jcr/ImportExportTest.java
@@ -123,6 +123,32 @@ public class ImportExportTest extends SingleUseAbstractTest {
         assertThat(newSourceNode.getProperty("badcharacters").getString(), is(BAD_CHARACTER_STRING));
     }
 
+    @FixFor( "MODE-1405" )
+    @Test
+    public void shouldImportProtectedContentUsingWorkpace() throws Exception {
+        String testName = "importExportEscapedXmlCharacters";
+        Node rootNode = session.getRootNode();
+        Node sourceNode = rootNode.addNode(testName + "Source", "nt:unstructured");
+        Node targetNode = rootNode.addNode(testName + "Target", "nt:unstructured");
+
+        // Test data
+        Node child = sourceNode.addNode("child");
+        child.addMixin("mix:created");
+        session.save();
+
+        // Verify there are 'jcr:createdBy' and 'jcr:created' properties ...
+        assertThat(child.getProperty("jcr:createdBy").getString(), is(notNullValue()));
+        assertThat(child.getProperty("jcr:created").getString(), is(notNullValue()));
+
+        testImportExport(sourceNode.getPath(), targetNode.getPath(), ExportType.SYSTEM, false, false, true);
+        Node newSourceNode = targetNode.getNode(testName + "Source");
+        Node newChild = newSourceNode.getNode("child");
+        // Verify there are 'jcr:createdBy' and 'jcr:created' properties ...
+        assertThat(newChild.getProperty("jcr:createdBy").getString(), is(notNullValue()));
+        assertThat(newChild.getProperty("jcr:created").getString(), is(notNullValue()));
+
+    }
+
     @Ignore( "JR TCK is broken" )
     @Test
     public void shouldImportExportEscapedXmlCharactersInDocumentViewUsingSession() throws Exception {


### PR DESCRIPTION
Corrected the behavior of the JCR import logic to always import protected content. The whole point of importing a previously-exported file is to recover all of the content the way it was, including the 'jcr:created', 'jcr:createdBy' and other protected properties. (Although note that the 'jcr:lastModified' and 'jcr:lastModifiedBy' properties will still be updated during the import.)

Added a new unit test to verify that the import now works correctly with protected content.
