### PR TITLE
MODE-1494 Changed the XSD sequencer to not generate 'application/xsd' for the MIME type

### DIFF
--- a/modeshape-common/src/main/java/org/modeshape/common/i18n/I18n.java
+++ b/modeshape-common/src/main/java/org/modeshape/common/i18n/I18n.java
@@ -32,18 +32,18 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Properties;
 import java.util.Set;
-import java.util.Map.Entry;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.CopyOnWriteArraySet;
-import org.modeshape.common.annotation.ThreadSafe;
 import org.modeshape.common.CommonI18n;
 import org.modeshape.common.SystemFailureException;
+import org.modeshape.common.annotation.ThreadSafe;
+import org.modeshape.common.logging.Logger;
 import org.modeshape.common.util.CheckArg;
 import org.modeshape.common.util.ClassUtil;
-import org.modeshape.common.logging.Logger;
 import org.modeshape.common.util.StringUtil;
 
 /**
@@ -241,7 +241,8 @@ public final class I18n implements I18nResource {
             final String localizationBaseName = i18nClass.getName();
             URL bundleUrl = repos.getLocalizationBundle(localizationBaseName, locale);
             if (bundleUrl == null) {
-                LOGGER.warn(CommonI18n.i18nBundleNotFoundInClasspath, repos.getPathsToSearchForBundle(localizationBaseName, locale));
+                LOGGER.warn(CommonI18n.i18nBundleNotFoundInClasspath,
+                            repos.getPathsToSearchForBundle(localizationBaseName, locale));
                 // Nothing was found, so try the default locale
                 Locale defaultLocale = Locale.getDefault();
                 if (!defaultLocale.equals(locale)) {
@@ -249,7 +250,8 @@ public final class I18n implements I18nResource {
                 }
                 // Return if no applicable localization file could be found
                 if (bundleUrl == null) {
-                    LOGGER.error(CommonI18n.i18nBundleNotFoundInClasspath, repos.getPathsToSearchForBundle(localizationBaseName, defaultLocale));
+                    LOGGER.error(CommonI18n.i18nBundleNotFoundInClasspath,
+                                 repos.getPathsToSearchForBundle(localizationBaseName, defaultLocale));
                     LOGGER.error(CommonI18n.i18nLocalizationFileNotFound, localizationBaseName);
                     problems.add(CommonI18n.i18nLocalizationFileNotFound.text(localizationBaseName));
                     return;
@@ -268,7 +270,8 @@ public final class I18n implements I18nResource {
                             try {
                                 I18n i18n = (I18n)fld.get(null);
                                 if (i18n.localeToTextMap.get(locale) == null) {
-                                    i18n.localeToProblemMap.put(locale, CommonI18n.i18nPropertyMissing.text(fld.getName(), bundleUrl));
+                                    i18n.localeToProblemMap.put(locale,
+                                                                CommonI18n.i18nPropertyMissing.text(fld.getName(), bundleUrl));
                                 }
                             } catch (IllegalAccessException notPossible) {
                                 // Would have already occurred in initialize method, but allowing for the impossible...
@@ -285,7 +288,9 @@ public final class I18n implements I18nResource {
         }
     }
 
-    private static Properties prepareBundleLoading( final Class<?> i18nClass, final Locale locale, final URL bundleUrl,
+    private static Properties prepareBundleLoading( final Class<?> i18nClass,
+                                                    final Locale locale,
+                                                    final URL bundleUrl,
                                                     final Set<String> problems ) {
         return new Properties() {
             private static final long serialVersionUID = 3920620306881072843L;
@@ -306,7 +311,8 @@ public final class I18n implements I18nResource {
                         if (i18n.localeToTextMap.putIfAbsent(locale, text) != null) {
                             // Duplicate id encountered
                             String prevProblem = i18n.localeToProblemMap.putIfAbsent(locale,
-                                    CommonI18n.i18nPropertyDuplicate.text(id, bundleUrl));
+                                                                                     CommonI18n.i18nPropertyDuplicate.text(id,
+                                                                                                                           bundleUrl));
                             assert prevProblem == null;
                         }
                     }
@@ -414,6 +420,7 @@ public final class I18n implements I18nResource {
      * @param arguments the arguments for the parameter replacement; may be <code>null</code> or empty
      * @return the localized text
      */
