### PR TITLE
MODE-1536 Corrected use of System.nanoTime() for all platforms

### DIFF
--- a/modeshape-jcr-api/src/main/java/org/modeshape/jcr/api/JcrTools.java
+++ b/modeshape-jcr-api/src/main/java/org/modeshape/jcr/api/JcrTools.java
@@ -855,7 +855,7 @@ public class JcrTools {
         } finally {
             session.logout();
         }
-        return TimeUnit.MILLISECONDS.convert(System.nanoTime() - startTime, TimeUnit.NANOSECONDS);
+        return TimeUnit.MILLISECONDS.convert(Math.abs(System.nanoTime() - startTime), TimeUnit.NANOSECONDS);
     }
 
     public static interface Operation {

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrSession.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrSession.java
@@ -1246,7 +1246,7 @@ public class JcrSession implements Session {
         cleanLocks();
         try {
             RunningState running = repository.runningState();
-            long lifetime = System.nanoTime() - this.nanosCreated;
+            long lifetime = Math.abs(System.nanoTime() - this.nanosCreated);
             Map<String, String> payload = Collections.singletonMap("userId", getUserID());
             running.statistics().recordDuration(DurationMetric.SESSION_LIFETIME, lifetime, TimeUnit.NANOSECONDS, payload);
             running.statistics().decrement(ValueMetric.SESSION_COUNT);

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/RepositoryNodeTypeManager.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/RepositoryNodeTypeManager.java
@@ -54,8 +54,8 @@ import org.modeshape.common.annotation.ThreadSafe;
 import org.modeshape.common.collection.HashMultimap;
 import org.modeshape.common.collection.Multimap;
 import org.modeshape.common.i18n.I18n;
-import org.modeshape.common.util.CheckArg;
 import org.modeshape.common.logging.Logger;
+import org.modeshape.common.util.CheckArg;
 import org.modeshape.jcr.api.query.qom.QueryCommand;
 import org.modeshape.jcr.cache.NodeCache;
 import org.modeshape.jcr.cache.NodeKey;
@@ -204,7 +204,7 @@ class RepositoryNodeTypeManager implements ChangeSetListener {
                     throw new InvalidNodeTypeDefinitionException(JcrI18n.cannotUnregisterInUseType.text(name));
                 }
             }
-            long time = TimeUnit.MILLISECONDS.convert(System.nanoTime() - start, TimeUnit.NANOSECONDS);
+            long time = TimeUnit.MILLISECONDS.convert(Math.abs(System.nanoTime() - start), TimeUnit.NANOSECONDS);
             logger.debug("{0} milliseconds to check if any of these node types are unused before unregistering them: {1}",
                          time,
                          nodeTypeNames);

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/SequencingRunner.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/SequencingRunner.java
@@ -203,7 +203,7 @@ final class SequencingRunner implements Runnable {
                         // fire the sequencing event after save (hopefully by this time the transaction has been committed)
                         fireSequencingEvent(selectedNode, outputNodes, outputSession, sequencerName);
 
-                        long durationInNanos = System.nanoTime() - start;
+                        long durationInNanos = Math.abs(System.nanoTime() - start);
                         Map<String, String> payload = new HashMap<String, String>();
                         payload.put("sequencerName", sequencer.getClass().getName());
                         payload.put("sequencedPath", changedProperty.getPath());

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/query/process/QueryEngine.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/query/process/QueryEngine.java
@@ -102,7 +102,7 @@ public class QueryEngine {
         // Create the canonical plan ...
         long start = System.nanoTime();
         PlanNode plan = planner.createPlan(context, query);
-        long duration = System.nanoTime() - start;
+        long duration = Math.abs(System.nanoTime() - start);
         Statistics stats = new Statistics(duration);
 
         QueryResultColumns resultColumns = QueryResultColumns.empty();
@@ -110,13 +110,13 @@ public class QueryEngine {
             // Optimize the plan ...
             start = System.nanoTime();
             PlanNode optimizedPlan = optimizer.optimize(context, plan);
-            duration = System.nanoTime() - start;
+            duration = Math.abs(System.nanoTime() - start);
             stats = stats.withOptimizationTime(duration);
 
             // Find the query result columns ...
             start = System.nanoTime();
             resultColumns = determineQueryResultColumns(optimizedPlan, context.getHints());
-            duration = System.nanoTime() - start;
+            duration = Math.abs(System.nanoTime() - start);
             stats = stats.withResultsFormulationTime(duration);
 
             if (!context.getProblems().hasErrors()) {
@@ -125,7 +125,7 @@ public class QueryEngine {
                     start = System.nanoTime();
                     return processor.execute(context, query, stats, optimizedPlan);
                 } finally {
-                    duration = System.nanoTime() - start;
+                    duration = Math.abs(System.nanoTime() - start);
                     stats = stats.withExecutionTime(duration);
                 }
             }

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/query/process/QueryProcessor.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/query/process/QueryProcessor.java
@@ -105,7 +105,7 @@ public abstract class QueryProcessor<ProcessingContextType> implements Processor
             }
 
         } finally {
-            statistics = statistics.withExecutionTime(System.nanoTime() - nanos);
+            statistics = statistics.withExecutionTime(Math.abs(System.nanoTime() - nanos));
         }
         assert tuples != null;
         final String planDesc = context.getHints().showPlan ? plan.getString() : null;

--- a/modeshape-jcr/src/test/java/org/modeshape/jcr/ClientLoad.java
+++ b/modeshape-jcr/src/test/java/org/modeshape/jcr/ClientLoad.java
@@ -77,7 +77,7 @@ public class ClientLoad {
 
                             long start = System.nanoTime();
                             result = callable.call();
-                            durationInNanos = System.nanoTime() - start;
+                            durationInNanos = Math.abs(System.nanoTime() - start);
                             latch.countDown();
                         } catch (Exception e) {
                             error = e;

--- a/modeshape-jcr/src/test/java/org/modeshape/jcr/JcrSessionTest.java
+++ b/modeshape-jcr/src/test/java/org/modeshape/jcr/JcrSessionTest.java
@@ -23,7 +23,6 @@
  */
 package org.modeshape.jcr;
 
-import javax.jcr.ReferentialIntegrityException;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsInstanceOf.instanceOf;
 import static org.hamcrest.core.IsNot.not;
@@ -50,6 +49,7 @@ import javax.jcr.NodeIterator;
 import javax.jcr.PathNotFoundException;
 import javax.jcr.Property;
 import javax.jcr.PropertyType;
+import javax.jcr.ReferentialIntegrityException;
 import javax.jcr.Repository;
 import javax.jcr.RepositoryException;
 import javax.jcr.UnsupportedRepositoryOperationException;
@@ -104,14 +104,14 @@ public class JcrSessionTest extends SingleUseAbstractTest {
         for (int i = 0; i != count; ++i) {
             node.addNode("childNode");
         }
-        long millis = TimeUnit.MILLISECONDS.convert(System.nanoTime() - start1, TimeUnit.NANOSECONDS);
+        long millis = TimeUnit.MILLISECONDS.convert(Math.abs(System.nanoTime() - start1), TimeUnit.NANOSECONDS);
         System.out.println("Time to create " + count + " nodes under root: " + millis + " ms");
 
         long start2 = System.nanoTime();
         session.save();
-        millis = TimeUnit.MILLISECONDS.convert(System.nanoTime() - start2, TimeUnit.NANOSECONDS);
+        millis = TimeUnit.MILLISECONDS.convert(Math.abs(System.nanoTime() - start2), TimeUnit.NANOSECONDS);
         System.out.println("Time to save " + count + " new nodes: " + millis + " ms");
-        millis = TimeUnit.MILLISECONDS.convert(System.nanoTime() - start1, TimeUnit.NANOSECONDS);
+        millis = TimeUnit.MILLISECONDS.convert(Math.abs(System.nanoTime() - start1), TimeUnit.NANOSECONDS);
         System.out.println("Total time to create " + count + " new nodes and save: " + millis + " ms");
 
         NodeIterator iter = node.getNodes("childNode");
@@ -125,7 +125,7 @@ public class JcrSessionTest extends SingleUseAbstractTest {
         start1 = System.nanoTime();
         node.addNode("oneMore");
         session.save();
-        millis = TimeUnit.MILLISECONDS.convert(System.nanoTime() - start1, TimeUnit.NANOSECONDS);
+        millis = TimeUnit.MILLISECONDS.convert(Math.abs(System.nanoTime() - start1), TimeUnit.NANOSECONDS);
         System.out.println("Time to create " + (count + 1) + "th node and save: " + millis + " ms");
     }
 
@@ -658,22 +658,22 @@ public class JcrSessionTest extends SingleUseAbstractTest {
 
         session.save();
 
-        //there are 2 strong refs
+        // there are 2 strong refs
         referenceableNode.remove();
         expectReferentialIntegrityException();
 
-        //remove the first strong ref
-        node1.setProperty("ref1", (Node) null);
+        // remove the first strong ref
+        node1.setProperty("ref1", (Node)null);
         referenceableNode.remove();
         expectReferentialIntegrityException();
 
-        //remove the second strong ref (we should be able to remove the node now)
+        // remove the second strong ref (we should be able to remove the node now)
         assertEquals(2, referenceableNode.getWeakReferences().getSize());
-        node1.setProperty("ref2", (Node) null);
+        node1.setProperty("ref2", (Node)null);
         referenceableNode.remove();
         session.save();
 
-        //check the node was actually deleted
+        // check the node was actually deleted
         assertFalse(session.getRootNode().hasNode("referenceable"));
     }
 
@@ -682,7 +682,7 @@ public class JcrSessionTest extends SingleUseAbstractTest {
             session.save();
             fail("Expected a referential integrity exception");
         } catch (ReferentialIntegrityException e) {
-            //expected
+            // expected
             session.refresh(false);
         }
     }

--- a/modeshape-jcr/src/test/java/org/modeshape/jcr/ModeShapeEngineTest.java
+++ b/modeshape-jcr/src/test/java/org/modeshape/jcr/ModeShapeEngineTest.java
@@ -213,7 +213,8 @@ public class ModeShapeEngineTest extends AbstractTransactionalTest {
         long start = System.nanoTime();
         Session session = repository.login();
         if (print) System.out.println("Initial session: "
-                                      + TimeUnit.MILLISECONDS.convert(System.nanoTime() - start, TimeUnit.NANOSECONDS) + " ms");
+                                      + TimeUnit.MILLISECONDS.convert(Math.abs(System.nanoTime() - start), TimeUnit.NANOSECONDS)
+                                      + " ms");
         session.logout();
 
         // Now create bunch of sessions simultaneously ...
@@ -228,7 +229,8 @@ public class ModeShapeEngineTest extends AbstractTransactionalTest {
         start = System.nanoTime();
         session = repository.login();
         if (print) System.out.println("Before close: "
-                                      + TimeUnit.MILLISECONDS.convert(System.nanoTime() - start, TimeUnit.NANOSECONDS) + " ms");
+                                      + TimeUnit.MILLISECONDS.convert(Math.abs(System.nanoTime() - start), TimeUnit.NANOSECONDS)
+                                      + " ms");
         session.logout();
 
         ClientLoad.forEachResult(results, new ClientResultProcessor<Session>() {
@@ -245,7 +247,8 @@ public class ModeShapeEngineTest extends AbstractTransactionalTest {
         start = System.nanoTime();
         session = repository.login();
         if (print) System.out.println("After close: "
-                                      + TimeUnit.MILLISECONDS.convert(System.nanoTime() - start, TimeUnit.NANOSECONDS) + " ms");
+                                      + TimeUnit.MILLISECONDS.convert(Math.abs(System.nanoTime() - start), TimeUnit.NANOSECONDS)
+                                      + " ms");
         session.logout();
 
         // Make sure the repository is running ...

--- a/modeshape-jcr/src/test/java/org/modeshape/jcr/cache/document/AbstractNodeCacheTest.java
+++ b/modeshape-jcr/src/test/java/org/modeshape/jcr/cache/document/AbstractNodeCacheTest.java
@@ -524,7 +524,7 @@ public abstract class AbstractNodeCacheTest extends AbstractSchematicDbTest {
 
         long nanos = System.nanoTime();
         CachedNode system = cache.getNode(systemRef);
-        print("Time (load): " + millis(System.nanoTime() - nanos) + " ms");
+        print("Time (load): " + millis(Math.abs(System.nanoTime() - nanos)) + " ms");
 
         for (int i = 0; i != 10; ++i) {
             cache.clear();
@@ -534,7 +534,7 @@ public abstract class AbstractNodeCacheTest extends AbstractSchematicDbTest {
             system.getName(cache);
             system.getProperty(JcrLexicon.UUID, cache);
             system.getProperty(JcrLexicon.PRIMARY_TYPE, cache);
-            print("Time (read): " + millis(System.nanoTime() - nanos) + " ms");
+            print("Time (read): " + millis(Math.abs(System.nanoTime() - nanos)) + " ms");
         }
 
         nanos = System.nanoTime();
@@ -543,7 +543,7 @@ public abstract class AbstractNodeCacheTest extends AbstractSchematicDbTest {
         system.getName(cache);
         system.getProperty(JcrLexicon.UUID, cache);
         system.getProperty(JcrLexicon.PRIMARY_TYPE, cache);
-        print("Time (read): " + millis(System.nanoTime() - nanos) + " ms");
+        print("Time (read): " + millis(Math.abs(System.nanoTime() - nanos)) + " ms");
 
         assertThat(system, is(notNullValue()));
         assertThat(system.getKey(), is(systemRef.getKey()));
@@ -568,11 +568,11 @@ public abstract class AbstractNodeCacheTest extends AbstractSchematicDbTest {
 
         nanos = System.nanoTime();
         CachedNode namespacesNode = cache.getNode(namespaces);
-        print("Time (load): " + millis(System.nanoTime() - nanos) + " ms");
+        print("Time (load): " + millis(Math.abs(System.nanoTime() - nanos)) + " ms");
         nanos = System.nanoTime();
         assertThat(namespacesNode.getPath(cache), is(path("/jcr:system/mode:namespaces")));
         assertThat(namespacesNode.getChildReferences(cache).isEmpty(), is(true));
-        print("Time (read): " + millis(System.nanoTime() - nanos) + " ms");
+        print("Time (read): " + millis(Math.abs(System.nanoTime() - nanos)) + " ms");
     }
 
     @Test

--- a/modeshape-jcr/src/test/java/org/modeshape/jcr/cache/document/WritableSessionCacheTest.java
+++ b/modeshape-jcr/src/test/java/org/modeshape/jcr/cache/document/WritableSessionCacheTest.java
@@ -26,6 +26,9 @@ package org.modeshape.jcr.cache.document;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.modeshape.common.statistic.Stopwatch;
@@ -34,9 +37,6 @@ import org.modeshape.jcr.cache.CachedNode;
 import org.modeshape.jcr.cache.MutableCachedNode;
 import org.modeshape.jcr.cache.NodeKey;
 import org.modeshape.jcr.cache.SessionCache;
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.Set;
 
 /**
  * Tests that operate against a {@link WritableSessionCache}. Each test method starts with a clean slate of content, which is
@@ -83,7 +83,7 @@ public class WritableSessionCacheTest extends AbstractSessionCacheTest {
                                                        name("newChild"),
                                                        property("p1a", 344),
                                                        property("p2", false));
-        print("Time (createChild): " + millis(System.nanoTime() - nanos) + " ms");
+        print("Time (createChild): " + millis(Math.abs(System.nanoTime() - nanos)) + " ms");
         assertThat(newChild.getPath(session1), is(path("/childB/newChild")));
         check(session1).children(nodeB, "childC", "childD", "newChild");
         check(session1).property("/childB/newChild", property("p1a", 344));
@@ -96,7 +96,7 @@ public class WritableSessionCacheTest extends AbstractSessionCacheTest {
         nanos = System.nanoTime();
         session1.save();
         print(false);
-        print("Time (save): " + millis(System.nanoTime() - nanos) + " ms");
+        print("Time (save): " + millis(Math.abs(System.nanoTime() - nanos)) + " ms");
 
         // Both sessions should see all 3 children ...
         check(session1).children(nodeB, "childC", "childD", "newChild");
@@ -366,15 +366,17 @@ public class WritableSessionCacheTest extends AbstractSessionCacheTest {
     public void shouldReturnTransientKeysAtOrBelowNode() {
         NodeKey rootKey = session1.getRootKey();
         MutableCachedNode root = session1.mutable(rootKey);
-        //root/childA
+        // root/childA
         MutableCachedNode childA = root.createChild(session(), newKey("x-childA"), name("childA"), property("p1", "value A"));
-        //root/childA/childB
+        // root/childA/childB
         MutableCachedNode childB = childA.createChild(session(), newKey("x-childB"), name("childB"), property("p1", "value B"));
-        //root/childC
+        // root/childC
         MutableCachedNode childC = root.createChild(session(), newKey("x-childC"), name("childC"), property("p1", "value C"));
 
-        assertEquals(new HashSet<NodeKey>(Arrays.asList(childA.getKey(), childB.getKey())), session1.getChangedNodeKeysAtOrBelow(childA));
-        assertEquals(new HashSet<NodeKey>(Arrays.asList(rootKey, childA.getKey(), childB.getKey(), childC.getKey())), session1.getChangedNodeKeysAtOrBelow(root));
+        assertEquals(new HashSet<NodeKey>(Arrays.asList(childA.getKey(), childB.getKey())),
+                     session1.getChangedNodeKeysAtOrBelow(childA));
+        assertEquals(new HashSet<NodeKey>(Arrays.asList(rootKey, childA.getKey(), childB.getKey(), childC.getKey())),
+                     session1.getChangedNodeKeysAtOrBelow(root));
         assertEquals(new HashSet<NodeKey>(Arrays.asList(childC.getKey())), session1.getChangedNodeKeysAtOrBelow(childC));
     }
 


### PR DESCRIPTION
Different platforms implement System.nanoTime() differently, and it's possible that computing the difference between two subsequent calls to the method will be a negative number. Therefore, changed all the places where we're using it to use the absolute value of the difference. On most platforms, this won't result in any change, but on some Windows platforms this fix should prevent computing negative durations.

All unit and integration tests pass.

(See [this StackOverflow discussion](http://stackoverflow.com/questions/510462/is-system-nanotime-completely-useless) for more information.)
