### PR TITLE
MODE-1458 Implemented Shareable Nodes

### DIFF
--- a/integration/modeshape-jbossas-integration-tests/src/main/java/org/modeshape/test/integration/StatelessBeanManagedTransactionBean.java
+++ b/integration/modeshape-jbossas-integration-tests/src/main/java/org/modeshape/test/integration/StatelessBeanManagedTransactionBean.java
@@ -42,9 +42,6 @@ import org.modeshape.jcr.api.JcrTools;
 /**
  * A stateless EJB that accesses a Repository using multiple bean-managed transactions (BMT) and creates a JCR Session a variety
  * of ways.
- * <p>
- * This class extends the {@link RepositoryProvider}, which has all the methods for obtaining repositories and using the sessions.
- * </p>
  */
 @Stateless
 @TransactionManagement( TransactionManagementType.BEAN )

--- a/modeshape-jcr-api/src/main/java/org/modeshape/jcr/api/text/TextExtractor.java
+++ b/modeshape-jcr-api/src/main/java/org/modeshape/jcr/api/text/TextExtractor.java
@@ -23,11 +23,9 @@
  */
 package org.modeshape.jcr.api.text;
 
-import javax.jcr.RepositoryException;
+import java.io.InputStream;
 import org.modeshape.jcr.api.Binary;
 import org.modeshape.jcr.api.Logger;
-import java.io.IOException;
-import java.io.InputStream;
 
 /**
  * An abstraction for components that are able to extract text content from an input stream.
@@ -51,7 +49,7 @@ public abstract class TextExtractor {
 
     /**
      * Extract text from the given {@link Binary}, using the given output to record the results.
-     *
+     * 
      * @param binary the binary value that can be used in the extraction process; never <code>null</code>
      * @param output the output from the sequencing operation; never <code>null</code>
      * @param context the context for the sequencing operation; never <code>null</code>
@@ -64,13 +62,15 @@ public abstract class TextExtractor {
     /**
      * Allows subclasses to process the stream of binary value property in "safe" fashion, making sure the stream is closed at the
      * end of the operation.
+     * 
      * @param binary a {@link org.modeshape.jcr.api.Binary} who is expected to contain a non-null binary value.
      * @param operation a {@link org.modeshape.jcr.api.text.TextExtractor.BinaryOperation} which should work with the stream
+     * @param <T> the return type of the binary operation
      * @return whatever type of result the stream operation returns
-     * @throws RepositoryException
-     * @throws IOException
+     * @throws Exception if there is an error processing the stream
      */
