### PR TITLE
MODE-1496 JCR-3313 Added fixed JCR TCK test and corrected result set column behavior

### DIFF
--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrQueryManager.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrQueryManager.java
@@ -134,10 +134,14 @@ class JcrQueryManager implements QueryManager {
                 // The query is not well-formed and cannot be parsed ...
                 throw new InvalidQueryException(JcrI18n.queryCannotBeParsedUsingLanguage.text(language, expression));
             }
+            // Set up the hints ...
             PlanHints hints = new PlanHints();
             hints.showPlan = true;
             hints.hasFullTextSearch = true; // always include the score
             hints.validateColumnExistance = false; // see MODE-1055
+            if (parser.getLanguage().equals(QueryLanguage.JCR_SQL2)) {
+                hints.qualifyExpandedColumnNames = true;
+            }
             return resultWith(expression, parser.getLanguage(), command, hints, storedAtPath);
         } catch (ParsingException e) {
             // The query is not well-formed and cannot be parsed ...
@@ -173,6 +177,7 @@ class JcrQueryManager implements QueryManager {
             PlanHints hints = new PlanHints();
             hints.showPlan = true;
             hints.hasFullTextSearch = true; // always include the score
+            hints.qualifyExpandedColumnNames = true; // always qualify expanded names with the selector name in JCR-SQL2
             return resultWith(expression, QueryLanguage.JCR_SQL2, command, hints, null);
         } catch (org.modeshape.jcr.query.parse.InvalidQueryException e) {
             // The query was parsed, but there is an error in the query

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/query/XPathQueryResult.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/query/XPathQueryResult.java
@@ -35,6 +35,7 @@ import javax.jcr.Value;
 import javax.jcr.query.QueryResult;
 import javax.jcr.query.Row;
 import javax.jcr.query.RowIterator;
+import org.modeshape.jcr.query.QueryResults.Columns;
 import org.modeshape.jcr.query.QueryResults.Location;
 import org.modeshape.jcr.query.validate.Schemata;
 
@@ -57,14 +58,17 @@ public class XPathQueryResult extends JcrQueryResult {
                              QueryResults graphResults,
                              Schemata schemata ) {
         super(context, query, graphResults, schemata);
-        List<String> columnNames = new LinkedList<String>(graphResults.getColumns().getColumnNames());
-        List<String> columnTypes = new LinkedList<String>(graphResults.getColumns().getColumnTypes());
-        if (graphResults.getColumns().hasFullTextSearchScores() && !columnNames.contains(JCR_SCORE_COLUMN_NAME)) {
+        Columns resultColumns = graphResults.getColumns();
+        List<String> columnNames = new LinkedList<String>(resultColumns.getColumnNames());
+        List<String> columnTypes = new LinkedList<String>(resultColumns.getColumnTypes());
+        if (resultColumns.hasFullTextSearchScores() && !columnNames.contains(JCR_SCORE_COLUMN_NAME)) {
             columnNames.add(0, JCR_SCORE_COLUMN_NAME);
             columnTypes.add(0, JCR_SCORE_COLUMN_TYPE);
         }
-        columnNames.add(0, JCR_PATH_COLUMN_NAME);
-        columnTypes.add(0, JCR_PATH_COLUMN_TYPE);
+        if (!resultColumns.getColumnNames().contains(JCR_PATH_COLUMN_NAME)) {
+            columnNames.add(0, JCR_PATH_COLUMN_NAME);
+            columnTypes.add(0, JCR_PATH_COLUMN_TYPE);
+        }
         this.columnNames = Collections.unmodifiableList(columnNames);
         this.columnTypes = Collections.unmodifiableList(columnTypes);
     }

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/query/model/Column.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/query/model/Column.java
@@ -126,6 +126,10 @@ public class Column implements LanguageObject, javax.jcr.query.qom.Column {
         return new Column(newSelectorName, propertyName, columnName);
     }
 
+    public Column withColumnName( String columnName ) {
+        return new Column(selectorName, propertyName, columnName);
+    }
+
     @Override
     public void accept( Visitor visitor ) {
         visitor.visit(this);

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/query/model/Visitors.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/query/model/Visitors.java
@@ -1126,7 +1126,7 @@ public class Visitors {
                 Object value = literal.value();
                 String typeName = null;
                 ValueFactories factories = context.getValueFactories();
-                if (value instanceof String) {
+                if (value instanceof String || value instanceof Character) {
                     append(SINGLE_QUOTE);
                     String str = factories.getStringFactory().create(value);
                     append(str);

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/query/plan/PlanHints.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/query/plan/PlanHints.java
@@ -85,6 +85,12 @@ public final class PlanHints implements Serializable, Cloneable {
      */
     public boolean useSessionContent = true;
 
+    /**
+     * Flag indicates whether to fully-qualify (with the selector name) the names of columns that are expanded from wildcard
+     * projections.
+     */
+    public boolean qualifyExpandedColumnNames = false;
+
     public PlanHints() {
     }
 
@@ -103,6 +109,8 @@ public final class PlanHints implements Serializable, Cloneable {
         sb.append(", showPlan=").append(showPlan);
         sb.append(", validateColumnExistance=").append(validateColumnExistance);
         sb.append(", includeSystemContent=").append(includeSystemContent);
+        sb.append(", useSessionContent=").append(useSessionContent);
+        sb.append(", qualifyExpandedColumnNames=").append(qualifyExpandedColumnNames);
         sb.append('}');
         return sb.toString();
     }
@@ -121,6 +129,8 @@ public final class PlanHints implements Serializable, Cloneable {
         clone.showPlan = this.showPlan;
         clone.validateColumnExistance = this.validateColumnExistance;
         clone.includeSystemContent = this.includeSystemContent;
+        clone.useSessionContent = this.useSessionContent;
+        clone.qualifyExpandedColumnNames = this.qualifyExpandedColumnNames;
         return clone;
     }
 }

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/query/process/QueryResultColumns.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/query/process/QueryResultColumns.java
@@ -198,6 +198,10 @@ public class QueryResultColumns implements Columns {
             Integer columnIndex = wrappedAround.columnIndexForName(columnName);
             if (columnIndex == null) {
                 String columnNameWithoutSelector = column.getColumnName() != null ? column.getColumnName() : column.getPropertyName();
+                if (columnNameWithoutSelector.startsWith(selectorName + ".")
+                    && columnNameWithoutSelector.length() > (selectorName.length() + 1)) {
+                    columnNameWithoutSelector = columnNameWithoutSelector.substring(selectorName.length() + 1);
+                }
                 columnIndex = wrappedAround.columnIndexForName(columnNameWithoutSelector);
                 if (columnIndex == null) {
                     String columnNameWithSelector = column.selectorName() + "." + columnNameWithoutSelector;

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/query/validate/ImmutableSchemata.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/query/validate/ImmutableSchemata.java
@@ -494,13 +494,19 @@ public class ImmutableSchemata implements Schemata {
                             }
                         }
                         String viewColumnName = column.getColumnName();
+                        if (viewColumnName.equals(column.getSelectorName() + "." + column.getPropertyName())) {
+                            viewColumnName = column.getPropertyName();
+                        }
                         if (columnNames.contains(viewColumnName)) continue;
                         String sourceColumnName = column.getPropertyName(); // getColumnName() returns alias
                         Column sourceColumn = source.getColumn(sourceColumnName);
                         if (sourceColumn == null) {
-                            throw new InvalidQueryException(Visitors.readable(command),
-                                                            "The view references a non-existant column '"
-                                                            + column.getColumnName() + "' in '" + source.getName() + "'");
+                            sourceColumn = source.getColumn(column.getColumnName());
+                            if (sourceColumn == null) {
+                                throw new InvalidQueryException(Visitors.readable(command),
+                                                                "The view references a non-existant column '"
+                                                                + column.getColumnName() + "' in '" + source.getName() + "'");
+                            }
                         }
                         Set<Operator> operators = operators(name, viewColumnName, sourceColumn.getOperators());
                         boolean orderable = orderable(name, viewColumnName, sourceColumn.isOrderable());

--- a/modeshape-jdbc-local/src/test/java/org/modeshape/jdbc/JcrDriverIntegrationTest.java
+++ b/modeshape-jdbc-local/src/test/java/org/modeshape/jdbc/JcrDriverIntegrationTest.java
@@ -122,7 +122,7 @@ public class JcrDriverIntegrationTest extends AbstractJdbcDriverTest {
     public void shouldBeAbleToExecuteSqlSelectAllCars() throws SQLException {
 
         String[] expected = {
-            "car:maker[STRING]    car:model[STRING]    car:year[STRING]    car:msrp[STRING]    car:userRating[LONG]    car:valueRating[LONG]    car:mpgCity[LONG]    car:mpgHighway[LONG]    car:lengthInInches[DOUBLE]    car:wheelbaseInInches[DOUBLE]    car:engine[STRING]    jcr:primaryType[STRING]    jcr:mixinTypes[STRING]    jcr:path[STRING]    jcr:name[STRING]    jcr:score[DOUBLE]    mode:localName[STRING]    mode:depth[LONG]",
+            "car:Car.car:maker[STRING]    car:Car.car:model[STRING]    car:Car.car:year[STRING]    car:Car.car:msrp[STRING]    car:Car.car:userRating[LONG]    car:Car.car:valueRating[LONG]    car:Car.car:mpgCity[LONG]    car:Car.car:mpgHighway[LONG]    car:Car.car:lengthInInches[DOUBLE]    car:Car.car:wheelbaseInInches[DOUBLE]    car:Car.car:engine[STRING]    car:Car.jcr:primaryType[STRING]    car:Car.jcr:mixinTypes[STRING]    car:Car.jcr:path[STRING]    car:Car.jcr:name[STRING]    car:Car.jcr:score[DOUBLE]    car:Car.mode:localName[STRING]    car:Car.mode:depth[LONG]",
             "Aston Martin    DB9    2008    $171,600    5    null    12    19    185.5    108.0    5,935 cc 5.9 liters V 12    car:Car    null    /Cars/Sports/Aston Martin DB9    Aston Martin DB9    1.7436792850494385    Aston Martin DB9    3",
             "Bentley    Continental    2008    $170,990    null    null    10    17    null    null    null    car:Car    null    /Cars/Luxury/Bentley Continental    Bentley Continental    1.7436792850494385    Bentley Continental    3",
             "Cadillac    DTS    2008    null    1    null    null    null    null    null    3.6 liter V6    car:Car    null    /Cars/Luxury/Cadillac DTS    Cadillac DTS    1.7436792850494385    Cadillac DTS    3",
@@ -141,7 +141,7 @@ public class JcrDriverIntegrationTest extends AbstractJdbcDriverTest {
     @Test
     public void shouldBeAbleToExecuteSqlQueryWithOrderByClauseUsingDefault() throws SQLException {
         String[] expected = {
-            "car:maker[STRING]    car:model[STRING]    car:year[STRING]    car:msrp[STRING]    car:userRating[LONG]    car:valueRating[LONG]    car:mpgCity[LONG]    car:mpgHighway[LONG]    car:lengthInInches[DOUBLE]    car:wheelbaseInInches[DOUBLE]    car:engine[STRING]    jcr:primaryType[STRING]    jcr:mixinTypes[STRING]    jcr:path[STRING]    jcr:name[STRING]    jcr:score[DOUBLE]    mode:localName[STRING]    mode:depth[LONG]",
+            "car:Car.car:maker[STRING]    car:Car.car:model[STRING]    car:Car.car:year[STRING]    car:Car.car:msrp[STRING]    car:Car.car:userRating[LONG]    car:Car.car:valueRating[LONG]    car:Car.car:mpgCity[LONG]    car:Car.car:mpgHighway[LONG]    car:Car.car:lengthInInches[DOUBLE]    car:Car.car:wheelbaseInInches[DOUBLE]    car:Car.car:engine[STRING]    car:Car.jcr:primaryType[STRING]    car:Car.jcr:mixinTypes[STRING]    car:Car.jcr:path[STRING]    car:Car.jcr:name[STRING]    car:Car.jcr:score[DOUBLE]    car:Car.mode:localName[STRING]    car:Car.mode:depth[LONG]",
             "Aston Martin    DB9    2008    $171,600    5    null    12    19    185.5    108.0    5,935 cc 5.9 liters V 12    car:Car    null    /Cars/Sports/Aston Martin DB9    Aston Martin DB9    1.7436792850494385    Aston Martin DB9    3",
             "Bentley    Continental    2008    $170,990    null    null    10    17    null    null    null    car:Car    null    /Cars/Luxury/Bentley Continental    Bentley Continental    1.7436792850494385    Bentley Continental    3",
             "Cadillac    DTS    2008    null    1    null    null    null    null    null    3.6 liter V6    car:Car    null    /Cars/Luxury/Cadillac DTS    Cadillac DTS    1.7436792850494385    Cadillac DTS    3",
@@ -173,7 +173,7 @@ public class JcrDriverIntegrationTest extends AbstractJdbcDriverTest {
     @Test
     public void shouldBeAbleToExecuteSqlQueryWithOrderedByClauseDesc() throws SQLException {
         String[] expected = {
-            "car:maker[STRING]    car:model[STRING]    car:year[STRING]    car:msrp[STRING]    car:userRating[LONG]    car:valueRating[LONG]    car:mpgCity[LONG]    car:mpgHighway[LONG]    car:lengthInInches[DOUBLE]    car:wheelbaseInInches[DOUBLE]    car:engine[STRING]    jcr:primaryType[STRING]    jcr:mixinTypes[STRING]    jcr:path[STRING]    jcr:name[STRING]    jcr:score[DOUBLE]    mode:localName[STRING]    mode:depth[LONG]",
+            "car:Car.car:maker[STRING]    car:Car.car:model[STRING]    car:Car.car:year[STRING]    car:Car.car:msrp[STRING]    car:Car.car:userRating[LONG]    car:Car.car:valueRating[LONG]    car:Car.car:mpgCity[LONG]    car:Car.car:mpgHighway[LONG]    car:Car.car:lengthInInches[DOUBLE]    car:Car.car:wheelbaseInInches[DOUBLE]    car:Car.car:engine[STRING]    car:Car.jcr:primaryType[STRING]    car:Car.jcr:mixinTypes[STRING]    car:Car.jcr:path[STRING]    car:Car.jcr:name[STRING]    car:Car.jcr:score[DOUBLE]    car:Car.mode:localName[STRING]    car:Car.mode:depth[LONG]",
             "Land Rover    LR3    2008    $48,525    5    2    12    17    null    null    null    car:Car    null    /Cars/Utility/Land Rover LR3    Land Rover LR3    1.7436792850494385    Land Rover LR3    3",
             "Lexus    IS350    2008    $36,305    4    5    18    25    null    null    null    car:Car    null    /Cars/Luxury/Lexus IS350    Lexus IS350    1.7436792850494385    Lexus IS350    3",
             "Infiniti    G37    2008    $34,900    3    4    18    24    null    null    null    car:Car    null    /Cars/Sports/Infiniti G37    Infiniti G37    1.7436792850494385    Infiniti G37    3",
@@ -208,7 +208,7 @@ public class JcrDriverIntegrationTest extends AbstractJdbcDriverTest {
     @FixFor( "MODE-722" )
     @Test
     public void shouldBeAbleToExecuteSqlQueryUsingJoinToFindAllCarsUnderHybrid() throws SQLException {
-        String[] expected = {"car:maker[STRING]    car:model[STRING]    car:year[STRING]    car:msrp[STRING]",
+        String[] expected = {"car.car:maker[STRING]    car.car:model[STRING]    car.car:year[STRING]    car.car:msrp[STRING]",
             "Nissan    Altima    2008    $18,260", "Toyota    Prius    2008    $21,500",
             "Toyota    Highlander    2008    $34,200"};
 


### PR DESCRIPTION
Corrected the behavior of query result column names when the query contains a wildcard in the SELECT statement.

Note that the TCK unit test that checks this is still commented out, pending a Jackrabbit release that fixes [JCR-3313](https://issues.apache.org/jira/browse/JCR-3313) (which I think will be 2.6.0).
