### PR TITLE
MODE-1492 Changed JCR TCK artifact version to 2.5.0

### DIFF
--- a/modeshape-jcr/src/test/java/org/modeshape/jcr/JcrObservationManagerTest.java
+++ b/modeshape-jcr/src/test/java/org/modeshape/jcr/JcrObservationManagerTest.java
@@ -1080,7 +1080,8 @@ public final class JcrObservationManagerTest extends SingleUseAbstractTest {
     // ===========================================================================================================================
 
     /**
-     * @see NodeReorderTest#testNodeReorder()
+     * @see NodeReorderTest#testNodeReorderSameName()
+     * @see NodeReorderTest#testNodeReorderSameNameWithRemove()
      * @throws Exception
      */
     @SuppressWarnings( "unchecked" )

--- a/modeshape-jcr/src/test/java/org/modeshape/jcr/JcrTckTest.java
+++ b/modeshape-jcr/src/test/java/org/modeshape/jcr/JcrTckTest.java
@@ -131,6 +131,7 @@ import org.apache.jackrabbit.test.api.WorkspaceTest;
 import org.apache.jackrabbit.test.api.nodetype.NodeTypeCreationTest;
 import org.apache.jackrabbit.test.api.observation.AddEventListenerTest;
 import org.apache.jackrabbit.test.api.observation.EventIteratorTest;
+import org.apache.jackrabbit.test.api.observation.EventJournalTest;
 import org.apache.jackrabbit.test.api.observation.EventTest;
 import org.apache.jackrabbit.test.api.observation.GetDateTest;
 import org.apache.jackrabbit.test.api.observation.GetIdentifierTest;
@@ -216,6 +217,7 @@ import org.apache.jackrabbit.test.api.version.GetCreatedTest;
 import org.apache.jackrabbit.test.api.version.GetPredecessorsTest;
 import org.apache.jackrabbit.test.api.version.GetReferencesNodeTest;
 import org.apache.jackrabbit.test.api.version.GetVersionableUUIDTest;
+import org.apache.jackrabbit.test.api.version.MergeActivityTest;
 import org.apache.jackrabbit.test.api.version.MergeCancelMergeTest;
 import org.apache.jackrabbit.test.api.version.MergeCheckedoutSubNodeTest;
 import org.apache.jackrabbit.test.api.version.MergeDoneMergeTest;
@@ -561,8 +563,7 @@ public class JcrTckTest {
             addTestSuite(WorkspaceOperationTest.class);
             //
             // JCR 2.0
-            // TODO author=Horia Chiorean date=4/19/12 description=https://issues.apache.org/jira/browse/JCR-2662
-            // addTestSuite(EventJournalTest.class);
+            addTestSuite(EventJournalTest.class);
             addTestSuite(GetDateTest.class);
             addTestSuite(GetIdentifierTest.class);
             addTestSuite(GetInfoTest.class);
@@ -612,9 +613,7 @@ public class JcrTckTest {
             addTestSuite(MergeShallowTest.class);
             addTestSuite(MergeNonVersionableSubNodeTest.class);
             addTestSuite(MergeSubNodeTest.class);
-
-            // TODO author=Horia Chiorean date=5/14/12 description=https://issues.apache.org/jira/browse/JCR-3307
-            // addTestSuite(MergeActivityTest.class);
+            addTestSuite(MergeActivityTest.class);
 
             // JCR 2.0
             addTestSuite(ActivitiesTest.class);

--- a/modeshape-jcr/src/test/resources/repositoryStubImpl.properties
+++ b/modeshape-jcr/src/test/resources/repositoryStubImpl.properties
@@ -49,6 +49,12 @@ javax.jcr.tck.SessionTest.testSaveContstraintViolationException.nodetype2=modete
 javax.jcr.tck.NodeTest.testRemoveMandatoryNode.nodetype2=modetest\:nodeWithMandatoryChild
 javax.jcr.tck.NodeTest.testRemoveMandatoryNode.nodename3=modetest\:mandatoryChild
 javax.jcr.tck.NodeTest.testSaveContstraintViolationException.nodetype2=modetest\:nodeWithMandatoryProperty
+
+# Test class: NodeTest
+# Test method: testSaveConstraintViolationException
+# nodetype that has a property that is mandatory but not autocreated
+javax.jcr.tck.NodeTest.testSaveConstraintViolationException.nodetype2=nt:file
+
 javax.jcr.tck.NodeOrderableChildNodesTest.testOrderBeforeUnsupportedRepositoryOperationException.nodetype2=modetest\:unorderableUnstructured
 javax.jcr.tck.NodeOrderableChildNodesTest.testOrderBeforeUnsupportedRepositoryOperationException.nodetype3=modetest\:unorderableUnstructured
 # For some reason, this test assumes testNodeType doesn't allow children - most other tests assume that it does
@@ -61,6 +67,11 @@ javax.jcr.tck.NodeRemoveMixinTest.nodetype=nt\:unstructured
 
 # Session test that requires a node that doesn't allow two children with the same name
 javax.jcr.tck.SessionTest.testMoveItemExistsException.nodetype2=modetest\:noSameNameSibs
+
+# Test class: SessionTest
+# Test method: testSaveConstraintViolationException
+# nodetype that has a property that is mandatory but not autocreated
+javax.jcr.tck.SessionTest.testSaveConstraintViolationException.nodetype2=nt:file
 
 # version test types
 javax.jcr.tck.versionableNodeType=modetest\:versionableUnstructured

--- a/modeshape-parent/pom.xml
+++ b/modeshape-parent/pom.xml
@@ -221,7 +221,7 @@
         <slf4j.log4j.version>1.6.1</slf4j.log4j.version>
         <log4j.version>1.2.16</log4j.version>
         <jcr.version>2.0</jcr.version>
-        <jackrabbit.jcr.tck.version>2.4.1</jackrabbit.jcr.tck.version>
+        <jackrabbit.jcr.tck.version>2.5.0</jackrabbit.jcr.tck.version>
         <picketbox.version>4.0.7.Final</picketbox.version>
         <byteman.version>1.5.1</byteman.version>
         <lucene.version>3.5.0</lucene.version>


### PR DESCRIPTION
This version includes several fixes for the TCK unit tests, including:
- https://issues.apache.org/jira/browse/JCR-2662 Journaled Observation tests should check for repository support ...
- https://issues.apache.org/jira/browse/JCR-3300 Tests should check for repository support ...
- https://issues.apache.org/jira/browse/JCR-3307 Activities tests should check for repository support ...

However, two issues are still outstanding in 2.5.0:
- https://issues.apache.org/jira/browse/JCR-2666 (Patch submitted 5/25/12, but test fails when running Jackrabbit Core) Restore tests assert incorrectly
- https://issues.apache.org/jira/browse/JCR-3313 (Patch submitted 5/24/12) QOM test asserts are too restrictive

In addition to changing the version number of the `org.apache.jackrabbit.jcr-tests` dependency, we also had to add some properties so that the new tests used node types that had required but not auto-created properties. Once this was done, all the same TCK tests passed with no problems.

All our unit tests pass with these changes.
