### PR TITLE
MODE-1449 Renamed internal Binary interface to BinaryValue

### DIFF
--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/AbstractJcrNode.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/AbstractJcrNode.java
@@ -559,7 +559,7 @@ abstract class AbstractJcrNode extends AbstractJcrItem implements Node {
     }
 
     final JcrValue valueFrom( InputStream value ) {
-        org.modeshape.jcr.value.Binary binary = context().getValueFactories().getBinaryFactory().create(value);
+        org.modeshape.jcr.value.BinaryValue binary = context().getValueFactories().getBinaryFactory().create(value);
         return valueFrom(PropertyType.BINARY, binary);
     }
 

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrSingleValueProperty.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrSingleValueProperty.java
@@ -39,7 +39,7 @@ import javax.jcr.nodetype.ConstraintViolationException;
 import javax.jcr.version.VersionException;
 import org.modeshape.common.annotation.NotThreadSafe;
 import org.modeshape.jcr.cache.NodeKey;
-import org.modeshape.jcr.value.Binary;
+import org.modeshape.jcr.value.BinaryValue;
 import org.modeshape.jcr.value.Name;
 import org.modeshape.jcr.value.Path;
 import org.modeshape.jcr.value.Property;
@@ -196,7 +196,7 @@ final class JcrSingleValueProperty extends AbstractJcrProperty {
     public InputStream getStream() throws RepositoryException {
         checkSession();
         try {
-            Binary binary = context().getValueFactories().getBinaryFactory().create(property().getFirstValue());
+            BinaryValue binary = context().getValueFactories().getBinaryFactory().create(property().getFirstValue());
             return new SelfClosingInputStream(binary);
         } catch (org.modeshape.jcr.value.ValueFormatException e) {
             throw new ValueFormatException(e.getMessage(), e);
@@ -207,7 +207,7 @@ final class JcrSingleValueProperty extends AbstractJcrProperty {
     public javax.jcr.Binary getBinary() throws ValueFormatException, RepositoryException {
         checkSession();
         try {
-            Binary binary = context().getValueFactories().getBinaryFactory().create(property().getFirstValue());
+            BinaryValue binary = context().getValueFactories().getBinaryFactory().create(property().getFirstValue());
             return binary;
         } catch (org.modeshape.jcr.value.ValueFormatException e) {
             throw new ValueFormatException(e.getMessage(), e);
@@ -405,9 +405,9 @@ final class JcrSingleValueProperty extends AbstractJcrProperty {
         checkForLock();
         checkForCheckedOut();
 
-        Binary binary = null;
-        if (value instanceof Binary) {
-            binary = (Binary)value;
+        BinaryValue binary = null;
+        if (value instanceof BinaryValue) {
+            binary = (BinaryValue)value;
         } else {
             // Otherwise, this isn't our instance, so copy the data ...
             binary = context().getValueFactories().getBinaryFactory().create(value.getStream());

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrValueFactory.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrValueFactory.java
@@ -31,7 +31,7 @@ import java.util.List;
 import javax.jcr.*;
 import org.modeshape.common.util.CheckArg;
 import org.modeshape.jcr.api.value.DateTime;
-import org.modeshape.jcr.value.Binary;
+import org.modeshape.jcr.value.BinaryValue;
 import org.modeshape.jcr.value.NamespaceRegistry;
 import org.modeshape.jcr.value.Reference;
 import org.modeshape.jcr.value.ReferenceFactory;
@@ -116,12 +116,12 @@ class JcrValueFactory implements org.modeshape.jcr.api.ValueFactory {
 
     @Override
     public JcrValue createValue( InputStream value ) {
-        Binary binary = valueFactories.getBinaryFactory().create(value);
+        BinaryValue binary = valueFactories.getBinaryFactory().create(value);
         return new JcrValue(valueFactories, PropertyType.BINARY, binary);
     }
 
     @Override
-    public Binary createBinary( InputStream value ) {
+    public BinaryValue createBinary( InputStream value ) {
         return valueFactories.getBinaryFactory().create(value);
     }
 
@@ -157,7 +157,7 @@ class JcrValueFactory implements org.modeshape.jcr.api.ValueFactory {
     }
 
     @Override
-    public Binary createBinary( byte[] value )  {
+    public BinaryValue createBinary( byte[] value )  {
         return valueFactories.getBinaryFactory().create(value);
     }
 

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/SelfClosingInputStream.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/SelfClosingInputStream.java
@@ -27,11 +27,11 @@ import java.io.IOException;
 import java.io.InputStream;
 import javax.jcr.RepositoryException;
 import org.modeshape.common.annotation.NotThreadSafe;
-import org.modeshape.jcr.value.Binary;
+import org.modeshape.jcr.value.BinaryValue;
 
 /**
- * An {@link InputStream} implementation that can be used to access the content of a supplied {@link Binary} value. This class,
- * however, guarantees that the binary lock is {@link Binary#dispose() released} whenever this class throws an exception or when
+ * An {@link InputStream} implementation that can be used to access the content of a supplied {@link BinaryValue} value. This class,
+ * however, guarantees that the binary lock is {@link BinaryValue#dispose() released} whenever this class throws an exception or when
  * the instance is {@link #close() closed}.
  * <p>
  * The draft version of the JSR-283 specification outlines a new mechanism for obtaining a lock on a binary value, and in fact
@@ -42,15 +42,15 @@ import org.modeshape.jcr.value.Binary;
 @NotThreadSafe
 class SelfClosingInputStream extends InputStream {
 
-    private final Binary binary;
+    private final BinaryValue binary;
     private InputStream stream;
 
     /**
-     * Create a self-closing {@link InputStream} to access the content of the supplied {@link Binary} value.
+     * Create a self-closing {@link InputStream} to access the content of the supplied {@link BinaryValue} value.
      * 
-     * @param binary the {@link Binary} object that this stream accesses; may not be null
+     * @param binary the {@link BinaryValue} object that this stream accesses; may not be null
      */
-    public SelfClosingInputStream( Binary binary ) {
+    public SelfClosingInputStream( BinaryValue binary ) {
         assert binary != null;
         this.binary = binary;
     }

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/document/DocumentTranslator.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/document/DocumentTranslator.java
@@ -946,8 +946,8 @@ public class DocumentTranslator {
         if (value instanceof URI) {
             return Schematic.newDocument("$uri", this.strings.create((URI)value));
         }
-        if (value instanceof org.modeshape.jcr.value.Binary) {
-            org.modeshape.jcr.value.Binary binary = (org.modeshape.jcr.value.Binary)value;
+        if (value instanceof org.modeshape.jcr.value.BinaryValue) {
+            org.modeshape.jcr.value.BinaryValue binary = (org.modeshape.jcr.value.BinaryValue)value;
             if (binary instanceof InMemoryBinaryValue) {
                 return new Binary(((InMemoryBinaryValue)binary).getBytes());
             }

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/document/SessionNode.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/document/SessionNode.java
@@ -57,7 +57,7 @@ import org.modeshape.jcr.cache.NodeCache;
 import org.modeshape.jcr.cache.NodeKey;
 import org.modeshape.jcr.cache.NodeNotFoundException;
 import org.modeshape.jcr.cache.SessionCache;
-import org.modeshape.jcr.value.Binary;
+import org.modeshape.jcr.value.BinaryValue;
 import org.modeshape.jcr.value.Name;
 import org.modeshape.jcr.value.NameFactory;
 import org.modeshape.jcr.value.NamespaceRegistry;
@@ -868,8 +868,8 @@ public class SessionNode implements MutableCachedNode {
             Property prop = iter.next();
             if (prop.isEmpty()) continue;
             for (Object value : prop) {
-                if (value instanceof Binary) {
-                    Binary binary = (Binary)value;
+                if (value instanceof BinaryValue) {
+                    BinaryValue binary = (BinaryValue)value;
                     // we don't care about the string encoding, as long as its consistent and will change if a property changes
                     sb.append(binary.getHexHash());
                 }

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/query/lucene/basic/BasicLuceneSchema.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/query/lucene/basic/BasicLuceneSchema.java
@@ -65,7 +65,7 @@ import org.modeshape.jcr.query.model.Literal;
 import org.modeshape.jcr.query.model.PropertyValue;
 import org.modeshape.jcr.query.model.SelectorName;
 import org.modeshape.jcr.query.model.SetCriteria;
-import org.modeshape.jcr.value.Binary;
+import org.modeshape.jcr.value.BinaryValue;
 import org.modeshape.jcr.value.Name;
 import org.modeshape.jcr.value.NamespaceRegistry;
 import org.modeshape.jcr.value.Path;
@@ -236,8 +236,8 @@ public class BasicLuceneSchema implements LuceneSchema {
                 fullText.append(' ').append(str);
             }
 
-        } else if (value instanceof Binary) {
-            Binary binary = (Binary)value;
+        } else if (value instanceof BinaryValue) {
+            BinaryValue binary = (BinaryValue)value;
 
             // Add a field with the length of the binary value ...
             previous = new DynamicField(previous, FieldName.LENGTH_PREFIX + propertyName, binary.getSize(), false, true);

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/value/BinaryFactory.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/value/BinaryFactory.java
@@ -27,23 +27,23 @@ import org.modeshape.common.annotation.ThreadSafe;
 import org.modeshape.jcr.value.binary.BinaryStoreException;
 
 /**
- * A factory for creating {@link Binary} instances. This interface extends the {@link ValueFactory} generic interface and adds
+ * A factory for creating {@link BinaryValue} instances. This interface extends the {@link ValueFactory} generic interface and adds
  * specific methods for creating binary objects.
  */
 @ThreadSafe
-public interface BinaryFactory extends ValueFactory<Binary> {
+public interface BinaryFactory extends ValueFactory<BinaryValue> {
 
     /**
      * Find an existing binary value given the supplied binary key. If no such binary value exists, null is returned. This method
      * can be used when the caller knows the secure hash (e.g., from a previously-held Binary object), and would like to reuse an
      * existing binary value (if possible).
      * 
-     * @param secureHash the secure hash of the binary content, which was probably {@link Binary#getHexHash() obtained} from a
-     *        previously-held {@link Binary} object; a null or empty value is allowed, but will always result in returning null
+     * @param secureHash the secure hash of the binary content, which was probably {@link BinaryValue#getHexHash() obtained} from a
+     *        previously-held {@link BinaryValue} object; a null or empty value is allowed, but will always result in returning null
      * @param size the size of the binary content
      * @return the existing Binary value that has the same secure hash; never null
      * @throws BinaryStoreException if there is a problem accessing the binary store
      */
-    Binary find( BinaryKey secureHash,
+    BinaryValue find( BinaryKey secureHash,
                  long size ) throws BinaryStoreException;
 }

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/value/BinaryValue.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/value/BinaryValue.java
@@ -25,12 +25,14 @@ package org.modeshape.jcr.value;
 
 import java.io.Serializable;
 import org.modeshape.common.annotation.Immutable;
+import org.modeshape.jcr.api.Binary;
 
 /**
- * Value holder for binary data. Binary instances are not mutable.
+ * Value holder for binary data. BinaryValue extends the public {@link Binary} interface (which itself extends
+ * {@link javax.jcr.Binary}) and adds requirements such as being serializable and comparable.
  */
 @Immutable
-public interface Binary extends Comparable<Binary>, Serializable, org.modeshape.jcr.api.Binary {
+public interface BinaryValue extends Comparable<BinaryValue>, Serializable, org.modeshape.jcr.api.Binary {
 
     /**
      * Get the length of this binary data.

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/value/PropertyType.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/value/PropertyType.java
@@ -48,7 +48,7 @@ import org.modeshape.jcr.api.value.DateTime;
 public enum PropertyType {
 
     STRING("String", ValueComparators.STRING_COMPARATOR, new ObjectCanonicalizer(), String.class),
-    BINARY("Binary", ValueComparators.BINARY_COMPARATOR, new ObjectCanonicalizer(), Binary.class),
+    BINARY("Binary", ValueComparators.BINARY_COMPARATOR, new ObjectCanonicalizer(), BinaryValue.class),
     LONG("Long", ValueComparators.LONG_COMPARATOR, new LongCanonicalizer(), Long.class, Integer.class, Short.class),
     DOUBLE("Double", ValueComparators.DOUBLE_COMPARATOR, new DoubleCanonicalizer(), Double.class, Float.class),
     DECIMAL("Decimal", ValueComparators.DECIMAL_COMPARATOR, new ObjectCanonicalizer(), BigDecimal.class),

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/value/ValueComparators.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/value/ValueComparators.java
@@ -103,15 +103,15 @@ public class ValueComparators {
         }
     };
     /**
-     * A comparator of binary values. Although {@link Binary} is {@link Comparable}, this comparator does not rely upon any
+     * A comparator of binary values. Although {@link BinaryValue} is {@link Comparable}, this comparator does not rely upon any
      * particular Binary implementation. Thus, Binary implementations can use this for their {@link Comparable#compareTo(Object)}
      * implementation.
      */
-    public static final Comparator<Binary> BINARY_COMPARATOR = new Comparator<Binary>() {
+    public static final Comparator<BinaryValue> BINARY_COMPARATOR = new Comparator<BinaryValue>() {
 
         @Override
-        public int compare( Binary o1,
-                            Binary o2 ) {
+        public int compare( BinaryValue o1,
+                            BinaryValue o2 ) {
             if (o1 == o2) return 0;
             if (o1 == null) return -1;
             if (o2 == null) return 1;
@@ -384,12 +384,12 @@ public class ValueComparators {
                     if (type1 == PropertyType.BINARY) {
                         value2 = stringFactory.create(o2);
                         hash2 = SecureHash.getHash(SecureHash.Algorithm.SHA_1, value2.getBytes());
-                        hash1 = ((Binary)o1).getHash();
+                        hash1 = ((BinaryValue)o1).getHash();
                     } else {
                         assert type2 == PropertyType.BINARY;
                         value1 = stringFactory.create(o1);
                         hash1 = SecureHash.getHash(SecureHash.Algorithm.SHA_1, value1.getBytes());
-                        hash2 = ((Binary)o2).getHash();
+                        hash2 = ((BinaryValue)o2).getHash();
                     }
                     // Compute the difference in the hashes ...
                     if (hash1.length == hash2.length) {

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/value/ValueFactory.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/value/ValueFactory.java
@@ -245,7 +245,7 @@ public interface ValueFactory<T> {
      * @throws IoException If an unexpected problem occurs while accessing the supplied binary value (such as an
      *         {@link IOException}).
      */
-    T create( Binary value ) throws ValueFormatException, IoException;
+    T create( BinaryValue value ) throws ValueFormatException, IoException;
 
     /**
      * Create a value from the binary content given by the supplied stream.
@@ -444,7 +444,7 @@ public interface ValueFactory<T> {
      * @throws ValueFormatException if the conversion from an array of objects could not be performed
      * @throws IoException If an unexpected problem occurs during the conversion.
      */
-    T[] create( Binary[] values ) throws ValueFormatException, IoException;
+    T[] create( BinaryValue[] values ) throws ValueFormatException, IoException;
 
     /**
      * Create an array of values from the specified information by determining which other <code>create</code> method applies for

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/value/ValueTypeSystem.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/value/ValueTypeSystem.java
@@ -93,17 +93,17 @@ public class ValueTypeSystem implements TypeSystem {
         };
         this.pathFactory = new Factory<Path>(valueFactories.getPathFactory());
         this.referenceFactory = new Factory<Reference>(valueFactories.getReferenceFactory());
-        this.binaryFactory = new Factory<Binary>(valueFactories.getBinaryFactory()) {
+        this.binaryFactory = new Factory<BinaryValue>(valueFactories.getBinaryFactory()) {
             @Override
             public String asReadableString( Object value ) {
-                Binary binary = this.valueFactory.create(value);
+                BinaryValue binary = this.valueFactory.create(value);
                 // Just print out the SHA-1 hash in Base64, plus length
                 return "(Binary,length=" + binary.getSize() + ",SHA1=" + Base64.encodeBytes(binary.getHash()) + ")";
             }
 
             @Override
             public long length( Object value ) {
-                Binary binary = this.valueFactory.create(value);
+                BinaryValue binary = this.valueFactory.create(value);
                 return binary != null ? binary.getSize() : 0;
             }
         };

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/value/basic/AbstractValueFactory.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/value/basic/AbstractValueFactory.java
@@ -36,7 +36,7 @@ import org.modeshape.common.text.TextDecoder;
 import org.modeshape.common.util.CheckArg;
 import org.modeshape.jcr.api.value.DateTime;
 import org.modeshape.jcr.cache.NodeKey;
-import org.modeshape.jcr.value.Binary;
+import org.modeshape.jcr.value.BinaryValue;
 import org.modeshape.jcr.value.IoException;
 import org.modeshape.jcr.value.Name;
 import org.modeshape.jcr.value.Path;
@@ -117,7 +117,7 @@ public abstract class AbstractValueFactory<T> implements ValueFactory<T> {
         if (value instanceof NodeKey) return create((NodeKey)value);
         if (value instanceof UUID) return create((UUID)value);
         if (value instanceof URI) return create((URI)value);
-        if (value instanceof Binary) return create((Binary)value);
+        if (value instanceof BinaryValue) return create((BinaryValue)value);
         if (value instanceof javax.jcr.Binary) {
             javax.jcr.Binary jcrBinary = (javax.jcr.Binary)value;
             try {
@@ -344,7 +344,7 @@ public abstract class AbstractValueFactory<T> implements ValueFactory<T> {
     }
 
     @Override
-    public T[] create( Binary[] values ) throws ValueFormatException, IoException {
+    public T[] create( BinaryValue[] values ) throws ValueFormatException, IoException {
         if (values == null) return null;
         final int length = values.length;
         T[] result = createEmptyArray(length);

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/value/basic/BooleanValueFactory.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/value/basic/BooleanValueFactory.java
@@ -34,7 +34,7 @@ import org.modeshape.common.text.TextDecoder;
 import org.modeshape.jcr.GraphI18n;
 import org.modeshape.jcr.api.value.DateTime;
 import org.modeshape.jcr.cache.NodeKey;
-import org.modeshape.jcr.value.Binary;
+import org.modeshape.jcr.value.BinaryValue;
 import org.modeshape.jcr.value.IoException;
 import org.modeshape.jcr.value.Name;
 import org.modeshape.jcr.value.Path;
@@ -191,7 +191,7 @@ public class BooleanValueFactory extends AbstractValueFactory<Boolean> {
     }
 
     @Override
-    public Boolean create( Binary value ) throws ValueFormatException, IoException {
+    public Boolean create( BinaryValue value ) throws ValueFormatException, IoException {
         // First create a string and then create the boolean from the string value ...
         return create(getStringValueFactory().create(value));
     }

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/value/basic/DecimalValueFactory.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/value/basic/DecimalValueFactory.java
@@ -34,7 +34,7 @@ import org.modeshape.common.text.TextDecoder;
 import org.modeshape.jcr.GraphI18n;
 import org.modeshape.jcr.api.value.DateTime;
 import org.modeshape.jcr.cache.NodeKey;
-import org.modeshape.jcr.value.Binary;
+import org.modeshape.jcr.value.BinaryValue;
 import org.modeshape.jcr.value.IoException;
 import org.modeshape.jcr.value.Name;
 import org.modeshape.jcr.value.Path;
@@ -184,7 +184,7 @@ public class DecimalValueFactory extends AbstractValueFactory<BigDecimal> {
     }
 
     @Override
-    public BigDecimal create( Binary value ) throws ValueFormatException, IoException {
+    public BigDecimal create( BinaryValue value ) throws ValueFormatException, IoException {
         // First create a string and then create the boolean from the string value ...
         return create(getStringValueFactory().create(value));
     }

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/value/basic/DoubleValueFactory.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/value/basic/DoubleValueFactory.java
@@ -34,7 +34,7 @@ import org.modeshape.common.text.TextDecoder;
 import org.modeshape.jcr.GraphI18n;
 import org.modeshape.jcr.api.value.DateTime;
 import org.modeshape.jcr.cache.NodeKey;
-import org.modeshape.jcr.value.Binary;
+import org.modeshape.jcr.value.BinaryValue;
 import org.modeshape.jcr.value.IoException;
 import org.modeshape.jcr.value.Name;
 import org.modeshape.jcr.value.Path;
@@ -191,7 +191,7 @@ public class DoubleValueFactory extends AbstractValueFactory<Double> {
     }
 
     @Override
-    public Double create( Binary value ) throws ValueFormatException, IoException {
+    public Double create( BinaryValue value ) throws ValueFormatException, IoException {
         // First create a string and then create the boolean from the string value ...
         return create(getStringValueFactory().create(value));
     }

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/value/basic/JodaDateTimeValueFactory.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/value/basic/JodaDateTimeValueFactory.java
@@ -35,7 +35,7 @@ import org.modeshape.common.text.TextDecoder;
 import org.modeshape.jcr.GraphI18n;
 import org.modeshape.jcr.api.value.DateTime;
 import org.modeshape.jcr.cache.NodeKey;
-import org.modeshape.jcr.value.Binary;
+import org.modeshape.jcr.value.BinaryValue;
 import org.modeshape.jcr.value.DateTimeFactory;
 import org.modeshape.jcr.value.IoException;
 import org.modeshape.jcr.value.Name;
@@ -192,7 +192,7 @@ public class JodaDateTimeValueFactory extends AbstractValueFactory<DateTime> imp
     }
 
     @Override
-    public DateTime create( Binary value ) throws ValueFormatException, IoException {
+    public DateTime create( BinaryValue value ) throws ValueFormatException, IoException {
         // First create a string and then create the boolean from the string value ...
         return create(getStringValueFactory().create(value));
     }

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/value/basic/LongValueFactory.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/value/basic/LongValueFactory.java
@@ -34,7 +34,7 @@ import org.modeshape.common.text.TextDecoder;
 import org.modeshape.jcr.GraphI18n;
 import org.modeshape.jcr.api.value.DateTime;
 import org.modeshape.jcr.cache.NodeKey;
-import org.modeshape.jcr.value.Binary;
+import org.modeshape.jcr.value.BinaryValue;
 import org.modeshape.jcr.value.IoException;
 import org.modeshape.jcr.value.Name;
 import org.modeshape.jcr.value.Path;
@@ -184,7 +184,7 @@ public class LongValueFactory extends AbstractValueFactory<Long> {
     }
 
     @Override
-    public Long create( Binary value ) throws ValueFormatException, IoException {
+    public Long create( BinaryValue value ) throws ValueFormatException, IoException {
         // First create a string and then create the boolean from the string value ...
         return create(getStringValueFactory().create(value));
     }

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/value/basic/NameValueFactory.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/value/basic/NameValueFactory.java
@@ -37,7 +37,7 @@ import org.modeshape.common.util.CheckArg;
 import org.modeshape.jcr.GraphI18n;
 import org.modeshape.jcr.api.value.DateTime;
 import org.modeshape.jcr.cache.NodeKey;
-import org.modeshape.jcr.value.Binary;
+import org.modeshape.jcr.value.BinaryValue;
 import org.modeshape.jcr.value.IoException;
 import org.modeshape.jcr.value.Name;
 import org.modeshape.jcr.value.NameFactory;
@@ -294,7 +294,7 @@ public class NameValueFactory extends AbstractValueFactory<Name> implements Name
     }
 
     @Override
-    public Name create( Binary value ) throws ValueFormatException, IoException {
+    public Name create( BinaryValue value ) throws ValueFormatException, IoException {
         // First create a string and then create the boolean from the string value ...
         return create(getStringValueFactory().create(value));
     }

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/value/basic/ObjectValueFactory.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/value/basic/ObjectValueFactory.java
@@ -34,7 +34,7 @@ import org.modeshape.common.text.TextDecoder;
 import org.modeshape.common.util.CheckArg;
 import org.modeshape.jcr.api.value.DateTime;
 import org.modeshape.jcr.cache.NodeKey;
-import org.modeshape.jcr.value.Binary;
+import org.modeshape.jcr.value.BinaryValue;
 import org.modeshape.jcr.value.IoException;
 import org.modeshape.jcr.value.Name;
 import org.modeshape.jcr.value.Path;
@@ -49,11 +49,11 @@ import org.modeshape.jcr.value.ValueFormatException;
 @Immutable
 public class ObjectValueFactory extends AbstractValueFactory<Object> {
 
-    private final ValueFactory<Binary> binaryValueFactory;
+    private final ValueFactory<BinaryValue> binaryValueFactory;
 
     public ObjectValueFactory( TextDecoder decoder,
                                ValueFactory<String> stringValueFactory,
-                               ValueFactory<Binary> binaryValueFactory ) {
+                               ValueFactory<BinaryValue> binaryValueFactory ) {
         super(PropertyType.OBJECT, decoder, stringValueFactory);
         CheckArg.isNotNull(binaryValueFactory, "binaryValueFactory");
         this.binaryValueFactory = binaryValueFactory;
@@ -62,7 +62,7 @@ public class ObjectValueFactory extends AbstractValueFactory<Object> {
     /**
      * @return binaryValueFactory
      */
-    protected ValueFactory<Binary> getBinaryValueFactory() {
+    protected ValueFactory<BinaryValue> getBinaryValueFactory() {
         return this.binaryValueFactory;
     }
 
@@ -173,7 +173,7 @@ public class ObjectValueFactory extends AbstractValueFactory<Object> {
     }
 
     @Override
-    public Object create( Binary value ) throws ValueFormatException, IoException {
+    public Object create( BinaryValue value ) throws ValueFormatException, IoException {
         return value;
     }
 

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/value/basic/PathValueFactory.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/value/basic/PathValueFactory.java
@@ -39,7 +39,7 @@ import org.modeshape.common.util.CheckArg;
 import org.modeshape.jcr.GraphI18n;
 import org.modeshape.jcr.api.value.DateTime;
 import org.modeshape.jcr.cache.NodeKey;
-import org.modeshape.jcr.value.Binary;
+import org.modeshape.jcr.value.BinaryValue;
 import org.modeshape.jcr.value.InvalidPathException;
 import org.modeshape.jcr.value.IoException;
 import org.modeshape.jcr.value.Name;
@@ -669,7 +669,7 @@ public class PathValueFactory extends AbstractValueFactory<Path> implements Path
     }
 
     @Override
-    public Path create( Binary value ) throws ValueFormatException, IoException {
+    public Path create( BinaryValue value ) throws ValueFormatException, IoException {
         // First create a string and then create the boolean from the string value ...
         return create(getStringValueFactory().create(value));
     }

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/value/basic/ReferenceValueFactory.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/value/basic/ReferenceValueFactory.java
@@ -34,7 +34,7 @@ import org.modeshape.common.text.TextDecoder;
 import org.modeshape.jcr.GraphI18n;
 import org.modeshape.jcr.api.value.DateTime;
 import org.modeshape.jcr.cache.NodeKey;
-import org.modeshape.jcr.value.Binary;
+import org.modeshape.jcr.value.BinaryValue;
 import org.modeshape.jcr.value.IoException;
 import org.modeshape.jcr.value.Name;
 import org.modeshape.jcr.value.Path;
@@ -197,7 +197,7 @@ public class ReferenceValueFactory extends AbstractValueFactory<Reference> imple
     }
 
     @Override
-    public Reference create( Binary value ) throws ValueFormatException, IoException {
+    public Reference create( BinaryValue value ) throws ValueFormatException, IoException {
         // First create a string and then create the boolean from the string value ...
         return create(getStringValueFactory().create(value));
     }

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/value/basic/StringValueFactory.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/value/basic/StringValueFactory.java
@@ -41,7 +41,7 @@ import org.modeshape.common.util.Logger;
 import org.modeshape.jcr.GraphI18n;
 import org.modeshape.jcr.api.value.DateTime;
 import org.modeshape.jcr.cache.NodeKey;
-import org.modeshape.jcr.value.Binary;
+import org.modeshape.jcr.value.BinaryValue;
 import org.modeshape.jcr.value.IoException;
 import org.modeshape.jcr.value.Name;
 import org.modeshape.jcr.value.NamespaceRegistry;
@@ -244,7 +244,7 @@ public class StringValueFactory extends AbstractValueFactory<String> {
     }
 
     @Override
-    public String create( Binary value ) throws ValueFormatException, IoException {
+    public String create( BinaryValue value ) throws ValueFormatException, IoException {
         if (value == null) return null;
         try {
             InputStream stream = value.getStream();

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/value/basic/UriValueFactory.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/value/basic/UriValueFactory.java
@@ -36,7 +36,7 @@ import org.modeshape.common.util.CheckArg;
 import org.modeshape.jcr.GraphI18n;
 import org.modeshape.jcr.api.value.DateTime;
 import org.modeshape.jcr.cache.NodeKey;
-import org.modeshape.jcr.value.Binary;
+import org.modeshape.jcr.value.BinaryValue;
 import org.modeshape.jcr.value.IoException;
 import org.modeshape.jcr.value.Name;
 import org.modeshape.jcr.value.NamespaceRegistry;
@@ -206,7 +206,7 @@ public class UriValueFactory extends AbstractValueFactory<URI> {
     }
 
     @Override
-    public URI create( Binary value ) throws ValueFormatException, IoException {
+    public URI create( BinaryValue value ) throws ValueFormatException, IoException {
         // First create a string and then create the boolean from the string value ...
         return create(getStringValueFactory().create(value));
     }

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/value/basic/UuidValueFactory.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/value/basic/UuidValueFactory.java
@@ -34,7 +34,7 @@ import org.modeshape.common.text.TextDecoder;
 import org.modeshape.jcr.GraphI18n;
 import org.modeshape.jcr.api.value.DateTime;
 import org.modeshape.jcr.cache.NodeKey;
-import org.modeshape.jcr.value.Binary;
+import org.modeshape.jcr.value.BinaryValue;
 import org.modeshape.jcr.value.IoException;
 import org.modeshape.jcr.value.Name;
 import org.modeshape.jcr.value.Path;
@@ -215,7 +215,7 @@ public class UuidValueFactory extends AbstractValueFactory<UUID> implements Uuid
     }
 
     @Override
-    public UUID create( Binary value ) throws ValueFormatException, IoException {
+    public UUID create( BinaryValue value ) throws ValueFormatException, IoException {
         // First create a string and then create the boolean from the string value ...
         return create(getStringValueFactory().create(value));
     }

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/value/binary/AbstractBinary.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/value/binary/AbstractBinary.java
@@ -32,15 +32,15 @@ import org.modeshape.common.SystemFailureException;
 import org.modeshape.common.annotation.Immutable;
 import org.modeshape.common.util.SecureHash;
 import org.modeshape.common.util.SecureHash.Algorithm;
-import org.modeshape.jcr.value.Binary;
+import org.modeshape.jcr.value.BinaryValue;
 import org.modeshape.jcr.value.BinaryKey;
 import org.modeshape.jcr.value.ValueComparators;
 
 /**
- * An abstract implementation of {@link Binary} that provides some common capabilities for other implementations.
+ * An abstract implementation of {@link BinaryValue} that provides some common capabilities for other implementations.
  */
 @Immutable
-public abstract class AbstractBinary implements Binary {
+public abstract class AbstractBinary implements BinaryValue {
 
     protected static final byte[] EMPTY_CONTENT = new byte[0];
 
@@ -123,7 +123,7 @@ public abstract class AbstractBinary implements Binary {
     }
 
     @Override
-    public int compareTo( Binary o ) {
+    public int compareTo( BinaryValue o ) {
         if (o == this) return 0;
         return ValueComparators.BINARY_COMPARATOR.compare(this, o);
     }
@@ -139,8 +139,8 @@ public abstract class AbstractBinary implements Binary {
     @Override
     public boolean equals( Object obj ) {
         if (obj == this) return true;
-        if (obj instanceof Binary) {
-            Binary that = (Binary)obj;
+        if (obj instanceof BinaryValue) {
+            BinaryValue that = (BinaryValue)obj;
             return ValueComparators.BINARY_COMPARATOR.compare(this, that) == 0;
         }
         return false;

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/value/binary/BinaryStore.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/value/binary/BinaryStore.java
@@ -30,7 +30,7 @@ import javax.jcr.RepositoryException;
 import org.modeshape.common.annotation.ThreadSafe;
 import org.modeshape.jcr.api.mimetype.MimeTypeDetector;
 import org.modeshape.jcr.api.text.TextExtractor;
-import org.modeshape.jcr.value.Binary;
+import org.modeshape.jcr.value.BinaryValue;
 import org.modeshape.jcr.value.BinaryKey;
 
 /**
@@ -82,7 +82,7 @@ public interface BinaryStore {
      * @return the binary value representing the stored binary value; never null
      * @throws BinaryStoreException
      */
-    Binary storeValue( InputStream stream ) throws BinaryStoreException;
+    BinaryValue storeValue( InputStream stream ) throws BinaryStoreException;
 
     /**
      * Get an {@link InputStream} to the binary content with the supplied key.
@@ -127,7 +127,7 @@ public interface BinaryStore {
      * @return the extracted text, or null if none could be extracted
      * @throws BinaryStoreException if the binary content could not be accessed
      */
-    String getText( Binary binary ) throws BinaryStoreException;
+    String getText( BinaryValue binary ) throws BinaryStoreException;
 
     /**
      * Get the MIME type for this binary value.
@@ -138,6 +138,6 @@ public interface BinaryStore {
      * @throws IOException if there is a problem reading the binary content
      * @throws RepositoryException if an error occurs.
      */
-    public String getMimeType( Binary binary,
+    public String getMimeType( BinaryValue binary,
                                String name ) throws IOException, RepositoryException;
 }

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/value/binary/BinaryStoreValueFactory.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/value/binary/BinaryStoreValueFactory.java
@@ -36,7 +36,7 @@ import org.modeshape.common.text.TextDecoder;
 import org.modeshape.jcr.GraphI18n;
 import org.modeshape.jcr.api.value.DateTime;
 import org.modeshape.jcr.cache.NodeKey;
-import org.modeshape.jcr.value.Binary;
+import org.modeshape.jcr.value.BinaryValue;
 import org.modeshape.jcr.value.BinaryFactory;
 import org.modeshape.jcr.value.BinaryKey;
 import org.modeshape.jcr.value.IoException;
@@ -53,10 +53,10 @@ import org.modeshape.jcr.value.basic.AbstractValueFactory;
  * concrete implementations.
  */
 @Immutable
-public class BinaryStoreValueFactory extends AbstractValueFactory<Binary> implements BinaryFactory {
+public class BinaryStoreValueFactory extends AbstractValueFactory<BinaryValue> implements BinaryFactory {
 
     private static final String CHAR_SET_NAME = "UTF-8";
-    private static final Binary[] EMPTY_BINARY_ARRAY = new Binary[] {};
+    private static final BinaryValue[] EMPTY_BINARY_ARRAY = new BinaryValue[] {};
 
     private final BinaryStore store;
 
@@ -86,133 +86,133 @@ public class BinaryStoreValueFactory extends AbstractValueFactory<Binary> implem
     }
 
     @Override
-    protected Binary[] createEmptyArray( int length ) {
+    protected BinaryValue[] createEmptyArray( int length ) {
         return EMPTY_BINARY_ARRAY;
     }
 
     @Override
-    public Binary create( String value ) {
+    public BinaryValue create( String value ) {
         if (value == null) return null;
         try {
             return create(value.getBytes(CHAR_SET_NAME));
         } catch (UnsupportedEncodingException err) {
             throw new ValueFormatException(value, getPropertyType(),
                                            GraphI18n.errorConvertingType.text(String.class.getSimpleName(),
-                                                                              Binary.class.getSimpleName(),
+                                                                              BinaryValue.class.getSimpleName(),
                                                                               value), err);
         }
     }
 
     @Override
-    public Binary create( String value,
+    public BinaryValue create( String value,
                           TextDecoder decoder ) {
         if (value == null) return null;
         return create(getDecoder(decoder).decode(value));
     }
 
     @Override
-    public Binary create( int value ) {
+    public BinaryValue create( int value ) {
         // Convert the value to a string, then to a binary ...
         return create(this.getStringValueFactory().create(value));
     }
 
     @Override
-    public Binary create( long value ) {
+    public BinaryValue create( long value ) {
         // Convert the value to a string, then to a binary ...
         return create(this.getStringValueFactory().create(value));
     }
 
     @Override
-    public Binary create( boolean value ) {
+    public BinaryValue create( boolean value ) {
         // Convert the value to a string, then to a binary ...
         return create(this.getStringValueFactory().create(value));
     }
 
     @Override
-    public Binary create( float value ) {
+    public BinaryValue create( float value ) {
         // Convert the value to a string, then to a binary ...
         return create(this.getStringValueFactory().create(value));
     }
 
     @Override
-    public Binary create( double value ) {
+    public BinaryValue create( double value ) {
         // Convert the value to a string, then to a binary ...
         return create(this.getStringValueFactory().create(value));
     }
 
     @Override
-    public Binary create( BigDecimal value ) {
+    public BinaryValue create( BigDecimal value ) {
         // Convert the value to a string, then to a binary ...
         return create(this.getStringValueFactory().create(value));
     }
 
     @Override
-    public Binary create( Calendar value ) {
+    public BinaryValue create( Calendar value ) {
         // Convert the value to a string, then to a binary ...
         return create(this.getStringValueFactory().create(value));
     }
 
     @Override
-    public Binary create( Date value ) {
+    public BinaryValue create( Date value ) {
         // Convert the value to a string, then to a binary ...
         return create(this.getStringValueFactory().create(value));
     }
 
     @Override
-    public Binary create( DateTime value ) throws ValueFormatException {
+    public BinaryValue create( DateTime value ) throws ValueFormatException {
         // Convert the value to a string, then to a binary ...
         return create(this.getStringValueFactory().create(value));
     }
 
     @Override
-    public Binary create( Name value ) {
+    public BinaryValue create( Name value ) {
         // Convert the value to a string, then to a binary ...
         return create(this.getStringValueFactory().create(value));
     }
 
     @Override
-    public Binary create( Path value ) {
+    public BinaryValue create( Path value ) {
         // Convert the value to a string, then to a binary ...
         return create(this.getStringValueFactory().create(value));
     }
 
     @Override
-    public Binary create( Path.Segment value ) {
+    public BinaryValue create( Path.Segment value ) {
         // Convert the value to a string, then to a binary ...
         return create(this.getStringValueFactory().create(value));
     }
 
     @Override
-    public Binary create( Reference value ) {
+    public BinaryValue create( Reference value ) {
         // Convert the value to a string, then to a binary ...
         return create(this.getStringValueFactory().create(value));
     }
 
     @Override
-    public Binary create( URI value ) {
+    public BinaryValue create( URI value ) {
         // Convert the value to a string, then to a binary ...
         return create(this.getStringValueFactory().create(value));
     }
 
     @Override
-    public Binary create( UUID value ) {
+    public BinaryValue create( UUID value ) {
         // Convert the value to a string, then to a binary ...
         return create(this.getStringValueFactory().create(value));
     }
 
     @Override
-    public Binary create( NodeKey value ) throws ValueFormatException {
+    public BinaryValue create( NodeKey value ) throws ValueFormatException {
         // Convert the value to a string, then to a binary ...
         return create(this.getStringValueFactory().create(value));
     }
 
     @Override
-    public Binary create( Binary value ) throws ValueFormatException, IoException {
+    public BinaryValue create( BinaryValue value ) throws ValueFormatException, IoException {
         return value;
     }
 
     @Override
-    public Binary create( byte[] value ) throws ValueFormatException {
+    public BinaryValue create( byte[] value ) throws ValueFormatException {
         if (value.length <= store.getMinimumBinarySizeInBytes()) {
             // It's small enough, so just create an in-memory value ...
             return new InMemoryBinaryValue(store, value);
@@ -226,7 +226,7 @@ public class BinaryStoreValueFactory extends AbstractValueFactory<Binary> implem
     }
 
     @Override
-    public Binary create( InputStream stream ) throws IoException {
+    public BinaryValue create( InputStream stream ) throws IoException {
         if (stream == null) return null;
         try {
             // Store the value in the store ...
@@ -238,7 +238,7 @@ public class BinaryStoreValueFactory extends AbstractValueFactory<Binary> implem
 
     @SuppressWarnings( "unused" )
     @Override
-    public Binary find( BinaryKey secureHash,
+    public BinaryValue find( BinaryKey secureHash,
                         long size ) throws BinaryStoreException {
         // In-memory binaries never need to be found, so it must be stored ...
         return new StoredBinaryValue(store, secureHash, size);

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/value/binary/DatabaseBinaryStore.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/value/binary/DatabaseBinaryStore.java
@@ -26,7 +26,7 @@ package org.modeshape.jcr.value.binary;
 import java.io.InputStream;
 import java.util.concurrent.TimeUnit;
 import org.modeshape.common.annotation.ThreadSafe;
-import org.modeshape.jcr.value.Binary;
+import org.modeshape.jcr.value.BinaryValue;
 import org.modeshape.jcr.value.BinaryKey;
 
 /**
@@ -36,7 +36,7 @@ import org.modeshape.jcr.value.BinaryKey;
 public class DatabaseBinaryStore extends AbstractBinaryStore {
 
     @Override
-    public Binary storeValue( InputStream stream ) throws BinaryStoreException {
+    public BinaryValue storeValue( InputStream stream ) throws BinaryStoreException {
         throw new BinaryStoreException("Not implemented");
     }
 
@@ -57,12 +57,12 @@ public class DatabaseBinaryStore extends AbstractBinaryStore {
     }
 
     @Override
-    public String getText( Binary binary ) throws BinaryStoreException {
+    public String getText( BinaryValue binary ) throws BinaryStoreException {
         throw new BinaryStoreException("Not implemented");
     }
 
     @Override
-    public String getMimeType( Binary binary,
+    public String getMimeType( BinaryValue binary,
                                String name ) {
         throw new UnsupportedOperationException("Not implemented");
     }

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/value/binary/EmptyBinaryValue.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/value/binary/EmptyBinaryValue.java
@@ -26,15 +26,15 @@ package org.modeshape.jcr.value.binary;
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import org.modeshape.common.annotation.Immutable;
-import org.modeshape.jcr.value.Binary;
+import org.modeshape.jcr.value.BinaryValue;
 
 /**
- * An empty {@link Binary} value.
+ * An empty {@link BinaryValue} value.
  */
 @Immutable
 public final class EmptyBinaryValue extends AbstractBinary {
 
-    public static final Binary INSTANCE = new EmptyBinaryValue();
+    public static final BinaryValue INSTANCE = new EmptyBinaryValue();
 
     private static final long serialVersionUID = 1L;
 
@@ -43,7 +43,7 @@ public final class EmptyBinaryValue extends AbstractBinary {
     }
 
     @Override
-    public int compareTo( Binary other ) {
+    public int compareTo( BinaryValue other ) {
         if (other == this) return 0;
         if (other instanceof EmptyBinaryValue) return 0;
         return super.compareTo(other);

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/value/binary/FileSystemBinaryStore.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/value/binary/FileSystemBinaryStore.java
@@ -46,7 +46,7 @@ import org.modeshape.common.util.SecureHash;
 import org.modeshape.common.util.SecureHash.Algorithm;
 import org.modeshape.common.util.SecureHash.HashingInputStream;
 import org.modeshape.jcr.JcrI18n;
-import org.modeshape.jcr.value.Binary;
+import org.modeshape.jcr.value.BinaryValue;
 import org.modeshape.jcr.value.BinaryKey;
 import org.modeshape.jcr.value.binary.FileLocks.WrappedLock;
 
@@ -97,7 +97,7 @@ public class FileSystemBinaryStore extends AbstractBinaryStore {
     }
 
     @Override
-    public Binary storeValue( InputStream stream ) throws BinaryStoreException {
+    public BinaryValue storeValue( InputStream stream ) throws BinaryStoreException {
         File tmpFile = null;
         try {
             // Write the contents to a temporary file, and while we do grab the SHA-1 hash and the length ...
@@ -383,12 +383,12 @@ public class FileSystemBinaryStore extends AbstractBinaryStore {
     }
 
     @Override
-    public String getText( Binary binary ) throws BinaryStoreException {
+    public String getText( BinaryValue binary ) throws BinaryStoreException {
         return null;
     }
 
     @Override
-    public String getMimeType( Binary binary,
+    public String getMimeType( BinaryValue binary,
                                String name ) throws IOException, RepositoryException {
         return detector().mimeTypeOf(name, binary.getStream());
     }

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/value/binary/InMemoryBinaryValue.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/value/binary/InMemoryBinaryValue.java
@@ -29,11 +29,11 @@ import java.io.InputStream;
 import javax.jcr.RepositoryException;
 import org.modeshape.common.annotation.Immutable;
 import org.modeshape.common.util.CheckArg;
-import org.modeshape.jcr.value.Binary;
+import org.modeshape.jcr.value.BinaryValue;
 import org.modeshape.jcr.value.BinaryKey;
 
 /**
- * An implementation of {@link Binary} that keeps the binary data in-memory.
+ * An implementation of {@link BinaryValue} that keeps the binary data in-memory.
  */
 @Immutable
 public class InMemoryBinaryValue extends AbstractBinary {

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/value/binary/InfinispanBinaryStore.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/value/binary/InfinispanBinaryStore.java
@@ -29,7 +29,7 @@ import org.infinispan.Cache;
 import org.infinispan.manager.CacheContainer;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.modeshape.common.annotation.ThreadSafe;
-import org.modeshape.jcr.value.Binary;
+import org.modeshape.jcr.value.BinaryValue;
 import org.modeshape.jcr.value.BinaryKey;
 
 /**
@@ -108,7 +108,7 @@ public class InfinispanBinaryStore extends AbstractBinaryStore {
     }
 
     @Override
-    public Binary storeValue( InputStream stream ) throws BinaryStoreException {
+    public BinaryValue storeValue( InputStream stream ) throws BinaryStoreException {
         throw new BinaryStoreException("Not implemented");
     }
 
@@ -129,12 +129,12 @@ public class InfinispanBinaryStore extends AbstractBinaryStore {
     }
 
     @Override
-    public String getText( Binary binary ) throws BinaryStoreException {
+    public String getText( BinaryValue binary ) throws BinaryStoreException {
         throw new BinaryStoreException("Not implemented");
     }
 
     @Override
-    public String getMimeType( Binary binary,
+    public String getMimeType( BinaryValue binary,
                                String name ) /* throws IOException, RepositoryException*/{
         throw new UnsupportedOperationException("Not implemented");
     }

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/value/binary/StoredBinaryValue.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/value/binary/StoredBinaryValue.java
@@ -27,11 +27,11 @@ import java.io.IOException;
 import java.io.InputStream;
 import javax.jcr.RepositoryException;
 import org.modeshape.common.annotation.Immutable;
-import org.modeshape.jcr.value.Binary;
+import org.modeshape.jcr.value.BinaryValue;
 import org.modeshape.jcr.value.BinaryKey;
 
 /**
- * A {@link Binary} implementation that gets the content from the {@link BinaryStore}.
+ * A {@link BinaryValue} implementation that gets the content from the {@link BinaryStore}.
  */
 @Immutable
 public class StoredBinaryValue extends AbstractBinary {

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/value/package-info.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/value/package-info.java
@@ -30,7 +30,7 @@
  * Property values can be of any type, although there are specific interfaces for the known types:
  * <ul>
  *  <li>{@link org.modeshape.jcr.value.PropertyType#STRING String} - A value represented with instances of the standard {@link java.lang.String} class.</li>
- *  <li>{@link org.modeshape.jcr.value.PropertyType#BINARY Binary} - A value represented with instances of the {@link org.modeshape.jcr.value.Binary} interface.</li>
+ *  <li>{@link org.modeshape.jcr.value.PropertyType#BINARY Binary} - A value represented with instances of the {@link org.modeshape.jcr.value.BinaryValue} interface.</li>
  *  <li>{@link org.modeshape.jcr.value.PropertyType#LONG Long} - A value represented with instances of the standard {@link java.lang.Long} class.</li>
  *  <li>{@link org.modeshape.jcr.value.PropertyType#DOUBLE Double} - A value represented with instances of the standard {@link java.lang.Double} class.</li>
  *  <li>{@link org.modeshape.jcr.value.PropertyType#DECIMAL Decimal} - A value represented with instances of the standard {@link java.math.BigDecimal} class.</li>
@@ -54,7 +54,7 @@
  * you often don't care what type the property value actually is, but instead care about converting it to a
  * property type that you know how to work with.  For example, you may be working with a property that represents
  * a date, and you want to work with the value as a {@link org.modeshape.jcr.api.value.DateTime} object, regardless of whether the values
- * are actually String, {@link org.modeshape.jcr.api.value.DateTime}, {@link org.modeshape.jcr.value.Binary}, or even {@link java.util.Calendar} or {@link java.util.Date}
+ * are actually String, {@link org.modeshape.jcr.api.value.DateTime}, {@link org.modeshape.jcr.value.BinaryValue}, or even {@link java.util.Calendar} or {@link java.util.Date}
  * instances.  You know its should be a date, so you want to get a value that behaves as a date.
  * </p>
  * <p>
@@ -109,7 +109,7 @@
  * </p>
  * <p>
  * The factory for creating {@link org.modeshape.jcr.api.value.DateTime} objects would then be an implementation of <code>ValueFactory&lt;DateTime></code>,
- * a factory for creating {@link org.modeshape.jcr.value.Binary} objects would be an implementation of <code>ValueFactory&lt;Binary</code>,
+ * a factory for creating {@link org.modeshape.jcr.value.BinaryValue} objects would be an implementation of <code>ValueFactory&lt;Binary</code>,
  * and so on.  In some cases, we'd like to add additional forms of <code>create(...)</code> for specific values, and
  * we can do this by extending a typed {@link org.modeshape.jcr.value.ValueFactory}.  For example, the {@link org.modeshape.jcr.value.DateTimeFactory} adds
  * more methods for creating {@link org.modeshape.jcr.api.value.DateTime} objects for the current time, current time in UTC, from another time

--- a/modeshape-jcr/src/test/java/org/modeshape/jcr/JcrValueTest.java
+++ b/modeshape-jcr/src/test/java/org/modeshape/jcr/JcrValueTest.java
@@ -305,7 +305,7 @@ public class JcrValueTest {
         Binary customBinary = createCustomBinary(stringValue);
         JcrValue jcrValue = new JcrValue(factories, PropertyType.BINARY, customBinary);
 
-        org.modeshape.jcr.value.Binary actualValue = jcrValue.getBinary();
+        org.modeshape.jcr.value.BinaryValue actualValue = jcrValue.getBinary();
 
         assertNotNull(actualValue);
         byte[] actualBytes = IoUtil.readBytes(actualValue.getStream());

--- a/modeshape-jcr/src/test/java/org/modeshape/jcr/value/basic/AbstractValueFactoryTest.java
+++ b/modeshape-jcr/src/test/java/org/modeshape/jcr/value/basic/AbstractValueFactoryTest.java
@@ -40,7 +40,7 @@ import org.modeshape.common.text.NoOpEncoder;
 import org.modeshape.common.text.TextDecoder;
 import org.modeshape.jcr.api.value.DateTime;
 import org.modeshape.jcr.cache.NodeKey;
-import org.modeshape.jcr.value.Binary;
+import org.modeshape.jcr.value.BinaryValue;
 import org.modeshape.jcr.value.IoException;
 import org.modeshape.jcr.value.Name;
 import org.modeshape.jcr.value.Path;
@@ -155,7 +155,7 @@ public class AbstractValueFactoryTest {
         }
 
         @Override
-        public String create( Binary value ) throws ValueFormatException, IoException {
+        public String create( BinaryValue value ) throws ValueFormatException, IoException {
             return null;
         }
 

--- a/modeshape-jcr/src/test/java/org/modeshape/jcr/value/basic/BinaryContains.java
+++ b/modeshape-jcr/src/test/java/org/modeshape/jcr/value/basic/BinaryContains.java
@@ -32,12 +32,12 @@ import org.hamcrest.Factory;
 import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeMatcher;
 import org.modeshape.common.util.IoUtil;
-import org.modeshape.jcr.value.Binary;
+import org.modeshape.jcr.value.BinaryValue;
 
 /**
  * @author Randall Hauch
  */
-public class BinaryContains extends TypeSafeMatcher<Binary> {
+public class BinaryContains extends TypeSafeMatcher<BinaryValue> {
 
     private byte[] expectedContent;
 
@@ -45,7 +45,7 @@ public class BinaryContains extends TypeSafeMatcher<Binary> {
         this.expectedContent = expectedContent;
     }
 
-    public BinaryContains( Binary expectedContent ) {
+    public BinaryContains( BinaryValue expectedContent ) {
         try {
             this.expectedContent = IoUtil.readBytes(expectedContent.getStream());
         } catch (RepositoryException e) {
@@ -58,7 +58,7 @@ public class BinaryContains extends TypeSafeMatcher<Binary> {
     }
 
     @Override
-    public boolean matchesSafely( Binary content ) {
+    public boolean matchesSafely( BinaryValue content ) {
         try {
             byte[] actualContents = IoUtil.readBytes(content.getStream());
             if (actualContents.length != expectedContent.length) return false;
@@ -92,22 +92,22 @@ public class BinaryContains extends TypeSafeMatcher<Binary> {
     }
 
     @Factory
-    public static Matcher<Binary> hasContent( Binary expectedContent ) {
+    public static Matcher<BinaryValue> hasContent( BinaryValue expectedContent ) {
         return new BinaryContains(expectedContent);
     }
 
     @Factory
-    public static Matcher<Binary> hasContent( String expectedContent ) throws UnsupportedEncodingException {
+    public static Matcher<BinaryValue> hasContent( String expectedContent ) throws UnsupportedEncodingException {
         return new BinaryContains(expectedContent.getBytes("UTF-8"));
     }
 
     @Factory
-    public static Matcher<Binary> hasContent( byte[] expectedContent ) {
+    public static Matcher<BinaryValue> hasContent( byte[] expectedContent ) {
         return new BinaryContains(expectedContent);
     }
 
     @Factory
-    public static Matcher<Binary> hasNoContent() {
+    public static Matcher<BinaryValue> hasNoContent() {
         return new BinaryContains(new byte[0]);
     }
 

--- a/modeshape-jcr/src/test/java/org/modeshape/jcr/value/binary/InMemoryBinaryValueTest.java
+++ b/modeshape-jcr/src/test/java/org/modeshape/jcr/value/binary/InMemoryBinaryValueTest.java
@@ -34,7 +34,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.modeshape.common.util.IoUtil;
 import org.modeshape.common.util.StringUtil;
-import org.modeshape.jcr.value.Binary;
+import org.modeshape.jcr.value.BinaryValue;
 
 /**
  * @author Randall Hauch
@@ -94,7 +94,7 @@ public class InMemoryBinaryValueTest {
 
     @Test
     public void shouldConsiderEquivalentThoseInstancesWithSameContent() {
-        Binary another = new InMemoryBinaryValue(store, validByteArrayContent);
+        BinaryValue another = new InMemoryBinaryValue(store, validByteArrayContent);
         assertThat(binary.equals(another), is(true));
         assertThat(binary.compareTo(another), is(0));
         assertThat(binary, is(another));
@@ -108,7 +108,7 @@ public class InMemoryBinaryValueTest {
         for (int i = 0; i != shorterContent.length; ++i) {
             shorterContent[i] = validByteArrayContent[i];
         }
-        Binary another = new InMemoryBinaryValue(store, shorterContent);
+        BinaryValue another = new InMemoryBinaryValue(store, shorterContent);
         assertThat(binary.equals(another), is(false));
         assertThat(binary.compareTo(another) > 0, is(true));
         assertThat(another.compareTo(binary) < 0, is(true));


### PR DESCRIPTION
ModeShape had 3 Binary interfaces, including the `javax.jcr.Binary` and the `org.modeshape.jcr.api.Binary` extension in the public API. The additional org.modeshape.jcr.value.Binary interface is really an internal value, but having it share the same name as the other two is more confusing and can lead to programming errors.

This internal interface was renamed to BinaryValue. A significant amount of code needed to be changed, which shows how much the internal interface is used within our codebase.

All tests pass with these changes.
