### PR TITLE
MODE-1524 Changed Infinispan Externalizer implementations

### DIFF
--- a/modeshape-schematic/src/main/java/org/infinispan/schematic/document/Binary.java
+++ b/modeshape-schematic/src/main/java/org/infinispan/schematic/document/Binary.java
@@ -26,7 +26,8 @@ import java.io.ObjectInput;
 import java.io.ObjectOutput;
 import java.util.Arrays;
 import java.util.Set;
-import org.infinispan.marshall.AbstractExternalizer;
+import org.infinispan.marshall.SerializeWith;
+import org.infinispan.schematic.internal.SchematicExternalizer;
 import org.infinispan.schematic.internal.marshall.Ids;
 import org.infinispan.util.Base64;
 import org.infinispan.util.Util;
@@ -38,6 +39,7 @@ import org.infinispan.util.Util;
  * @since 5.1
  */
 @Immutable
+@SerializeWith( Binary.Externalizer.class )
 public final class Binary {
 
     private final byte type;
@@ -92,8 +94,7 @@ public final class Binary {
         return Base64.encodeBytes(data);
     }
 
-    public static class Externalizer extends AbstractExternalizer<Binary> {
-        /** The serialVersionUID */
+    public static class Externalizer extends SchematicExternalizer<Binary> {
         private static final long serialVersionUID = 1L;
 
         @Override

--- a/modeshape-schematic/src/main/java/org/infinispan/schematic/document/Code.java
+++ b/modeshape-schematic/src/main/java/org/infinispan/schematic/document/Code.java
@@ -25,7 +25,8 @@ import java.io.IOException;
 import java.io.ObjectInput;
 import java.io.ObjectOutput;
 import java.util.Set;
-import org.infinispan.marshall.AbstractExternalizer;
+import org.infinispan.marshall.SerializeWith;
+import org.infinispan.schematic.internal.SchematicExternalizer;
 import org.infinispan.schematic.internal.marshall.Ids;
 import org.infinispan.util.Util;
 
@@ -36,6 +37,7 @@ import org.infinispan.util.Util;
  * @since 5.1
  */
 @Immutable
+@SerializeWith( Code.Externalizer.class )
 public class Code {
 
     private final String code;
@@ -69,8 +71,7 @@ public class Code {
         return "Code (" + getCode() + ')';
     }
 
-    public static class Externalizer extends AbstractExternalizer<Code> {
-        /** The serialVersionUID */
+    public static class Externalizer extends SchematicExternalizer<Code> {
         private static final long serialVersionUID = 1L;
 
         @Override

--- a/modeshape-schematic/src/main/java/org/infinispan/schematic/document/CodeWithScope.java
+++ b/modeshape-schematic/src/main/java/org/infinispan/schematic/document/CodeWithScope.java
@@ -21,6 +21,8 @@
  */
 package org.infinispan.schematic.document;
 
+import org.infinispan.marshall.SerializeWith;
+
 /**
  * A {@link Bson.Type#JAVASCRIPT_WITH_SCOPE JavaScript code with scope} value for use within a {@link Document BSON Object}.
  * 
@@ -28,6 +30,7 @@ package org.infinispan.schematic.document;
  * @since 5.1
  */
 @Immutable
+@SerializeWith( Code.Externalizer.class )
 public final class CodeWithScope extends Code {
 
     private final Document scope;

--- a/modeshape-schematic/src/main/java/org/infinispan/schematic/document/MaxKey.java
+++ b/modeshape-schematic/src/main/java/org/infinispan/schematic/document/MaxKey.java
@@ -24,11 +24,13 @@ package org.infinispan.schematic.document;
 import java.io.ObjectInput;
 import java.io.ObjectOutput;
 import java.util.Set;
-import org.infinispan.marshall.AbstractExternalizer;
+import org.infinispan.marshall.SerializeWith;
+import org.infinispan.schematic.internal.SchematicExternalizer;
 import org.infinispan.schematic.internal.marshall.Ids;
 import org.infinispan.util.Util;
 
 @Immutable
+@SerializeWith( MaxKey.Externalizer.class )
 public final class MaxKey {
 
     /**
@@ -70,8 +72,7 @@ public final class MaxKey {
         return INSTANCE;
     }
 
-    public static class Externalizer extends AbstractExternalizer<MaxKey> {
-        /** The serialVersionUID */
+    public static class Externalizer extends SchematicExternalizer<MaxKey> {
         private static final long serialVersionUID = 1L;
 
         @Override

--- a/modeshape-schematic/src/main/java/org/infinispan/schematic/document/MinKey.java
+++ b/modeshape-schematic/src/main/java/org/infinispan/schematic/document/MinKey.java
@@ -24,11 +24,13 @@ package org.infinispan.schematic.document;
 import java.io.ObjectInput;
 import java.io.ObjectOutput;
 import java.util.Set;
-import org.infinispan.marshall.AbstractExternalizer;
+import org.infinispan.marshall.SerializeWith;
+import org.infinispan.schematic.internal.SchematicExternalizer;
 import org.infinispan.schematic.internal.marshall.Ids;
 import org.infinispan.util.Util;
 
 @Immutable
+@SerializeWith( MinKey.Externalizer.class )
 public class MinKey {
 
     private static final String MIN_KEY_VALUE = "";
@@ -58,8 +60,7 @@ public class MinKey {
         return "MaxKey";
     }
 
-    public static class Externalizer extends AbstractExternalizer<MinKey> {
-        /** The serialVersionUID */
+    public static class Externalizer extends SchematicExternalizer<MinKey> {
         private static final long serialVersionUID = 1L;
 
         @Override

--- a/modeshape-schematic/src/main/java/org/infinispan/schematic/document/Null.java
+++ b/modeshape-schematic/src/main/java/org/infinispan/schematic/document/Null.java
@@ -24,7 +24,8 @@ package org.infinispan.schematic.document;
 import java.io.ObjectInput;
 import java.io.ObjectOutput;
 import java.util.Set;
-import org.infinispan.marshall.AbstractExternalizer;
+import org.infinispan.marshall.SerializeWith;
+import org.infinispan.schematic.internal.SchematicExternalizer;
 import org.infinispan.schematic.internal.marshall.Ids;
 import org.infinispan.util.Util;
 
@@ -35,6 +36,7 @@ import org.infinispan.util.Util;
  * @since 5.1
  */
 @Immutable
+@SerializeWith( Null.Externalizer.class )
 public class Null {
 
     protected static final Null INSTANCE = new Null();
@@ -74,8 +76,7 @@ public class Null {
         return INSTANCE;
     }
 
-    public static class Externalizer extends AbstractExternalizer<Null> {
-        /** The serialVersionUID */
+    public static class Externalizer extends SchematicExternalizer<Null> {
         private static final long serialVersionUID = 1L;
 
         @Override

--- a/modeshape-schematic/src/main/java/org/infinispan/schematic/document/ObjectId.java
+++ b/modeshape-schematic/src/main/java/org/infinispan/schematic/document/ObjectId.java
@@ -25,7 +25,8 @@ import java.io.IOException;
 import java.io.ObjectInput;
 import java.io.ObjectOutput;
 import java.util.Set;
-import org.infinispan.marshall.AbstractExternalizer;
+import org.infinispan.marshall.SerializeWith;
+import org.infinispan.schematic.internal.SchematicExternalizer;
 import org.infinispan.schematic.internal.document.BsonUtils;
 import org.infinispan.schematic.internal.marshall.Ids;
 import org.infinispan.util.Base64;
@@ -39,6 +40,7 @@ import org.infinispan.util.Util;
  * @since 5.1
  */
 @Immutable
+@SerializeWith( ObjectId.Externalizer.class )
 public final class ObjectId {
 
     private final int time;
@@ -117,8 +119,7 @@ public final class ObjectId {
         return "ObjectID(" + time + ':' + machine + ':' + process + ':' + inc + ')';
     }
 
-    public static class Externalizer extends AbstractExternalizer<ObjectId> {
-        /** The serialVersionUID */
+    public static class Externalizer extends SchematicExternalizer<ObjectId> {
         private static final long serialVersionUID = 1L;
 
         @Override

--- a/modeshape-schematic/src/main/java/org/infinispan/schematic/document/Symbol.java
+++ b/modeshape-schematic/src/main/java/org/infinispan/schematic/document/Symbol.java
@@ -26,7 +26,8 @@ import java.io.ObjectInput;
 import java.io.ObjectOutput;
 import java.io.Serializable;
 import java.util.Set;
-import org.infinispan.marshall.AbstractExternalizer;
+import org.infinispan.marshall.SerializeWith;
+import org.infinispan.schematic.internal.SchematicExternalizer;
 import org.infinispan.schematic.internal.marshall.Ids;
 import org.infinispan.util.Util;
 
@@ -37,6 +38,7 @@ import org.infinispan.util.Util;
  * @since 5.1
  */
 @Immutable
+@SerializeWith( Symbol.Externalizer.class )
 public final class Symbol implements Serializable {
 
     private static final long serialVersionUID = 1L;
@@ -76,8 +78,7 @@ public final class Symbol implements Serializable {
         return symbol;
     }
 
-    public static class Externalizer extends AbstractExternalizer<Symbol> {
-        /** The serialVersionUID */
+    public static class Externalizer extends SchematicExternalizer<Symbol> {
         private static final long serialVersionUID = 1L;
 
         @Override

--- a/modeshape-schematic/src/main/java/org/infinispan/schematic/document/Timestamp.java
+++ b/modeshape-schematic/src/main/java/org/infinispan/schematic/document/Timestamp.java
@@ -26,7 +26,8 @@ import java.io.ObjectInput;
 import java.io.ObjectOutput;
 import java.util.Date;
 import java.util.Set;
-import org.infinispan.marshall.AbstractExternalizer;
+import org.infinispan.marshall.SerializeWith;
+import org.infinispan.schematic.internal.SchematicExternalizer;
 import org.infinispan.schematic.internal.marshall.Ids;
 import org.infinispan.util.Util;
 
@@ -38,6 +39,7 @@ import org.infinispan.util.Util;
  * @since 5.1
  */
 @Immutable
+@SerializeWith( Timestamp.Externalizer.class )
 public final class Timestamp {
 
     private final Date time;
@@ -90,8 +92,7 @@ public final class Timestamp {
         return "TS(" + time + ':' + inc + ')';
     }
 
-    public static class Externalizer extends AbstractExternalizer<Timestamp> {
-        /** The serialVersionUID */
+    public static class Externalizer extends SchematicExternalizer<Timestamp> {
         private static final long serialVersionUID = 1L;
 
         @Override

--- a/modeshape-schematic/src/main/java/org/infinispan/schematic/internal/SchematicEntryDelta.java
+++ b/modeshape-schematic/src/main/java/org/infinispan/schematic/internal/SchematicEntryDelta.java
@@ -29,7 +29,7 @@ import java.util.List;
 import java.util.Set;
 import org.infinispan.atomic.Delta;
 import org.infinispan.atomic.DeltaAware;
-import org.infinispan.marshall.AbstractExternalizer;
+import org.infinispan.marshall.SerializeWith;
 import org.infinispan.schematic.SchematicEntry;
 import org.infinispan.schematic.internal.delta.DocumentObserver;
 import org.infinispan.schematic.internal.delta.Operation;
@@ -45,6 +45,7 @@ import org.infinispan.util.logging.LogFactory;
  * @since 5.1
  * @see org.infinispan.atomic.AtomicHashMapDelta
  */
+@SerializeWith( SchematicEntryDelta.Externalizer.class )
 public class SchematicEntryDelta implements Delta, DocumentObserver {
     private static final Log log = LogFactory.getLog(SchematicEntryDelta.class);
     private static final boolean trace = log.isTraceEnabled();
@@ -82,8 +83,7 @@ public class SchematicEntryDelta implements Delta, DocumentObserver {
         return changeLog == null ? 0 : changeLog.size();
     }
 
-    public static class Externalizer extends AbstractExternalizer<SchematicEntryDelta> {
-        /** The serialVersionUID */
+    public static class Externalizer extends SchematicExternalizer<SchematicEntryDelta> {
         private static final long serialVersionUID = 1L;
 
         @SuppressWarnings( "synthetic-access" )
@@ -108,8 +108,8 @@ public class SchematicEntryDelta implements Delta, DocumentObserver {
             return Ids.SCHEMATIC_VALUE_DELTA;
         }
 
-        @SuppressWarnings( "unchecked" )
         @Override
+        @SuppressWarnings( "unchecked" )
         public Set<Class<? extends SchematicEntryDelta>> getTypeClasses() {
             return Util.<Class<? extends SchematicEntryDelta>>asSet(SchematicEntryDelta.class);
         }

--- a/modeshape-schematic/src/main/java/org/infinispan/schematic/internal/SchematicEntryLiteral.java
+++ b/modeshape-schematic/src/main/java/org/infinispan/schematic/internal/SchematicEntryLiteral.java
@@ -29,7 +29,6 @@ import org.infinispan.Cache;
 import org.infinispan.atomic.Delta;
 import org.infinispan.atomic.DeltaAware;
 import org.infinispan.context.FlagContainer;
-import org.infinispan.marshall.AbstractExternalizer;
 import org.infinispan.marshall.SerializeWith;
 import org.infinispan.schematic.SchematicEntry;
 import org.infinispan.schematic.document.Binary;
@@ -293,8 +292,7 @@ public class SchematicEntryLiteral implements SchematicEntry, DeltaAware {
     /**
      * The {@link org.infinispan.marshall.Externalizer Externalizer} for {@link SchematicEntryLiteral} instances.
      */
-    public static class Externalizer extends AbstractExternalizer<SchematicEntryLiteral> {
-        /** The serialVersionUID */
+    public static final class Externalizer extends SchematicExternalizer<SchematicEntryLiteral> {
         private static final long serialVersionUID = 1L;
 
         @Override

--- a/modeshape-schematic/src/main/java/org/infinispan/schematic/internal/SchematicExternalizer.java
+++ b/modeshape-schematic/src/main/java/org/infinispan/schematic/internal/SchematicExternalizer.java
@@ -1,0 +1,64 @@
+/*
+ * ModeShape (http://www.modeshape.org)
+ * See the COPYRIGHT.txt file distributed with this work for information
+ * regarding copyright ownership.  Some portions may be licensed
+ * to Red Hat, Inc. under one or more contributor license agreements.
+ * See the AUTHORS.txt file in the distribution for a full listing of 
+ * individual contributors.
+ *
+ * ModeShape is free software. Unless otherwise indicated, all code in ModeShape
+ * is licensed to you under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ * 
+ * ModeShape is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.infinispan.schematic.internal;
+
+import java.util.Set;
+import org.infinispan.marshall.AdvancedExternalizer;
+import org.infinispan.marshall.Externalizer;
+
+/**
+ * An abstract base class for all Schematic {@link org.infinispan.marshall.Externalizer Externalizer} implementations.
+ * <p>
+ * There are two primary advantages of implementing {@link AdvancedExternalizer} versus implementing
+ * {@link org.infinispan.marshall.Externalizer}:
+ * <ol>
+ * <li>The class to be externalized must be modified with a {@code @SerializeWith} annotation. Since {@link SchematicEntryLiteral}
+ * is our class, this is possible.</li>
+ * <li>The generated payloads (shipped between Infinispan processes) are slightly smaller, since it includes only the
+ * {@link AdvancedExternalizer}'s {@link #getId() identifier} instead of the class information and/or the serialized
+ * {@link org.infinispan.marshall.Externalizer}. But for this to work, the advanced externalizers need to be registered with the
+ * cache container at startup.</li>
+ * </ol>
+ * Unfortunately, Infinispan in AS7.1 does not allow defining {@link AdvancedExternalizer} classes for the cache container, and
+ * thus they cannot be used (see <a href="https://issues.jboss.org/browse/MODE-1524">MODE-1524</a> for details). Therefore, we
+ * have to rely only upon implementing {@link org.infinispan.marshall.Externalizer}.
+ * </p>
+ * <p>
+ * This abstract class was created so that the Schematic externalizers can easily extend it, but so that we can encapsulate in
+ * this abstract class the use of {@link Externalizer} or {@link AdvancedExternalizer}. Once Infinispan in AS7 supports
+ * user-defined advanced externalizers, then we can simply change this class to implement {@link AdvancedExternalizer} rather than
+ * {@link Externalizer}.
+ * 
+ * @param <T> the type of class
+ */
+public abstract class SchematicExternalizer<T> implements org.infinispan.marshall.Externalizer<T>
+/*implements AdvancedExternalizer<T>*/{
+
+    private static final long serialVersionUID = 1L;
+
+    public abstract Integer getId();
+
+    public abstract Set<Class<? extends T>> getTypeClasses();
+
+}

--- a/modeshape-schematic/src/main/java/org/infinispan/schematic/internal/delta/AddValueIfAbsentOperation.java
+++ b/modeshape-schematic/src/main/java/org/infinispan/schematic/internal/delta/AddValueIfAbsentOperation.java
@@ -26,8 +26,9 @@ import java.io.IOException;
 import java.io.ObjectInput;
 import java.io.ObjectOutput;
 import java.util.Set;
-import org.infinispan.marshall.AbstractExternalizer;
+import org.infinispan.marshall.SerializeWith;
 import org.infinispan.schematic.document.Path;
+import org.infinispan.schematic.internal.SchematicExternalizer;
 import org.infinispan.schematic.internal.document.MutableArray;
 import org.infinispan.schematic.internal.document.MutableDocument;
 import org.infinispan.schematic.internal.marshall.Ids;
@@ -39,6 +40,7 @@ import org.infinispan.util.Util;
  * @author Randall Hauch <rhauch@redhat.com> (C) 2011 Red Hat Inc.
  * @since 5.1
  */
+@SerializeWith( AddValueIfAbsentOperation.Externalizer.class )
 public class AddValueIfAbsentOperation extends AddValueOperation {
 
     protected transient boolean added;
@@ -71,8 +73,7 @@ public class AddValueIfAbsentOperation extends AddValueOperation {
         return super.toString() + " if absent";
     }
 
-    public static class Externalizer extends AbstractExternalizer<AddValueIfAbsentOperation> {
-        /** The serialVersionUID */
+    public static final class Externalizer extends SchematicExternalizer<AddValueIfAbsentOperation> {
         private static final long serialVersionUID = 1L;
 
         @Override

--- a/modeshape-schematic/src/main/java/org/infinispan/schematic/internal/delta/AddValueOperation.java
+++ b/modeshape-schematic/src/main/java/org/infinispan/schematic/internal/delta/AddValueOperation.java
@@ -26,8 +26,9 @@ import java.io.IOException;
 import java.io.ObjectInput;
 import java.io.ObjectOutput;
 import java.util.Set;
-import org.infinispan.marshall.AbstractExternalizer;
+import org.infinispan.marshall.SerializeWith;
 import org.infinispan.schematic.document.Path;
+import org.infinispan.schematic.internal.SchematicExternalizer;
 import org.infinispan.schematic.internal.document.MutableArray;
 import org.infinispan.schematic.internal.document.MutableDocument;
 import org.infinispan.schematic.internal.marshall.Ids;
@@ -39,6 +40,7 @@ import org.infinispan.util.Util;
  * @author Randall Hauch <rhauch@redhat.com> (C) 2011 Red Hat Inc.
  * @since 5.1
  */
+@SerializeWith( AddValueOperation.Externalizer.class )
 public class AddValueOperation extends ArrayOperation {
 
     protected static final int APPEND_INDEX = -1;
@@ -98,8 +100,7 @@ public class AddValueOperation extends ArrayOperation {
         return "Add to '" + parentPath + "' the value '" + value + "'" + (index >= 0 ? " at index " + index : "");
     }
 
-    public static class Externalizer extends AbstractExternalizer<AddValueOperation> {
-        /** The serialVersionUID */
+    public static final class Externalizer extends SchematicExternalizer<AddValueOperation> {
         private static final long serialVersionUID = 1L;
 
         @Override

--- a/modeshape-schematic/src/main/java/org/infinispan/schematic/internal/delta/ClearOperation.java
+++ b/modeshape-schematic/src/main/java/org/infinispan/schematic/internal/delta/ClearOperation.java
@@ -29,9 +29,10 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
-import org.infinispan.marshall.AbstractExternalizer;
+import org.infinispan.marshall.SerializeWith;
 import org.infinispan.schematic.document.Immutable;
 import org.infinispan.schematic.document.Path;
+import org.infinispan.schematic.internal.SchematicExternalizer;
 import org.infinispan.schematic.internal.document.MutableArray;
 import org.infinispan.schematic.internal.document.MutableDocument;
 import org.infinispan.schematic.internal.marshall.Ids;
@@ -44,6 +45,7 @@ import org.infinispan.util.Util;
  * @since 5.1
  */
 @Immutable
+@SerializeWith( ClearOperation.Externalizer.class )
 public class ClearOperation extends ArrayOperation {
 
     private transient List<?> removedValues;
@@ -78,8 +80,7 @@ public class ClearOperation extends ArrayOperation {
         return "Clear at '" + parentPath + "' the existing values";
     }
 
-    public static class Externalizer extends AbstractExternalizer<ClearOperation> {
-        /** The serialVersionUID */
+    public static final class Externalizer extends SchematicExternalizer<ClearOperation> {
         private static final long serialVersionUID = 1L;
 
         @Override

--- a/modeshape-schematic/src/main/java/org/infinispan/schematic/internal/delta/PutOperation.java
+++ b/modeshape-schematic/src/main/java/org/infinispan/schematic/internal/delta/PutOperation.java
@@ -26,8 +26,9 @@ import java.io.IOException;
 import java.io.ObjectInput;
 import java.io.ObjectOutput;
 import java.util.Set;
-import org.infinispan.marshall.AbstractExternalizer;
+import org.infinispan.marshall.SerializeWith;
 import org.infinispan.schematic.document.Path;
+import org.infinispan.schematic.internal.SchematicExternalizer;
 import org.infinispan.schematic.internal.document.MutableDocument;
 import org.infinispan.schematic.internal.marshall.Ids;
 import org.infinispan.util.Util;
@@ -37,6 +38,7 @@ import org.infinispan.util.Util;
  * 
  * @author (various)
  */
+@SerializeWith( PutOperation.Externalizer.class )
 public class PutOperation extends Operation {
     protected final String fieldName;
     protected final Object oldValue;
@@ -88,8 +90,7 @@ public class PutOperation extends Operation {
                + (oldValue != null ? "' (replaces '" + oldValue + "')" : "");
     }
 
-    public static class Externalizer extends AbstractExternalizer<PutOperation> {
-        /** The serialVersionUID */
+    public static final class Externalizer extends SchematicExternalizer<PutOperation> {
         private static final long serialVersionUID = 1L;
 
         @Override

--- a/modeshape-schematic/src/main/java/org/infinispan/schematic/internal/delta/RemoveAllValuesOperation.java
+++ b/modeshape-schematic/src/main/java/org/infinispan/schematic/internal/delta/RemoveAllValuesOperation.java
@@ -30,9 +30,10 @@ import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
-import org.infinispan.marshall.AbstractExternalizer;
+import org.infinispan.marshall.SerializeWith;
 import org.infinispan.schematic.document.Array.Entry;
 import org.infinispan.schematic.document.Path;
+import org.infinispan.schematic.internal.SchematicExternalizer;
 import org.infinispan.schematic.internal.document.BasicArray;
 import org.infinispan.schematic.internal.document.MutableArray;
 import org.infinispan.schematic.internal.document.MutableDocument;
@@ -45,6 +46,7 @@ import org.infinispan.util.Util;
  * @author Randall Hauch <rhauch@redhat.com> (C) 2011 Red Hat Inc.
  * @since 5.1
  */
+@SerializeWith( RemoveAllValuesOperation.Externalizer.class )
 public class RemoveAllValuesOperation extends ArrayOperation {
 
     protected final Collection<?> values;
@@ -105,8 +107,7 @@ public class RemoveAllValuesOperation extends ArrayOperation {
         return "Remove at '" + parentPath + "' the values: " + values;
     }
 
-    public static class Externalizer extends AbstractExternalizer<RemoveAllValuesOperation> {
-        /** The serialVersionUID */
+    public static final class Externalizer extends SchematicExternalizer<RemoveAllValuesOperation> {
         private static final long serialVersionUID = 1L;
 
         @Override

--- a/modeshape-schematic/src/main/java/org/infinispan/schematic/internal/delta/RemoveAtIndexOperation.java
+++ b/modeshape-schematic/src/main/java/org/infinispan/schematic/internal/delta/RemoveAtIndexOperation.java
@@ -26,8 +26,9 @@ import java.io.IOException;
 import java.io.ObjectInput;
 import java.io.ObjectOutput;
 import java.util.Set;
-import org.infinispan.marshall.AbstractExternalizer;
+import org.infinispan.marshall.SerializeWith;
 import org.infinispan.schematic.document.Path;
+import org.infinispan.schematic.internal.SchematicExternalizer;
 import org.infinispan.schematic.internal.document.MutableArray;
 import org.infinispan.schematic.internal.document.MutableDocument;
 import org.infinispan.schematic.internal.marshall.Ids;
@@ -39,6 +40,7 @@ import org.infinispan.util.Util;
  * @author Randall Hauch <rhauch@redhat.com> (C) 2011 Red Hat Inc.
  * @since 5.1
  */
+@SerializeWith( RemoveAtIndexOperation.Externalizer.class )
 public class RemoveAtIndexOperation extends ArrayOperation {
 
     protected final int index;
@@ -77,8 +79,7 @@ public class RemoveAtIndexOperation extends ArrayOperation {
         return "Remove at '" + parentPath + "' the value at index " + index;
     }
 
-    public static class Externalizer extends AbstractExternalizer<RemoveAtIndexOperation> {
-        /** The serialVersionUID */
+    public static final class Externalizer extends SchematicExternalizer<RemoveAtIndexOperation> {
         private static final long serialVersionUID = 1L;
 
         @Override

--- a/modeshape-schematic/src/main/java/org/infinispan/schematic/internal/delta/RemoveOperation.java
+++ b/modeshape-schematic/src/main/java/org/infinispan/schematic/internal/delta/RemoveOperation.java
@@ -26,9 +26,10 @@ import java.io.IOException;
 import java.io.ObjectInput;
 import java.io.ObjectOutput;
 import java.util.Set;
-import org.infinispan.marshall.AbstractExternalizer;
+import org.infinispan.marshall.SerializeWith;
 import org.infinispan.schematic.document.Immutable;
 import org.infinispan.schematic.document.Path;
+import org.infinispan.schematic.internal.SchematicExternalizer;
 import org.infinispan.schematic.internal.document.MutableDocument;
 import org.infinispan.schematic.internal.marshall.Ids;
 import org.infinispan.util.Util;
@@ -39,6 +40,7 @@ import org.infinispan.util.Util;
  * @author (various)
  */
 @Immutable
+@SerializeWith( RemoveOperation.Externalizer.class )
 public class RemoveOperation extends Operation {
     protected final String fieldName;
     protected final Object oldValue;
@@ -81,8 +83,7 @@ public class RemoveOperation extends Operation {
         return "Remove from '" + parentPath + "' the '" + fieldName + "' field value '" + oldValue + "'";
     }
 
-    public static class Externalizer extends AbstractExternalizer<RemoveOperation> {
-        /** The serialVersionUID */
+    public static final class Externalizer extends SchematicExternalizer<RemoveOperation> {
         private static final long serialVersionUID = 1L;
 
         @Override

--- a/modeshape-schematic/src/main/java/org/infinispan/schematic/internal/delta/RemoveValueOperation.java
+++ b/modeshape-schematic/src/main/java/org/infinispan/schematic/internal/delta/RemoveValueOperation.java
@@ -26,8 +26,9 @@ import java.io.IOException;
 import java.io.ObjectInput;
 import java.io.ObjectOutput;
 import java.util.Set;
-import org.infinispan.marshall.AbstractExternalizer;
+import org.infinispan.marshall.SerializeWith;
 import org.infinispan.schematic.document.Path;
+import org.infinispan.schematic.internal.SchematicExternalizer;
 import org.infinispan.schematic.internal.document.MutableArray;
 import org.infinispan.schematic.internal.document.MutableDocument;
 import org.infinispan.schematic.internal.marshall.Ids;
@@ -39,6 +40,7 @@ import org.infinispan.util.Util;
  * @author Randall Hauch <rhauch@redhat.com> (C) 2011 Red Hat Inc.
  * @since 5.1
  */
+@SerializeWith( RemoveValueOperation.Externalizer.class )
 public class RemoveValueOperation extends ArrayOperation {
 
     protected final Object value;
@@ -78,8 +80,7 @@ public class RemoveValueOperation extends ArrayOperation {
         return "Remove at '" + parentPath + "' the value '" + value + "'";
     }
 
-    public static class Externalizer extends AbstractExternalizer<RemoveValueOperation> {
-        /** The serialVersionUID */
+    public static final class Externalizer extends SchematicExternalizer<RemoveValueOperation> {
         private static final long serialVersionUID = 1L;
 
         @Override

--- a/modeshape-schematic/src/main/java/org/infinispan/schematic/internal/delta/RetainAllValuesOperation.java
+++ b/modeshape-schematic/src/main/java/org/infinispan/schematic/internal/delta/RetainAllValuesOperation.java
@@ -28,9 +28,10 @@ import java.io.ObjectOutput;
 import java.util.Collection;
 import java.util.List;
 import java.util.Set;
-import org.infinispan.marshall.AbstractExternalizer;
+import org.infinispan.marshall.SerializeWith;
 import org.infinispan.schematic.document.Array.Entry;
 import org.infinispan.schematic.document.Path;
+import org.infinispan.schematic.internal.SchematicExternalizer;
 import org.infinispan.schematic.internal.document.MutableArray;
 import org.infinispan.schematic.internal.document.MutableDocument;
 import org.infinispan.schematic.internal.marshall.Ids;
@@ -42,6 +43,7 @@ import org.infinispan.util.Util;
  * @author Randall Hauch <rhauch@redhat.com> (C) 2011 Red Hat Inc.
  * @since 5.1
  */
+@SerializeWith( RetainAllValuesOperation.Externalizer.class )
 public class RetainAllValuesOperation extends ArrayOperation {
 
     protected final Collection<?> values;
@@ -83,8 +85,7 @@ public class RetainAllValuesOperation extends ArrayOperation {
         return "Retain at '" + parentPath + "' the values: " + values;
     }
 
-    public static class Externalizer extends AbstractExternalizer<RetainAllValuesOperation> {
-        /** The serialVersionUID */
+    public static final class Externalizer extends SchematicExternalizer<RetainAllValuesOperation> {
         private static final long serialVersionUID = 1L;
 
         @Override

--- a/modeshape-schematic/src/main/java/org/infinispan/schematic/internal/delta/SetValueOperation.java
+++ b/modeshape-schematic/src/main/java/org/infinispan/schematic/internal/delta/SetValueOperation.java
@@ -26,8 +26,9 @@ import java.io.IOException;
 import java.io.ObjectInput;
 import java.io.ObjectOutput;
 import java.util.Set;
-import org.infinispan.marshall.AbstractExternalizer;
+import org.infinispan.marshall.SerializeWith;
 import org.infinispan.schematic.document.Path;
+import org.infinispan.schematic.internal.SchematicExternalizer;
 import org.infinispan.schematic.internal.document.MutableArray;
 import org.infinispan.schematic.internal.document.MutableDocument;
 import org.infinispan.schematic.internal.marshall.Ids;
@@ -39,6 +40,7 @@ import org.infinispan.util.Util;
  * @author Randall Hauch <rhauch@redhat.com> (C) 2011 Red Hat Inc.
  * @since 5.1
  */
+@SerializeWith( SetValueOperation.Externalizer.class )
 public class SetValueOperation extends ArrayOperation {
 
     protected final Object value;
@@ -83,8 +85,8 @@ public class SetValueOperation extends ArrayOperation {
         return "Set at '" + parentPath + "' the value '" + value + "' (at index " + index + ")";
     }
 
-    public static class Externalizer extends AbstractExternalizer<SetValueOperation> {
-        /** The serialVersionUID */
+    @SerializeWith( Externalizer.class )
+    public static final class Externalizer extends SchematicExternalizer<SetValueOperation> {
         private static final long serialVersionUID = 1L;
 
         @Override

--- a/modeshape-schematic/src/main/java/org/infinispan/schematic/internal/document/BasicArray.java
+++ b/modeshape-schematic/src/main/java/org/infinispan/schematic/internal/document/BasicArray.java
@@ -35,6 +35,7 @@ import java.util.Properties;
 import java.util.Set;
 import java.util.UUID;
 import java.util.regex.Pattern;
+import org.infinispan.marshall.SerializeWith;
 import org.infinispan.schematic.document.Array;
 import org.infinispan.schematic.document.Binary;
 import org.infinispan.schematic.document.Bson;
@@ -63,6 +64,7 @@ import org.infinispan.schematic.internal.schema.DocumentTransformer.SystemProper
  * 
  * @author Randall Hauch <rhauch@redhat.com> (C) 2011 Red Hat Inc.
  */
+@SerializeWith( DocumentExternalizer.class )
 public class BasicArray implements MutableArray {
 
     private static final long serialVersionUID = 1L;

--- a/modeshape-schematic/src/main/java/org/infinispan/schematic/internal/document/BasicDocument.java
+++ b/modeshape-schematic/src/main/java/org/infinispan/schematic/internal/document/BasicDocument.java
@@ -29,6 +29,7 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.UUID;
 import java.util.regex.Pattern;
+import org.infinispan.marshall.SerializeWith;
 import org.infinispan.schematic.document.Array;
 import org.infinispan.schematic.document.Binary;
 import org.infinispan.schematic.document.Bson;
@@ -44,6 +45,7 @@ import org.infinispan.schematic.document.Symbol;
 import org.infinispan.schematic.internal.schema.DocumentTransformer.PropertiesTransformer;
 import org.infinispan.schematic.internal.schema.DocumentTransformer.SystemPropertiesTransformer;
 
+@SerializeWith( DocumentExternalizer.class )
 public class BasicDocument extends LinkedHashMap<String, Object> implements MutableDocument {
 
     private static final long serialVersionUID = 1L;

--- a/modeshape-schematic/src/main/java/org/infinispan/schematic/internal/document/DocumentExternalizer.java
+++ b/modeshape-schematic/src/main/java/org/infinispan/schematic/internal/document/DocumentExternalizer.java
@@ -26,14 +26,13 @@ import java.io.IOException;
 import java.io.ObjectInput;
 import java.io.ObjectOutput;
 import java.util.Set;
-import org.infinispan.marshall.AbstractExternalizer;
 import org.infinispan.schematic.document.Bson;
 import org.infinispan.schematic.document.Document;
-import org.infinispan.schematic.document.Json;
+import org.infinispan.schematic.internal.SchematicExternalizer;
 import org.infinispan.schematic.internal.marshall.Ids;
 import org.infinispan.util.Util;
 
-public class DocumentExternalizer extends AbstractExternalizer<Document> {
+public class DocumentExternalizer extends SchematicExternalizer<Document> {
     /** The serialVersionUID */
     private static final long serialVersionUID = 1L;
 
@@ -45,16 +44,18 @@ public class DocumentExternalizer extends AbstractExternalizer<Document> {
         byte[] bytes = Bson.write(doc);
         // Write the number of bytes ...
         output.writeInt(bytes.length);
-        // Write the BSON output ...
-        output.write(bytes);
+        if (bytes.length > 0) {
+            // Write the BSON output ...
+            output.write(bytes);
 
-        // Try to read the bytes back in, and if there's a failure, then write out the doc ...
-        try {
-            Bson.read(new ByteArrayInputStream(bytes));
-        } catch (RuntimeException e) {
-            // Print the original document ...
-            System.err.println("Failed to write and read BSON document: ");
-            System.err.println(Json.write(doc));
+            // // Try to read the bytes back in, and if there's a failure, then write out the doc ...
+            // try {
+            // Bson.read(new ByteArrayInputStream(bytes));
+            // } catch (RuntimeException e) {
+            // // Print the original document ...
+            // System.err.println("Failed to write and read BSON document: ");
+            // System.err.println(Json.write(doc));
+            // }
         }
     }
 

--- a/modeshape-schematic/src/main/java/org/infinispan/schematic/internal/document/Paths.java
+++ b/modeshape-schematic/src/main/java/org/infinispan/schematic/internal/document/Paths.java
@@ -30,9 +30,10 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Set;
-import org.infinispan.marshall.AbstractExternalizer;
+import org.infinispan.marshall.SerializeWith;
 import org.infinispan.schematic.document.Immutable;
 import org.infinispan.schematic.document.Path;
+import org.infinispan.schematic.internal.SchematicExternalizer;
 import org.infinispan.schematic.internal.marshall.Ids;
 import org.infinispan.util.Util;
 
@@ -124,6 +125,7 @@ public class Paths {
     }
 
     @Immutable
+    @SerializeWith( Paths.Externalizer.class )
     protected static final class EmptyPath implements Path {
         @Override
         public Iterator<String> iterator() {
@@ -209,6 +211,7 @@ public class Paths {
     }
 
     @Immutable
+    @SerializeWith( Paths.Externalizer.class )
     protected static final class SinglePath implements Path {
 
         private final String fieldName;
@@ -312,6 +315,7 @@ public class Paths {
     }
 
     @Immutable
+    @SerializeWith( Paths.Externalizer.class )
     protected static final class MultiSegmentPath implements Path {
 
         private final List<String> fieldNames;
@@ -446,8 +450,7 @@ public class Paths {
         }
     }
 
-    public static class Externalizer extends AbstractExternalizer<Path> {
-        /** The serialVersionUID */
+    public static class Externalizer extends SchematicExternalizer<Path> {
         private static final long serialVersionUID = 1L;
 
         @Override

--- a/modeshape-schematic/src/test/java/org/infinispan/schematic/AbstractSchematicDbTest.java
+++ b/modeshape-schematic/src/test/java/org/infinispan/schematic/AbstractSchematicDbTest.java
@@ -1,0 +1,67 @@
+/*
+ * ModeShape (http://www.modeshape.org)
+ * See the COPYRIGHT.txt file distributed with this work for information
+ * regarding copyright ownership.  Some portions may be licensed
+ * to Red Hat, Inc. under one or more contributor license agreements.
+ * See the AUTHORS.txt file in the distribution for a full listing of 
+ * individual contributors.
+ *
+ * ModeShape is free software. Unless otherwise indicated, all code in ModeShape
+ * is licensed to you under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ * 
+ * ModeShape is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.infinispan.schematic;
+
+import javax.transaction.TransactionManager;
+import org.infinispan.config.Configuration;
+import org.infinispan.manager.EmbeddedCacheManager;
+import org.infinispan.test.TestingUtil;
+import org.infinispan.test.fwk.TestCacheManagerFactory;
+import org.infinispan.transaction.lookup.DummyTransactionManagerLookup;
+import org.junit.After;
+import org.junit.Before;
+
+@SuppressWarnings( "deprecation" )
+public abstract class AbstractSchematicDbTest {
+
+    protected SchematicDb db;
+    protected EmbeddedCacheManager cm;
+    protected TransactionManager tm;
+
+    @Before
+    public void beforeTest() {
+        Configuration c = new Configuration();
+        c = c.fluent().transaction().transactionManagerLookup(new DummyTransactionManagerLookup()).build();
+        cm = TestCacheManagerFactory.createCacheManager(c);
+        // Now create the SchematicDb ...
+        db = Schematic.get(cm, "documents");
+        tm = TestingUtil.getTransactionManager(db.getCache());
+    }
+
+    @After
+    public void afterTest() {
+        try {
+            TestingUtil.killCacheManagers(cm);
+        } finally {
+            cm = null;
+            db = null;
+            try {
+                TestingUtil.killTransaction(tm);
+            } finally {
+                tm = null;
+            }
+        }
+    }
+
+}

--- a/modeshape-schematic/src/test/java/org/infinispan/schematic/SchematicDbTest.java
+++ b/modeshape-schematic/src/test/java/org/infinispan/schematic/SchematicDbTest.java
@@ -7,45 +7,15 @@ import static org.junit.Assert.assertThat;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Map;
-import org.infinispan.config.Configuration;
-import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.schematic.SchemaLibrary.Results;
 import org.infinispan.schematic.SchematicEntry.FieldName;
 import org.infinispan.schematic.document.Document;
 import org.infinispan.schematic.document.EditableDocument;
 import org.infinispan.schematic.document.Json;
 import org.infinispan.schematic.internal.document.BasicDocument;
-import org.infinispan.test.TestingUtil;
-import org.infinispan.test.fwk.TestCacheManagerFactory;
-import org.infinispan.transaction.lookup.DummyTransactionManagerLookup;
-import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
 
-@SuppressWarnings( "deprecation" )
-public class SchematicDbTest {
-
-    private SchematicDb db;
-    private EmbeddedCacheManager cm;
-
-    // private TransactionManager tm;
-
-    @Before
-    public void beforeTest() {
-        Configuration c = new Configuration();
-        c = c.fluent().transaction().transactionManagerLookup(new DummyTransactionManagerLookup()).build();
-        cm = TestCacheManagerFactory.createCacheManager(c);
-        // Now create the SchematicDb ...
-        db = Schematic.get(cm, "documents");
-        // tm = TestingUtil.getTransactionManager(db.getCache());
-    }
-
-    @After
-    public void afterTest() {
-        TestingUtil.killCacheManagers(cm);
-        db = null;
-        // tm = null;
-    }
+public class SchematicDbTest extends AbstractSchematicDbTest {
 
     protected static InputStream resource( String resourcePath ) {
         InputStream result = SchemaValidationTest.class.getClassLoader().getResourceAsStream(resourcePath);

--- a/modeshape-schematic/src/test/java/org/infinispan/schematic/SchematicDbWithBerkleyTest.java
+++ b/modeshape-schematic/src/test/java/org/infinispan/schematic/SchematicDbWithBerkleyTest.java
@@ -4,22 +4,17 @@ import java.io.File;
 import org.infinispan.config.Configuration;
 import org.infinispan.config.GlobalConfiguration;
 import org.infinispan.loaders.bdbje.BdbjeCacheStoreConfig;
-import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.schematic.document.Document;
 import org.infinispan.schematic.document.EditableDocument;
-import org.infinispan.test.TestingUtil;
 import org.infinispan.test.fwk.TestCacheManagerFactory;
 import org.infinispan.transaction.lookup.DummyTransactionManagerLookup;
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
 @SuppressWarnings( "deprecation" )
-public class SchematicDbWithBerkleyTest {
+public class SchematicDbWithBerkleyTest extends AbstractSchematicDbTest {
 
-    private SchematicDb db;
-    private EmbeddedCacheManager cm;
-
+    @Override
     @Before
     public void beforeTest() {
         File dbDir = new File("target/bdb");
@@ -39,14 +34,9 @@ public class SchematicDbWithBerkleyTest {
              .addCacheLoader(berkleyConfig)
              .build();
         cm = TestCacheManagerFactory.createCacheManager(global, c, true);
+        tm = cm.getCache().getAdvancedCache().getTransactionManager();
         // Now create the SchematicDb ...
         db = Schematic.get(cm, "documents");
-    }
-
-    @After
-    public void afterTest() {
-        TestingUtil.killCacheManagers(cm);
-        db = null;
     }
 
     @Test

--- a/modeshape-schematic/src/test/java/org/infinispan/schematic/internal/schema/DocumentTransformerTest.java
+++ b/modeshape-schematic/src/test/java/org/infinispan/schematic/internal/schema/DocumentTransformerTest.java
@@ -68,7 +68,7 @@ public class DocumentTransformerTest {
 
     @Test
     public void shouldTransformDocumentWithStringValueWhereIntegerExpected() throws Exception {
-        print = true;
+        // print = true;
         Document doc = doc("{ 'name' : 'Acme Bottle Opener', 'id' : '123' , 'price' : 2.99, 'tags' : [ 'easy', 'under-10-dollars' ] }");
         transform(doc, PARTS_SCHEMA_URI, 1);
     }


### PR DESCRIPTION
The Infinispan Schematic Externalizers were changed from implementing AdvancedExternalizer (which has some benefits but also issues in AS7.1) to Externalizer (which works in all environments but isn't as efficient as AdvancedExternalizer).

One important fix: several of the externalized classes did not have a SerializeWith annotation.
