### PR TITLE
MODE-1419 Enabled full text searching

### DIFF
--- a/extractors/modeshape-extractor-tika/src/test/java/org/modeshape/extractor/tika/TikaTextExtractorRepositoryTest.java
+++ b/extractors/modeshape-extractor-tika/src/test/java/org/modeshape/extractor/tika/TikaTextExtractorRepositoryTest.java
@@ -24,26 +24,24 @@
 
 package org.modeshape.extractor.tika;
 
+import static junit.framework.Assert.assertEquals;
+import java.io.IOException;
+import java.io.InputStream;
 import javax.jcr.RepositoryException;
 import javax.jcr.query.Query;
 import javax.jcr.query.QueryResult;
-import static junit.framework.Assert.assertEquals;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.modeshape.jcr.SingleUseAbstractTest;
 import org.modeshape.jcr.api.JcrTools;
 import org.modeshape.jcr.query.JcrQuery;
-import java.io.IOException;
-import java.io.InputStream;
 
 /**
- * Integration test which configures a repository to use a Tika-based extractor, creates and saves a node which has a binary
- * value from a text file and using the query mechanism tests that the text is extracted from the binary value and stored
- * in the indexes.
- *
+ * Integration test which configures a repository to use a Tika-based extractor, creates and saves a node which has a binary value
+ * from a text file and using the query mechanism tests that the text is extracted from the binary value and stored in the
+ * indexes.
+ * 
  * @author Horia Chiorean
  */
