### PR TITLE
MODE-1472 - Removed SLF4J from the modeshape-client.jar

### DIFF
--- a/modeshape-common/src/main/java/org/modeshape/common/util/log/LogFactory.java
+++ b/modeshape-common/src/main/java/org/modeshape/common/util/log/LogFactory.java
@@ -37,7 +37,8 @@ public abstract class LogFactory {
 
     static {
         try {
-            ClassUtil.loadClassStrict("org.apache.log4j.Logger");
+            ClassUtil.loadClassStrict("org.slf4j.LoggerFactory");
+            ClassUtil.loadClassStrict("org.slf4j.Logger");
             LOGFACTORY = new SLF4JLoggerFactory();
 
         } catch (ClassNotFoundException cnfe) {

--- a/modeshape-jdbc-local/pom.xml
+++ b/modeshape-jdbc-local/pom.xml
@@ -81,17 +81,11 @@
         -->
         <dependency>
             <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
             <artifactId>slf4j-log4j12</artifactId>
-            <scope>runtime</scope>
         </dependency>
         <dependency>
             <groupId>log4j</groupId>
             <artifactId>log4j</artifactId>
-            <scope>runtime</scope>
         </dependency>
         <!--
           PicketBox (JAAS implementation used in test cases)

--- a/modeshape-jdbc-local/src/main/java/org/modeshape/jdbc/JcrMetaData.java
+++ b/modeshape-jdbc-local/src/main/java/org/modeshape/jdbc/JcrMetaData.java
@@ -38,7 +38,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.logging.Level;
 import javax.jcr.PropertyType;
 import javax.jcr.Repository;
 import javax.jcr.RepositoryException;
@@ -424,7 +423,7 @@ public class JcrMetaData implements DatabaseMetaData {
                                  String schemaPattern,
                                  String tableNamePattern,
                                  String columnNamePattern ) throws SQLException {
-        LocalJcrDriver.logger.log(Level.FINE, "getcolumns: " + catalog + ":" + schemaPattern + ":" + tableNamePattern + ":"
+        LocalJcrDriver.logger.debug("getcolumns: " + catalog + ":" + schemaPattern + ":" + tableNamePattern + ":"
                                               + columnNamePattern);
 
         // Get all tables if tableNamePattern is null
@@ -1496,7 +1495,7 @@ public class JcrMetaData implements DatabaseMetaData {
                                 String tableNamePattern,
                                 String[] types ) throws SQLException {
 
-        LocalJcrDriver.logger.log(Level.FINE, "getTables: " + catalog + ":" + schemaPattern + ":" + tableNamePattern + ":"
+        LocalJcrDriver.logger.debug("getTables: " + catalog + ":" + schemaPattern + ":" + tableNamePattern + ":"
                                               + types);
 
         // Get all tables if tableNamePattern is null

--- a/modeshape-jdbc-local/src/main/java/org/modeshape/jdbc/LocalJcrDriver.java
+++ b/modeshape-jdbc-local/src/main/java/org/modeshape/jdbc/LocalJcrDriver.java
@@ -29,12 +29,11 @@ import java.sql.DriverPropertyInfo;
 import java.sql.SQLException;
 import java.util.Properties;
 import java.util.Set;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 import javax.jcr.Repository;
 import javax.naming.Context;
 import javax.naming.NamingException;
 import org.modeshape.common.collection.Collections;
+import org.modeshape.common.util.Logger;
 import org.modeshape.jdbc.delegate.ConnectionInfo;
 import org.modeshape.jdbc.delegate.LocalRepositoryDelegate;
 import org.modeshape.jdbc.delegate.RepositoryDelegate;
@@ -104,8 +103,7 @@ public class LocalJcrDriver implements java.sql.Driver {
             DriverManager.registerDriver(INSTANCE);
         } catch (SQLException e) {
             // Logging
-            String logMsg = JdbcLocalI18n.driverErrorRegistering.text(e.getMessage());
-            logger.log(Level.SEVERE, logMsg);
+            logger.error(JdbcLocalI18n.driverErrorRegistering, e.getMessage());
         }
     }
 

--- a/modeshape-jdbc/pom.xml
+++ b/modeshape-jdbc/pom.xml
@@ -85,17 +85,11 @@
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
             <artifactId>slf4j-log4j12</artifactId>
-            <scope>runtime</scope>
         </dependency>
         <dependency>
             <groupId>log4j</groupId>
             <artifactId>log4j</artifactId>
-            <scope>runtime</scope>
         </dependency>
         <!--
           PicketBox (JAAS implementation used in test cases)
@@ -225,8 +219,6 @@
 
                                         <unzip src="target/tempjars/jaxrs-api-1.2.1.GA.jar" dest="target/temploc"/>
                                         <unzip src="target/tempjars/jcr-2.0.jar" dest="target/temploc"/>
-                                        <unzip src="target/tempjars/slf4j-api-1.6.1.jar" dest="target/temploc"/>
-                                        <!--unzip src="target/tempjars/slf4j-log4j12-1.6.1.jar" dest="target/temploc" /-->
 
                                         <unzip src="target/tempjars/commons-codec-1.4.jar" dest="target/temploc"/>
                                         <move file="target/temploc/META-INF/LICENSE.txt"

--- a/modeshape-jdbc/src/assembly/kit.xml
+++ b/modeshape-jdbc/src/assembly/kit.xml
@@ -36,7 +36,7 @@
             <includes>
                 <include>org.modeshape:modeshape-jcr-api</include>
                 <include>javax.jcr:jcr</include>
-                <include>org.slf4j:slf4j-api</include>
+
                 <!-- Needed for the driver's HTTP communication -->
                 <include>org.modeshape:modeshape-web-jcr-rest-client</include>
                 <include>org.jboss.resteasy:*</include>

--- a/modeshape-jdbc/src/main/java/org/modeshape/jdbc/JcrDriver.java
+++ b/modeshape-jdbc/src/main/java/org/modeshape/jdbc/JcrDriver.java
@@ -98,7 +98,7 @@ public class JcrDriver extends LocalJcrDriver {
         try {
             DriverManager.registerDriver(INSTANCE);
         } catch (SQLException e) {
-            logger.log(Level.SEVERE, JdbcI18n.driverErrorRegistering.text(e.getMessage()));
+            logger.error(JdbcI18n.driverErrorRegistering, e.getMessage());
         }
     }
 

--- a/web/modeshape-web-jcr-rest-client/pom.xml
+++ b/web/modeshape-web-jcr-rest-client/pom.xml
@@ -84,17 +84,11 @@
           -->
         <dependency>
             <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
             <artifactId>slf4j-log4j12</artifactId>
-            <scope>runtime</scope>
         </dependency>
         <dependency>
             <groupId>log4j</groupId>
             <artifactId>log4j</artifactId>
-            <scope>runtime</scope>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
- unnecessary dependencies to slf4j have been removed
- the LogFactory from common searches for SFL4j's API in the classpath prior to defaulting to java.util
