### PR TITLE
MODE-1484 Added more error handling to file system connector

### DIFF
--- a/extensions/modeshape-connector-filesystem/src/main/java/org/modeshape/connector/filesystem/FileSystemI18n.java
+++ b/extensions/modeshape-connector-filesystem/src/main/java/org/modeshape/connector/filesystem/FileSystemI18n.java
@@ -104,6 +104,7 @@ public final class FileSystemI18n {
     public static I18n maxPathLengthExceeded;
     public static I18n couldNotStoreProperty;
     public static I18n couldNotStoreProperties;
+    public static I18n couldNotReadListOfFilesInDirectory;
 
     static {
         try {

--- a/extensions/modeshape-connector-filesystem/src/main/java/org/modeshape/connector/filesystem/FileSystemWorkspace.java
+++ b/extensions/modeshape-connector-filesystem/src/main/java/org/modeshape/connector/filesystem/FileSystemWorkspace.java
@@ -527,7 +527,20 @@ class FileSystemWorkspace extends PathWorkspace<PathNode> implements NodeCaching
             if (file == null) return null;
 
             if (file.isDirectory()) {
-                String[] childNames = file.list(source.filenameFilter(true));
+                String[] childNames = null;
+                int attempts = 5;
+                while (childNames == null && (--attempts) >= 0) {
+                    // there must have been an I/O error, so try again ...
+                    childNames = file.list(source.filenameFilter(true));
+                }
+                if (childNames == null) {
+                    // Still null after multiple attempts; we can't really proceed.
+                    // Meaning the file/directory will not be mapped as a node ...
+                    Logger.getLogger(getClass()).error(FileSystemI18n.couldNotReadListOfFilesInDirectory,
+                                                       file.getAbsolutePath(),
+                                                       path.getString(registry));
+                    return null;
+                }
                 Arrays.sort(childNames);
 
                 List<Segment> childSegments = new ArrayList<Segment>(childNames.length);

--- a/extensions/modeshape-connector-filesystem/src/main/resources/org/modeshape/connector/filesystem/FileSystemI18n.properties
+++ b/extensions/modeshape-connector-filesystem/src/main/resources/org/modeshape/connector/filesystem/FileSystemI18n.properties
@@ -95,3 +95,4 @@ getCanonicalPathFailed = Could not determine canonical path
 maxPathLengthExceeded = The maximum absolute path length ({0}) for source "{1}" was exceeded by the node at: {2} ({3})
 couldNotStoreProperty = Unable to store "{0}" property for the file "{1}" in the "{2}" file system source. Check the "extraProperties" setting for this source.
 couldNotStoreProperties = Unable to store the extra properties {0} for the file "{1}" in the "{2}" file system source. Check the "extraProperties" setting for this source.
+couldNotReadListOfFilesInDirectory = Unable to read the list of files/directories within the "{0}" directory; the node "{1}" will be hidden


### PR DESCRIPTION
The file system connector was not properly handling the case when "java.io.File.list(FilenameFilter)" returns null, which it can sometimes do if there's an I/O error. Now, if this happens, the method call is retried up to 4 more times; after that, if the call still returns null, an error message will be logged and no node will be created for the problematic file.

All unit and integration tests pass with these changes.