-@Ignore("Enable this once MODE-1419 and MODE-1547 are fixed")
 public class TikaTextExtractorRepositoryTest extends SingleUseAbstractTest {
 
     private JcrTools jcrTools = new JcrTools();
@@ -56,22 +54,19 @@ public class TikaTextExtractorRepositoryTest extends SingleUseAbstractTest {
     @Test
     public void shouldExtractAndIndexContentFromPlainTextFile() throws Exception {
         uploadFile("text-file.txt");
-        assertExtractedTextHasBeenIndexed(
-                "select [jcr:path] from [nt:resource] as res where contains(res.*, 'The Quick Red Fox Jumps Over the Lazy Brown Dog')");
+        assertExtractedTextHasBeenIndexed("select [jcr:path] from [nt:resource] as res where contains(res.*, 'The Quick Red Fox Jumps Over the Lazy Brown Dog')");
     }
 
     @Test
     public void shouldExtractAndIndexContentFromDocFile() throws Exception {
         uploadFile("modeshape.doc");
-        assertExtractedTextHasBeenIndexed(
-                "select [jcr:path] from [nt:resource] as res where contains(res.*, 'ModeShape supports')");
+        assertExtractedTextHasBeenIndexed("select [jcr:path] from [nt:resource] as res where contains(res.*, 'ModeShape supports')");
     }
 
     @Test
     public void shouldExtractAndIndexContentFromPdfGSFile() throws Exception {
         uploadFile("modeshape_gs.pdf");
-        assertExtractedTextHasBeenIndexed(
-                "select [jcr:path] from [nt:resource] as res where contains(res.*, 'ModeShape supports')");
+        assertExtractedTextHasBeenIndexed("select [jcr:path] from [nt:resource] as res where contains(res.*, 'ModeShape supports')");
     }
 
     private void assertExtractedTextHasBeenIndexed( String validationQuery ) throws RepositoryException {
@@ -81,10 +76,10 @@ public class TikaTextExtractorRepositoryTest extends SingleUseAbstractTest {
     }
 
     private void uploadFile( String filepath ) throws RepositoryException, IOException, InterruptedException {
-        //this will create jcr:content of type nt:resource with the jcr:data property
+        // this will create jcr:content of type nt:resource with the jcr:data property
         jcrTools.uploadFile(session, "/" + filepath, getResource(filepath));
         session.save();
-        //wait a bit to make sure the text extraction has happened
+        // wait a bit to make sure the text extraction has happened
         Thread.sleep(500);
     }
 

--- a/extractors/modeshape-extractor-tika/src/test/resources/repo-config.json
+++ b/extractors/modeshape-extractor-tika/src/test/resources/repo-config.json
@@ -20,6 +20,7 @@
     },
     "query" : {
         "enabled" : true,
+        "enableFullTextSearch" : true,
         "rebuildUponStartup" : "if_missing",
         "indexStorage" : {
             "type" : "ram"

--- a/integration/modeshape-jbossas-integration-tests/src/test/java/org/modeshape/test/integration/TikaTextExtractorIntegrationTest.java
+++ b/integration/modeshape-jbossas-integration-tests/src/test/java/org/modeshape/test/integration/TikaTextExtractorIntegrationTest.java
@@ -24,11 +24,13 @@
 
 package org.modeshape.test.integration;
 
+import static junit.framework.Assert.assertEquals;
+import java.io.File;
+import java.io.InputStream;
 import javax.annotation.Resource;
 import javax.jcr.Session;
 import javax.jcr.query.Query;
 import javax.jcr.query.QueryResult;
-import static junit.framework.Assert.assertEquals;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.ArchivePaths;
@@ -37,22 +39,18 @@ import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.modeshape.jcr.JcrRepository;
 import org.modeshape.jcr.api.JcrTools;
 import org.modeshape.jcr.query.JcrQuery;
-import java.io.File;
-import java.io.InputStream;
 
 /**
  * Arquillian test which checks that text-extraction works in an AS7 container.
- *
+ * 
  * @author Horia Chiorean
  */
-@Ignore("Enable this once MODE-1419 and MODE-1547 are fixed")
-@RunWith( Arquillian.class)
+@RunWith( Arquillian.class )
 public class TikaTextExtractorIntegrationTest {
 
     private JcrTools jcrTools = new JcrTools();
@@ -91,18 +89,19 @@ public class TikaTextExtractorIntegrationTest {
         uploadFileAndCheckExtraction("text-extractor/modeshape.doc", queryString);
     }
 
-    private void uploadFileAndCheckExtraction(String filepath, String validationQuery) throws Exception {
-        //this will create jcr:content of type nt:resource with the jcr:data property
+    private void uploadFileAndCheckExtraction( String filepath,
+                                               String validationQuery ) throws Exception {
+        // this will create jcr:content of type nt:resource with the jcr:data property
         jcrTools.uploadFile(session, "/" + filepath, getResource(filepath));
         session.save();
-        //wait a bit to make sure the text extraction has happened
+        // wait a bit to make sure the text extraction has happened
         Thread.sleep(500);
         Query query = session.getWorkspace().getQueryManager().createQuery(validationQuery, JcrQuery.JCR_SQL2);
         QueryResult result = query.execute();
         assertEquals("Node with text content not found", 1, result.getNodes().getSize());
     }
 
-    private InputStream getResource(String path) {
+    private InputStream getResource( String path ) {
         return getClass().getClassLoader().getResourceAsStream(path);
     }
 }

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/RepositoryConfiguration.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/RepositoryConfiguration.java
@@ -323,6 +323,7 @@ public class RepositoryConfiguration {
         public static final String CLASSNAME = "classname";
         public static final String DATA_SOURCE_JNDI_NAME = "dataSourceJndiName";
         public static final String DATA_CACHE_NAME = "dataCacheName";
+        public static final String FULL_TEXT_SEARCH_ENABLED = "enableFullTextSearch";
         public static final String METADATA_CACHE_NAME = "metadataCacheName";
         public static final String QUERY = "query";
         public static final String QUERY_ENABLED = "enabled";
@@ -443,6 +444,7 @@ public class RepositoryConfiguration {
         public static final String ANONYMOUS_USERNAME = "<anonymous>";
 
         public static final boolean QUERY_ENABLED = true;
+        public static final boolean FULL_TEXT_SEARCH_ENABLED = true;
 
         public static final boolean MONITORING_ENABLED = true;
 
@@ -1235,13 +1237,25 @@ public class RepositoryConfiguration {
         }
 
         /**
-         * Determine whether queries are enabled. The default is to enable queries, but this can be used to turn off support for
-         * queries and improve performance.
+         * Determine whether queries and searches are enabled. The default is to enable queries, but this can be used to turn off
+         * support for queries and improve performance.
          * 
          * @return true if queries are enabled, or false if they are disabled
+         * @see #fullTextSearchEnabled()
          */
-        public boolean enabled() {
+        public boolean queriesEnabled() {
             return query.getBoolean(FieldName.QUERY_ENABLED, Default.QUERY_ENABLED);
+        }
+
+        /**
+         * Get whether full-text searching is enabled for this repository. Note that full-text search requires that
+         * {@link #queriesEnabled() queries are enabled}, so this method returns false if queries are disabled.
+         * 
+         * @return true if full-text searching is enabled, or false otherwise
+         * @see #queriesEnabled()
+         */
+        public boolean fullTextSearchEnabled() {
+            return queriesEnabled() && query.getBoolean(FieldName.FULL_TEXT_SEARCH_ENABLED, Default.FULL_TEXT_SEARCH_ENABLED);
         }
 
         /**
@@ -1347,7 +1361,8 @@ public class RepositoryConfiguration {
             setDefProp(props, FieldName.INDEXING_INDEX_FORMAT, Default.INDEXING_INDEX_FORMAT);
             setDefProp(props, FieldName.INDEXING_READER_STRATEGY, Default.INDEXING_READER_STRATEGY.toString().toLowerCase());
             setDefProp(props, FieldName.INDEXING_MODE, Default.INDEXING_MODE.toString().toLowerCase());
-            setDefProp(props, FieldName.INDEXING_MODE_SYSTEM_CONTENT, Default.INDEXING_MODE_SYSTEM_CONTENT.toString().toLowerCase());
+            setDefProp(props, FieldName.INDEXING_MODE_SYSTEM_CONTENT, Default.INDEXING_MODE_SYSTEM_CONTENT.toString()
+                                                                                                          .toLowerCase());
             setDefProp(props, FieldName.INDEXING_ASYNC_THREAD_POOL_SIZE, Default.INDEXING_ASYNC_THREAD_POOL_SIZE);
             setDefProp(props, FieldName.INDEXING_ASYNC_MAX_QUEUE_SIZE, Default.INDEXING_ASYNC_MAX_QUEUE_SIZE);
             return props;
@@ -1399,7 +1414,7 @@ public class RepositoryConfiguration {
 
         /**
          * Get the name of the thread pool that should be used for sequencing work.
-         *
+         * 
          * @return the thread pool name; never null
          */
         public String getThreadPoolName() {
@@ -1408,7 +1423,7 @@ public class RepositoryConfiguration {
 
         /**
          * Get the ordered list of text extractors. All text extractors are configured with this list.
-         *
+         * 
          * @return the immutable list of text extractors; never null but possibly empty
          */
         public List<Component> getTextExtractors() {

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/query/JcrQueryResult.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/query/JcrQueryResult.java
@@ -382,7 +382,7 @@ public class JcrQueryResult implements org.modeshape.jcr.api.query.QueryResult {
             return context.createValue(PropertyType.LONG, value);
         }
 
-        protected Value jcrDouble( Float score ) {
+        protected Value jcrDouble( Double score ) {
             return context.createValue(PropertyType.DOUBLE, score);
         }
     }
@@ -475,7 +475,7 @@ public class JcrQueryResult implements org.modeshape.jcr.api.query.QueryResult {
                     return iterator.jcrLong(depth);
                 }
                 if (JCR_SCORE_COLUMN_NAME.equals(propertyName)) {
-                    Float score = iterator.scoreIndex == -1 ? 0.0f : (Float)tuple[iterator.scoreIndex];
+                    Double score = iterator.scoreIndex == -1 ? 0.0d : (Double)tuple[iterator.scoreIndex];
                     return iterator.jcrDouble(score);
                 }
             }
@@ -605,7 +605,7 @@ public class JcrQueryResult implements org.modeshape.jcr.api.query.QueryResult {
                 }
                 if (JCR_SCORE_COLUMN_NAME.equals(propertyName)) {
                     int scoreIndex = iterator.columns.getFullTextSearchScoreIndexFor(columnName);
-                    Float score = scoreIndex == -1 ? 0.0f : (Float)tuple[scoreIndex];
+                    Double score = scoreIndex == -1 ? 0.0d : (Double)tuple[scoreIndex];
                     return iterator.jcrDouble(score);
                 }
             }

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/query/XPathQueryResult.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/query/XPathQueryResult.java
@@ -132,7 +132,7 @@ public class XPathQueryResult extends JcrQueryResult {
                 return ((XPathQueryResultRowIterator)iterator).jcrPath(location.getPath());
             }
             if (JCR_SCORE_COLUMN_NAME.equals(columnName)) {
-                Float score = (Float)tuple[iterator.scoreIndex];
+                Double score = (Double)tuple[iterator.scoreIndex];
                 return ((XPathQueryResultRowIterator)iterator).jcrDouble(score);
             }
             return super.getValue(columnName);

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/query/lucene/LuceneQueryEngine.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/query/lucene/LuceneQueryEngine.java
@@ -84,17 +84,19 @@ public class LuceneQueryEngine extends QueryEngine {
      * @param optimizer the optimizer that should be used
      * @param searchFactory the search factory for accessing the indexes
      * @param version the Lucene version used by the indexes
+     * @param enableFullTextSearch true if full-text searching is enabled, or false otherwise
      */
     public LuceneQueryEngine( ExecutionContext context,
                               String repositoryName,
                               Planner planner,
                               Optimizer optimizer,
                               SearchFactoryImplementor searchFactory,
-                              Version version ) {
+                              Version version,
+                              boolean enableFullTextSearch ) {
         super(planner, optimizer, new LuceneQueryProcessor(repositoryName, searchFactory));
         this.repositoryContext = context;
         // this.repositoryName = repositoryName;
-        this.schema = new BasicLuceneSchema(this.repositoryContext, searchFactory, version);
+        this.schema = new BasicLuceneSchema(this.repositoryContext, searchFactory, version, enableFullTextSearch);
         ((LuceneQueryProcessor)this.processor).initialize(schema);
     }
 

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/query/lucene/basic/BasicTupleCollector.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/query/lucene/basic/BasicTupleCollector.java
@@ -293,7 +293,7 @@ public class BasicTupleCollector extends TupleCollector {
         @Override
         protected Object computeValue( Path path,
                                        float score ) {
-            return new Float(score);
+            return new Double(score);
         }
     }
 

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/query/xpath/XPathToQueryTranslator.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/query/xpath/XPathToQueryTranslator.java
@@ -64,6 +64,7 @@ import org.modeshape.jcr.query.xpath.XPath.OrderBySpec;
 import org.modeshape.jcr.query.xpath.XPath.ParenthesizedExpression;
 import org.modeshape.jcr.query.xpath.XPath.PathExpression;
 import org.modeshape.jcr.query.xpath.XPath.StepExpression;
+import org.modeshape.jcr.query.xpath.XPath.TextTest;
 import org.modeshape.jcr.query.xpath.XPath.Union;
 import org.modeshape.jcr.value.PropertyType;
 
@@ -181,6 +182,17 @@ public class XPathToQueryTranslator {
                 } else if (nodeTest instanceof AttributeNameTest) {
                     AttributeNameTest attributeName = (AttributeNameTest)nodeTest;
                     builder.select(nameFrom(attributeName.getNameTest()));
+                } else if (nodeTest instanceof TextTest) {
+                    NameTest nameTest = new NameTest("jcr", "xmltext");
+                    List<Component> predicates = axis.getPredicates();
+                    if (predicates == null || predicates.isEmpty() || appliesToPathConstraint(predicates)) {
+                        AxisStep textStep = new AxisStep(nameTest, axis.getPredicates());
+                        path.add(textStep);
+                    } else {
+                        tableName = translateSource(tableName, path, where);
+                        translatePredicates(predicates, tableName, where);
+                        path.clear();
+                    }
                 } else {
                     throw new InvalidQueryException(query, "The '" + step + "' step is not supported");
                 }

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/value/binary/DatabaseBinaryStore.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/value/binary/DatabaseBinaryStore.java
@@ -26,8 +26,8 @@ package org.modeshape.jcr.value.binary;
 import java.io.InputStream;
 import java.util.concurrent.TimeUnit;
 import org.modeshape.common.annotation.ThreadSafe;
-import org.modeshape.jcr.value.BinaryValue;
 import org.modeshape.jcr.value.BinaryKey;
+import org.modeshape.jcr.value.BinaryValue;
 
 /**
  * A {@link BinaryStore} implementation that uses a database for persisting binary values.
@@ -57,11 +57,6 @@ public class DatabaseBinaryStore extends AbstractBinaryStore {
     }
 
     @Override
-    public String getText( BinaryValue binary ) throws BinaryStoreException {
-        throw new BinaryStoreException("Not implemented");
-    }
-
-    @Override
     public String getMimeType( BinaryValue binary,
                                String name ) {
         throw new UnsupportedOperationException("Not implemented");
@@ -74,7 +69,7 @@ public class DatabaseBinaryStore extends AbstractBinaryStore {
 
     @Override
     public void storeExtractedText( BinaryValue source,
-                                       String extractedText ) throws BinaryStoreException {
+                                    String extractedText ) throws BinaryStoreException {
         throw new UnsupportedOperationException("Not implemented");
     }
 }

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/value/binary/InfinispanBinaryStore.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/value/binary/InfinispanBinaryStore.java
@@ -29,8 +29,8 @@ import org.infinispan.Cache;
 import org.infinispan.manager.CacheContainer;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.modeshape.common.annotation.ThreadSafe;
-import org.modeshape.jcr.value.BinaryValue;
 import org.modeshape.jcr.value.BinaryKey;
+import org.modeshape.jcr.value.BinaryValue;
 
 /**
  * A {@link BinaryStore} implementation that uses a database for persisting binary values.
@@ -129,11 +129,6 @@ public class InfinispanBinaryStore extends AbstractBinaryStore {
     }
 
     @Override
-    public String getText( BinaryValue binary ) throws BinaryStoreException {
-        throw new BinaryStoreException("Not implemented");
-    }
-
-    @Override
     public String getMimeType( BinaryValue binary,
                                String name ) {
         throw new UnsupportedOperationException("Not implemented");
@@ -146,7 +141,7 @@ public class InfinispanBinaryStore extends AbstractBinaryStore {
 
     @Override
     public void storeExtractedText( BinaryValue source,
-                                       String extractedText ) throws BinaryStoreException {
+                                    String extractedText ) throws BinaryStoreException {
         throw new UnsupportedOperationException("Not implemented");
     }
 }

--- a/modeshape-jcr/src/main/resources/org/modeshape/jcr/repository-config-schema.json
+++ b/modeshape-jcr/src/main/resources/org/modeshape/jcr/repository-config-schema.json
@@ -291,6 +291,11 @@
                     "default" : true,
                     "description" : "A boolean flag that specifies whether this repository is expected to execute searches and queries. If client applications will never perform searches or queries, then maintaining the query indexes is an unnecessary overhead, and can be disabled. Note that this is merely a hint, and that searches and queries might still work when this is set to 'false'."
                 },
+                "enableFullTextSearch" : {
+                    "type" : "boolean",
+                    "default" : true,
+                    "description" : "A boolean flag that specifies whether this repository is expected to execute full-text searches. If client applications will never perform full-text searches, then maintaining the full-text indexes is an unnecessary overhead, and can be disabled. The default is 'false', meaning that full-text searching is disabled by default."
+                },
                 "rebuildUponStartup" : {
                     "type" : "string",
                     "enum" : ["if_missing","always"],

--- a/modeshape-jcr/src/test/java/org/modeshape/jcr/JcrQueryManagerTest.java
+++ b/modeshape-jcr/src/test/java/org/modeshape/jcr/JcrQueryManagerTest.java
@@ -1316,28 +1316,38 @@ public class JcrQueryManagerTest extends MultiUseAbstractTest {
 
     @Test
     @FixFor( "MODE-1547" )
-    @Ignore(" enable once FTS is configured ")
     public void shouldBeAbleToExecuteFullTextSearchQueriesOnPropertiesWhichIncludeStopWords() throws Exception {
         String propertyText = "the quick Brown fox jumps over to the dog in at the gate";
-        session.getRootNode().addNode("FTSNode").setProperty("FTSProp", propertyText);
-        session.save();
+        Node ftsNode = session.getRootNode().addNode("FTSNode").setProperty("FTSProp", propertyText).getParent();
+        try {
+            session.save();
 
-        executeJcrSQL2AndExpectOneResult("select [jcr:path] from [nt:unstructured] as n where contains([nt:unstructured].*,'" + propertyText +"')");
+            executeJcrSQL2AndExpectOneResult("select [jcr:path] from [nt:unstructured] as n where contains([nt:unstructured].*,'"
+                                             + propertyText + "')");
 
-        executeJcrSQL2AndExpectOneResult("select [jcr:path] from [nt:unstructured] as n where contains(FTSProp,'" + propertyText +"')");
-        executeJcrSQL2AndExpectOneResult("select [jcr:path] from [nt:unstructured] as n where contains(n.*,'" + propertyText +"')");
+            executeJcrSQL2AndExpectOneResult("select [jcr:path] from [nt:unstructured] as n where contains(FTSProp,'"
+                                             + propertyText + "')");
+            executeJcrSQL2AndExpectOneResult("select [jcr:path] from [nt:unstructured] as n where contains(n.*,'" + propertyText
+                                             + "')");
 
-        executeJcrSQL2AndExpectOneResult("select [jcr:path] from [nt:unstructured] as n where contains(FTSProp,'" + propertyText.toUpperCase() +"')");
-        executeJcrSQL2AndExpectOneResult("select [jcr:path] from [nt:unstructured] as n where contains(n.*,'" + propertyText.toUpperCase() +"')");
+            executeJcrSQL2AndExpectOneResult("select [jcr:path] from [nt:unstructured] as n where contains(FTSProp,'"
+                                             + propertyText.toUpperCase() + "')");
+            executeJcrSQL2AndExpectOneResult("select [jcr:path] from [nt:unstructured] as n where contains(n.*,'"
+                                             + propertyText.toUpperCase() + "')");
 
-        executeJcrSQL2AndExpectOneResult("select [jcr:path] from [nt:unstructured] as n where contains(FTSProp,'the quick Dog')");
-        executeJcrSQL2AndExpectOneResult("select [jcr:path] from [nt:unstructured] as n where contains(n.*,'the quick Dog')");
+            executeJcrSQL2AndExpectOneResult("select [jcr:path] from [nt:unstructured] as n where contains(FTSProp,'the quick Dog')");
+            executeJcrSQL2AndExpectOneResult("select [jcr:path] from [nt:unstructured] as n where contains(n.*,'the quick Dog')");
 
-        executeJcrSQL2AndExpectOneResult("select [jcr:path] from [nt:unstructured] as n where contains(FTSProp,'the quick jumps over gate')");
-        executeJcrSQL2AndExpectOneResult("select [jcr:path] from [nt:unstructured] as n where contains(n.*,'the quick jumps over gate')");
+            executeJcrSQL2AndExpectOneResult("select [jcr:path] from [nt:unstructured] as n where contains(FTSProp,'the quick jumps over gate')");
+            executeJcrSQL2AndExpectOneResult("select [jcr:path] from [nt:unstructured] as n where contains(n.*,'the quick jumps over gate')");
 
-        executeJcrSQL2AndExpectOneResult("select [jcr:path] from [nt:unstructured] as n where contains(FTSProp,'the gate')");
-        executeJcrSQL2AndExpectOneResult("select [jcr:path] from [nt:unstructured] as n where contains(n.*,'the gate')");
+            executeJcrSQL2AndExpectOneResult("select [jcr:path] from [nt:unstructured] as n where contains(FTSProp,'the gate')");
+            executeJcrSQL2AndExpectOneResult("select [jcr:path] from [nt:unstructured] as n where contains(n.*,'the gate')");
+        } finally {
+            // Try to remove the node (which messes up the expected results from subsequent tests) ...
+            ftsNode.remove();
+            session.save();
+        }
     }
 
     private void executeJcrSQL2AndExpectOneResult( String sql ) throws RepositoryException {

--- a/modeshape-jcr/src/test/java/org/modeshape/jcr/JcrRepositoryTest.java
+++ b/modeshape-jcr/src/test/java/org/modeshape/jcr/JcrRepositoryTest.java
@@ -305,7 +305,7 @@ public class JcrRepositoryTest extends AbstractTransactionalTest {
         assertThat(repository.getDescriptor(Repository.OPTION_TRANSACTIONS_SUPPORTED), is("true"));
         assertThat(repository.getDescriptor(Repository.OPTION_VERSIONING_SUPPORTED), is("true"));
         assertThat(repository.getDescriptor(Repository.QUERY_XPATH_DOC_ORDER), is("false"));
-        assertThat(repository.getDescriptor(Repository.QUERY_XPATH_POS_INDEX), is("true"));
+        assertThat(repository.getDescriptor(Repository.QUERY_XPATH_POS_INDEX), is("false"));
         assertThat(repository.getDescriptor(Repository.REP_NAME_DESC), is("ModeShape"));
         assertThat(repository.getDescriptor(Repository.REP_VENDOR_DESC), is("JBoss, a division of Red Hat"));
         assertThat(repository.getDescriptor(Repository.REP_VENDOR_URL_DESC), is("http://www.modeshape.org"));

--- a/modeshape-jcr/src/test/java/org/modeshape/jcr/JcrTckTest.java
+++ b/modeshape-jcr/src/test/java/org/modeshape/jcr/JcrTckTest.java
@@ -180,9 +180,11 @@ import org.apache.jackrabbit.test.api.query.SaveTest;
 import org.apache.jackrabbit.test.api.query.SetLimitTest;
 import org.apache.jackrabbit.test.api.query.SetOffsetTest;
 import org.apache.jackrabbit.test.api.query.SimpleSelectionTest;
+import org.apache.jackrabbit.test.api.query.TextNodeTest;
 import org.apache.jackrabbit.test.api.query.XPathDocOrderTest;
 import org.apache.jackrabbit.test.api.query.XPathJcrPathTest;
 import org.apache.jackrabbit.test.api.query.XPathOrderByTest;
+import org.apache.jackrabbit.test.api.query.XPathPosIndexTest;
 import org.apache.jackrabbit.test.api.query.XPathQueryLevel2Test;
 import org.apache.jackrabbit.test.api.query.qom.AndConstraintTest;
 import org.apache.jackrabbit.test.api.query.qom.BindVariableValueTest;
@@ -474,7 +476,7 @@ public class JcrTckTest {
 
             addTestSuite(SQLJoinTest.class);
             addTestSuite(SQLJcrPathTest.class);
-            //TODO author=Horia Chiorean date=7/16/12 description=https://issues.apache.org/jira/browse/JCR-3376
+            // TODO author=Horia Chiorean date=7/16/12 description=https://issues.apache.org/jira/browse/JCR-3376
             addTestSuite(excludeTests(SQLPathTest.class, "testChildAxisRoot"));
             addTestSuite(XPathDocOrderTest.class);
             addTestSuite(XPathOrderByTest.class);
@@ -510,11 +512,10 @@ public class JcrTckTest {
             addTestSuite(SetLimitTest.class);
             addTestSuite(SetOffsetTest.class);
 
-            // TODO author=Horia Chiorean date=4/20/12 description=https://issues.jboss.org/browse/MODE-1419
-            addTestSuite(excludeTests(SQLQueryLevel2Test.class, "testScoreColumn", "testFullTextSearch", "testPathColumn"));
-            // addTestSuite(XPathPosIndexTest.class);
-            addTestSuite(excludeTests(XPathQueryLevel2Test.class, "testScoreColumn", "testFullTextSearch", "testPathColumn"));
-            // addTestSuite(TextNodeTest.class);
+            addTestSuite(SQLQueryLevel2Test.class);
+            addTestSuite(XPathPosIndexTest.class);
+            addTestSuite(XPathQueryLevel2Test.class);
+            addTestSuite(TextNodeTest.class);
         }
     }
 

--- a/modeshape-jcr/src/test/java/org/modeshape/jcr/sequencer/AbstractSequencerTest.java
+++ b/modeshape-jcr/src/test/java/org/modeshape/jcr/sequencer/AbstractSequencerTest.java
@@ -68,7 +68,7 @@ import org.slf4j.LoggerFactory;
  */
 public abstract class AbstractSequencerTest extends SingleUseAbstractTest {
 
-    private static final int DEFAULT_WAIT_TIME_SECONDS = 8;
+    private static final int DEFAULT_WAIT_TIME_SECONDS = 15;
 
     protected Node rootNode;
 

--- a/modeshape-jcr/src/test/resources/repositoryStubImpl.properties
+++ b/modeshape-jcr/src/test/resources/repositoryStubImpl.properties
@@ -55,6 +55,8 @@ javax.jcr.tck.NodeTest.testSaveContstraintViolationException.nodetype2=modetest\
 # nodetype that has a property that is mandatory but not autocreated
 javax.jcr.tck.NodeTest.testSaveConstraintViolationException.nodetype2=nt:file
 
+javax.jcr.tck.TextNodeTest.testroot=/testroot/textNodeTests
+
 javax.jcr.tck.NodeOrderableChildNodesTest.testOrderBeforeUnsupportedRepositoryOperationException.nodetype2=modetest\:unorderableUnstructured
 javax.jcr.tck.NodeOrderableChildNodesTest.testOrderBeforeUnsupportedRepositoryOperationException.nodetype3=modetest\:unorderableUnstructured
 # For some reason, this test assumes testNodeType doesn't allow children - most other tests assume that it does

--- a/modeshape-jcr/src/test/resources/tck/default/repo-config.json
+++ b/modeshape-jcr/src/test/resources/tck/default/repo-config.json
@@ -9,6 +9,8 @@
         "transactionManagerLookup" : "org.infinispan.transaction.lookup.DummyTransactionManagerLookup"
     },
     "query" : {
+        "enabled" : true,
+        "enableFullTextSearch" : true,
         "indexing": {
             "systemContentMode" : "sync"
         }


### PR DESCRIPTION
Added full-text search back in. Note that it can be explicitly disabled/enabled within a repository configuration, and it is currently _enabled_ by default. Quite a few test cases were added back in, and some of them highlighted some issues with search/query scores (were floats, but expected to be doubles).

Also, one quirk of the AS7 subsystem startup is that the text extractors are added to a running repository, and that means that there's a time during startup when there are no text extractors (and any added binary values don't get extracted during storage), followed quickly by the enabling of text extractors (by the time the property with the binary value is indexed). This manifested itself as a blocked sequencing thread within the ZIP Sequencer integration test (using AS7).

All unit and integration tests pass with these changes, including those that were enabled by these changes.
