### PR TITLE
MODE-1546 Handled periodic failure

### DIFF
--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/AbstractJcrNode.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/AbstractJcrNode.java
@@ -85,6 +85,7 @@ import org.modeshape.jcr.cache.ChildReferences;
 import org.modeshape.jcr.cache.MutableCachedNode;
 import org.modeshape.jcr.cache.NodeCache;
 import org.modeshape.jcr.cache.NodeKey;
+import org.modeshape.jcr.cache.NodeNotFoundInParentException;
 import org.modeshape.jcr.cache.PropertyTypeUtil;
 import org.modeshape.jcr.cache.SessionCache;
 import org.modeshape.jcr.value.Name;
@@ -2955,9 +2956,15 @@ abstract class AbstractJcrNode extends AbstractJcrItem implements Node {
             // expected by the TCK
             throw new InvalidItemStateException(e);
         }
-        parent.checkForLock();
-        Path path = path();
-        session.checkPermission(path, ModeShapePermissions.REMOVE);
+        Path path = null;
+        try {
+            parent.checkForLock();
+            path = path();
+            session.checkPermission(path, ModeShapePermissions.REMOVE);
+        } catch (NodeNotFoundInParentException e) {
+            // expected by the TCK
+            throw new InvalidItemStateException(e);
+        }
 
         if (!parent.isCheckedOut()) {
             // The parent node is checked in, so we can only remove this node if this node has an OPV of 'ignore'.

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/CachedNode.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/CachedNode.java
@@ -54,6 +54,8 @@ public interface CachedNode {
      * 
      * @param cache the cache to which this node belongs, required in case this node needs to use the cache; may not be null
      * @return the name; never null, but the root node will have a zero-length name
+     * @throws NodeNotFoundInParentException if this node no longer exists inside the parent node (and perhaps in no other parent)
+     * @throws NodeNotFoundException if this node no longer exists
      * @see #getSegment(NodeCache)
      * @see #getPath(NodeCache)
      */
@@ -64,6 +66,8 @@ public interface CachedNode {
      * 
      * @param cache the cache to which this node belongs, required in case this node needs to use the cache; may not be null
      * @return the segment; never null, but the root node will have a zero-length name
+     * @throws NodeNotFoundInParentException if this node no longer exists inside the parent node (and perhaps in no other parent)
+     * @throws NodeNotFoundException if this node no longer exists
      * @see #getName(NodeCache)
      * @see #getPath(NodeCache)
      */
@@ -74,9 +78,10 @@ public interface CachedNode {
      * 
      * @param cache the cache to which this node belongs, required in case this node needs to use the cache; may not be null
      * @return the node's path; never null with at least one segment for all nodes except the root node
+     * @throws NodeNotFoundInParentException if this node no longer exists inside the parent node (and perhaps in no other parent)
+     * @throws NodeNotFoundException if this node no longer exists
      * @see #getName(NodeCache)
      * @see #getSegment(NodeCache)
-     * @throws NodeNotFoundException if this node does not exist anymore
      */
     Path getPath( NodeCache cache ) throws NodeNotFoundException;
 

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/NodeNotFoundInParentException.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/NodeNotFoundInParentException.java
@@ -1,0 +1,58 @@
+/*
+ * ModeShape (http://www.modeshape.org)
+ * See the COPYRIGHT.txt file distributed with this work for information
+ * regarding copyright ownership.  Some portions may be licensed
+ * to Red Hat, Inc. under one or more contributor license agreements.
+ * See the AUTHORS.txt file in the distribution for a full listing of 
+ * individual contributors.
+ *
+ * ModeShape is free software. Unless otherwise indicated, all code in ModeShape
+ * is licensed to you under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ * 
+ * ModeShape is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.modeshape.jcr.cache;
+
+/**
+ * An exception signalling that a node does not exist in the specified parent.
+ */
+public class NodeNotFoundInParentException extends NodeNotFoundException {
+
+    private static final long serialVersionUID = 1L;
+
+    private final NodeKey parentKey;
+
+    /**
+     * @param key the key for the node that does not exist
+     * @param parentKey the key for the parent node
+     */
+    public NodeNotFoundInParentException( NodeKey key,
+                                          NodeKey parentKey ) {
+        super(key);
+        this.parentKey = parentKey;
+    }
+
+    @Override
+    public String toString() {
+        return super.toString();
+    }
+
+    /**
+     * Get the key for the parent node.
+     * 
+     * @return the key for the parent node
+     */
+    public NodeKey getParentKey() {
+        return parentKey;
+    }
+}

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/document/SessionNode.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/document/SessionNode.java
@@ -57,6 +57,7 @@ import org.modeshape.jcr.cache.MutableCachedNode;
 import org.modeshape.jcr.cache.NodeCache;
 import org.modeshape.jcr.cache.NodeKey;
 import org.modeshape.jcr.cache.NodeNotFoundException;
+import org.modeshape.jcr.cache.NodeNotFoundInParentException;
 import org.modeshape.jcr.cache.SessionCache;
 import org.modeshape.jcr.value.BinaryValue;
 import org.modeshape.jcr.value.Name;
@@ -371,11 +372,23 @@ public class SessionNode implements MutableCachedNode {
         return getSegment(cache, parent);
     }
 
+    /**
+     * Get the segment for this node.
+     * 
+     * @param cache the cache
+     * @param parent the parent node
+     * @return the segment
+     * @throws NodeNotFoundInParentException if the node doesn't exist in the referenced parent
+     */
     protected final Segment getSegment( NodeCache cache,
                                         CachedNode parent ) {
         if (parent != null) {
             ChildReference ref = parent.getChildReferences(cache).getChild(key, new BasicContext());
-            return ref != null ? ref.getSegment() : null;
+            if (ref == null) {
+                // This node doesn't exist in the parent
+                throw new NodeNotFoundInParentException(key, parent.getKey());
+            }
+            return ref.getSegment();
         }
         // This is the root node ...
         return workspace(cache).childReferenceForRoot().getSegment();


### PR DESCRIPTION
Attempted to fix a failure that shows up periodically, most of the time when the indexing is being performed, but sometimes in other cases. The error is due to the inability of a CachedNode to compute its path segment, because the parent no longer contains a child reference to the node. This change attempts to correct that problem by identifying the case and throwing a NodeNotFoundInParent exception. The indexer can simply ignore such nodes.