+    @Override
     public String text( Object... arguments ) {
         return text(null, arguments);
     }
@@ -425,6 +432,7 @@ public final class I18n implements I18nResource {
      * @param arguments the arguments for the parameter replacement; may be <code>null</code> or empty
      * @return the localized text
      */
+    @Override
     public String text( Locale locale,
                         Object... arguments ) {
         try {

--- a/modeshape-jcr-api/src/main/java/org/modeshape/jcr/api/mimetype/MimeTypeConstants.java
+++ b/modeshape-jcr-api/src/main/java/org/modeshape/jcr/api/mimetype/MimeTypeConstants.java
@@ -34,10 +34,8 @@ public final class MimeTypeConstants {
 
     public static final String TEXT_PLAIN = "text/plain";
     public static final String RTF = "text/rtf";
-    public static final String XML = "text/xml";
     public static final String HTML = "text/html";
     public static final String WSDL = "application/wsdl+xml";
-    public static final String XSD = "application/xsd";
     public static final String APPLICATION_XML = "application/xml";
     public static final String TEXT_XML = "text/xml";
     public static final String HTML_XML = "application/xhtml+xml";
@@ -45,6 +43,12 @@ public final class MimeTypeConstants {
     public static final String XSLT = "application/xslt+xml";
     public static final String XSFP = "application/xsfp+xml";
     public static final String MXML = "application/xv+xml";
+
+    /** This is not a valid MIME type, but we're using it in case other people use it */
+    @Deprecated
+    public static final String XSD = "application/xsd";
+    @Deprecated
+    public static final String XSD_XML = "application/xsd+xml";
 
     public static final String MP3 = "audio/mpeg";
     public static final String WAV = "audio/x-wav";

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/AbstractJcrProperty.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/AbstractJcrProperty.java
@@ -330,6 +330,7 @@ abstract class AbstractJcrProperty extends AbstractJcrItem implements Property, 
     @Override
     public abstract JcrValue getValue() throws ValueFormatException, RepositoryException;
 
+    @SuppressWarnings( "deprecation" )
     @Override
     public void save() throws RepositoryException {
         checkSession();

--- a/modeshape-jcr/src/test/java/org/modeshape/mimetype/ApertureMimeTypeDetectorTest.java
+++ b/modeshape-jcr/src/test/java/org/modeshape/mimetype/ApertureMimeTypeDetectorTest.java
@@ -23,8 +23,74 @@
  */
 package org.modeshape.mimetype;
 
+import static org.modeshape.jcr.api.mimetype.MimeTypeConstants.BASH;
+import static org.modeshape.jcr.api.mimetype.MimeTypeConstants.BMP;
+import static org.modeshape.jcr.api.mimetype.MimeTypeConstants.CALENDAR;
+import static org.modeshape.jcr.api.mimetype.MimeTypeConstants.COREL_PRESENTATION;
+import static org.modeshape.jcr.api.mimetype.MimeTypeConstants.COREL_QUATTRO_PRO;
+import static org.modeshape.jcr.api.mimetype.MimeTypeConstants.COREL_QUATTRO_SPREADSHEET;
+import static org.modeshape.jcr.api.mimetype.MimeTypeConstants.COREL_WORD_PERFECT;
+import static org.modeshape.jcr.api.mimetype.MimeTypeConstants.GIF;
+import static org.modeshape.jcr.api.mimetype.MimeTypeConstants.GZIP;
+import static org.modeshape.jcr.api.mimetype.MimeTypeConstants.HTML;
+import static org.modeshape.jcr.api.mimetype.MimeTypeConstants.ICON;
+import static org.modeshape.jcr.api.mimetype.MimeTypeConstants.JAR;
+import static org.modeshape.jcr.api.mimetype.MimeTypeConstants.JAR_MANIFEST;
+import static org.modeshape.jcr.api.mimetype.MimeTypeConstants.JAVA;
+import static org.modeshape.jcr.api.mimetype.MimeTypeConstants.JAVA_CLASS;
+import static org.modeshape.jcr.api.mimetype.MimeTypeConstants.JPEG;
+import static org.modeshape.jcr.api.mimetype.MimeTypeConstants.MESSAGE_RFC;
+import static org.modeshape.jcr.api.mimetype.MimeTypeConstants.MICROSOFT_EXCEL;
+import static org.modeshape.jcr.api.mimetype.MimeTypeConstants.MICROSOFT_EXCEL_OPENXML;
+import static org.modeshape.jcr.api.mimetype.MimeTypeConstants.MICROSOFT_OFFICE;
+import static org.modeshape.jcr.api.mimetype.MimeTypeConstants.MICROSOFT_OFFICE_DOCUMENT_OPENXML;
+import static org.modeshape.jcr.api.mimetype.MimeTypeConstants.MICROSOFT_OUTLOOK;
+import static org.modeshape.jcr.api.mimetype.MimeTypeConstants.MICROSOFT_POWERPOINT;
+import static org.modeshape.jcr.api.mimetype.MimeTypeConstants.MICROSOFT_POWERPOINT_OPENXML;
+import static org.modeshape.jcr.api.mimetype.MimeTypeConstants.MICROSOFT_PUBLISHER;
+import static org.modeshape.jcr.api.mimetype.MimeTypeConstants.MICROSOFT_VISIO;
+import static org.modeshape.jcr.api.mimetype.MimeTypeConstants.MICROSOFT_WORD;
+import static org.modeshape.jcr.api.mimetype.MimeTypeConstants.MICROSOFT_WORKS;
+import static org.modeshape.jcr.api.mimetype.MimeTypeConstants.MOZILLA_ADDRESS_BOOK;
+import static org.modeshape.jcr.api.mimetype.MimeTypeConstants.MP3;
+import static org.modeshape.jcr.api.mimetype.MimeTypeConstants.OGG;
+import static org.modeshape.jcr.api.mimetype.MimeTypeConstants.OPEN_DOC_FORMULA;
+import static org.modeshape.jcr.api.mimetype.MimeTypeConstants.OPEN_DOC_GRAPHICS;
+import static org.modeshape.jcr.api.mimetype.MimeTypeConstants.OPEN_DOC_GRAPHICS_TEMPLATE;
+import static org.modeshape.jcr.api.mimetype.MimeTypeConstants.OPEN_DOC_PRESENTATION;
+import static org.modeshape.jcr.api.mimetype.MimeTypeConstants.OPEN_DOC_PRESENTATION_TEMPLATE;
+import static org.modeshape.jcr.api.mimetype.MimeTypeConstants.OPEN_DOC_SPREADSHEET;
+import static org.modeshape.jcr.api.mimetype.MimeTypeConstants.OPEN_DOC_SPREADSHEET_TEMPLATE;
+import static org.modeshape.jcr.api.mimetype.MimeTypeConstants.OPEN_DOC_TEXT;
+import static org.modeshape.jcr.api.mimetype.MimeTypeConstants.OPEN_DOC_TEXT_TEMPLATE;
+import static org.modeshape.jcr.api.mimetype.MimeTypeConstants.OPEN_OFFICE_CALC;
+import static org.modeshape.jcr.api.mimetype.MimeTypeConstants.OPEN_OFFICE_CALC_TEMPLATE;
+import static org.modeshape.jcr.api.mimetype.MimeTypeConstants.OPEN_OFFICE_DRAW;
+import static org.modeshape.jcr.api.mimetype.MimeTypeConstants.OPEN_OFFICE_DRAW_TEMPLATE;
+import static org.modeshape.jcr.api.mimetype.MimeTypeConstants.OPEN_OFFICE_IMPRESS;
+import static org.modeshape.jcr.api.mimetype.MimeTypeConstants.OPEN_OFFICE_IMPRESS_TEMPLATE;
+import static org.modeshape.jcr.api.mimetype.MimeTypeConstants.OPEN_OFFICE_WRITER;
+import static org.modeshape.jcr.api.mimetype.MimeTypeConstants.OPEN_OFFICE_WRITER_TEMPLATE;
+import static org.modeshape.jcr.api.mimetype.MimeTypeConstants.PDF;
+import static org.modeshape.jcr.api.mimetype.MimeTypeConstants.PNG;
+import static org.modeshape.jcr.api.mimetype.MimeTypeConstants.PORTABLE_PIXMAP;
+import static org.modeshape.jcr.api.mimetype.MimeTypeConstants.POSTSCRIPT;
+import static org.modeshape.jcr.api.mimetype.MimeTypeConstants.RTF;
+import static org.modeshape.jcr.api.mimetype.MimeTypeConstants.STAR_OFFICE_CALC;
+import static org.modeshape.jcr.api.mimetype.MimeTypeConstants.STAR_OFFICE_DRAW;
+import static org.modeshape.jcr.api.mimetype.MimeTypeConstants.STAR_OFFICE_IMPRESS;
+import static org.modeshape.jcr.api.mimetype.MimeTypeConstants.STAR_OFFICE_WRITER;
+import static org.modeshape.jcr.api.mimetype.MimeTypeConstants.TEXT_PLAIN;
+import static org.modeshape.jcr.api.mimetype.MimeTypeConstants.TEXT_XML;
+import static org.modeshape.jcr.api.mimetype.MimeTypeConstants.TGA;
+import static org.modeshape.jcr.api.mimetype.MimeTypeConstants.TIFF;
+import static org.modeshape.jcr.api.mimetype.MimeTypeConstants.VCARD;
+import static org.modeshape.jcr.api.mimetype.MimeTypeConstants.WAV;
+import static org.modeshape.jcr.api.mimetype.MimeTypeConstants.WMF;
+import static org.modeshape.jcr.api.mimetype.MimeTypeConstants.XCF;
+import static org.modeshape.jcr.api.mimetype.MimeTypeConstants.XPM;
+import static org.modeshape.jcr.api.mimetype.MimeTypeConstants.ZIP;
 import org.junit.Test;
-import static org.modeshape.jcr.api.mimetype.MimeTypeConstants.*;
 import org.modeshape.jcr.api.mimetype.MimeTypeDetector;
 import org.modeshape.jcr.mimetype.ApertureMimeTypeDetector;
 
@@ -34,7 +100,7 @@ import org.modeshape.jcr.mimetype.ApertureMimeTypeDetector;
  * @author Horia Chiorean
  */
 public class ApertureMimeTypeDetectorTest extends AbstractMimeTypeTest {
- 
+
     @Override
     protected MimeTypeDetector getDetector() {
         return new ApertureMimeTypeDetector();
@@ -222,52 +288,52 @@ public class ApertureMimeTypeDetectorTest extends AbstractMimeTypeTest {
 
     @Test
     public void shouldProvideMimeTypeForXml_test_xml() throws Exception {
-        testMimeType("test.xml", XML);
+        testMimeType("test.xml", TEXT_XML);
     }
 
     @Test
     public void shouldProvideMimeTypeForXml_test_excel_spreadsheet_xml() throws Exception {
-        testMimeType("test_excel_spreadsheet.xml", XML);
+        testMimeType("test_excel_spreadsheet.xml", TEXT_XML);
     }
 
     @Test
     public void shouldProvideMimeTypeForXml_CurrencyFormatterExample_mxml() throws Exception {
-        testMimeType("CurrencyFormatterExample.mxml", XML);
+        testMimeType("CurrencyFormatterExample.mxml", TEXT_XML);
     }
 
     @Test
     public void shouldProvideMimeTypeForXml_xml_handwritten_xml() throws Exception {
-        testMimeType("docs/xml-handwritten.xml", XML);
+        testMimeType("docs/xml-handwritten.xml", TEXT_XML);
     }
 
     @Test
     public void shouldProvideMimeTypeForXml_xml_nonexistent_dtd_xml() throws Exception {
-        testMimeType("docs/xml-nonexistent-dtd.xml", XML);
+        testMimeType("docs/xml-nonexistent-dtd.xml", TEXT_XML);
     }
 
     @Test
     public void shouldProvideMimeTypeForXml_xml_nonexistent_remote_dtd_xml() throws Exception {
-        testMimeType("docs/xml-nonexistent-remote-dtd.xml", XML);
+        testMimeType("docs/xml-nonexistent-remote-dtd.xml", TEXT_XML);
     }
 
     @Test
     public void shouldProvideMimeTypeForXml_xml_nonexistent_remote_xsd_xml() throws Exception {
-        testMimeType("docs/xml-nonexistent-remote-xsd.xml", XML);
+        testMimeType("docs/xml-nonexistent-remote-xsd.xml", TEXT_XML);
     }
 
     @Test
     public void shouldProvideMimeTypeForXml_xml_nonexistent_xsd_xml() throws Exception {
-        testMimeType("docs/xml-nonexistent-xsd.xml", XML);
+        testMimeType("docs/xml-nonexistent-xsd.xml", TEXT_XML);
     }
 
     @Test
     public void shouldProvideMimeTypeForXml_xml_utf8_bom() throws Exception {
-        testMimeType("docs/xml-utf8-bom", XML);
+        testMimeType("docs/xml-utf8-bom", TEXT_XML);
     }
 
     @Test
     public void shouldProvideMimeTypeForXsd() throws Exception {
-        testMimeType("Descriptor.1.0.xsd", XML);
+        testMimeType("Descriptor.1.0.xsd", TEXT_XML);
     }
 
     @Test

--- a/sequencers/modeshape-sequencer-xsd/src/main/java/org/modeshape/sequencer/xsd/XsdSequencer.java
+++ b/sequencers/modeshape-sequencer-xsd/src/main/java/org/modeshape/sequencer/xsd/XsdSequencer.java
@@ -41,12 +41,16 @@ import org.modeshape.sequencer.sramp.AbstractSrampSequencer;
  */
 public class XsdSequencer extends AbstractSrampSequencer {
 
+    @SuppressWarnings( "deprecation" )
     @Override
     public void initialize( NamespaceRegistry registry,
                             NodeTypeManager nodeTypeManager ) throws RepositoryException, IOException {
         super.initialize(registry, nodeTypeManager);
         registerNodeTypes("xsd.cnd", nodeTypeManager, true);
-        registerDefaultMimeTypes(MimeTypeConstants.XSD, MimeTypeConstants.APPLICATION_XML, MimeTypeConstants.TEXT_XML);
+        registerDefaultMimeTypes(MimeTypeConstants.XSD, // just in case clients set these mime type
+                                 MimeTypeConstants.XSD_XML, // on nodes to be sequenced
+                                 MimeTypeConstants.APPLICATION_XML,
+                                 MimeTypeConstants.TEXT_XML);
     }
 
     @Override


### PR DESCRIPTION
The correct MIME type for XSD files is "application/xml" or "text/xml", so changed the XSD sequencer to generate "application/xml" for the MIME type property on the derived output.

Also clean up a few compiler warnings.
