### PR TITLE
MODE-1477- Fixed asynchronous failure of the TCK tests

### DIFF
--- a/modeshape-jcr/src/test/resources/repositoryStubImpl.properties
+++ b/modeshape-jcr/src/test/resources/repositoryStubImpl.properties
@@ -159,6 +159,9 @@ javax.jcr.tck.OrderByMultiTypeTest.nodetype=modetest:queryable
 javax.jcr.tck.OrderByMultiTypeTest.propertyname1=selectableProp1
 javax.jcr.tck.OrderByMultiTypeTest.propertyname2=longProp
 
+#Locking tests (DeepLockTest) alter the test root (adding a new mixin) which conflicts with other tests when run in parallel: DocExportViewTest
+javax.jcr.tck.lock.testroot=/testroot/lockingWorkarea
+
 # Test users
 javax.jcr.tck.superuser.name=superuser
 javax.jcr.tck.superuser.pwd=superuser

--- a/modeshape-jcr/src/test/resources/tck/systemViewForTckTests.xml
+++ b/modeshape-jcr/src/test/resources/tck/systemViewForTckTests.xml
@@ -153,6 +153,11 @@ Line 2</sv:value>
         <sv:value>&lt;foo&amp;foo&gt;</sv:value>
       </sv:property>
     </sv:node>
+    <sv:node sv:name="lockingWorkarea">
+      <sv:property sv:name="jcr:primaryType" sv:type="Name">
+        <sv:value>nt:unstructured</sv:value>
+      </sv:property>
+    </sv:node>
     <sv:node sv:name="someQueryableNodeA">
       <sv:property sv:name="jcr:primaryType" sv:type="Name">
         <sv:value>modetest:queryable</sv:value>


### PR DESCRIPTION
Updated the test configuration stub for the TCK tests to use a separate root node for the locking tests

The reason why the  ExportDocViewTest was failing asynchronously was because of the locking tests which were modifying the root test node, which is used in this test as well.
