### PR TITLE
MODE-1361 - Fixed sequencing outputPath in case when the parent of the output is new and has the same name as the alleged output node

### DIFF
--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/SequencingRunner.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/SequencingRunner.java
@@ -118,8 +118,14 @@ final class SequencingRunner implements Runnable {
                 // Remove any existing output (from a prior sequencing run on this same input) ...
                 removeExistingOutputNodes(parentOfOutput, outputNodeName, work.getSelectedPath());
 
-                // Create the output node ...
-                outputNode = (AbstractJcrNode)parentOfOutput.addNode(outputNodeName, JcrConstants.NT_UNSTRUCTURED);
+                // Create the output node
+                if (parentOfOutput.isNew() && parentOfOutput.getName().equals(outputNodeName)) {
+                    //avoid creating a duplicate path with the same name
+                    outputNode = (AbstractJcrNode)parentOfOutput;
+                }
+                else {
+                    outputNode = (AbstractJcrNode)parentOfOutput.addNode(outputNodeName, JcrConstants.NT_UNSTRUCTURED);
+                }
 
                 // and make sure the output node has the 'mode:derived' mixin ...
                 outputNode.addMixin(DERIVED_NODE_TYPE_NAME);
@@ -249,10 +255,10 @@ final class SequencingRunner implements Runnable {
 
     /**
      * Finds the top nodes which have been created during the sequencing process, based on the original output node. It is
-     * important that this is called before the session is save, because it uses the new flag.
+     * important that this is called before the session is saved, because it uses the new flag.
      * 
-     * @param rootOutputNode the node under which the output node should be created (or might exist)
-     * @return the output nodes that were created during the sequencing process; never null
+     * @param rootOutputNode the node under which the output of the sequencing process was written to.
+     * @return the first level of output nodes that were created during the sequencing process; never null
      * @throws RepositoryException if there is a problem finding the output nodes
      */
     private List<AbstractJcrNode> findOutputNodes( AbstractJcrNode rootOutputNode ) throws RepositoryException {

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/change/NodeSequenced.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/change/NodeSequenced.java
@@ -42,8 +42,8 @@ public class NodeSequenced extends AbstractSequencingChange {
     @Override
     public String toString() {
         final StringBuilder sb = new StringBuilder();
-        sb.append("Sequenced new node: ").append(getKey()).append(" at path: ").append(getPath());
-        sb.append(" from the node: ").append(outputNodeKey).append(" at path: ").append(outputNodePath);
+        sb.append("Sequenced new node: ").append(outputNodeKey).append(" at path: ").append(outputNodePath);
+        sb.append(" from the node: ").append(getKey()).append(" at path: ").append(getPath());
         return sb.toString();
     }
 }

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/change/NodeSequencingFailure.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/change/NodeSequencingFailure.java
@@ -55,4 +55,12 @@ public class NodeSequencingFailure extends AbstractSequencingChange {
     public Throwable getCause() {
         return cause;
     }
+
+    @Override
+    public String toString() {
+        final StringBuilder sb = new StringBuilder();
+        sb.append("Failure while sequencing the node at:").append(getPath()).append(" with key:").append(getKey());
+        sb.append(". Cause: ").append(cause.getMessage());
+        return sb.toString();
+    }
 }

--- a/modeshape-jcr/src/test/java/org/modeshape/jcr/TestSequencersHolder.java
+++ b/modeshape-jcr/src/test/java/org/modeshape/jcr/TestSequencersHolder.java
@@ -43,14 +43,13 @@ import org.modeshape.jcr.api.sequencer.Sequencer;
  */
 public class TestSequencersHolder {
 
-    public static class FaultyDuringExecute extends Sequencer {
-        public static final AtomicInteger EXECUTE_CALL_COUNTER = new AtomicInteger();
+    public static final String DERIVED_NODE_NAME = "derivedNode";
 
+    public static class FaultyDuringExecute extends Sequencer {
         @Override
         public boolean execute( Property inputProperty,
                                 Node outputNode,
                                 Sequencer.Context context ) throws Exception {
-            EXECUTE_CALL_COUNTER.incrementAndGet();
             throw new IllegalArgumentException("We're expecting to get this exception");
         }
     }
@@ -78,9 +77,6 @@ public class TestSequencersHolder {
      */
     public static class DefaultSequencer extends Sequencer {
 
-        public static final String DERIVED_NODE_NAME = "derivedNode";
-        public static final AtomicInteger COUNTER = new AtomicInteger();
-
         @Override
         public boolean execute( Property inputProperty,
                                 Node outputNode,
@@ -89,7 +85,6 @@ public class TestSequencersHolder {
             CheckArg.isNotNull(outputNode, "outputNode");
             CheckArg.isNotNull(context, "context");
             CheckArg.isNotNull(context.getTimestamp(), "context.getTimestamp()");
-            COUNTER.incrementAndGet();
             outputNode.addNode(DERIVED_NODE_NAME);
             return true;
         }
@@ -100,7 +95,6 @@ public class TestSequencersHolder {
      */
     @SuppressWarnings( "unused" )
     public static class SequencerWithProperties extends Sequencer {
-        public static boolean executed;
 
         private List<Integer> intList;
         private Set<Integer> intSet;
@@ -154,7 +148,7 @@ public class TestSequencersHolder {
             assertNotNull("subSequencerList not set", subSequencerList);
             assertFalse(subSequencerList.isEmpty());
 
-            executed = true;
+            outputNode.addNode(DERIVED_NODE_NAME);
 
             return true;
         }

--- a/modeshape-jcr/src/test/java/org/modeshape/sequencer/cnd/CndSequencerTest.java
+++ b/modeshape-jcr/src/test/java/org/modeshape/sequencer/cnd/CndSequencerTest.java
@@ -83,7 +83,7 @@ public class CndSequencerTest extends AbstractSequencerTest {
     }
 
     private void verifyEmbeddedImageNode( Node imagesNode ) throws Exception {
-        Node embeddedImageNode = getSequencedNode(imagesNode, "image:embeddedImage");
+        Node embeddedImageNode = getOutputNode(imagesNode, "image:embeddedImage");
         assertNotNull(embeddedImageNode);
         new NodeDefinitionVerifier().name("image:embeddedImage")
                                     .nodeTypeName("image:embeddedImage")
@@ -96,7 +96,7 @@ public class CndSequencerTest extends AbstractSequencerTest {
     }
 
     private void verifyImageMetadataNode( Node imagesNode ) throws Exception {
-        Node imageMetadataNode = getSequencedNode(imagesNode, "image:metadata");
+        Node imageMetadataNode = getOutputNode(imagesNode, "image:metadata");
         assertNotNull(imageMetadataNode);
         new NodeDefinitionVerifier().name("image:metadata")
                                     .superTypes("nt:unstructured", "mix:mimeType")

--- a/sequencers/modeshape-sequencer-ddl/src/test/java/org/modeshape/sequencer/ddl/AbstractDdlSequencerTest.java
+++ b/sequencers/modeshape-sequencer-ddl/src/test/java/org/modeshape/sequencer/ddl/AbstractDdlSequencerTest.java
@@ -102,12 +102,12 @@ public abstract class AbstractDdlSequencerTest extends AbstractSequencerTest {
     protected Node sequenceDdl( String ddlFile ) throws Exception {
         String fileName = ddlFile.substring(ddlFile.lastIndexOf("/") + 1);
         createNodeWithContentFromFile(fileName, ddlFile);
-        Node sequencedNode = getSequencedNode(rootNode, "ddl/" + fileName);
+        Node outputNode = getOutputNode(rootNode, "ddl/" + fileName);
 
-        assertNotNull(sequencedNode);
-        assertThat(sequencedNode.getNodes().getSize(), is(1l));
+        assertNotNull(outputNode);
+        assertThat(outputNode.getNodes().getSize(), is(1l));
 
-        Node statementsNode = sequencedNode.getNode(STATEMENTS_CONTAINER);
+        Node statementsNode = outputNode.getNode(STATEMENTS_CONTAINER);
         assertNotNull(statementsNode);
         return statementsNode;
     }

--- a/sequencers/modeshape-sequencer-images/src/test/java/org/modeshape/sequencer/image/ImageMetadataSequencerTest.java
+++ b/sequencers/modeshape-sequencer-images/src/test/java/org/modeshape/sequencer/image/ImageMetadataSequencerTest.java
@@ -46,10 +46,10 @@ public class ImageMetadataSequencerTest extends AbstractSequencerTest {
         String filename = "caution.jpg";
         Node imageNode = createNodeWithContentFromFile(filename, filename);
 
-        Node sequencedNodeDifferentLocation = getSequencedNode(rootNode, "sequenced/images/" + filename);
+        Node sequencedNodeDifferentLocation = getOutputNode(rootNode, "sequenced/images/" + filename);
         assertMetaDataProperties(sequencedNodeDifferentLocation, "image/jpeg", "jpeg", 48, 48, 24, false, 1, 72, 72, 0.666667, 0.666667);
 
-        Node sequencedNodeSameLocation = getSequencedNode(imageNode, ImageMetadataLexicon.METADATA_NODE);
+        Node sequencedNodeSameLocation = getOutputNode(imageNode, ImageMetadataLexicon.METADATA_NODE);
         assertMetaDataProperties(sequencedNodeSameLocation, "image/jpeg", "jpeg", 48, 48, 24, false, 1, 72, 72, 0.666667, 0.666667);
     }
 
@@ -58,10 +58,10 @@ public class ImageMetadataSequencerTest extends AbstractSequencerTest {
         String filename = "caution.png";
         Node imageNode = createNodeWithContentFromFile(filename, filename);
 
-        Node sequencedNodeDifferentLocation = getSequencedNode(rootNode, "sequenced/images/" + filename);
+        Node sequencedNodeDifferentLocation = getOutputNode(rootNode, "sequenced/images/" + filename);
         assertMetaDataProperties(sequencedNodeDifferentLocation, "image/png", "png", 48, 48, 24, false, 1, -1, -1, -1, -1);
 
-        Node sequencedNodeSameLocation = getSequencedNode(imageNode, ImageMetadataLexicon.METADATA_NODE);
+        Node sequencedNodeSameLocation = getOutputNode(imageNode, ImageMetadataLexicon.METADATA_NODE);
         assertMetaDataProperties(sequencedNodeSameLocation, "image/png", "png", 48, 48, 24, false, 1, -1, -1, -1, -1);
     }
 
@@ -70,10 +70,10 @@ public class ImageMetadataSequencerTest extends AbstractSequencerTest {
         String filename = "caution.gif";
         Node imageNode = createNodeWithContentFromFile(filename, filename);
 
-        Node sequencedNodeDifferentLocation = getSequencedNode(rootNode, "sequenced/images/" + filename);
+        Node sequencedNodeDifferentLocation = getOutputNode(rootNode, "sequenced/images/" + filename);
         assertMetaDataProperties(sequencedNodeDifferentLocation, "image/gif", "gif", 48, 48, 8, false, 1, -1, -1, -1, -1);
 
-        Node sequencedNodeSameLocation = getSequencedNode(imageNode, ImageMetadataLexicon.METADATA_NODE);
+        Node sequencedNodeSameLocation = getOutputNode(imageNode, ImageMetadataLexicon.METADATA_NODE);
         assertMetaDataProperties(sequencedNodeSameLocation, "image/gif", "gif", 48, 48, 8, false, 1, -1, -1, -1, -1);
     }
 
@@ -81,8 +81,8 @@ public class ImageMetadataSequencerTest extends AbstractSequencerTest {
     public void shouldGenerateNoMetadataforPictImageFiles() throws Exception {
         String filename = "caution.pict";
         Node imageNode = createNodeWithContentFromFile(filename, filename);
-        assertNull(getSequencedNode(rootNode, "sequenced/images/" + filename, 1));
-        assertNull(getSequencedNode(imageNode, ImageMetadataLexicon.METADATA_NODE, 1));
+        assertNull(getOutputNode(rootNode, "sequenced/images/" + filename, 1));
+        assertNull(getOutputNode(imageNode, ImageMetadataLexicon.METADATA_NODE, 1));
     }   
 
     private void assertMetaDataProperties( Node metadataNode, String mimeType, String format, int width, int height, int bitsPerPixel,

--- a/sequencers/modeshape-sequencer-java/src/test/java/org/modeshape/sequencer/classfile/ClassFileSequencerTest.java
+++ b/sequencers/modeshape-sequencer-java/src/test/java/org/modeshape/sequencer/classfile/ClassFileSequencerTest.java
@@ -45,16 +45,16 @@ public class ClassFileSequencerTest extends AbstractSequencerTest {
 
         // expected by sequencer in the same location
         String expectedSequencedPathSameLocation = "enum.class/org";
-        Node sequencedNode = getSequencedNode(rootNode, expectedSequencedPathSameLocation);
-        assertNotNull(sequencedNode);
-        Node enumNode = sequencedNode.getNode(packagePath.substring(packagePath.indexOf("/") + 1));
+        Node outputNode = getOutputNode(rootNode, expectedSequencedPathSameLocation);
+        assertNotNull(outputNode);
+        Node enumNode = outputNode.getNode(packagePath.substring(packagePath.indexOf("/") + 1));
         CLASS_FILE_HELPER.assertSequencedMockEnum(enumNode);
 
         // expected by sequencer in a different location
         String expectedSequencedPathNewLocation = "classes/enum.class";
-        sequencedNode = getSequencedNode(rootNode, expectedSequencedPathNewLocation);
-        assertNotNull(sequencedNode);
-        enumNode = sequencedNode.getNode(packagePath);
+        outputNode = getOutputNode(rootNode, expectedSequencedPathNewLocation);
+        assertNotNull(outputNode);
+        enumNode = outputNode.getNode(packagePath);
         CLASS_FILE_HELPER.assertSequencedMockEnum(enumNode);
     }
 
@@ -65,16 +65,16 @@ public class ClassFileSequencerTest extends AbstractSequencerTest {
 
         // expected by sequencer in the same location
         String expectedSequencedPathSameLocation = "mockclass.class/org";
-        Node sequencedNode = getSequencedNode(rootNode, expectedSequencedPathSameLocation);
-        assertNotNull(sequencedNode);
-        Node classNode = sequencedNode.getNode(packagePath.substring(packagePath.indexOf("/") + 1));
+        Node outputNode = getOutputNode(rootNode, expectedSequencedPathSameLocation);
+        assertNotNull(outputNode);
+        Node classNode = outputNode.getNode(packagePath.substring(packagePath.indexOf("/") + 1));
         CLASS_FILE_HELPER.assertSequencedMockClass(classNode);
 
         // expected by sequencer in a different location
         String expectedSequencedPathNewLocation = "classes/mockclass.class";
-        sequencedNode = getSequencedNode(rootNode, expectedSequencedPathNewLocation);
-        assertNotNull(sequencedNode);
-        classNode = sequencedNode.getNode(packagePath);
+        outputNode = getOutputNode(rootNode, expectedSequencedPathNewLocation);
+        assertNotNull(outputNode);
+        classNode = outputNode.getNode(packagePath);
         CLASS_FILE_HELPER.assertSequencedMockClass(classNode);
     }
 }

--- a/sequencers/modeshape-sequencer-java/src/test/java/org/modeshape/sequencer/javafile/JavaFileSequencerTest.java
+++ b/sequencers/modeshape-sequencer-java/src/test/java/org/modeshape/sequencer/javafile/JavaFileSequencerTest.java
@@ -46,9 +46,9 @@ public class JavaFileSequencerTest extends AbstractSequencerTest {
 
         //expected by sequencer in a different location
         String expectedOutputPath = "java/enum.java";
-        Node sequencedNode = getSequencedNode(rootNode, expectedOutputPath);
-        assertNotNull(sequencedNode);
-        Node enumNode = sequencedNode.getNode(packagePath);
+        Node outputNode = getOutputNode(rootNode, expectedOutputPath);
+        assertNotNull(outputNode);
+        Node enumNode = outputNode.getNode(packagePath);
         JAVA_FILE_HELPER.assertSequencedMockEnum(enumNode);
     }
 
@@ -59,9 +59,9 @@ public class JavaFileSequencerTest extends AbstractSequencerTest {
 
         //expected by sequencer in a different location
         String expectedOutputPath = "java/mockclass.java";
-        Node sequencedNode = getSequencedNode(rootNode, expectedOutputPath);
-        assertNotNull(sequencedNode);
-        Node javaNode = sequencedNode.getNode(packagePath);
+        Node outputNode = getOutputNode(rootNode, expectedOutputPath);
+        assertNotNull(outputNode);
+        Node javaNode = outputNode.getNode(packagePath);
         JAVA_FILE_HELPER.assertSequencedMockClass(javaNode);
     }
 }

--- a/sequencers/modeshape-sequencer-mp3/src/test/java/org/modeshape/sequencer/mp3/Mp3SequencerTest.java
+++ b/sequencers/modeshape-sequencer-mp3/src/test/java/org/modeshape/sequencer/mp3/Mp3SequencerTest.java
@@ -41,10 +41,10 @@ public class Mp3SequencerTest extends AbstractSequencerTest {
     public void shouldSequenceMp3() throws Exception {
         createNodeWithContentFromFile("sample.mp3", "sample1.mp3");
         
-        Node sequencedNodeSameLocation = getSequencedNode(rootNode, "sample.mp3/" + Mp3MetadataLexicon.METADATA_NODE);
+        Node sequencedNodeSameLocation = getOutputNode(rootNode, "sample.mp3/" + Mp3MetadataLexicon.METADATA_NODE);
         assertSequencedMp3(sequencedNodeSameLocation);
 
-        Node sequencedNodeDifferentLocation = getSequencedNode(rootNode, "mp3s/sample.mp3");
+        Node sequencedNodeDifferentLocation = getOutputNode(rootNode, "mp3s/sample.mp3");
         assertSequencedMp3(sequencedNodeDifferentLocation);
     }
 

--- a/sequencers/modeshape-sequencer-msoffice/src/test/java/org/modeshape/sequencer/msoffice/MSOfficeMetadataSequencerTest.java
+++ b/sequencers/modeshape-sequencer-msoffice/src/test/java/org/modeshape/sequencer/msoffice/MSOfficeMetadataSequencerTest.java
@@ -84,14 +84,14 @@ public class MSOfficeMetadataSequencerTest extends AbstractSequencerTest {
     @Test
     public void shouldSequenceWordFiles() throws Exception {
         createNodeWithContentFromFile("word.doc", "word.doc");
-        Node sequencedNode = getSequencedNode(rootNode, "word.doc/" + METADATA_NODE);
-        assertNotNull(sequencedNode);
+        Node outputNode = getOutputNode(rootNode, "word.doc/" + METADATA_NODE);
+        assertNotNull(outputNode);
 
-        assertEquals(METADATA_NODE, sequencedNode.getPrimaryNodeType().getName());
-        assertEquals(MICROSOFT_WORD, sequencedNode.getProperty(JCR_MIME_TYPE).getString());
-        assertMetadata(sequencedNode);
+        assertEquals(METADATA_NODE, outputNode.getPrimaryNodeType().getName());
+        assertEquals(MICROSOFT_WORD, outputNode.getProperty(JCR_MIME_TYPE).getString());
+        assertMetadata(outputNode);
 
-        NodeIterator headingsIterator = sequencedNode.getNodes();
+        NodeIterator headingsIterator = outputNode.getNodes();
         assertEquals(WORD_HEADINGS.size(), headingsIterator.getSize());
         while (headingsIterator.hasNext()) {
             Node heading = headingsIterator.nextNode();
@@ -101,25 +101,25 @@ public class MSOfficeMetadataSequencerTest extends AbstractSequencerTest {
         }
     }
 
-    private void assertMetadata( Node sequencedNode ) throws RepositoryException {
-        assertEquals("Test Comment", sequencedNode.getProperty(COMMENT).getString());
-        assertEquals("Michael Trezzi", sequencedNode.getProperty(AUTHOR).getString());
-        assertEquals("jboss, test, dna", sequencedNode.getProperty(KEYWORDS).getString());
-        assertEquals("Test Document", sequencedNode.getProperty(TITLE).getString());
-        assertEquals("Test Subject", sequencedNode.getProperty(SUBJECT).getString());
+    private void assertMetadata( Node outputNode ) throws RepositoryException {
+        assertEquals("Test Comment", outputNode.getProperty(COMMENT).getString());
+        assertEquals("Michael Trezzi", outputNode.getProperty(AUTHOR).getString());
+        assertEquals("jboss, test, dna", outputNode.getProperty(KEYWORDS).getString());
+        assertEquals("Test Document", outputNode.getProperty(TITLE).getString());
+        assertEquals("Test Subject", outputNode.getProperty(SUBJECT).getString());
     }
 
     @Test
     public void shouldSequenceExcelFiles() throws Exception {
         createNodeWithContentFromFile("excel.xls", "excel.xls");
-        Node sequencedNode = getSequencedNode(rootNode, "excel.xls/" + METADATA_NODE);
-        assertNotNull(sequencedNode);
+        Node outputNode = getOutputNode(rootNode, "excel.xls/" + METADATA_NODE);
+        assertNotNull(outputNode);
 
-        assertEquals(METADATA_NODE, sequencedNode.getPrimaryNodeType().getName());
-        assertEquals(MICROSOFT_EXCEL, sequencedNode.getProperty(JCR_MIME_TYPE).getString());
-        assertMetadata(sequencedNode);
+        assertEquals(METADATA_NODE, outputNode.getPrimaryNodeType().getName());
+        assertEquals(MICROSOFT_EXCEL, outputNode.getProperty(JCR_MIME_TYPE).getString());
+        assertMetadata(outputNode);
 
-        NodeIterator sheetsIterator = sequencedNode.getNodes();
+        NodeIterator sheetsIterator = outputNode.getNodes();
         assertEquals(EXCEL_SHEETS.size(), sheetsIterator.getSize());
         while (sheetsIterator.hasNext()) {
             Node sheet = sheetsIterator.nextNode();
@@ -137,12 +137,12 @@ public class MSOfficeMetadataSequencerTest extends AbstractSequencerTest {
     @Test
     public void shouldSequencePowerpointFiles() throws Exception {
         createNodeWithContentFromFile("powerpoint.ppt", "powerpoint.ppt");
-        Node sequencedNode = getSequencedNode(rootNode, "powerpoint.ppt/" + METADATA_NODE);
-        assertNotNull(sequencedNode);
+        Node outputNode = getOutputNode(rootNode, "powerpoint.ppt/" + METADATA_NODE);
+        assertNotNull(outputNode);
 
-        assertEquals(METADATA_NODE, sequencedNode.getPrimaryNodeType().getName());
-        assertEquals(MICROSOFT_POWERPOINT, sequencedNode.getProperty(JCR_MIME_TYPE).getString());
-        NodeIterator slidesIterator = sequencedNode.getNodes();
+        assertEquals(METADATA_NODE, outputNode.getPrimaryNodeType().getName());
+        assertEquals(MICROSOFT_POWERPOINT, outputNode.getProperty(JCR_MIME_TYPE).getString());
+        NodeIterator slidesIterator = outputNode.getNodes();
         assertEquals(1, slidesIterator.getSize());
 
         Node slide = slidesIterator.nextNode();

--- a/sequencers/modeshape-sequencer-text/src/test/java/org/modeshape/sequencer/text/AbstractTextSequencerTest.java
+++ b/sequencers/modeshape-sequencer-text/src/test/java/org/modeshape/sequencer/text/AbstractTextSequencerTest.java
@@ -48,12 +48,12 @@ public abstract class AbstractTextSequencerTest extends AbstractSequencerTest {
 
     protected void assertRowsWithCustomRowFactory( String sequencedRootPath ) throws Exception {
         final int ROW_COUNT = 6;
-        Node sequencedNode = getSequencedNode(rootNode, sequencedRootPath);
-        assertNotNull(sequencedNode);
-        assertEquals(ROW_COUNT, sequencedNode.getNodes().getSize());
+        Node outputNode = getOutputNode(rootNode, sequencedRootPath);
+        assertNotNull(outputNode);
+        assertEquals(ROW_COUNT, outputNode.getNodes().getSize());
 
         for (int rowIndex = 1; rowIndex <= ROW_COUNT; rowIndex++) {
-            Node row = assertRow(sequencedNode, rowIndex, new String[]{});
+            Node row = assertRow(outputNode, rowIndex, new String[]{});
             String[] expectedColumns = TEST_COLUMNS;
             for (int colIndex = 0; colIndex < expectedColumns.length; colIndex++) {
                 assertEquals(expectedColumns[colIndex], row.getProperty(DATA + colIndex).getString());
@@ -63,31 +63,31 @@ public abstract class AbstractTextSequencerTest extends AbstractSequencerTest {
 
     protected void assertFileWithMissingRecords( String filePath ) throws Exception {
         final int ROW_COUNT = 6;
-        Node sequencedNode = getSequencedNode(rootNode, filePath);
-        assertNotNull(sequencedNode);
-        assertEquals(ROW_COUNT, sequencedNode.getNodes().getSize());
+        Node outputNode = getOutputNode(rootNode, filePath);
+        assertNotNull(outputNode);
+        assertEquals(ROW_COUNT, outputNode.getNodes().getSize());
 
         for (int rowIndex = 1; rowIndex <= ROW_COUNT; rowIndex++) {
             if (rowIndex == 3) {
-                assertRow(sequencedNode, rowIndex, new String[] {"foo"});
+                assertRow(outputNode, rowIndex, new String[] {"foo"});
             } else {
-                assertRow(sequencedNode, rowIndex, TEST_COLUMNS);
+                assertRow(outputNode, rowIndex, TEST_COLUMNS);
             }
         }
     }
 
-    protected void assertRows( String rootSequencedNodePath, int rowsCount, String[] expectedColumnData ) throws Exception {
-        Node sequencedNode = getSequencedNode(rootNode, rootSequencedNodePath);
-        assertNotNull(sequencedNode);
-        assertEquals(rowsCount, sequencedNode.getNodes().getSize());
+    protected void assertRows( String rootoutputNodePath, int rowsCount, String[] expectedColumnData ) throws Exception {
+        Node outputNode = getOutputNode(rootNode, rootoutputNodePath);
+        assertNotNull(outputNode);
+        assertEquals(rowsCount, outputNode.getNodes().getSize());
 
         for (int rowIndex = 1; rowIndex <= rowsCount; rowIndex++) {
-            assertRow(sequencedNode, rowIndex, expectedColumnData);
+            assertRow(outputNode, rowIndex, expectedColumnData);
         }
     }
 
-    protected Node assertRow( Node rootSequencedNode, int index,  String[] expectedColumnData) throws Exception {
-        Node row = (index == 1) ? rootSequencedNode.getNode(ROW) : rootSequencedNode.getNode(ROW + "[" + index + "]");
+    protected Node assertRow( Node rootoutputNode, int index,  String[] expectedColumnData) throws Exception {
+        Node row = (index == 1) ? rootoutputNode.getNode(ROW) : rootoutputNode.getNode(ROW + "[" + index + "]");
         assertEquals(NT_UNSTRUCTURED, row.getPrimaryNodeType().getName());
         assertEquals(expectedColumnData.length, row.getNodes().getSize());
         for (int colIndex = 0; colIndex < expectedColumnData.length; colIndex++) {

--- a/sequencers/modeshape-sequencer-wsdl/src/test/java/org/modeshape/sequencer/wsdl/WsdlSequencerTest.java
+++ b/sequencers/modeshape-sequencer-wsdl/src/test/java/org/modeshape/sequencer/wsdl/WsdlSequencerTest.java
@@ -124,7 +124,7 @@ public class WsdlSequencerTest extends AbstractSequencerTest {
 
     private void assertSequencedSuccessfully( String filePath ) throws Exception {
         Node parentNode = createNodeWithContentFromFile(filePath, filePath);
-        Node wsdlDocument = getSequencedNode(rootNode, "wsdl/" + filePath);
+        Node wsdlDocument = getOutputNode(rootNode, "wsdl/" + filePath);
         assertNotNull(wsdlDocument);
         assertEquals(WsdlLexicon.WSDL_DOCUMENT, wsdlDocument.getPrimaryNodeType().getName());
         assertCreatedBySessionUser(wsdlDocument, session);

--- a/sequencers/modeshape-sequencer-xml/src/test/java/org/modeshape/sequencer/xml/AbstractXmlSequencerTest.java
+++ b/sequencers/modeshape-sequencer-xml/src/test/java/org/modeshape/sequencer/xml/AbstractXmlSequencerTest.java
@@ -39,7 +39,7 @@ public abstract class AbstractXmlSequencerTest extends AbstractSequencerTest {
 
     protected Node sequenceAndAssertDocument( String documentFilename ) throws Exception {
         createNodeWithContentFromFile(documentFilename, documentFilename);
-        Node document = getSequencedNode(rootNode, "xml/" + documentFilename);
+        Node document = getOutputNode(rootNode, "xml/" + documentFilename);
         assertNotNull(document);
         assertEquals(XmlLexicon.DOCUMENT, document.getPrimaryNodeType().getName());
         return document;

--- a/sequencers/modeshape-sequencer-xsd/src/test/java/org/modeshape/sequencer/xsd/XsdSequencerTest.java
+++ b/sequencers/modeshape-sequencer-xsd/src/test/java/org/modeshape/sequencer/xsd/XsdSequencerTest.java
@@ -50,11 +50,11 @@ public class XsdSequencerTest extends AbstractSequencerTest {
 
         createNodeWithContentFromFile(nodeName, filename);
 
-        Node sequencedNode = getSequencedNode(rootNode, nodeName + "/" + XsdLexicon.SCHEMA_DOCUMENT);
-        assertNotNull(sequencedNode);
-        assertCreatedBySessionUser(sequencedNode, session);
-        assertEquals(XsdLexicon.SCHEMA_DOCUMENT, sequencedNode.getPrimaryNodeType().getName());
-        assertTrue(sequencedNode.getNodes().getSize() > 0);
+        Node outputNode = getOutputNode(rootNode, nodeName + "/" + XsdLexicon.SCHEMA_DOCUMENT);
+        assertNotNull(outputNode);
+        assertCreatedBySessionUser(outputNode, session);
+        assertEquals(XsdLexicon.SCHEMA_DOCUMENT, outputNode.getPrimaryNodeType().getName());
+        assertTrue(outputNode.getNodes().getSize() > 0);
     }
 
     @Test

--- a/sequencers/modeshape-sequencer-zip/src/test/java/org/modeshape/sequencer/zip/ZipSequencerTest.java
+++ b/sequencers/modeshape-sequencer-zip/src/test/java/org/modeshape/sequencer/zip/ZipSequencerTest.java
@@ -51,14 +51,14 @@ public class ZipSequencerTest extends AbstractSequencerTest {
         String filename = "testzip.zip";
         createNodeWithContentFromFile(filename, filename);
 
-        Node sequencedZip = getSequencedNode(rootNode, "zip/" + filename);
-        assertNotNull(sequencedZip);
-        assertEquals(ZipLexicon.FILE, sequencedZip.getPrimaryNodeType().getName());
+        Node outputZip = getOutputNode(rootNode, "zip/" + filename);
+        assertNotNull(outputZip);
+        assertEquals(ZipLexicon.FILE, outputZip.getPrimaryNodeType().getName());
 
-        assertEquals(2, sequencedZip.getNodes().getSize());
-        assertFile(sequencedZip, "test1.txt", "This is a test content of file 1\n");
+        assertEquals(2, outputZip.getNodes().getSize());
+        assertFile(outputZip, "test1.txt", "This is a test content of file 1\n");
 
-        Node folder = sequencedZip.getNode("test subfolder");
+        Node folder = outputZip.getNode("test subfolder");
         assertEquals(1, folder.getNodes().getSize());
         assertEquals(JcrConstants.NT_FOLDER, folder.getPrimaryNodeType().getName());
 
@@ -87,12 +87,12 @@ public class ZipSequencerTest extends AbstractSequencerTest {
     public void shouldSequenceZip2() throws Exception {
         String filename = "test-files.zip";
         Node parent = createNodeWithContentFromFile(filename, filename);
-        Node sequencedNode = parent.getNode("jcr:content");
+        Node outputNode = parent.getNode("jcr:content");
 
-        Node sequencedZip = getSequencedNode(rootNode, "zip/" + filename);
-        assertNotNull(sequencedZip);
-        assertEquals(ZipLexicon.FILE, sequencedZip.getPrimaryNodeType().getName());
-        assertSequencingEventInfo(sequencedNode, session.getUserID(), "ZIP sequencer", sequencedNode.getPath(), "/zip");
+        Node outputZip = getOutputNode(rootNode, "zip/" + filename);
+        assertNotNull(outputZip);
+        assertEquals(ZipLexicon.FILE, outputZip.getPrimaryNodeType().getName());
+        assertSequencingEventInfo(outputNode, session.getUserID(), "ZIP sequencer", outputNode.getPath(), "/zip");
 
         // Find the sequenced node ...
         String path = "/zip/test-files.zip";       
@@ -112,10 +112,10 @@ public class ZipSequencerTest extends AbstractSequencerTest {
     public void shouldFailIfZipCorrupted() throws Throwable {
         String filename = "corrupt.zip";
         Node parent = createNodeWithContentFromFile(filename, filename);
-        Node sequencedNode = parent.getNode("jcr:content");
-        expectSequencingFailure(sequencedNode);
+        Node outputNode = parent.getNode("jcr:content");
+        expectSequencingFailure(outputNode);
 
-        Map sequencingEventInfo = assertSequencingEventInfo(sequencedNode, session.getUserID(), "ZIP sequencer", sequencedNode.getPath(), "/zip");
+        Map sequencingEventInfo = assertSequencingEventInfo(outputNode, session.getUserID(), "ZIP sequencer", outputNode.getPath(), "/zip");
         assertEquals(EOFException.class.getName(), sequencingEventInfo.get(Event.Sequencing.SEQUENCING_FAILURE_CAUSE).getClass().getName());
     }
 


### PR DESCRIPTION
Also, updated the generic SequencingTest to use the sequencing events instead of Thread.sleep.
