### PR TITLE
MODE-1489 - Fixed infinite loop when calling orderBefore multiple times without save

### DIFF
--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/AbstractJcrNode.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/AbstractJcrNode.java
@@ -1308,6 +1308,10 @@ abstract class AbstractJcrNode extends AbstractJcrItem implements Node {
                 throw new ItemNotFoundException(JcrI18n.invalidPathParameter.text(destChildRelPath, "destChildRelPath"));
             }
 
+            if (srcPath.isSameAs(destPath)) {
+                return;
+            }
+
             ChildReference destRef = childRefs.getChild(destPath.getLastSegment());
             if (destRef == null) {
                 String workspaceName = workspaceName();

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/document/SessionNode.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/document/SessionNode.java
@@ -1220,6 +1220,9 @@ public class SessionNode implements MutableCachedNode {
          */
         public void insertBefore( ChildReference before,
                                   ChildReference inserted ) {
+            if (before == inserted) {
+                return;
+            }
             // Get or create atomically ...
             InsertedChildReferences insertions = this.insertions.get();
             if (insertions == null) {
@@ -1234,19 +1237,19 @@ public class SessionNode implements MutableCachedNode {
         @Override
         public boolean isRemoved( ChildReference ref ) {
             Set<NodeKey> removals = this.removals.get();
-            return removals == null ? false : removals.contains(ref.getKey());
+            return removals != null && removals.contains(ref.getKey());
         }
 
         @Override
         public boolean isRenamed( ChildReference ref ) {
             Map<NodeKey, Name> renames = this.newNames.get();
-            return renames == null ? false : renames.containsKey(ref.getKey());
+            return renames != null && renames.containsKey(ref.getKey());
         }
 
         @Override
         public boolean isRenamed( Name newName ) {
             Map<NodeKey, Name> renames = this.newNames.get();
-            return renames == null ? false : renames.containsValue(newName);
+            return renames != null && renames.containsValue(newName);
         }
 
         /**


### PR DESCRIPTION
The problem was caused by the fact that there was a "circular" reference when the first orderBefore had been called on the same child, both as source and destination (i.e. orderBefore(child0, child0)). The fix was done on several levels:
- orderBefore on the same source and target should be a no-op (as per spec)
- insertBefore on the child references of a session node should be a no-op if the references are identical
- the child references iterator, when another delegate iterator is provided, should not loop indefinitely if there are circular references
