### PR TITLE
MODE-1514 Renamed JcrEngine to ModeShapeEngine

### DIFF
--- a/demos/embedded-repo/src/main/java/org/modeshape/demo/embedded/repo/EmbeddedRepositoryDemo.java
+++ b/demos/embedded-repo/src/main/java/org/modeshape/demo/embedded/repo/EmbeddedRepositoryDemo.java
@@ -6,7 +6,7 @@ import javax.jcr.Repository;
 import javax.jcr.RepositoryException;
 import javax.jcr.Session;
 import org.modeshape.common.collection.Problems;
-import org.modeshape.jcr.JcrEngine;
+import org.modeshape.jcr.ModeShapeEngine;
 import org.modeshape.jcr.RepositoryConfiguration;
 
 public class EmbeddedRepositoryDemo {
@@ -14,7 +14,7 @@ public class EmbeddedRepositoryDemo {
     public static void main( String[] argv ) {
 
         // Create and start the engine ...
-        JcrEngine engine = new JcrEngine();
+        ModeShapeEngine engine = new ModeShapeEngine();
         engine.start();
 
         // Load the configuration for a repository via the classloader (can also use path to a file)...

--- a/demos/sequencers/src/main/java/org/modeshape/demo/sequencer/SequencerDemo.java
+++ b/demos/sequencers/src/main/java/org/modeshape/demo/sequencer/SequencerDemo.java
@@ -13,7 +13,7 @@ import javax.jcr.Repository;
 import javax.jcr.RepositoryException;
 import javax.jcr.Session;
 import org.modeshape.common.collection.Problems;
-import org.modeshape.jcr.JcrEngine;
+import org.modeshape.jcr.ModeShapeEngine;
 import org.modeshape.jcr.RepositoryConfiguration;
 import org.modeshape.jcr.api.JcrTools;
 
@@ -24,7 +24,7 @@ public class SequencerDemo {
     public static void main( String[] argv ) {
 
         // Create and start the engine ...
-        JcrEngine engine = new JcrEngine();
+        ModeShapeEngine engine = new ModeShapeEngine();
         engine.start();
 
         // Load the configuration for a repository via the classloader (can also use path to a file)...

--- a/deploy/jbossas/modeshape-jbossas-subsystem/src/main/java/org/modeshape/jboss/service/EngineService.java
+++ b/deploy/jbossas/modeshape-jbossas-subsystem/src/main/java/org/modeshape/jboss/service/EngineService.java
@@ -28,29 +28,29 @@ import org.jboss.msc.service.Service;
 import org.jboss.msc.service.StartContext;
 import org.jboss.msc.service.StopContext;
 import org.modeshape.common.util.CheckArg;
-import org.modeshape.jcr.JcrEngine;
+import org.modeshape.jcr.ModeShapeEngine;
 
 /**
- * An <code>EngineService</code> instance is a JBoss service object for a {@link JcrEngine}.
+ * An <code>EngineService</code> instance is a JBoss service object for a {@link ModeShapeEngine}.
  */
-public final class EngineService implements Service<JcrEngine>, Serializable {
+public final class EngineService implements Service<ModeShapeEngine>, Serializable {
 
     private static final long serialVersionUID = 1L;
 
-    private final JcrEngine engine;
+    private final ModeShapeEngine engine;
 
     /**
      * Set the engine instance for this service
      * 
      * @param engine the engine (never <code>null</code>)
      */
-    public EngineService( JcrEngine engine ) {
+    public EngineService( ModeShapeEngine engine ) {
         CheckArg.isNotNull(engine, "engine");
         this.engine = engine;
     }
 
     @Override
-    public JcrEngine getValue() throws IllegalStateException, IllegalArgumentException {
+    public ModeShapeEngine getValue() throws IllegalStateException, IllegalArgumentException {
         return this.engine;
     }
 

--- a/deploy/jbossas/modeshape-jbossas-subsystem/src/main/java/org/modeshape/jboss/service/RepositoryService.java
+++ b/deploy/jbossas/modeshape-jbossas-subsystem/src/main/java/org/modeshape/jboss/service/RepositoryService.java
@@ -45,8 +45,8 @@ import org.modeshape.common.logging.Logger;
 import org.modeshape.jboss.subsystem.MappedAttributeDefinition;
 import org.modeshape.jcr.ConfigurationException;
 import org.modeshape.jcr.Environment;
-import org.modeshape.jcr.JcrEngine;
 import org.modeshape.jcr.JcrRepository;
+import org.modeshape.jcr.ModeShapeEngine;
 import org.modeshape.jcr.NoSuchRepositoryException;
 import org.modeshape.jcr.RepositoryConfiguration;
 import org.modeshape.jcr.RepositoryConfiguration.FieldName;
@@ -62,7 +62,7 @@ public class RepositoryService implements Service<JcrRepository>, Environment {
     public static final String CONTENT_CONTAINER_NAME = "content";
     public static final String BINARY_STORAGE_CONTAINER_NAME = "binaries";
 
-    private final InjectedValue<JcrEngine> engineInjector = new InjectedValue<JcrEngine>();
+    private final InjectedValue<ModeShapeEngine> engineInjector = new InjectedValue<ModeShapeEngine>();
     private final InjectedValue<CacheContainer> cacheManagerInjector = new InjectedValue<CacheContainer>();
     private final InjectedValue<TransactionManager> txnMgrInjector = new InjectedValue<TransactionManager>();
     private final InjectedValue<ChannelFactory> channelFactoryInjector = new InjectedValue<ChannelFactory>();
@@ -85,7 +85,7 @@ public class RepositoryService implements Service<JcrRepository>, Environment {
         }
     }
 
-    private JcrEngine getEngine() {
+    private ModeShapeEngine getEngine() {
         return engineInjector.getValue();
     }
 
@@ -118,7 +118,7 @@ public class RepositoryService implements Service<JcrRepository>, Environment {
 
     @Override
     public void start( StartContext arg0 ) throws StartException {
-        JcrEngine engine = getEngine();
+        ModeShapeEngine engine = getEngine();
         Logger logger = Logger.getLogger(getClass());
         try {
             final String repositoryName = repositoryName();
@@ -191,7 +191,7 @@ public class RepositoryService implements Service<JcrRepository>, Environment {
 
     @Override
     public void stop( StopContext context ) {
-        JcrEngine engine = getEngine();
+        ModeShapeEngine engine = getEngine();
         if (engine != null) {
             try {
                 // Undeploy the repository ...
@@ -212,7 +212,7 @@ public class RepositoryService implements Service<JcrRepository>, Environment {
      */
     public void changeField( MappedAttributeDefinition defn,
                              ModelNode newValue ) throws RepositoryException, OperationFailedException {
-        JcrEngine engine = getEngine();
+        ModeShapeEngine engine = getEngine();
         String repositoryName = repositoryName();
 
         // Get a snapshot of the current configuration ...
@@ -251,7 +251,7 @@ public class RepositoryService implements Service<JcrRepository>, Environment {
     public void changeSequencerField( MappedAttributeDefinition defn,
                                       ModelNode newValue,
                                       String sequencerName ) throws RepositoryException, OperationFailedException {
-        JcrEngine engine = getEngine();
+        ModeShapeEngine engine = getEngine();
         String repositoryName = repositoryName();
 
         // Get a snapshot of the current configuration ...
@@ -303,9 +303,9 @@ public class RepositoryService implements Service<JcrRepository>, Environment {
     }
 
     /**
-     * @return the injector used to set the JcrEngine reference
+     * @return the injector used to set the {@link ModeShapeEngine} reference
      */
-    public InjectedValue<JcrEngine> getEngineInjector() {
+    public InjectedValue<ModeShapeEngine> getEngineInjector() {
         return engineInjector;
     }
 

--- a/deploy/jbossas/modeshape-jbossas-subsystem/src/main/java/org/modeshape/jboss/service/SequencerService.java
+++ b/deploy/jbossas/modeshape-jbossas-subsystem/src/main/java/org/modeshape/jboss/service/SequencerService.java
@@ -36,15 +36,15 @@ import org.jboss.msc.service.StopContext;
 import org.jboss.msc.value.InjectedValue;
 import org.modeshape.common.collection.Problems;
 import org.modeshape.jcr.ConfigurationException;
-import org.modeshape.jcr.JcrEngine;
 import org.modeshape.jcr.JcrI18n;
 import org.modeshape.jcr.JcrRepository;
+import org.modeshape.jcr.ModeShapeEngine;
 import org.modeshape.jcr.NoSuchRepositoryException;
 import org.modeshape.jcr.RepositoryConfiguration;
 
 public class SequencerService implements Service<JcrRepository> {
 
-    private final InjectedValue<JcrEngine> jcrEngineInjector = new InjectedValue<JcrEngine>();
+    private final InjectedValue<ModeShapeEngine> engineInjector = new InjectedValue<ModeShapeEngine>();
     private final InjectedValue<JcrRepository> jcrRepositoryInjector = new InjectedValue<JcrRepository>();
 
     private final Properties sequencerProperties;
@@ -61,13 +61,13 @@ public class SequencerService implements Service<JcrRepository> {
         return null;
     }
 
-    private JcrEngine getJcrEngine() {
-        return jcrEngineInjector.getValue();
+    private ModeShapeEngine getModeShapeEngine() {
+        return engineInjector.getValue();
     }
 
     @Override
     public void start( StartContext arg0 ) throws StartException {
-        JcrEngine engine = getJcrEngine();
+        ModeShapeEngine engine = getModeShapeEngine();
 
         JcrRepository repository = null;
         try {
@@ -128,10 +128,10 @@ public class SequencerService implements Service<JcrRepository> {
     }
 
     /**
-     * @return the jcrEngineInjector
+     * @return the injector
      */
-    public InjectedValue<JcrEngine> getJcrEngineInjector() {
-        return jcrEngineInjector;
+    public InjectedValue<ModeShapeEngine> getModeShapeEngineInjector() {
+        return engineInjector;
     }
 
     /**

--- a/deploy/jbossas/modeshape-jbossas-subsystem/src/main/java/org/modeshape/jboss/subsystem/AddModeShapeSubsystem.java
+++ b/deploy/jbossas/modeshape-jbossas-subsystem/src/main/java/org/modeshape/jboss/subsystem/AddModeShapeSubsystem.java
@@ -43,7 +43,7 @@ import org.modeshape.common.naming.SingletonInitialContextFactory;
 import org.modeshape.jboss.lifecycle.JBossLifeCycleListener;
 import org.modeshape.jboss.service.EngineService;
 import org.modeshape.jboss.service.ReferenceFactoryService;
-import org.modeshape.jcr.JcrEngine;
+import org.modeshape.jcr.ModeShapeEngine;
 
 class AddModeShapeSubsystem extends AbstractAddStepHandler {
 
@@ -95,25 +95,25 @@ class AddModeShapeSubsystem extends AbstractAddStepHandler {
         engine = buildModeShapeEngine(model);
 
         // Engine service
-        ServiceBuilder<JcrEngine> engineBuilder = target.addService(ModeShapeServiceNames.ENGINE, engine);
+        ServiceBuilder<ModeShapeEngine> engineBuilder = target.addService(ModeShapeServiceNames.ENGINE, engine);
         engineBuilder.setInitialMode(ServiceController.Mode.ACTIVE);
-        ServiceController<JcrEngine> controller = engineBuilder.install();
+        ServiceController<ModeShapeEngine> controller = engineBuilder.install();
         controller.getServiceContainer().addTerminateListener(shutdownListener);
         newControllers.add(controller);
 
         // JNDI Binding
-        final ReferenceFactoryService<JcrEngine> referenceFactoryService = new ReferenceFactoryService<JcrEngine>();
+        final ReferenceFactoryService<ModeShapeEngine> referenceFactoryService = new ReferenceFactoryService<ModeShapeEngine>();
         final ServiceName referenceFactoryServiceName = ModeShapeServiceNames.ENGINE.append("reference-factory"); //$NON-NLS-1$
         final ServiceBuilder<?> referenceBuilder = target.addService(referenceFactoryServiceName, referenceFactoryService);
-        referenceBuilder.addDependency(ModeShapeServiceNames.ENGINE, JcrEngine.class, referenceFactoryService.getInjector());
+        referenceBuilder.addDependency(ModeShapeServiceNames.ENGINE, ModeShapeEngine.class, referenceFactoryService.getInjector());
         referenceBuilder.setInitialMode(ServiceController.Mode.ACTIVE);
 
         final ContextNames.BindInfo bindInfo = ContextNames.bindInfoFor(ModeShapeJndiNames.JNDI_BASE_NAME);
         final BinderService binderService = new BinderService(bindInfo.getBindName());
         final ServiceBuilder<?> binderBuilder = target.addService(bindInfo.getBinderServiceName(), binderService);
         binderBuilder.addDependency(ModeShapeServiceNames.ENGINE,
-                                    JcrEngine.class,
-                                    new ManagedReferenceInjector<JcrEngine>(binderService.getManagedObjectInjector()));
+                                    ModeShapeEngine.class,
+                                    new ManagedReferenceInjector<ModeShapeEngine>(binderService.getManagedObjectInjector()));
         binderBuilder.addDependency(bindInfo.getParentContextServiceName(),
                                     ServiceBasedNamingStore.class,
                                     binderService.getNamingStoreInjector());
@@ -127,7 +127,7 @@ class AddModeShapeSubsystem extends AbstractAddStepHandler {
     }
 
     private EngineService buildModeShapeEngine( ModelNode model ) {
-        EngineService engine = new EngineService(new JcrEngine());
+        EngineService engine = new EngineService(new ModeShapeEngine());
         return engine;
     }
 }

--- a/deploy/jbossas/modeshape-jbossas-subsystem/src/main/java/org/modeshape/jboss/subsystem/AddRepository.java
+++ b/deploy/jbossas/modeshape-jbossas-subsystem/src/main/java/org/modeshape/jboss/subsystem/AddRepository.java
@@ -52,7 +52,7 @@ import org.modeshape.jboss.service.BinaryStorage;
 import org.modeshape.jboss.service.IndexStorage;
 import org.modeshape.jboss.service.ReferenceFactoryService;
 import org.modeshape.jboss.service.RepositoryService;
-import org.modeshape.jcr.JcrEngine;
+import org.modeshape.jcr.ModeShapeEngine;
 import org.modeshape.jcr.JcrRepository;
 import org.modeshape.jcr.RepositoryConfiguration;
 import org.modeshape.jcr.RepositoryConfiguration.FieldName;
@@ -233,7 +233,7 @@ public class AddRepository extends AbstractAddStepHandler {
         ServiceBuilder<JcrRepository> builder = target.addService(repositoryServiceName, repositoryService);
 
         // Add dependency to the ModeShape engine service ...
-        builder.addDependency(ModeShapeServiceNames.ENGINE, JcrEngine.class, repositoryService.getEngineInjector());
+        builder.addDependency(ModeShapeServiceNames.ENGINE, ModeShapeEngine.class, repositoryService.getEngineInjector());
 
         // Add dependency to the JGroups channel (used for events) ...
         if (clusterStackName != null) {

--- a/deploy/jbossas/modeshape-jbossas-subsystem/src/main/java/org/modeshape/jboss/subsystem/AddSequencer.java
+++ b/deploy/jbossas/modeshape-jbossas-subsystem/src/main/java/org/modeshape/jboss/subsystem/AddSequencer.java
@@ -39,7 +39,7 @@ import org.jboss.msc.service.ServiceBuilder;
 import org.jboss.msc.service.ServiceController;
 import org.jboss.msc.service.ServiceTarget;
 import org.modeshape.jboss.service.SequencerService;
-import org.modeshape.jcr.JcrEngine;
+import org.modeshape.jcr.ModeShapeEngine;
 import org.modeshape.jcr.JcrRepository;
 import org.modeshape.jcr.RepositoryConfiguration.FieldName;
 
@@ -108,7 +108,7 @@ public class AddSequencer extends AbstractAddStepHandler {
         ServiceBuilder<JcrRepository> sequencerBuilder = target.addService(ModeShapeServiceNames.sequencerServiceName(repositoryName,
                                                                                                                       sequencerName),
                                                                            sequencerService);
-        sequencerBuilder.addDependency(ModeShapeServiceNames.ENGINE, JcrEngine.class, sequencerService.getJcrEngineInjector());
+        sequencerBuilder.addDependency(ModeShapeServiceNames.ENGINE, ModeShapeEngine.class, sequencerService.getModeShapeEngineInjector());
         sequencerBuilder.addDependency(ModeShapeServiceNames.repositoryServiceName(repositoryName),
                                        JcrRepository.class,
                                        sequencerService.getJcrRepositoryInjector());

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrRepository.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrRepository.java
@@ -85,7 +85,7 @@ import org.modeshape.common.collection.SimpleProblems;
 import org.modeshape.common.logging.Logger;
 import org.modeshape.common.util.CheckArg;
 import org.modeshape.common.util.NamedThreadFactory;
-import org.modeshape.jcr.JcrEngine.State;
+import org.modeshape.jcr.ModeShapeEngine.State;
 import org.modeshape.jcr.RepositoryConfiguration.AnonymousSecurity;
 import org.modeshape.jcr.RepositoryConfiguration.BinaryStorage;
 import org.modeshape.jcr.RepositoryConfiguration.Component;
@@ -309,7 +309,7 @@ public class JcrRepository implements org.modeshape.jcr.api.Repository {
      * @throws FileNotFoundException if the Infinispan configuration file is changed but could not be found
      * @throws IOException if there is a problem with the specified Infinispan configuration file
      * @throws NamingException if there is a problem looking in JNDI for the Infinispan CacheContainer
-     * @see JcrEngine#update(String, Changes)
+     * @see ModeShapeEngine#update(String, Changes)
      */
     void apply( Changes changes ) throws IOException, NamingException {
         try {
@@ -841,7 +841,7 @@ public class JcrRepository implements org.modeshape.jcr.api.Repository {
     /**
      * Clean up the repository content's garbage.
      * 
-     * @see JcrEngine.GarbageCollectionTask#run()
+     * @see ModeShapeEngine.GarbageCollectionTask#run()
      */
     void cleanUp() {
         RunningState running = runningState.get();

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrRepositoryFactory.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrRepositoryFactory.java
@@ -81,9 +81,9 @@ import org.modeshape.jcr.api.RepositoryFactory;
  * the JCR repository located in JNDI at the name "jcr/local/my_repository". Note that the use of such URLs requires that the
  * repository already be registered in JNDI at that location.</li>
  * <li><strong>JNDI location of engine and repository name</strong> - The URL contains the location in JNDI of an existing
- * ModeShape {@link JcrEngine engine} instance and the name of the <code>javax.jcr.Repository</code> repository as a URL query
- * parameter. For example, "<code>jndi:jcr/local?repositoryName=my_repository</code>" identifies a ModeShape engine registered in
- * JNDI at "jcr/local", and looks in that engine for a JCR repository named "<code>my_repository</code>".</li>
+ * ModeShape {@link ModeShapeEngine engine} instance and the name of the <code>javax.jcr.Repository</code> repository as a URL
+ * query parameter. For example, "<code>jndi:jcr/local?repositoryName=my_repository</code>" identifies a ModeShape engine
+ * registered in JNDI at "jcr/local", and looks in that engine for a JCR repository named "<code>my_repository</code>".</li>
  * <li><strong>Location of a repository configuration</strong> - The URL contains a location that is resolvable to a configuration
  * file for the repository. If the configuration file has not already been loaded by the factory, then the configuration file is
  * read and used to deploy a new repository; subsequent uses of the same URL will return the previously deployed repository
@@ -107,7 +107,7 @@ public class JcrRepositoryFactory implements RepositoryFactory {
     /**
      * The engine that hosts the deployed repository instances.
      */
-    private static final JcrEngine ENGINE = new JcrEngine();
+    private static final ModeShapeEngine ENGINE = new ModeShapeEngine();
 
     /**
      * The name of the key for the ModeShape JCR URL in the parameter map
@@ -160,9 +160,9 @@ public class JcrRepositoryFactory implements RepositoryFactory {
      * JcrRepositoryFactory#URL.
      * <p>
      * The value of this key is treated as a URL with the format {@code PROTOCOL://PATH[?repositoryName=REPOSITORY_NAME]} where
-     * PROTOCOL is "jndi" or "file", PATH is the JNDI name of the JcrEngine or the path to the configuration file, and
-     * REPOSITORY_NAME is the name of the repository to return if there is more than one JCR repository in the given JcrEngine or
-     * configuration file.
+     * PROTOCOL is "jndi" or "file", PATH is the JNDI name of the {@link ModeShapeEngine} or the path to the configuration file,
+     * and REPOSITORY_NAME is the name of the repository to return if there is more than one JCR repository in the given
+     * {@link ModeShapeEngine} or configuration file.
      * </p>
      * 
      * @param parameters a map of parameters to use to look up the repository; may be null
@@ -171,9 +171,9 @@ public class JcrRepositoryFactory implements RepositoryFactory {
      *         <li>the parameters map is empty; or,</li>
      *         <li>there is no parameter with the {@link #URL}; or,</li>
      *         <li>the value for the {@link #URL} key is null or cannot be parsed into a ModeShape JCR URL; or,</li>
-     *         <li>the ModeShape JCR URL is parseable but does not point to a JcrEngine (in the JNDI tree) or a configuration file
-     *         (in the classpath or file system); or,</li>
-     *         <li>or there is an error starting up the JcrEngine with the given configuration information.</li>
+     *         <li>the ModeShape JCR URL is parseable but does not point to a {@link ModeShapeEngine} (in the JNDI tree) or a
+     *         configuration file (in the classpath or file system); or,</li>
+     *         <li>or there is an error starting up the {@link ModeShapeEngine} with the given configuration information.</li>
      *         <ul>
      * @see RepositoryFactory#getRepository(Map)
      */
@@ -229,7 +229,7 @@ public class JcrRepositoryFactory implements RepositoryFactory {
         return null;
     }
 
-    private JcrEngine getEngine() {
+    private ModeShapeEngine getEngine() {
         // Make sure the engine is started ...
         switch (ENGINE.getState()) {
             case NOT_RUNNING:
@@ -272,13 +272,14 @@ public class JcrRepositoryFactory implements RepositoryFactory {
     }
 
     /**
-     * Returns a {@link JcrEngine} for the configuration in the given file.
+     * Returns a {@link ModeShapeEngine} for the configuration in the given file.
      * <p>
-     * If a {@link JcrEngine} has already been loaded by this class for the given configuration file, that engine will be reused.
+     * If a {@link ModeShapeEngine} has already been loaded by this class for the given configuration file, that engine will be
+     * reused.
      * </p>
      * 
      * @param configUrl the URL to the file in the file system or relative to the classpath; may not be null
-     * @return a {@code JcrEngine} that was initialized from the given configuration file or null if no engine could be
+     * @return a {@code ModeShapeEngine} that was initialized from the given configuration file or null if no engine could be
      *         initialized from that file without errors.
      */
     private JcrRepository getRepositoryFromConfigFile( URL configUrl ) {
@@ -309,7 +310,7 @@ public class JcrRepositoryFactory implements RepositoryFactory {
 
             // Look for an existing repository with the same URL ...
             String configKey = configUrl.toString();
-            JcrEngine engine = getEngine();
+            ModeShapeEngine engine = getEngine();
             if (engine.getRepositoryKeys().contains(configKey)) {
                 try {
                     return engine.getRepository(configKey);
@@ -426,8 +427,8 @@ public class JcrRepositoryFactory implements RepositoryFactory {
             InitialContext ic = new InitialContext(hashtable(parameters));
 
             Object ob = ic.lookup(jndiName);
-            if (ob instanceof JcrEngine) {
-                JcrEngine engine = (JcrEngine)ob;
+            if (ob instanceof ModeShapeEngine) {
+                ModeShapeEngine engine = (ModeShapeEngine)ob;
                 switch (engine.getState()) {
                     case NOT_RUNNING:
                     case STOPPING:
@@ -507,12 +508,13 @@ public class JcrRepositoryFactory implements RepositoryFactory {
      * Returns the repository with the given name from the {@link Repositories} referenced by {@code jcrUrl} if the engine and the
      * named repository exist, null otherwise.
      * <p>
-     * If the {@code jcrUrl} parameter contains a valid, ModeShape-compatible URL for a {@link JcrEngine} that has not yet been
-     * started, that {@code JcrEngine} will be created and {@link JcrEngine#start() started} as a side effect of this method.
+     * If the {@code jcrUrl} parameter contains a valid, ModeShape-compatible URL for a {@link ModeShapeEngine} that has not yet
+     * been started, that {@code ModeShapeEngine} will be created and {@link ModeShapeEngine#start() started} as a side effect of
+     * this method.
      * </p>
      * <p>
      * If the {@code repositoryName} parameter is null, the repository name specified in the {@code jcrUrl} parameter will be used
-     * instead. If no repository name is specified in the {@code jcrUrl} parameter and the {@code JcrEngine} has exactly one
+     * instead. If no repository name is specified in the {@code jcrUrl} parameter and the {@code ModeShapeEngine} has exactly one
      * repository, that repository will be used. Otherwise, this method will return {@code null}.
      * </p>
      * 
@@ -523,7 +525,7 @@ public class JcrRepositoryFactory implements RepositoryFactory {
      *         the {@code repositoryName} and the given engine has exactly one repository or the {@code jcrUrl} specifies a
      *         repository. If any of these conditions do not hold, {@code null} is returned.
      * @throws RepositoryException if the named repository exists but cannot be accessed
-     * @see JcrEngine#getRepository(String)
+     * @see ModeShapeEngine#getRepository(String)
      */
     public Repository getRepository( String jcrUrl,
                                      String repositoryName ) throws RepositoryException {

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/JndiRepositoryFactory.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/JndiRepositoryFactory.java
@@ -56,7 +56,7 @@ public class JndiRepositoryFactory implements ObjectFactory {
     private static final String CONFIG_FILES = "configFiles";
     private static final String REPOSITORY_NAME = "repositoryName";
 
-    private static final JcrEngine engine = new JcrEngine();
+    private static final ModeShapeEngine engine = new ModeShapeEngine();
     protected static final Logger log = Logger.getLogger(JndiRepositoryFactory.class);
 
     /**
@@ -74,9 +74,9 @@ public class JndiRepositoryFactory implements ObjectFactory {
     /**
      * Get or initialize the JCR Repository instance as described by the supplied configuration file and repository name.
      * 
-     * @param configFileName the name of the file containing the configuration information for the {@code JcrEngine}; may not be
-     *        null. This method will first attempt to load this file as a resource from the classpath. If no resource with the
-     *        given name exists, the name will be treated as a file name and loaded from the file system. May be null if the
+     * @param configFileName the name of the file containing the configuration information for the {@code ModeShapeEngine}; may
+     *        not be null. This method will first attempt to load this file as a resource from the classpath. If no resource with
+     *        the given name exists, the name will be treated as a file name and loaded from the file system. May be null if the
      *        repository should already exist.
      * @param repositoryName the name of the repository; may be null if the repository name is to be read from the configuration
      *        file (note that this does require parsing the configuration file)
@@ -193,10 +193,10 @@ public class JndiRepositoryFactory implements ObjectFactory {
      * Creates an {@code JcrRepository} or ModeShape engine using the reference information specified.
      * <p>
      * This method first attempts to convert the {@code obj} parameter into a {@link Reference reference to JNDI configuration
-     * information}. If that is successful, a {@link JcrEngine} will be created (if not previously created by a call to this
+     * information}. If that is successful, a {@link ModeShapeEngine} will be created (if not previously created by a call to this
      * method) and it will be configured from the resource or file at the location specified by the {@code configFile} key in the
-     * reference. After the configuration is successful, the {@link JcrEngine#getRepository(String) JcrEngine will be queried} for
-     * the repository with the name specified by the value of the @{code repositoryName} key in the reference.
+     * reference. After the configuration is successful, the {@link ModeShapeEngine#getRepository(String) ModeShapeEngine} will be
+     * queried} for the repository with the name specified by the value of the @{code repositoryName} key in the reference.
      * </p>
      * 
      * @param obj the reference to the JNDI configuration information; must be a non-null instance of {@link Reference}
@@ -208,8 +208,8 @@ public class JndiRepositoryFactory implements ObjectFactory {
      * @throws IOException if there is an error or problem reading the configuration resource at the supplied path
      * @throws SAXException if the contents of the configuration resource are not valid XML
      * @throws NamingException if there is an error registering the namespace listener
-     * @throws RepositoryException if the {@link JcrEngine#start() JcrEngine could not be started}, the named repository does not
-     *         exist in the given configuration resource, or the named repository could not be created
+     * @throws RepositoryException if the {@link ModeShapeEngine#start() ModeShapeEngine could not be started}, the named
+     *         repository does not exist in the given configuration resource, or the named repository could not be created
      */
     @Override
     public Object getObjectInstance( Object obj,

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/ModeShapeEngine.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/ModeShapeEngine.java
@@ -50,9 +50,9 @@ import org.infinispan.schematic.document.Changes;
 import org.infinispan.schematic.document.Editor;
 import org.modeshape.common.annotation.ThreadSafe;
 import org.modeshape.common.collection.Problems;
+import org.modeshape.common.logging.Logger;
 import org.modeshape.common.util.CheckArg;
 import org.modeshape.common.util.ImmediateFuture;
-import org.modeshape.common.logging.Logger;
 import org.modeshape.common.util.NamedThreadFactory;
 import org.modeshape.jcr.api.Repositories;
 
@@ -60,7 +60,7 @@ import org.modeshape.jcr.api.Repositories;
  * A container for repositories.
  */
 @ThreadSafe
-public class JcrEngine implements Repositories {
+public class ModeShapeEngine implements Repositories {
 
     private final ReadWriteLock lock = new ReentrantReadWriteLock();
 
@@ -76,7 +76,7 @@ public class JcrEngine implements Repositories {
         STOPPING;
     }
 
-    public JcrEngine() {
+    public ModeShapeEngine() {
     }
 
     protected final boolean checkRunning() {
@@ -539,8 +539,8 @@ public class JcrEngine implements Repositories {
      * Here's some code that shows how this is done:
      * 
      * <pre>
-     *   JcrEngine engine = ...
-     *   Repository deployed = engine.{@link JcrEngine#getRepository(String) getRepository("repo")};
+     *   ModeShapeEngine engine = ...
+     *   Repository deployed = engine.{@link ModeShapeEngine#getRepository(String) getRepository("repo")};
      *   RepositoryConfiguration deployedConfig = deployed.{@link JcrRepository#getConfiguration() getConfiguration()};
      *   
      *   // Create an editor, which is actually manipulating a copy of the configuration document ...
@@ -556,7 +556,7 @@ public class JcrEngine implements Repositories {
      *       // you've done something wrong with your editor
      *   } else {
      *       // Update the deployed repository's configuration with these changes ...
-     *       Future&lt;Boolean> future = engine.{@link JcrEngine#update(String, Changes) update("repo",changes)};
+     *       Future&lt;Boolean> future = engine.{@link ModeShapeEngine#update(String, Changes) update("repo",changes)};
      *           
      *       // Optionally block while the repository instance is changed to 
      *       // reflect the new configuration ...

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/RepositoryConfiguration.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/RepositoryConfiguration.java
@@ -1584,7 +1584,7 @@ public class RepositoryConfiguration {
      * Also, the following code shows how an existing RepositoryConfiguration instance for a deployed repository can be updated:
      * 
      * <pre>
-     *   JcrEngine engine = ...
+     *   ModeShapeEngine engine = ...
      *   Repository deployed = engine.getRepository("repo");
      *   RepositoryConfiguration deployedConfig = deployed.getConfiguration();
      * 

--- a/modeshape-jcr/src/main/resources/org/modeshape/jcr/JcrI18n.properties
+++ b/modeshape-jcr/src/main/resources/org/modeshape/jcr/JcrI18n.properties
@@ -24,11 +24,11 @@
 
 initializing = Initializing {0} version {1}
 
-engineStarting = JcrEngine starting...
-engineStarted = JcrEngine started in {0} ms
-couldNotStartEngine = Could not start the JcrEngine
-engineStopping = JcrEngine stopping...
-engineStopped = JcrEngine stopped in {0} ms
+engineStarting = ModeShape engine starting...
+engineStarted = ModeShape engine started in {0} ms
+couldNotStartEngine = Could not start the ModeShape engine
+engineStopping = ModeShape engine stopping...
+engineStopped = ModeShape engine stopped in {0} ms
 repositoryReferencesNonExistantSource = The '{0}' repository references the '{1}' repository source that does not exist
 indexRebuildingStarted = Started rebuilding indexes for repository '{0}'
 indexRebuildingComplete = Completed rebuilding indexes for repository '{0}'

--- a/modeshape-jcr/src/test/java/org/modeshape/jcr/ModeShapeEngineTest.java
+++ b/modeshape-jcr/src/test/java/org/modeshape/jcr/ModeShapeEngineTest.java
@@ -18,19 +18,19 @@ import org.junit.Before;
 import org.junit.Test;
 import org.modeshape.jcr.ClientLoad.Client;
 import org.modeshape.jcr.ClientLoad.ClientResultProcessor;
-import org.modeshape.jcr.JcrEngine.State;
+import org.modeshape.jcr.ModeShapeEngine.State;
 import org.modeshape.jcr.RepositoryConfiguration.Default;
 import org.modeshape.jcr.RepositoryConfiguration.FieldName;
 
-public class JcrEngineTest extends AbstractTransactionalTest {
+public class ModeShapeEngineTest extends AbstractTransactionalTest {
 
     private RepositoryConfiguration config;
-    private JcrEngine engine;
+    private ModeShapeEngine engine;
 
     @Before
     public void beforeEach() throws Exception {
         config = RepositoryConfiguration.read("{ \"name\":\"my-repo\" }");
-        engine = new JcrEngine();
+        engine = new ModeShapeEngine();
     }
 
     @After

--- a/modeshape-jcr/src/test/java/org/modeshape/jcr/ModeShapeRepositoryStub.java
+++ b/modeshape-jcr/src/test/java/org/modeshape/jcr/ModeShapeRepositoryStub.java
@@ -56,7 +56,7 @@ public class ModeShapeRepositoryStub extends RepositoryStub {
     private Properties configProps;
     private String repositoryConfigurationName;
     private JcrRepository repository;
-    private JcrEngine engine;
+    private ModeShapeEngine engine;
 
     static {
         // Initialize the JAAS configuration to allow for an admin login later
@@ -110,7 +110,7 @@ public class ModeShapeRepositoryStub extends RepositoryStub {
                                                 + configFileName + "\" on the classpath");
             }
 
-            engine = new JcrEngine();
+            engine = new ModeShapeEngine();
             engine.start();
 
             // Deploy and start the repository, and block until started...

--- a/modeshape-jcr/src/test/java/org/modeshape/jcr/TestingUtil.java
+++ b/modeshape-jcr/src/test/java/org/modeshape/jcr/TestingUtil.java
@@ -32,7 +32,7 @@ import javax.transaction.TransactionManager;
 import org.infinispan.Cache;
 import org.modeshape.common.util.FileUtil;
 import org.modeshape.common.logging.Logger;
-import org.modeshape.jcr.JcrEngine.State;
+import org.modeshape.jcr.ModeShapeEngine.State;
 import org.modeshape.jcr.value.binary.TransientBinaryStore;
 
 /**
@@ -88,7 +88,7 @@ public class TestingUtil {
         }
     }
 
-    public static void killEngine( JcrEngine engine ) {
+    public static void killEngine( ModeShapeEngine engine ) {
         if (engine == null) return;
         try {
             if (engine.getState() != State.RUNNING) return;

--- a/modeshape-jcr/src/test/java/org/modeshape/jcr/store/InMemoryTest.java
+++ b/modeshape-jcr/src/test/java/org/modeshape/jcr/store/InMemoryTest.java
@@ -38,7 +38,7 @@ import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.Test;
 import org.modeshape.common.statistic.Stopwatch;
-import org.modeshape.jcr.JcrEngine;
+import org.modeshape.jcr.ModeShapeEngine;
 import org.modeshape.jcr.RepositoryConfiguration;
 import org.modeshape.jcr.TestingEnvironment;
 import org.modeshape.jcr.TestingUtil;
@@ -57,7 +57,7 @@ public class InMemoryTest {
     private TestingEnvironment environment;
     private TransactionManager txnMgr;
     private RepositoryConfiguration config;
-    protected JcrEngine engine;
+    protected ModeShapeEngine engine;
     protected Repository repository;
     protected Session session;
 
@@ -72,7 +72,7 @@ public class InMemoryTest {
         INFINISPAN_STARTUP.stop();
         MODESHAPE_STARTUP.start();
         config = new RepositoryConfiguration(REPO_NAME, environment);
-        engine = new JcrEngine();
+        engine = new ModeShapeEngine();
         engine.start();
         engine.deploy(config);
         repository = engine.startRepository(config.getName()).get();

--- a/modeshape-jdbc-local/src/main/java/org/modeshape/jdbc/delegate/RepositoryDelegate.java
+++ b/modeshape-jdbc-local/src/main/java/org/modeshape/jdbc/delegate/RepositoryDelegate.java
@@ -135,7 +135,7 @@ public interface RepositoryDelegate {
     <T> T unwrap( Class<T> iface ) throws SQLException;
 
     /**
-     * Called to get all the repository names currently available in the JcrEngine.
+     * Called to get all the repository names currently available in the ModeShapeEngine.
      * 
      * @return Set<String> of repository names
      * @throws RepositoryException

--- a/modeshape-jdbc-local/src/main/java/org/modeshape/jdbc/metadata/MetaDataQueryResult.java
+++ b/modeshape-jdbc-local/src/main/java/org/modeshape/jdbc/metadata/MetaDataQueryResult.java
@@ -23,24 +23,25 @@
  */
 package org.modeshape.jdbc.metadata;
 
-import javax.jcr.ItemNotFoundException;
-import javax.jcr.Node;
-import javax.jcr.NodeIterator;
-import javax.jcr.RepositoryException;
-import javax.jcr.Value;
-import javax.jcr.query.Row;
-import javax.jcr.query.RowIterator;
-import org.modeshape.jdbc.JdbcJcrValueFactory;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import java.util.Iterator;
 import java.util.List;
 import java.util.NoSuchElementException;
+import javax.jcr.ItemNotFoundException;
+import javax.jcr.Node;
+import javax.jcr.NodeIterator;
+import javax.jcr.RepositoryException;
+import javax.jcr.Value;
+import javax.jcr.query.QueryResult;
+import javax.jcr.query.Row;
+import javax.jcr.query.RowIterator;
+import org.modeshape.jdbc.JdbcJcrValueFactory;
 
 /**
  * The MetaDataQueryResult is used to provide {@link NodeIterator} and the {@link RowIterator} in order to provide query results
  * when metadata is requested. This is done because there are no sql queries that can be executed to obtain certain types of
- * metadata in a return QueryResult from the JcrEngine.
+ * metadata in a return {@link QueryResult} from the ModeShapeEngine.
  */
 public class MetaDataQueryResult implements javax.jcr.query.QueryResult {
 

--- a/modeshape-jdbc-local/src/test/java/org/modeshape/jdbc/AbstractJdbcDriverTest.java
+++ b/modeshape-jdbc-local/src/test/java/org/modeshape/jdbc/AbstractJdbcDriverTest.java
@@ -42,15 +42,15 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.modeshape.jcr.JcrRepository;
 import org.modeshape.jcr.JcrRepository.QueryLanguage;
+import org.modeshape.jcr.ModeShapeEngine;
 import org.modeshape.jcr.MultiUseAbstractTest;
 import org.modeshape.jcr.RepositoryConfiguration;
-import org.modeshape.jcr.TestingEnvironment;
 
 /**
- * This is a test suite that operates against a complete JcrRepository instance created and managed using the JcrEngine.
- * Essentially this is an integration test, but it does test lower-level functionality of the implementation of the JCR interfaces
- * related to querying. (It is simply more difficult to unit test these implementations because of the difficulty in mocking the
- * many other components to replicate the same functionality.)
+ * This is a test suite that operates against a complete JcrRepository instance created and managed using the
+ * {@link ModeShapeEngine}. Essentially this is an integration test, but it does test lower-level functionality of the
+ * implementation of the JCR interfaces related to querying. (It is simply more difficult to unit test these implementations
+ * because of the difficulty in mocking the many other components to replicate the same functionality.)
  * <p>
  * Also, because queries are read-only, the engine is set up once and used for the entire set of test methods.
  * </p>

--- a/modeshape-jdbc-local/src/test/java/org/modeshape/jdbc/JcrDriverIntegrationTest.java
+++ b/modeshape-jdbc-local/src/test/java/org/modeshape/jdbc/JcrDriverIntegrationTest.java
@@ -27,21 +27,16 @@ import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import java.sql.Driver;
-import java.sql.ResultSet;
-import java.sql.SQLException;
 import java.util.Properties;
 import javax.naming.Context;
-import org.junit.Ignore;
-import org.junit.Test;
-import org.modeshape.common.FixFor;
 import org.modeshape.jcr.JcrRepository;
-import org.modeshape.jcr.JcrRepository.QueryLanguage;
+import org.modeshape.jcr.ModeShapeEngine;
 
 /**
- * This is a test suite that operates against a complete JcrRepository instance created and managed using the JcrEngine.
- * Essentially this is an integration test, but it does test lower-level functionality of the implementation of the JCR interfaces
- * related to querying. (It is simply more difficult to unit test these implementations because of the difficulty in mocking the
- * many other components to replicate the same functionality.)
+ * This is a test suite that operates against a complete JcrRepository instance created and managed using the
+ * {@link ModeShapeEngine}. Essentially this is an integration test, but it does test lower-level functionality of the
+ * implementation of the JCR interfaces related to querying. (It is simply more difficult to unit test these implementations
+ * because of the difficulty in mocking the many other components to replicate the same functionality.)
  * <p>
  * Also, because queries are read-only, the engine is set up once and used for the entire set of test methods.
  * </p>

--- a/modeshape-jdbc/src/test/java/org/modeshape/jdbc/JcrDriverIntegrationTest.java
+++ b/modeshape-jdbc/src/test/java/org/modeshape/jdbc/JcrDriverIntegrationTest.java
@@ -23,19 +23,20 @@
  */
 package org.modeshape.jdbc;
 
-import javax.naming.Context;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import org.modeshape.jcr.JcrRepository;
 import java.sql.Driver;
 import java.util.Properties;
+import javax.naming.Context;
+import org.modeshape.jcr.JcrRepository;
+import org.modeshape.jcr.ModeShapeEngine;
 
 /**
- * This is a test suite that operates against a complete JcrRepository instance created and managed using the JcrEngine.
- * Essentially this is an integration test, but it does test lower-level functionality of the implementation of the JCR interfaces
- * related to querying. (It is simply more difficult to unit test these implementations because of the difficulty in mocking the
- * many other components to replicate the same functionality.)
+ * This is a test suite that operates against a complete JcrRepository instance created and managed using the
+ * {@link ModeShapeEngine}. Essentially this is an integration test, but it does test lower-level functionality of the
+ * implementation of the JCR interfaces related to querying. (It is simply more difficult to unit test these implementations
+ * because of the difficulty in mocking the many other components to replicate the same functionality.)
  * <p>
  * Also, because queries are read-only, the engine is set up once and used for the entire set of test methods.
  * </p>

--- a/modeshape-performance-tests/src/test/java/org/modeshape/test/performance/InMemoryPerformanceTest.java
+++ b/modeshape-performance-tests/src/test/java/org/modeshape/test/performance/InMemoryPerformanceTest.java
@@ -44,7 +44,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.modeshape.common.statistic.Stopwatch;
 import org.modeshape.jcr.Environment;
-import org.modeshape.jcr.JcrEngine;
+import org.modeshape.jcr.ModeShapeEngine;
 import org.modeshape.jcr.RepositoryConfiguration;
 import org.modeshape.jcr.TestingEnvironment;
 
@@ -60,7 +60,7 @@ public class InMemoryPerformanceTest {
     private Environment environment;
     private TransactionManager txnMgr;
     private RepositoryConfiguration config;
-    protected JcrEngine engine;
+    protected ModeShapeEngine engine;
     protected Repository repository;
     protected Session session;
 
@@ -86,7 +86,7 @@ public class InMemoryPerformanceTest {
         INFINISPAN_STARTUP.stop();
 
         MODESHAPE_STARTUP.start();
-        engine = new JcrEngine();
+        engine = new ModeShapeEngine();
         engine.start();
         engine.deploy(config);
         repository = engine.startRepository(config.getName()).get();

--- a/web/modeshape-web-jcr/src/test/java/org/modeshape/web/jcr/RepositoryManagerTest.java
+++ b/web/modeshape-web-jcr/src/test/java/org/modeshape/web/jcr/RepositoryManagerTest.java
@@ -40,7 +40,7 @@ public class RepositoryManagerTest {
     }
 
     @Test
-    public void shouldLoadFileBasedJcrEngineFromClassPath() throws Exception {
+    public void shouldLoadFileBasedModeShapeEngineFromClassPath() throws Exception {
         // This will start up the repository ...
         RepositoryManager.initialize(context);
 


### PR DESCRIPTION
We're trying to position ModeShape first and foremost as a distributed, hierarchical, transactional, and consistent data store that happens to use the JCR API for its public API. Therefore, ModeShape's engine isn't so much a "JCR engine" as it is just a "ModeShape engine". Thus, the renaming.

All unit and integration tests pass with these changes.
