### PR TITLE
MODE-1460 Revert: Use flags to eliminate unnecessary grid requests

### DIFF
--- a/modeshape-schematic/src/main/java/org/infinispan/schematic/internal/SchematicEntryProxy.java
+++ b/modeshape-schematic/src/main/java/org/infinispan/schematic/internal/SchematicEntryProxy.java
@@ -26,7 +26,6 @@ import javax.transaction.Transaction;
 import javax.transaction.TransactionManager;
 import org.infinispan.AdvancedCache;
 import org.infinispan.Cache;
-import org.infinispan.DecoratedCache;
 import org.infinispan.batch.AutoBatchSupport;
 import org.infinispan.container.entries.CacheEntry;
 import org.infinispan.context.Flag;
@@ -62,7 +61,6 @@ public class SchematicEntryProxy extends AutoBatchSupport implements SchematicEn
     private static final boolean trace = log.isTraceEnabled();
 
     final AdvancedCache<String, SchematicEntry> cache;
-    final AdvancedCache<String, SchematicEntry> cacheForWriting;
     final String key;
     final FlagContainer flagContainer;
     protected TransactionTable transactionTable;
@@ -74,8 +72,6 @@ public class SchematicEntryProxy extends AutoBatchSupport implements SchematicEn
                          FlagContainer flagContainer ) {
         this.key = key;
         this.cache = cache;
-        this.cacheForWriting = new DecoratedCache<String, SchematicEntry>(this.cache, Flag.SKIP_REMOTE_LOOKUP,
-                                                                          Flag.SKIP_CACHE_LOAD);
         this.batchContainer = cache.getBatchContainer();
         this.flagContainer = flagContainer;
         transactionTable = cache.getComponentRegistry().getComponent(TransactionTable.class);
@@ -173,7 +169,7 @@ public class SchematicEntryProxy extends AutoBatchSupport implements SchematicEn
         if (suppressLocks) {
             flagContainer.setFlags(Flag.SKIP_LOCKING);
         }
-        cacheForWriting.put(key, copy); // can't rely upon the return value
+        cache.put(key, copy);
         return copy;
     }
 


### PR DESCRIPTION
This reverts commit c3d62b92c338237b603b224a4bcc91a0005f8f42, which caused a class cast exception.
