### PR TITLE
MODE-1510 Corrected configuration of Infinispan for index storage

### DIFF
--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/RepositoryConfiguration.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/RepositoryConfiguration.java
@@ -1287,6 +1287,9 @@ public class RepositoryConfiguration {
                 setDefProp(props,
                            FieldName.INDEX_STORAGE_INFINISPAN_CHUNK_SIZE_IN_BYTES,
                            Default.INDEX_STORAGE_INFINISPAN_CHUNK_SIZE_IN_BYTES);
+                setDefProp(props, FieldName.CACHE_CONFIGURATION, getCacheConfiguration());
+                // The cache names will be set when the Hibernate Search configuration is created; that way we don't have
+                // the repository name hard-coded in the properties ...
             }
             return props;
         }

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/query/lucene/basic/BasicLuceneConfiguration.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/query/lucene/basic/BasicLuceneConfiguration.java
@@ -116,6 +116,17 @@ public class BasicLuceneConfiguration extends LuceneSearchConfiguration {
             setProperty("hibernate.search.default.data_cachename", dataCacheName);
             setProperty("hibernate.search.default.metadata_cachename", metaCacheName);
             setProperty("hibernate.search.default.chunk_size", chunkSize);
+            String cacheConfigValue = storage.getProperty(FieldName.CACHE_CONFIGURATION);
+            if (cacheConfigValue != null && cacheConfigValue.trim().length() != 0) {
+                File configFile = new File(cacheConfigValue);
+                if (configFile.exists() && configFile.isFile() && configFile.canRead() && configFile.getName().endsWith(".xml")) {
+                    // Looks like a file and ends in ".xml", so we'll assume a file ...
+                    setProperty("hibernate.search.default.configuration_resourcename", configFile.getAbsolutePath());
+                } else {
+                    // Must be a JNDI reference ??
+                    setProperty("hibernate.search.default.cachemanager_jndiname", cacheConfigValue.trim());
+                }
+            }
         } else if (storageType.equals(FieldValue.INDEX_STORAGE_CUSTOM)) {
             storageType = storage.getProperty(FieldName.CLASSNAME);
             setProperty("hibernate.search.default.directory_provider", storageType);


### PR DESCRIPTION
ModeShape internally generates a Hibernate Search engine configuration based upon ModeShape's configuration. Hibernate Search can use the Infinispan Lucene Directory to store Lucene indexes in Infinispan, but ModeShape incorrectly passed down the information about where the Infinispan configuration was, preventing using the same Infinispan configuration for both content storage and index storage.

This change corrects this problem, and allows defaulting to the same file-based Infinispan configuration for index storage that's used for content storage. This fix should also work in AS7, since the JNDI name of the cache container is passed through.

The build completes successfully with these changes.