-    protected final <T> T processStream(Binary binary, BinaryOperation<T> operation) throws Exception {
+    protected final <T> T processStream( Binary binary,
+                                         BinaryOperation<T> operation ) throws Exception {
         InputStream stream = binary.getStream();
         if (stream == null) {
             throw new IllegalArgumentException("The binary value is empty");
@@ -78,14 +78,13 @@ public abstract class TextExtractor {
 
         try {
             return operation.execute(stream);
-        }
-        finally {
+        } finally {
             stream.close();
         }
     }
 
-    public final void setLogger(Logger logger) {
-        if (logger ==  null) {
+    public final void setLogger( Logger logger ) {
+        if (logger == null) {
             throw new IllegalArgumentException("Logger cannot be null");
         }
         this.logger = logger;
@@ -105,9 +104,11 @@ public abstract class TextExtractor {
 
     /**
      * Interface which can be used by subclasses to process the input stream of a binary property.
+     * 
+     * @param <T> the return type of the binary operation
      */
     protected interface BinaryOperation<T> {
-        T execute(InputStream stream) throws Exception;
+        T execute( InputStream stream ) throws Exception;
     }
 
     /**
@@ -124,7 +125,7 @@ public abstract class TextExtractor {
 
         /**
          * Record the text as being extracted. This method can be called multiple times during a single extract.
-         *
+         * 
          * @param text the text extracted from the content.
          */
         void recordText( String text );

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrDocumentViewExporter.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrDocumentViewExporter.java
@@ -94,10 +94,10 @@ class JcrDocumentViewExporter extends AbstractJcrExporter {
                             boolean noRecurse ) throws RepositoryException, SAXException {
         ExecutionContext executionContext = session.context();
 
-        if (node instanceof JcrSharedNode) {
+        JcrSharedNode sharedNode = asSharedNode(node);
+        if (sharedNode != null) {
             // This is a shared node, and per Section 14.7 of the JCR 2.0 specification, they have to be written out
             // in a special way ...
-            AbstractJcrNode sharedNode = ((JcrSharedNode)node).proxyNode();
             AttributesImpl atts = new AttributesImpl();
 
             // jcr:primaryType = nt:share ...
@@ -112,6 +112,7 @@ class JcrDocumentViewExporter extends AbstractJcrExporter {
             endElement(contentHandler, name);
             return;
         }
+        exporting(node);
 
         // If this node is a special xmltext node, output it as raw content (see JCR 1.0 spec - section 6.4.2.3)
         if (node.getDepth() > 0 && isXmlTextNode(node)) {

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrI18n.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrI18n.java
@@ -158,6 +158,9 @@ public final class JcrI18n {
     public static I18n unableToModifySystemNodes;
     public static I18n unableToMoveNodeToBeChildOfDecendent;
     public static I18n nodeHasAlreadyBeenRemovedFromThisSession;
+    public static I18n unableToShareNodeWithinSubgraph;
+    public static I18n unableToShareNodeWithinSameParent;
+    public static I18n unableToMoveNodeDueToCycle;
 
     public static I18n typeNotFound;
     public static I18n supertypeNotFound;
@@ -273,6 +276,7 @@ public final class JcrI18n {
     public static I18n primaryTypeCannotBeAbstract;
     public static I18n setPrimaryTypeOnRootNodeIsNotSupported;
     public static I18n suppliedNodeTypeIsNotMixinType;
+    public static I18n cannotRemoveShareableMixinThatIsShared;
 
     public static I18n errorReadingNodeTypesFromRemote;
     public static I18n problemReadingNodeTypesFromRemote;

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrNodeListIterator.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrNodeListIterator.java
@@ -35,11 +35,11 @@ import org.modeshape.common.util.CheckArg;
 class JcrNodeListIterator implements NodeIterator {
 
     private final long size;
-    private final Iterator<AbstractJcrNode> nodes;
+    private final Iterator<? extends Node> nodes;
     private Node nextNode;
     private long position = 0L;
 
-    protected JcrNodeListIterator( Iterator<AbstractJcrNode> nodeIter,
+    protected JcrNodeListIterator( Iterator<? extends Node> nodeIter,
                                    long size ) {
         this.nodes = nodeIter;
         this.size = size;

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrNodeType.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrNodeType.java
@@ -281,11 +281,15 @@ class JcrNodeType implements NodeType {
         Name childPrimaryTypeName = context.getValueFactories().getNameFactory().create(primaryNodeTypeName);
 
         NodeTypes nodeTypes = nodeTypes();
-        JcrNodeDefinition childNodeDefinition = nodeTypes.findChildNodeDefinition(this.name, null, childName,
-                                                                                  childPrimaryTypeName, 0, true);
+        JcrNodeDefinition childNodeDefinition = nodeTypes.findChildNodeDefinition(this.name,
+                                                                                  null,
+                                                                                  childName,
+                                                                                  childPrimaryTypeName,
+                                                                                  0,
+                                                                                  true);
 
         if (childNodeDefinition != null && RESIDUAL_ITEM_NAME.equals(childNodeDefinition.getName())) {
-            //the TCK expects that for residual children definitions, this returns true
+            // the TCK expects that for residual children definitions, this returns true
             return true;
         }
 
@@ -586,23 +590,25 @@ class JcrNodeType implements NodeType {
      * @param nodeTypeManager the new repository node type manager
      * @return a new {@link JcrNodeType} that has the same state as this node type, but with the given node type manager.
      */
-    final JcrNodeType with( RepositoryNodeTypeManager nodeTypeManager) {
-        return new JcrNodeType(this.key, this.context, this.session, nodeTypeManager, this.name, this.declaredSupertypes, this.primaryItemName,
-                               this.childNodeDefinitions, this.propertyDefinitions, this.mixin, this.isAbstract, this.queryable,
-                               this.orderableChildNodes);
+    final JcrNodeType with( RepositoryNodeTypeManager nodeTypeManager ) {
+        return new JcrNodeType(this.key, this.context, this.session, nodeTypeManager, this.name, this.declaredSupertypes,
+                               this.primaryItemName, this.childNodeDefinitions, this.propertyDefinitions, this.mixin,
+                               this.isAbstract, this.queryable, this.orderableChildNodes);
     }
 
     /**
      * Returns a {@link JcrNodeType} that is equivalent to this {@link JcrNodeType}, except with a different execution context.
      * 
      * @param context the new execution context
-     * @param session an active user session, in the context of which the node type is created. May be null, during system initialization.
+     * @param session an active user session, in the context of which the node type is created. May be null, during system
+     *        initialization.
      * @return a new {@link JcrNodeType} that has the same state as this node type, but with the given node type manager.
      */
-    final JcrNodeType with( ExecutionContext context, JcrSession session) {
-        return new JcrNodeType(this.key, context, session, this.nodeTypeManager, this.name, this.declaredSupertypes, this.primaryItemName,
-                               this.childNodeDefinitions, this.propertyDefinitions, this.mixin, this.isAbstract, this.queryable,
-                               this.orderableChildNodes);
+    final JcrNodeType with( ExecutionContext context,
+                            JcrSession session ) {
+        return new JcrNodeType(this.key, context, session, this.nodeTypeManager, this.name, this.declaredSupertypes,
+                               this.primaryItemName, this.childNodeDefinitions, this.propertyDefinitions, this.mixin,
+                               this.isAbstract, this.queryable, this.orderableChildNodes);
     }
 
     final NodeTypes nodeTypes() {

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrRepository.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrRepository.java
@@ -23,6 +23,36 @@
  */
 package org.modeshape.jcr;
 
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.security.AccessControlContext;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+import java.util.WeakHashMap;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CopyOnWriteArraySet;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
 import javax.jcr.AccessDeniedException;
 import javax.jcr.Credentials;
 import javax.jcr.LoginException;
@@ -111,36 +141,6 @@ import org.modeshape.jcr.value.binary.AbstractBinaryStore;
 import org.modeshape.jcr.value.binary.BinaryStore;
 import org.modeshape.jcr.value.binary.InfinispanBinaryStore;
 import org.modeshape.jcr.value.binary.UnusedBinaryChangeSetListener;
-import java.io.FileNotFoundException;
-import java.io.IOException;
-import java.security.AccessControlContext;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Properties;
-import java.util.Set;
-import java.util.WeakHashMap;
-import java.util.concurrent.Callable;
-import java.util.concurrent.CopyOnWriteArraySet;
-import java.util.concurrent.Executor;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.ScheduledThreadPoolExecutor;
-import java.util.concurrent.ThreadFactory;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicReference;
-import java.util.concurrent.locks.Lock;
-import java.util.concurrent.locks.ReadWriteLock;
-import java.util.concurrent.locks.ReentrantLock;
-import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 /**
  * 
@@ -746,14 +746,12 @@ public class JcrRepository implements org.modeshape.jcr.api.Repository {
         descriptors.put(Repository.OPTION_LOCKING_SUPPORTED, valueFor(factories, true));
         descriptors.put(Repository.OPTION_OBSERVATION_SUPPORTED, valueFor(factories, true));
         descriptors.put(Repository.OPTION_QUERY_SQL_SUPPORTED, valueFor(factories, true));
-        // TODO: Transactions
-        descriptors.put(Repository.OPTION_TRANSACTIONS_SUPPORTED, valueFor(factories, false));
+        descriptors.put(Repository.OPTION_TRANSACTIONS_SUPPORTED, valueFor(factories, true));
         descriptors.put(Repository.OPTION_VERSIONING_SUPPORTED, valueFor(factories, true));
         descriptors.put(Repository.QUERY_XPATH_DOC_ORDER, valueFor(factories, false)); // see MODE-613
         descriptors.put(Repository.QUERY_XPATH_POS_INDEX, valueFor(factories, true));
 
         descriptors.put(Repository.WRITE_SUPPORTED, valueFor(factories, true));
-        // TODO: Change in 3.0
         descriptors.put(Repository.IDENTIFIER_STABILITY, valueFor(factories, Repository.IDENTIFIER_STABILITY_INDEFINITE_DURATION));
         descriptors.put(Repository.OPTION_XML_IMPORT_SUPPORTED, valueFor(factories, true));
         descriptors.put(Repository.OPTION_XML_EXPORT_SUPPORTED, valueFor(factories, true));
@@ -766,7 +764,6 @@ public class JcrRepository implements org.modeshape.jcr.api.Repository {
         descriptors.put(Repository.OPTION_RETENTION_SUPPORTED, valueFor(factories, false));
         descriptors.put(Repository.OPTION_LIFECYCLE_SUPPORTED, valueFor(factories, false));
         descriptors.put(Repository.OPTION_NODE_AND_PROPERTY_WITH_SAME_NAME_SUPPORTED, valueFor(factories, true));
-        // TODO: Change in 3.0
         descriptors.put(Repository.OPTION_UPDATE_PRIMARY_NODE_TYPE_SUPPORTED, valueFor(factories, true));
         descriptors.put(Repository.OPTION_UPDATE_MIXIN_NODE_TYPES_SUPPORTED, valueFor(factories, true));
         descriptors.put(Repository.OPTION_SHAREABLE_NODES_SUPPORTED, valueFor(factories, true));
@@ -783,7 +780,6 @@ public class JcrRepository implements org.modeshape.jcr.api.Repository {
         descriptors.put(Repository.NODE_TYPE_MANAGEMENT_MULTIVALUED_PROPERTIES_SUPPORTED, valueFor(factories, true));
         descriptors.put(Repository.NODE_TYPE_MANAGEMENT_MULTIPLE_BINARY_PROPERTIES_SUPPORTED, valueFor(factories, true));
         descriptors.put(Repository.NODE_TYPE_MANAGEMENT_VALUE_CONSTRAINTS_SUPPORTED, valueFor(factories, true));
-        // TODO: Change in 3.0
         descriptors.put(Repository.NODE_TYPE_MANAGEMENT_UPDATE_IN_USE_SUPORTED, valueFor(factories, true));
         descriptors.put(Repository.QUERY_LANGUAGES,
                         new JcrValue[] {valueFor(factories, Query.XPATH), valueFor(factories, Query.JCR_SQL2),

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrSharedNode.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrSharedNode.java
@@ -23,7 +23,23 @@
  */
 package org.modeshape.jcr;
 
-import org.modeshape.common.annotation.NotThreadSafe;
+import javax.jcr.AccessDeniedException;
+import javax.jcr.InvalidItemStateException;
+import javax.jcr.ItemNotFoundException;
+import javax.jcr.RepositoryException;
+import javax.jcr.lock.LockException;
+import javax.jcr.nodetype.ConstraintViolationException;
+import javax.jcr.version.VersionException;
+import org.modeshape.common.annotation.ThreadSafe;
+import org.modeshape.jcr.JcrSharedNodeCache.SharedSet;
+import org.modeshape.jcr.cache.CachedNode;
+import org.modeshape.jcr.cache.ChildReference;
+import org.modeshape.jcr.cache.MutableCachedNode;
+import org.modeshape.jcr.cache.NodeKey;
+import org.modeshape.jcr.cache.SessionCache;
+import org.modeshape.jcr.value.Name;
+import org.modeshape.jcr.value.Path;
+import org.modeshape.jcr.value.Path.Segment;
 
 /**
  * A concrete {@link javax.jcr.Node JCR Node} implementation that is used for all nodes that are part of a shared set but not the
@@ -39,210 +55,80 @@ import org.modeshape.common.annotation.NotThreadSafe;
  * @see JcrRootNode
  * @see JcrNode
  */
-@NotThreadSafe
-class JcrSharedNode extends JcrNode {
+@ThreadSafe
+final class JcrSharedNode extends JcrNode {
 
-    /** The UUID of the "mode:share" proxy node, hidden from the user. */
-    private AbstractJcrNode original;
-    private AbstractJcrNode proxy;
+    private final NodeKey parentKey;
+    private final SharedSet sharedSet;
 
-    JcrSharedNode( AbstractJcrNode proxy,
-                   AbstractJcrNode original ) {
-        // Set the super's nodeId and location to be that of the original, not the proxy. We'll override
-        // all the methods that need the proxy information ....
-        super(proxy.session, original.key());
-        this.proxy = proxy;
-        this.original = original;
-        assert proxy.session == original.session : "Only able to share nodes within the same session";
-        assert !proxy.isRoot() : "The root node can never be a shared node";
-        assert !original.isRoot() : "The root node can never be shareable";
+    protected JcrSharedNode( SharedSet sharedSet,
+                             NodeKey parentKey ) {
+        super(sharedSet.session(), sharedSet.key());
+        this.parentKey = parentKey;
+        this.sharedSet = sharedSet;
+        assert this.parentKey != null;
+        assert this.sharedSet != null;
     }
 
-    /**
-     * Get the node that represents the proxy, and is a true representation of the underlying node with a primary type of
-     * {@link ModeShapeLexicon#SHARE mode:share} and lone {@link ModeShapeLexicon#SHARED_UUID mode:sharedUuid} property.
-     * 
-     * @return the proxy node
-     */
-    AbstractJcrNode proxyNode() {
-        return proxy;
-    }
-
-    /**
-     * Get the node that represents the original node that is being shared by this proxy.
-     * 
-     * @return the original node
-     */
-    AbstractJcrNode originalNode() {
-        return original;
-    }
-
-    /**
-     * {@inheritDoc}
-     * 
-     * @see org.modeshape.jcr.AbstractJcrNode#isShareable()
-     */
-    @Override
-    boolean isShareable() {
-        return original != null;
-    }
-
-    /**
-     * {@inheritDoc}
-     * 
-     * @see org.modeshape.jcr.AbstractJcrNode#isShared()
-     */
     @Override
     boolean isShared() {
         return true;
     }
-    //
-    // @Override
-    // protected void doDestroy() throws AccessDeniedException, RepositoryException {
-    // proxyNode().editor().destroy();
-    // }
-    //
-    // @Override
-    // Node<JcrNodePayload, JcrPropertyPayload> nodeInfo()
-    // throws InvalidItemStateException, AccessDeniedException, RepositoryException {
-    // return original.nodeInfo();
-    // }
-    //
-    // Node<JcrNodePayload, JcrPropertyPayload> proxyInfo()
-    // throws InvalidItemStateException, AccessDeniedException, RepositoryException {
-    // return proxy.nodeInfo();
-    // }
-    //
-    // /**
-    // * {@inheritDoc}
-    // * <p>
-    // * The parent of this shared node is the parent of the proxy, not of the original shareable node.
-    // * </p>
-    // *
-    // * @see org.modeshape.jcr.AbstractJcrNode#parentNodeInfo()
-    // */
-    // @Override
-    // Node<JcrNodePayload, JcrPropertyPayload> parentNodeInfo()
-    // throws InvalidItemStateException, AccessDeniedException, RepositoryException {
-    // return proxyInfo().getParent();
-    // }
-    //
-    // /**
-    // * {@inheritDoc}
-    // * <p>
-    // * The path of this shared node is the path of the proxy, not of the original shareable node.
-    // * </p>
-    // *
-    // * @see org.modeshape.jcr.AbstractJcrNode#path()
-    // */
-    // @Override
-    // Path path() throws RepositoryException {
-    // return proxyInfo().getPath();
-    // }
-    //
-    // /**
-    // * {@inheritDoc}
-    // * <p>
-    // * The segment of this shared node is the segment of the proxy, not of the original shareable node.
-    // * </p>
-    // *
-    // * @see org.modeshape.jcr.AbstractJcrNode#path()
-    // */
-    // @Override
-    // Path.Segment segment() throws RepositoryException {
-    // return proxyInfo().getSegment();
-    // }
-    //
-    // /**
-    // * {@inheritDoc}
-    // *
-    // * @see org.modeshape.jcr.AbstractJcrNode#getCorrespondenceId()
-    // */
-    // @Override
-    // protected CorrespondenceId getCorrespondenceId() throws RepositoryException {
-    // return original.getCorrespondenceId();
-    // }
-    //
-    // /**
-    // * {@inheritDoc}
-    // *
-    // * @see org.modeshape.jcr.AbstractJcrNode#removeMixin(java.lang.String)
-    // */
-    // @Override
-    // public void removeMixin( String mixinName ) throws RepositoryException {
-    // if (cache.stringFactory().create(JcrMixLexicon.SHAREABLE).equals(mixinName)) {
-    // // Per section 14.15 of the JCR 2.0 specification, we can do a few things.
-    // // We could remove this shared node via removeShare(),
-    // // or do something else to the content to adjust to the missing mixin name,
-    // // or we could throw an exception ...
-    // throw new ConstraintViolationException();
-    // }
-    // super.removeMixin(mixinName);
-    // }
-    //
-    // /**
-    // * {@inheritDoc}
-    // *
-    // * @see org.modeshape.jcr.AbstractJcrNode#getProperty(java.lang.String)
-    // */
-    // @Override
-    // public Property getProperty( String relativePath ) throws RepositoryException {
-    // return adapt(super.getProperty(relativePath));
-    // }
-    //
-    // /**
-    // * {@inheritDoc}
-    // *
-    // * @see org.modeshape.jcr.AbstractJcrNode#getProperties()
-    // */
-    // @Override
-    // public PropertyIterator getProperties() throws RepositoryException {
-    // return adapt(super.getProperties());
-    // }
-    //
-    // /**
-    // * {@inheritDoc}
-    // *
-    // * @see org.modeshape.jcr.AbstractJcrNode#getProperties(java.lang.String)
-    // */
-    // @Override
-    // public PropertyIterator getProperties( String namePattern ) throws RepositoryException {
-    // return adapt(super.getProperties(namePattern));
-    // }
-    //
-    // /**
-    // * {@inheritDoc}
-    // *
-    // * @see org.modeshape.jcr.AbstractJcrNode#getProperties(java.lang.String[])
-    // */
-    // @Override
-    // public PropertyIterator getProperties( String[] nameGlobs ) throws RepositoryException {
-    // return adapt(super.getProperties(nameGlobs));
-    // }
-    //
-    // /**
-    // * Adapt the property objects so that their owner is this node, not the original's.
-    // *
-    // * @param property the property from the original
-    // * @return the adapted property
-    // */
-    // protected Property adapt( Property property ) {
-    // if (property instanceof JcrSingleValueProperty) {
-    // JcrSingleValueProperty original = (JcrSingleValueProperty)property;
-    // return new JcrSingleValueProperty(cache, this, original.name());
-    // }
-    // if (property instanceof JcrMultiValueProperty) {
-    // JcrMultiValueProperty original = (JcrMultiValueProperty)property;
-    // return new JcrMultiValueProperty(cache, this, original.name());
-    // }
-    // return property;
-    // }
-    //
-    // protected PropertyIterator adapt( PropertyIterator propertyIter ) {
-    // Collection<Property> props = new ArrayList<Property>((int)propertyIter.getSize());
-    // while (propertyIter.hasNext()) {
-    // props.add(adapt(propertyIter.nextProperty()));
-    // }
-    // return new JcrPropertyIterator(props);
-    // }
+
+    @Override
+    protected NodeKey parentKey() {
+        return parentKey;
+    }
+
+    @Override
+    protected void doRemove()
+        throws VersionException, LockException, ConstraintViolationException, AccessDeniedException, RepositoryException {
+        // Remove this from the shared set ...
+        sharedSet.remove(this);
+
+        // Then remove the child from the parent but do not destroy the node ...
+        SessionCache cache = sessionCache();
+        NodeKey key = key();
+        MutableCachedNode parent = mutableParent();
+        parent.removeChild(cache, key);
+    }
+
+    @Override
+    public AbstractJcrNode getParent() throws ItemNotFoundException, RepositoryException {
+        checkSession();
+        return parent();
+    }
+
+    protected AbstractJcrNode parent() throws ItemNotFoundException {
+        return session().node(parentKey, null);
+    }
+
+    @Override
+    SharedSet sharedSet() {
+        return sharedSet;
+    }
+
+    @Override
+    Path path() throws ItemNotFoundException, InvalidItemStateException {
+        AbstractJcrNode parent = parent();
+        CachedNode node = parent.node();
+        SessionCache cache = session.cache();
+        ChildReference childRef = node.getChildReferences(cache).getChild(sharedSet.key());
+        Path parentPath = parent.path();
+        return session().pathFactory().create(parentPath, childRef.getSegment());
+    }
+
+    @Override
+    protected Name name() throws RepositoryException {
+        return segment().getName();
+    }
+
+    @Override
+    protected Segment segment() throws RepositoryException {
+        AbstractJcrNode parent = parent();
+        CachedNode node = parent.node();
+        SessionCache cache = session.cache();
+        ChildReference childRef = node.getChildReferences(cache).getChild(sharedSet.key());
+        return childRef.getSegment();
+    }
 }

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrSharedNodeCache.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrSharedNodeCache.java
@@ -1,0 +1,226 @@
+/*
+ * ModeShape (http://www.modeshape.org)
+ * See the COPYRIGHT.txt file distributed with this work for information
+ * regarding copyright ownership.  Some portions may be licensed
+ * to Red Hat, Inc. under one or more contributor license agreements.
+ * See the AUTHORS.txt file in the distribution for a full listing of 
+ * individual contributors.
+ *
+ * ModeShape is free software. Unless otherwise indicated, all code in ModeShape
+ * is licensed to you under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ * 
+ * ModeShape is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.modeshape.jcr;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import javax.jcr.InvalidItemStateException;
+import javax.jcr.ItemNotFoundException;
+import javax.jcr.NodeIterator;
+import javax.jcr.RepositoryException;
+import javax.jcr.Session;
+import org.modeshape.jcr.cache.CachedNode;
+import org.modeshape.jcr.cache.NodeKey;
+import org.modeshape.jcr.cache.SessionCache;
+import org.modeshape.jcr.value.Path;
+
+/**
+ * A class that manages for a single {@link JcrSession} the various sets of shared nodes for each of the shareable nodes. Some
+ * terminology:
+ * <ul>
+ * <li><i>shareable node</i> - A node that has the <code>mix:shareable</code> mixin, and which is capable of being shared.</li>
+ * <li><i>shared node</i> - The result of sharing a shareable node. Each shared node has its own name and location.</li>
+ * </ul>
+ * <p>
+ * The set of Node instances that represent the shared nodes for a given shareable node could be stored in the AbstractJcrNode
+ * instance that is the shareable node. However, since the "mix:shareable" can be added or removed at any time, we can't create a
+ * subclass of AbstractJcrNode to store this information, and we also don't want to store a null reference in <i>every</i>
+ * AbstractJcrNode instance.
+ * </p>
+ * <p>
+ * Therefore, this class is created lazily within the {@link JcrSession} and is used to maintain the Node instances for each of
+ * the shared nodes for each shareable node. This cache is required so that clients always get the same Node instance.
+ * </p>
+ */
+final class JcrSharedNodeCache {
+
+    private final ConcurrentMap<NodeKey, SharedSet> sharedSets = new ConcurrentHashMap<NodeKey, SharedSet>();
+
+    protected final JcrSession session;
+
+    JcrSharedNodeCache( JcrSession session ) {
+        this.session = session;
+    }
+
+    public JcrSession session() {
+        return session;
+    }
+
+    /**
+     * Get the {@link SharedSet} for the given shareable node.
+     * 
+     * @param shareableNode the shareable node
+     * @return the SharedSet; never null
+     */
+    public SharedSet getSharedSet( AbstractJcrNode shareableNode ) {
+        NodeKey shareableNodeKey = shareableNode.key();
+        SharedSet sharedSet = sharedSets.get(shareableNodeKey);
+        if (sharedSet == null) {
+            SharedSet newSharedSet = new SharedSet(shareableNode);
+            sharedSet = sharedSets.putIfAbsent(shareableNodeKey, newSharedSet);
+            if (sharedSet == null) sharedSet = newSharedSet;
+        }
+        return sharedSet;
+    }
+
+    /**
+     * The set of shared nodes for a single shareable node.
+     */
+    final class SharedSet {
+        /** The sharable node */
+        protected final AbstractJcrNode shareableNode;
+
+        /** The cache of Node instances that represent the shared nodes for a single shareable node. */
+        private final ConcurrentMap<NodeKey, JcrSharedNode> sharedNodesByParentKey = new ConcurrentHashMap<NodeKey, JcrSharedNode>();
+
+        protected SharedSet( AbstractJcrNode shareableNode ) {
+            this.shareableNode = shareableNode;
+            assert this.shareableNode != null;
+        }
+
+        /**
+         * Get the NodeKey for the shareable node.
+         * 
+         * @return the key; never null and always the same
+         */
+        public final NodeKey key() {
+            return shareableNode.key();
+        }
+
+        /**
+         * Get the {@link Session} to which this set belongs.
+         * 
+         * @return the session instance; never null and always the same
+         */
+        public final JcrSession session() {
+            return JcrSharedNodeCache.this.session();
+        }
+
+        /**
+         * Get the {@link JcrSharedNode shared Node instance} that is a child of the specified parent.
+         * 
+         * @param cachedNode the cached node; may not be null
+         * @param parentKey the key of the parent node; may not b enull
+         * @return the shared node instance; never null
+         */
+        public AbstractJcrNode getSharedNode( CachedNode cachedNode,
+                                              NodeKey parentKey ) {
+            assert parentKey != null;
+            if (!key().equals(parentKey)) {
+
+                // Obtain the set of keys for all parents ...
+                final SessionCache cache = session.cache();
+                Set<NodeKey> additionalParents = cachedNode.getAdditionalParentKeys(cache);
+
+                // And get the shared node for the parent key, first making sure the parent exists ...
+                if (additionalParents.contains(parentKey) && session.nodeExists(parentKey)) {
+                    return getOrCreateSharedNode(parentKey);
+                }
+            }
+            return shareableNode;
+        }
+
+        /**
+         * Determine and return the first of any nodes in the shared set exist at a location that is at or below the supplied
+         * path.
+         * 
+         * @param path the path; may not be null
+         * @return the node in the shared set that exists at or below the supplied path; or null if none of the nodes in the
+         *         shared set are at or below the supplied path
+         * @throws ItemNotFoundException
+         * @throws InvalidItemStateException
+         * @throws RepositoryException
+         */
+        public AbstractJcrNode getSharedNodeAtOrBelow( Path path )
+            throws RepositoryException, ItemNotFoundException, InvalidItemStateException {
+            NodeIterator iter = getSharedNodes();
+            while (iter.hasNext()) {
+                AbstractJcrNode shared = (AbstractJcrNode)iter.nextNode();
+                if (shared.path().isAtOrBelow(path)) return shared;
+            }
+            return null;
+        }
+
+        protected void remove( JcrSharedNode sharedNode ) {
+            sharedNodesByParentKey.remove(sharedNode.parentKey());
+        }
+
+        private JcrSharedNode getOrCreateSharedNode( NodeKey parentKey ) {
+            assert parentKey != null;
+            JcrSharedNode sharedNode = sharedNodesByParentKey.get(parentKey);
+            if (sharedNode == null) {
+                JcrSharedNode newShared = new JcrSharedNode(this, parentKey);
+                sharedNode = sharedNodesByParentKey.putIfAbsent(parentKey, newShared);
+                if (sharedNode == null) sharedNode = newShared;
+            }
+            return sharedNode;
+        }
+
+        /**
+         * Get the number of shared nodes within this shared set.
+         * 
+         * @return the number of shared nodes; always 1 or more
+         * @throws RepositoryException if there's a problem getting the size
+         */
+        public int getSize() throws RepositoryException {
+            final SessionCache cache = session().cache();
+            Set<NodeKey> additionalParents = shareableNode.node().getAdditionalParentKeys(cache);
+            return additionalParents.size() + 1;
+        }
+
+        /**
+         * Find all of the {@link javax.jcr.Node}s that make up the shared set.
+         * 
+         * @return the iterator over the nodes in the node set; never null, but possibly empty if this is not shareable, or of
+         *         size 1 if the node is shareable but hasn't been shared
+         * @throws RepositoryException if there is a problem finding the nodes in the set
+         */
+        public NodeIterator getSharedNodes() throws RepositoryException {
+            // Obtain the set of keys for all parents ...
+            final SessionCache cache = session().cache();
+            Set<NodeKey> additionalParents = shareableNode.node().getAdditionalParentKeys(cache);
+
+            // Obtain the Node objects for each of these ...
+            final NodeKey key = shareableNode.key();
+            final String workspaceKey = key.getWorkspaceKey();
+            Collection<AbstractJcrNode> sharedNodes = new ArrayList<AbstractJcrNode>(additionalParents.size() + 1);
+            sharedNodes.add(shareableNode); // add the shareable node
+            for (NodeKey parentKey : additionalParents) {
+                if (!workspaceKey.equals(parentKey.getWorkspaceKey())) {
+                    // The parent node has to be in this workspace ...
+                    continue;
+                }
+                if (session.nodeExists(parentKey)) {
+                    sharedNodes.add(getOrCreateSharedNode(parentKey));
+                }
+            }
+
+            // Return an iterator ...
+            return new JcrNodeListIterator(sharedNodes.iterator(), sharedNodes.size());
+        }
+    }
+}

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrSystemViewExporter.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrSystemViewExporter.java
@@ -127,7 +127,8 @@ class JcrSystemViewExporter extends AbstractJcrExporter {
 
         startElement(contentHandler, JcrSvLexicon.NODE, atts);
 
-        if (node instanceof JcrSharedNode) {
+        JcrSharedNode sharedNode = asSharedNode(node);
+        if (sharedNode != null) {
             // This is a shared node, and per Section 14.7 of the JCR 2.0 specification, they have to be written out
             // in a special way ...
 
@@ -135,9 +136,9 @@ class JcrSystemViewExporter extends AbstractJcrExporter {
             emitProperty(JcrLexicon.PRIMARY_TYPE, PropertyType.NAME, JcrNtLexicon.SHARE, contentHandler, skipBinary);
 
             // jcr:uuid = UUID of shared node ...
-            emitProperty(JcrLexicon.UUID, PropertyType.STRING, node.getIdentifier(), contentHandler, skipBinary);
+            emitProperty(JcrLexicon.UUID, PropertyType.STRING, sharedNode.getIdentifier(), contentHandler, skipBinary);
         } else {
-
+            exporting(node);
             // Output any special properties first (see Javadoc for SPECIAL_PROPERTY_NAMES for more context)
             for (Name specialPropertyName : SPECIAL_PROPERTY_NAMES) {
                 Property specialProperty = ((AbstractJcrNode)node).getProperty(specialPropertyName);

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/CachedNode.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/CachedNode.java
@@ -81,12 +81,20 @@ public interface CachedNode {
     Path getPath( NodeCache cache ) throws NodeNotFoundException;
 
     /**
-     * Get the node key for this node's primary parent.
+     * Get the node key for this node's primary parent within this workspace.
      * 
      * @param cache the cache to which this node belongs, required in case this node needs to use the cache; may not be null
      * @return the parent's key; null if this is the root node or it has been removed from the document by someone else
      */
     NodeKey getParentKey( NodeCache cache );
+
+    /**
+     * Get the node key for this node's primary parent in any workspace.
+     * 
+     * @param cache the cache to which this node belongs, required in case this node needs to use the cache; may not be null
+     * @return the parent's key; null if this is the root node or it has been removed from the document by someone else
+     */
+    NodeKey getParentKeyInAnyWorkspace( NodeCache cache );
 
     /**
      * Get the keys for all of the nodes (other than the {@link #getParentKey(NodeCache) primary parent}) under which this node
@@ -186,4 +194,15 @@ public interface CachedNode {
      */
     Set<NodeKey> getReferrers( NodeCache cache,
                                ReferenceType type );
+
+    /**
+     * Determine if this node is effectively at or below the supplied path. Note that because of
+     * {@link #getAdditionalParentKeys(NodeCache) additional parents}, a node has multiple effective paths.
+     * 
+     * @param cache the cache to which this node belongs, required in case this node needs to use the cache; may not be null
+     * @param path the path to be used for comparison; may not be null
+     * @return true if this node can be considered at or below the supplied path; or false otherwise
+     */
+    boolean isAtOrBelow( NodeCache cache,
+                         Path path );
 }

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/MutableCachedNode.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/MutableCachedNode.java
@@ -23,6 +23,7 @@
  */
 package org.modeshape.jcr.cache;
 
+import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
 import org.modeshape.jcr.value.Name;
@@ -112,6 +113,24 @@ public interface MutableCachedNode extends CachedNode {
      */
     void setProperties( SessionCache cache,
                         Iterable<Property> properties );
+
+    /**
+     * Set the properties on this node.
+     * 
+     * @param cache the cache to which this node belongs; may not be null
+     * @param properties the iterator over the properties to be set; may not be null
+     * @throws NodeNotFoundException if this node no longer exists
+     */
+    void setProperties( SessionCache cache,
+                        Iterator<Property> properties );
+
+    /**
+     * Remove all of the properties from this node.
+     * 
+     * @param cache the cache to which this node belongs; may not be null
+     * @throws NodeNotFoundException if this node no longer exists
+     */
+    void removeAllProperties( SessionCache cache );
 
     /**
      * Remove the property with the given name.
@@ -215,15 +234,20 @@ public interface MutableCachedNode extends CachedNode {
     /**
      * Link the existing node with the supplied key to be appended as a child of this node. After this method, the referenced node
      * is considered a child of this node as well as a child of its original parent(s).
+     * <p>
+     * The link can be removed by simply {@link #removeChild(SessionCache, NodeKey) removing} the linked child from the parent,
+     * and this works whether or not the parent is the original parent or an additional parent.
+     * </p>
      * 
      * @param cache the cache to which this node belongs; may not be null
      * @param childKey the key for the child that is to be removed; may not be null
      * @param name the name for the (linked) node, or null if the existing name is to be used
+     * @return true if the link was created, or false if the link already existed as a child of this node
      * @throws NodeNotFoundException if the node does not exist
      */
-    void linkChild( SessionCache cache,
-                    NodeKey childKey,
-                    Name name );
+    boolean linkChild( SessionCache cache,
+                       NodeKey childKey,
+                       Name name );
 
     /**
      * Remove the node from being a child of this node and append it as a child before the supplied node.
@@ -317,4 +341,11 @@ public interface MutableCachedNode extends CachedNode {
      * @return the set of {@link NodeKey} instances, never null.
      */
     public Set<NodeKey> getChangedReferrerNodes();
+
+    /**
+     * Return whether this node contains only changes to the additional parents.
+     * 
+     * @return true if this node contains only added or removed additional parents.
+     */
+    public boolean hasOnlyChangesToAdditionalParents();
 }

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/NodeKey.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/NodeKey.java
@@ -184,6 +184,10 @@ public final class NodeKey implements Serializable, Comparable<NodeKey> {
         return new NodeKey(getSourceKey(), getWorkspaceKey(), UUID.randomUUID().toString());
     }
 
+    public NodeKey withRandomIdAndWorkspace( String workspaceKey ) {
+        return new NodeKey(getSourceKey(), workspaceKey, UUID.randomUUID().toString());
+    }
+
     public NodeKey withId( String identifier ) {
         return new NodeKey(getSourceKey(), getWorkspaceKey(), identifier);
     }

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/SessionCache.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/SessionCache.java
@@ -36,7 +36,7 @@ public interface SessionCache extends NodeCache {
      * The context of a save operation, created during each call to {@link #save} and passed to the
      * {@link PreSave#process(MutableCachedNode, SaveContext)} invocations.
      */
-    static interface SaveContext {
+    public static interface SaveContext {
         /**
          * Get the instance in time that the save is taking place.
          * 
@@ -59,7 +59,7 @@ public interface SessionCache extends NodeCache {
      * implementations are free to make additional modifications to the supplied nodes, and even create additional nodes or change
      * persistent but unchanged nodes, as long as these operations are done within the same calling thread.
      */
-    static interface PreSave {
+    public static interface PreSave {
         /**
          * Process the supplied node prior to saving the changes. This allows implementations to use the changes to automatically
          * adjust this node or other content.
@@ -169,7 +169,7 @@ public interface SessionCache extends NodeCache {
      * 
      * @param node the node at or below which all changes should be cleared; may not be null
      */
-    void clear( CachedNode node );
+    public void clear( CachedNode node );
 
     /**
      * Get the cache the reflects the workspace content, without any of the transient, unsaved changes of this session.

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/change/AbstractSequencingChange.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/change/AbstractSequencingChange.java
@@ -24,13 +24,12 @@
 
 package org.modeshape.jcr.cache.change;
 
-import org.modeshape.common.util.CheckArg;
 import org.modeshape.jcr.cache.NodeKey;
 import org.modeshape.jcr.value.Path;
 
 /**
  * Base class for the changes involving sequencing
- *
+ * 
  * @author Horia Chiorean
  */
 public abstract class AbstractSequencingChange extends AbstractNodeChange {
@@ -47,12 +46,10 @@ public abstract class AbstractSequencingChange extends AbstractNodeChange {
                                         String selectedPath,
                                         String sequencerName ) {
         super(sequencedNodeKey, sequencedNodePath);
-
-        CheckArg.isNotNull(outputPath, "outputPath");
-        CheckArg.isNotNull(userId, "userId");
-        CheckArg.isNotNull(selectedPath, "selectedPath");
-        CheckArg.isNotNull(sequencerName, "sequencerName");
-
+        assert outputPath != null;
+        assert userId != null;
+        assert selectedPath != null;
+        assert sequencerName != null;
         this.outputPath = outputPath;
         this.userId = userId;
         this.selectedPath = selectedPath;

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/change/ChangeSet.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/change/ChangeSet.java
@@ -41,6 +41,8 @@ public interface ChangeSet extends Iterable<Change>, Serializable {
      */
     public int size();
 
+    public boolean isEmpty();
+
     public String getUserId();
 
     public Map<String, String> getUserData();

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/change/Changes.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/change/Changes.java
@@ -31,38 +31,89 @@ import org.modeshape.jcr.value.Path;
 import org.modeshape.jcr.value.Property;
 
 /**
- * 
+ * An interface used to signal various kinds of changes.
  */
 public interface Changes {
 
+    /**
+     * Signal that a new workspace has been added.
+     * 
+     * @param workspaceName the name of the workspace; may not be null
+     */
     void workspaceAdded( String workspaceName );
 
+    /**
+     * Signal that a new workspace has been removed.
+     * 
+     * @param workspaceName the name of the workspace; may not be null
+     */
     void workspaceRemoved( String workspaceName );
 
+    /**
+     * Signal that a new node was created.
+     * 
+     * @param key the key for the new node; may not be null
+     * @param parentKey the key for the parent of the new node; may not be null
+     * @param path the path to the new node; may not be null
+     * @param properties the properties in the new node, or null if there are none
+     */
     void nodeCreated( NodeKey key,
                       NodeKey parentKey,
                       Path path,
                       Map<Name, Property> properties );
 
+    /**
+     * Signal that a node was removed.
+     * 
+     * @param key the key for the removed node; may not be null
+     * @param parentKey the key for the old parent of the removed node; may not be null
+     * @param path the path to the removed node; may not be null
+     */
     void nodeRemoved( NodeKey key,
                       NodeKey parentKey,
                       Path path );
 
+    /**
+     * Signal that a node was renamed (but still has the same parent)
+     * 
+     * @param key the key for the node; may not be null
+     * @param newPath the new path for the node; may not be null
+     * @param oldName the old name (including SNS index); may not be null
+     */
     void nodeRenamed( NodeKey key,
                       Path newPath,
                       Path.Segment oldName );
 
+    /**
+     * Signal that a node was moved from one parent to another, and may have also been renamed.
+     * 
+     * @param key the key for the node; may not be null
+     * @param newParent the new parent for the node; may not be null
+     * @param oldParent the old parent for the node; may not be null
+     * @param newPath the new path for the node after it has been moved; may not be null
+     * @param oldPath the old path for the node before it was moved; may not be null
+     */
     void nodeMoved( NodeKey key,
                     NodeKey newParent,
                     NodeKey oldParent,
                     Path newPath,
                     Path oldPath );
 
-    void nodeReordered( NodeKey key, 
+    /**
+     * Signal that a node was placed into a new location within the same parent.
+     * 
+     * @param key the key for the node; may not be null
+     * @param parent the key for the parent of the node; may not be null
+     * @param newPath the new path for the node after it has been reordered; may not be null
+     * @param oldPath the old path for the node before it was reordered; may not be null
+     * @param reorderedBeforePath the path of the node before which the node was moved; or null if the node was reordered to the
+     *        end of the list of children of the parent node
+     */
+    void nodeReordered( NodeKey key,
                         NodeKey parent,
                         Path newPath,
                         Path oldPath,
-                        Path reorderedBeforePath);
+                        Path reorderedBeforePath );
 
     /**
      * Create an event signifying that something about the node (other than the properties or location) changed.
@@ -73,6 +124,19 @@ public interface Changes {
     void nodeChanged( NodeKey key,
                       Path path );
 
+    /**
+     * Signal that a node was successfully sequenced.
+     * 
+     * @param sequencedNodeKey the key of the node that was used as input and sequenced; may not be null
+     * @param sequencedNodePath the path of the node that was used as input and sequenced; may not be null
+     * @param outputNodeKey the key of the top-level node output by the sequencing operation; may not be null
+     * @param outputNodePath the path of the top-level node output by the sequencing operation; may not be null
+     * @param outputPath the string representation of the output path of the sequencing operation
+     * @param userId the username of the session that generated the change that led to the sequencing operation
+     * @param selectedPath the string representation of the path that led to the sequencing operation (which may or may not be the
+     *        same as the sequenced node path); may not be null
+     * @param sequencerName the name of the sequencer; may not be null
+     */
     void nodeSequenced( NodeKey sequencedNodeKey,
                         Path sequencedNodePath,
                         NodeKey outputNodeKey,
@@ -80,8 +144,20 @@ public interface Changes {
                         String outputPath,
                         String userId,
                         String selectedPath,
-                        String sequencerName);
+                        String sequencerName );
 
+    /**
+     * Signal that a node was not sequenced successfully.
+     * 
+     * @param sequencedNodeKey the key of the node that was used as input and sequenced; may not be null
+     * @param sequencedNodePath the path of the node that was used as input and sequenced; may not be null
+     * @param outputPath the string representation of the output path of the sequencing operation
+     * @param userId the username of the session that generated the change that led to the (failed) sequencing operation
+     * @param selectedPath the string representation of the path that led to the (failed) sequencing operation (which may or may
+     *        not be the same as the sequenced node path); may not be null
+     * @param sequencerName the name of the sequencer; may not be null
+     * @param cause the exception that caused the failure; may not be null
+     */
     void nodeSequencingFailure( NodeKey sequencedNodeKey,
                                 Path sequencedNodePath,
                                 String outputPath,
@@ -90,14 +166,36 @@ public interface Changes {
                                 String sequencerName,
                                 Throwable cause );
 
+    /**
+     * Signal that a property was added to a node.
+     * 
+     * @param key the key of the node that was changed; may not be null
+     * @param nodePath the path of the node that was changed
+     * @param property the new property, with name and value(s); may not be null
+     */
     void propertyAdded( NodeKey key,
                         Path nodePath,
                         Property property );
 
+    /**
+     * Signal that a property was removed from a node.
+     * 
+     * @param key the key of the node that was changed; may not be null
+     * @param nodePath the path of the node that was changed
+     * @param property the property that was removed, with name and value(s); may not be null
+     */
     void propertyRemoved( NodeKey key,
                           Path nodePath,
                           Property property );
 
+    /**
+     * Signal that a property was changed on a node.
+     * 
+     * @param key the key of the node that was changed; may not be null
+     * @param nodePath the path of the node that was changed
+     * @param newProperty the new property, with name and value(s); may not be null
+     * @param oldProperty the old property, with name and value(s); may not be null
+     */
     void propertyChanged( NodeKey key,
                           Path nodePath,
                           Property newProperty,

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/change/NodeAdded.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/change/NodeAdded.java
@@ -47,6 +47,7 @@ public class NodeAdded extends AbstractNodeChange {
                       Map<Name, Property> properties ) {
         super(key, path);
         this.parentKey = parentKey;
+        assert this.parentKey != null;
         if (properties == null || properties.isEmpty()) {
             this.properties = EMPTY_PROPERTIES;
         } else {

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/change/NodeSequenced.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/change/NodeSequenced.java
@@ -1,12 +1,11 @@
 package org.modeshape.jcr.cache.change;
 
-import org.modeshape.common.util.CheckArg;
 import org.modeshape.jcr.cache.NodeKey;
 import org.modeshape.jcr.value.Path;
 
 /**
  * Change which is triggered after the sequencing process of a node is finished.
- *
+ * 
  * @author Horia Chiorean
  */
 public class NodeSequenced extends AbstractSequencingChange {
@@ -21,20 +20,28 @@ public class NodeSequenced extends AbstractSequencingChange {
                           String outputPath,
                           String userId,
                           String selectedPath,
-                          String sequencerName) {
+                          String sequencerName ) {
         super(sequencedNodeKey, sequencedNodePath, outputPath, userId, selectedPath, sequencerName);
-
-        CheckArg.isNotNull(outputNodeKey, "outputNodeKey");
-        CheckArg.isNotNull(outputNodePath, "outputNodePath");
-
+        assert outputNodeKey != null;
+        assert outputNodePath != null;
         this.outputNodeKey = outputNodeKey;
         this.outputNodePath = outputNodePath;
     }
 
+    /**
+     * Get the key of the top-level node that was output by the sequencer.
+     * 
+     * @return the output node key; never null
+     */
     public NodeKey getOutputNodeKey() {
         return outputNodeKey;
     }
 
+    /**
+     * Get the path of the top-level node that was output by the sequencer.
+     * 
+     * @return the output node path; never null
+     */
     public Path getOutputNodePath() {
         return outputNodePath;
     }

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/change/NodeSequencingFailure.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/change/NodeSequencingFailure.java
@@ -24,13 +24,12 @@
 
 package org.modeshape.jcr.cache.change;
 
-import org.modeshape.common.util.CheckArg;
 import org.modeshape.jcr.cache.NodeKey;
 import org.modeshape.jcr.value.Path;
 
 /**
  * Change which is triggered if the sequencing of a node fails
- *
+ * 
  * @author Horia Chiorean
  */
 public class NodeSequencingFailure extends AbstractSequencingChange {
@@ -48,10 +47,15 @@ public class NodeSequencingFailure extends AbstractSequencingChange {
                                   String sequencerName,
                                   Throwable cause ) {
         super(sequencedNodeKey, sequencedNodePath, outputPath, userId, selectedPath, sequencerName);
-        CheckArg.isNotNull(cause, "cause");
+        assert cause != null;
         this.cause = cause;
     }
 
+    /**
+     * Get the cause of the failure.
+     * 
+     * @return the exception; never null
+     */
     public Throwable getCause() {
         return cause;
     }

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/change/RecordingChanges.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/change/RecordingChanges.java
@@ -185,6 +185,11 @@ public class RecordingChanges implements Changes, ChangeSet {
         return events.size();
     }
 
+    @Override
+    public boolean isEmpty() {
+        return events.isEmpty() && nodeKeys.isEmpty(); // not all changed nodes cause events (e.g., shared nodes)
+    }
+
     /**
      * Returns an iterator over the elements in this queue in proper sequence. The returned iterator is a "weakly consistent"
      * iterator that will never throw {@link ConcurrentModificationException}, and guarantees to traverse elements as they existed

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/document/AbstractSessionCache.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/document/AbstractSessionCache.java
@@ -23,6 +23,10 @@
  */
 package org.modeshape.jcr.cache.document;
 
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.UUID;
 import org.modeshape.common.annotation.Immutable;
 import org.modeshape.jcr.ExecutionContext;
 import org.modeshape.jcr.api.value.DateTime;
@@ -36,10 +40,6 @@ import org.modeshape.jcr.value.NameFactory;
 import org.modeshape.jcr.value.Path;
 import org.modeshape.jcr.value.PathFactory;
 import org.modeshape.jcr.value.ValueFactories;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.Set;
-import java.util.UUID;
 
 /**
  * 
@@ -120,9 +120,10 @@ public abstract class AbstractSessionCache implements SessionCache, DocumentCach
     final SessionEnvironment sessionContext() {
         return sessionContext;
     }
-    
+
     @Override
-    public final void addContextData(String key, String value) {
+    public final void addContextData( String key,
+                                      String value ) {
         this.context = context.with(key, value);
     }
 
@@ -190,7 +191,7 @@ public abstract class AbstractSessionCache implements SessionCache, DocumentCach
         return result;
     }
 
-
     @Override
     public abstract SessionNode mutable( NodeKey key );
+
 }

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/document/DocumentTranslator.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/document/DocumentTranslator.java
@@ -193,8 +193,10 @@ public class DocumentTranslator {
                 Object v = iter.next();
                 if (v == null) continue;
                 String key = (String)v;
-                if (key.equals(primaryWorkspaceKey) || key.equals(secondaryWorkspaceKey)) {
-                    keys.add(new NodeKey(key));
+                NodeKey nodeKey = new NodeKey(key);
+                String workspaceKey = nodeKey.getWorkspaceKey();
+                if (workspaceKey.equals(primaryWorkspaceKey) || workspaceKey.equals(secondaryWorkspaceKey)) {
+                    keys.add(nodeKey);
                 }
             }
             return keys;
@@ -557,7 +559,7 @@ public class DocumentTranslator {
             }
             if (additionalParents != null) {
                 for (NodeKey removed : additionalParents.getRemovals()) {
-                    parents.remove(removed.toString());
+                    parents.remove((Object)removed.toString()); // remove by value (not by name)
                 }
                 for (NodeKey added : additionalParents.getAdditions()) {
                     parents.addStringIfAbsent(added.toString());

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/document/WorkspaceCache.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/document/WorkspaceCache.java
@@ -226,4 +226,9 @@ public class WorkspaceCache implements DocumentCache, ChangeSetListener {
         this.closed = true;
         clear();
     }
+
+    @Override
+    public String toString() {
+        return workspaceName;
+    }
 }

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/txn/SynchronizedTransactions.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/txn/SynchronizedTransactions.java
@@ -78,7 +78,7 @@ public final class SynchronizedTransactions extends Transactions {
     public void updateCache( WorkspaceCache workspace,
                              ChangeSet changes,
                              Transaction transaction ) {
-        if (changes != null && changes.size() != 0) {
+        if (changes != null && !changes.isEmpty()) {
             if (transaction instanceof SynchronizedTransaction) {
                 // We're in a transaction being managed outside of ModeShape (e.g., container-managed, user-managed,
                 // distributed, etc.) ...

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/txn/Transactions.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/txn/Transactions.java
@@ -111,7 +111,7 @@ public abstract class Transactions {
                              ChangeSet changes,
                              Transaction transaction ) {
         // Notify the workspaces of the changes made. This is done outside of our lock but still before the save returns ...
-        if (changes != null && changes.size() != 0) {
+        if (changes != null && !changes.isEmpty()) {
             // Notify the workspace (outside of the lock, but still before the save returns) ...
             workspace.changed(changes);
         }

--- a/modeshape-jcr/src/main/resources/org/modeshape/jcr/JcrI18n.properties
+++ b/modeshape-jcr/src/main/resources/org/modeshape/jcr/JcrI18n.properties
@@ -148,6 +148,9 @@ unableToRemoveSystemNodes = Unable to remove the '{0}' node in workspace "{1}" b
 unableToModifySystemNodes = Unable to modify the '{0}' node in workspace "{1}" because the node is within the '/jcr:system' area
 unableToMoveNodeToBeChildOfDecendent = Node "{0}" in workspace "{2}" cannot be moved under a decendant node ("{1}") 
 nodeHasAlreadyBeenRemovedFromThisSession = Node "{0}" in workspace "{1} has already been removed from this session
+unableToShareNodeWithinSubgraph = Unable to share '{0}' at '{1}' since it would create a circularity
+unableToShareNodeWithinSameParent = Unable to share '{0}' at '{1}' since it has already been shared at '{2}'
+unableToMoveNodeDueToCycle = Unable to move node at '{0}' to '{1}' since '{2}' would reate a circularity
 
 SPEC_NAME_DESC = Content Repository for Java Technology API
 
@@ -259,6 +262,7 @@ unableToChangePrimaryTypeDueToParentsChildDefinition = Unable to change the prim
 primaryTypeCannotBeAbstract = The prrimary type of a node cannot be abstract, like "{0}"
 setPrimaryTypeOnRootNodeIsNotSupported = ModeShape does not support modifying the root node's primary type
 suppliedNodeTypeIsNotMixinType = The specified node type '{0}' is not a mixin, and cannot be used as a mixin.
+cannotRemoveShareableMixinThatIsShared = Unable to remove the 'mix:shareable' mixin from the node '{0}' since it is currently shared at {1} places: {2}
 
 errorReadingNodeTypesFromRemote = Node types changed due to remote update. Node types are likely to be different across nodes in the cluster.  Encountered following errors reading node types from graph: {0}
 problemReadingNodeTypesFromRemote = Node types changed due to remote update. Encountered following problems reading node types from graph: {0}

--- a/modeshape-jcr/src/test/java/org/modeshape/jcr/InMemoryTestBinary.java
+++ b/modeshape-jcr/src/test/java/org/modeshape/jcr/InMemoryTestBinary.java
@@ -24,20 +24,18 @@
 
 package org.modeshape.jcr;
 
-
-import javax.jcr.RepositoryException;
-import org.modeshape.common.util.IoUtil;
-import org.modeshape.common.util.SecureHash;
-import org.modeshape.common.util.StringUtil;
-import org.modeshape.jcr.api.Binary;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.security.NoSuchAlgorithmException;
+import org.modeshape.common.util.IoUtil;
+import org.modeshape.common.util.SecureHash;
+import org.modeshape.common.util.StringUtil;
+import org.modeshape.jcr.api.Binary;
 
 /**
  * An in-memory implementation of a {@link javax.jcr.Binary} which should used for tests.
- *
+ * 
  * @author Horia Chiorean
  */
 public final class InMemoryTestBinary implements Binary {
@@ -54,7 +52,7 @@ public final class InMemoryTestBinary implements Binary {
         }
     }
 
-    public InMemoryTestBinary(InputStream is) throws IOException {
+    public InMemoryTestBinary( InputStream is ) throws IOException {
         this(IoUtil.readBytes(is));
     }
 
@@ -64,13 +62,13 @@ public final class InMemoryTestBinary implements Binary {
     }
 
     @Override
-    public InputStream getStream() throws RepositoryException {
+    public InputStream getStream() {
         return new ByteArrayInputStream(bytes);
     }
 
     @Override
     public int read( byte[] b,
-                     long position ) throws IOException, RepositoryException {
+                     long position ) throws IOException {
         if (getSize() <= position) {
             return -1;
         }
@@ -95,8 +93,7 @@ public final class InMemoryTestBinary implements Binary {
             if (stream != null) {
                 try {
                     stream.close();
-                }
-                catch (IOException t) {
+                } catch (IOException t) {
                     // Only throw if we've not already thrown an exception ...
                     if (error == null) {
                         throw t;
@@ -107,7 +104,7 @@ public final class InMemoryTestBinary implements Binary {
     }
 
     @Override
-    public long getSize() throws RepositoryException {
+    public long getSize() {
         return bytes.length;
     }
 
@@ -122,12 +119,12 @@ public final class InMemoryTestBinary implements Binary {
     }
 
     @Override
-    public String getMimeType() throws IOException, RepositoryException {
+    public String getMimeType() {
         return null;
     }
 
     @Override
-    public String getMimeType( String name ) throws IOException, RepositoryException {
+    public String getMimeType( String name ) {
         return null;
     }
 }

--- a/modeshape-jcr/src/test/java/org/modeshape/jcr/JcrRepositoryTest.java
+++ b/modeshape-jcr/src/test/java/org/modeshape/jcr/JcrRepositoryTest.java
@@ -302,7 +302,7 @@ public class JcrRepositoryTest extends AbstractTransactionalTest {
         assertThat(repository.getDescriptor(Repository.OPTION_LOCKING_SUPPORTED), is("true"));
         assertThat(repository.getDescriptor(Repository.OPTION_OBSERVATION_SUPPORTED), is("true"));
         assertThat(repository.getDescriptor(Repository.OPTION_QUERY_SQL_SUPPORTED), is("true"));
-        assertThat(repository.getDescriptor(Repository.OPTION_TRANSACTIONS_SUPPORTED), is("false"));
+        assertThat(repository.getDescriptor(Repository.OPTION_TRANSACTIONS_SUPPORTED), is("true"));
         assertThat(repository.getDescriptor(Repository.OPTION_VERSIONING_SUPPORTED), is("true"));
         assertThat(repository.getDescriptor(Repository.QUERY_XPATH_DOC_ORDER), is("false"));
         assertThat(repository.getDescriptor(Repository.QUERY_XPATH_POS_INDEX), is("true"));

--- a/modeshape-jcr/src/test/java/org/modeshape/jcr/JcrTckTest.java
+++ b/modeshape-jcr/src/test/java/org/modeshape/jcr/JcrTckTest.java
@@ -106,6 +106,7 @@ import org.apache.jackrabbit.test.api.SetValueReferenceTest;
 import org.apache.jackrabbit.test.api.SetValueStringTest;
 import org.apache.jackrabbit.test.api.SetValueValueFormatExceptionTest;
 import org.apache.jackrabbit.test.api.SetValueVersionExceptionTest;
+import org.apache.jackrabbit.test.api.ShareableNodeTest;
 import org.apache.jackrabbit.test.api.StringPropertyTest;
 import org.apache.jackrabbit.test.api.UndefinedPropertyTest;
 import org.apache.jackrabbit.test.api.ValueFactoryTest;
@@ -421,9 +422,17 @@ public class JcrTckTest {
 
         suite.addTestSuite(GetWeakReferencesTest.class);
 
-        // shareable nodes
-        // TODO author=Horia Chiorean date=4/13/12 description=https://issues.jboss.org/browse/MODE-1458
         // suite.addTestSuite(ShareableNodeTest.class);
+        // TODO author=Randall Hauch date=7/2/12 description=https://issues.apache.org/jira/browse/JCR-3370 (get path)
+        // TODO author=Randall Hauch date=7/2/12 description=https://issues.apache.org/jira/browse/JCR-3371 (remove mixin)
+        // TODO author=Randall Hauch date=7/9/12 description=https://issues.apache.org/jira/browse/JCR-3380 (move)
+        suite.addTestSuite(excludeTests(ShareableNodeTest.class,
+                                        "testGetPath",
+                                        "testRemoveMixin",
+                                        "testMoveShareableNode",
+                                        "testTransientMoveShareableNode",
+                                        "testModifyDescendantAndSave",
+                                        "testModifyDescendantAndRemoveShareAndSave"));
 
         return suite;
     }

--- a/modeshape-jcr/src/test/java/org/modeshape/jcr/bus/RepositoryChangeBusTest.java
+++ b/modeshape-jcr/src/test/java/org/modeshape/jcr/bus/RepositoryChangeBusTest.java
@@ -226,6 +226,11 @@ public class RepositoryChangeBusTest {
         }
 
         @Override
+        public boolean isEmpty() {
+            return true;
+        }
+
+        @Override
         public String getUserId() {
             return null;
         }

--- a/modeshape-jcr/src/test/resources/log4j.properties
+++ b/modeshape-jcr/src/test/resources/log4j.properties
@@ -13,6 +13,7 @@ log4j.logger.org.infinispan=INFO
 log4j.logger.com.mchange.v2.c3p0=WARN
 log4j.logger.org.apache.jackrabbit.test=WARN
 log4j.logger.org.modeshape.jcr.tck=WARN
+log4j.logger.org.modeshape.jcr.ModeShapeTckTest=WARN
 
 # This line turns off INFO messages in the org.infinispan.factories.GlobalComponentRegistries
 # class. As of Infinispan 5.1.0.BETA4, Infinispan logs its version information every time
@@ -20,6 +21,9 @@ log4j.logger.org.modeshape.jcr.tck=WARN
 # affect a few other log messages, so this should be removed as soon as Infinispan
 # logs the message only once; see https://issues.jboss.org/browse/ISPN-1518
 log4j.logger.org.infinispan.factories.GlobalComponentRegistry=OFF
+
+# This line turns on detailed log messages 
+#log4j.logger.org.modeshape=DEBUG
 
 # This line turns on TRACING messages in the LuceneSearchIndex, which show which
 # operations are being performed on the index (including the data going into the index) ...

--- a/modeshape-jcr/src/test/resources/repositoryStubImpl.properties
+++ b/modeshape-jcr/src/test/resources/repositoryStubImpl.properties
@@ -173,6 +173,9 @@ javax.jcr.tck.OrderByMultiTypeTest.propertyname2=longProp
 #Locking tests (DeepLockTest) alter the test root (adding a new mixin) which conflicts with other tests when run in parallel: DocExportViewTest
 javax.jcr.tck.lock.testroot=/testroot/lockingWorkarea
 
+#Shareable node tests (see https://issues.apache.org/jira/browse/JCR-3370 for issues on why these are set)
+javax.jcr.tck.ShareableNodeTest.testroot=/testshareableNodes
+
 # Test users
 javax.jcr.tck.superuser.name=superuser
 javax.jcr.tck.superuser.pwd=superuser

--- a/modeshape-schematic/src/main/java/org/infinispan/schematic/internal/document/BasicArray.java
+++ b/modeshape-schematic/src/main/java/org/infinispan/schematic/internal/document/BasicArray.java
@@ -771,8 +771,13 @@ public class BasicArray implements MutableArray {
 
     @Override
     public Object remove( String name ) {
-        int index = indexFrom(name);
-        return isValidIndex(index) ? values.remove(index) : null;
+        try {
+            int index = indexFrom(name);
+            return isValidIndex(index) ? values.remove(index) : null;
+        } catch (NumberFormatException e) {
+            // Must be a value ...
+            return removeValue(name);
+        }
     }
 
     @Override


### PR DESCRIPTION
The JCR shareable nodes feature was implemented using the linked nodes capability of the internal Repository Cache framework. All basic functionality is implemented and all TCK tests pass with the exception of several tests that have bugs/issues (see https://issues.apache.org/jira/browse/JCR-3370, https://issues.apache.org/jira/browse/JCR-3371 and https://issues.apache.org/jira/browse/JCR-3380). Two other shareable node tests are currently failing because of how Node.save() is implemented (see https://issues.jboss.org/browse/MODE-1552). Note that Node.save() is deprecated, and a workaround is to simply use Session.save() instead.
