### PR TITLE
MODE-1558 - Updated the handling & releasing of thread pools 

### DIFF
--- a/modeshape-common/src/main/java/org/modeshape/common/util/ThreadPoolFactory.java
+++ b/modeshape-common/src/main/java/org/modeshape/common/util/ThreadPoolFactory.java
@@ -23,7 +23,7 @@
  */
 package org.modeshape.common.util;
 
-import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
 
 /**
  * Factory interface for creating/obtaining named thread pools.
@@ -37,16 +37,18 @@ public interface ThreadPoolFactory {
      * @param name the name of the thread pool; may not be null
      * @return the thread pool executor; never null
      */
-    Executor getThreadPool( String name );
+    ExecutorService getThreadPool( String name );
 
     /**
+     * Signal that the supplied thread pool is no longer needed.
+     *
      * Obtain a cached thread pool with the supplied name, or create and return one if no thread pool exists with that name. When
      * finished with the thread pool, it should be {@link #releaseThreadPool released}.
      *
      * @param name the name of the thread pool; may not be null
      * @return the thread pool executor; never null
      */
-    Executor getCachedTreadPool( String name );
+    ExecutorService getCachedTreadPool( String name );
 
     /**
      * Obtain a scheduled thread pool with the supplied name, or create and return one if no thread pool exists with that name. When
@@ -55,12 +57,13 @@ public interface ThreadPoolFactory {
      * @param name the name of the thread pool; may not be null
      * @return the thread pool executor; never null
      */
-    Executor getScheduledThreadPool( String name );
+    ExecutorService getScheduledThreadPool( String name );
 
     /**
-     * Signal that the supplied thread pool is no longer needed.
-     *
+     * Performs a {@link java.util.concurrent.ExecutorService#shutdownNow()} on the given pool, if the pool has been created
+     * previously by this class. Clients which use this method should handle, if necessary, any potential {@link InterruptedException}
+    *
      * @param pool the pool that is no longer needed
      */
-    void releaseThreadPool( Executor pool );
+    void releaseThreadPool( ExecutorService pool );
 }

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/ExecutionContext.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/ExecutionContext.java
@@ -49,7 +49,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
-import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
 
 /**
  * An ExecutionContext is a representation of the environment or context in which a component or operation is operating. Some
@@ -254,22 +254,20 @@ public class ExecutionContext implements ThreadPoolFactory, Cloneable {
     }
 
     @Override
-    public Executor getThreadPool( String name ) {
+    public ExecutorService getThreadPool( String name ) {
         return this.threadPools.getThreadPool(name);
     }
 
     @Override
-    public void releaseThreadPool( Executor pool ) {
+    public void releaseThreadPool( ExecutorService pool ) {
         this.threadPools.releaseThreadPool(pool);
     }
 
-    @Override
-    public Executor getCachedTreadPool( String name ) {
+    public ExecutorService getCachedTreadPool( String name ) {
         return this.threadPools.getCachedTreadPool(name);
     }
 
-    @Override
-    public Executor getScheduledThreadPool( String name ) {
+    public ExecutorService getScheduledThreadPool( String name ) {
         return this.threadPools.getScheduledThreadPool(name);
     }
 

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/RepositoryQueryManager.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/RepositoryQueryManager.java
@@ -91,6 +91,7 @@ class RepositoryQueryManager {
     }
 
     void shutdown() {
+        indexingExecutorService.shutdown();
         if (queryEngine != null) {
             try {
                 engineInitLock.lock();
@@ -105,6 +106,7 @@ class RepositoryQueryManager {
                 engineInitLock.unlock();
             }
         }
+
     }
 
     public CancellableQuery query( ExecutionContext context,

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/Sequencers.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/Sequencers.java
@@ -284,6 +284,7 @@ public class Sequencers implements ChangeSetListener {
     }
 
     protected final void shutdown() {
+        repository.sequencingQueue().shutdown();
         shutdown = true;
     }
 

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/bus/RepositoryChangeBus.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/bus/RepositoryChangeBus.java
@@ -80,6 +80,7 @@ public final class RepositoryChangeBus implements ChangeBus {
 
     @Override
     public void shutdown() {
+        executor.shutdown();
         shutdown = true;
         workspaceListenerQueues.clear();
         try {


### PR DESCRIPTION
Subsystems (e.g. query, sequencing etc) should close their executors when shutdown is called on them.
