### PR TITLE
MODE-1546 - Cleaned up and fixed some issues in the attempt to fix the intermittent failures

### DIFF
--- a/modeshape-common/src/main/java/org/modeshape/common/util/ThreadPools.java
+++ b/modeshape-common/src/main/java/org/modeshape/common/util/ThreadPools.java
@@ -64,7 +64,6 @@ public class ThreadPools implements ThreadPoolFactory {
             executor = poolsByName.putIfAbsent(name, executorService);
             if (executor != null) {
                 // There was an existing one created since we originally checked, so shut down the new executor we just created
-                // ...
                 executor.shutdownNow();
             }
             executor = executorService;

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/AbstractJcrNode.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/AbstractJcrNode.java
@@ -254,22 +254,12 @@ abstract class AbstractJcrNode extends AbstractJcrItem implements Node {
     }
 
     /**
-     * Checks if this node is foreign by comparing the node's source key & workspace key against the same keys from the session
-     * root. This method is used for reference resolving.
-     * 
-     * @return true if the node is considered foreign, false otherwise.
+     * Checks if this node is foreign for its current owning session
+     *
+     * @see JcrSession#isForeignKey(org.modeshape.jcr.cache.NodeKey)
      */
     protected final boolean isForeign() {
-        NodeKey nodeKey = key();
-        if (nodeKey == null) {
-            return false;
-        }
-        String nodeWorkspaceKey = nodeKey.getWorkspaceKey();
-
-        NodeKey rootKey = cache().getRootKey();
-        boolean sameWorkspace = rootKey.getWorkspaceKey().equals(nodeWorkspaceKey);
-        boolean sameSource = rootKey.getSourceKey().equalsIgnoreCase(nodeKey.getSourceKey());
-        return !sameWorkspace || !sameSource;
+        return session().isForeignKey(key());
     }
 
     protected final boolean isInTheSameProcessAs( String otherProcessId ) {
@@ -278,7 +268,7 @@ abstract class AbstractJcrNode extends AbstractJcrItem implements Node {
 
     @Override
     public final String getIdentifier() {
-        return isForeign() ? key().toString() : key().getIdentifier();
+        return session().nodeIdentifier(key());
     }
 
     /**
@@ -3298,8 +3288,8 @@ abstract class AbstractJcrNode extends AbstractJcrItem implements Node {
                 propertyBuff.append(prop).append(", ");
             }
             return this.getPath() + " {" + propertyBuff.toString() + "}";
-        } catch (RepositoryException re) {
-            return re.getMessage();
+        } catch (Exception e) {
+            return e.getMessage();
         }
     }
 

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrRepository.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrRepository.java
@@ -81,6 +81,7 @@ import org.modeshape.common.collection.Problems;
 import org.modeshape.common.collection.SimpleProblems;
 import org.modeshape.common.logging.Logger;
 import org.modeshape.common.util.CheckArg;
+import org.modeshape.common.util.NamedThreadFactory;
 import org.modeshape.jcr.ModeShapeEngine.State;
 import org.modeshape.jcr.RepositoryConfiguration.AnonymousSecurity;
 import org.modeshape.jcr.RepositoryConfiguration.BinaryStorage;
@@ -280,7 +281,7 @@ public class JcrRepository implements org.modeshape.jcr.api.Repository {
      */
     Future<Boolean> shutdown() {
         // Create a simple executor that will do the backgrounding for us ...
-        final ExecutorService executor = Executors.newSingleThreadExecutor();
+        final ExecutorService executor = Executors.newSingleThreadExecutor(new NamedThreadFactory("modeshape-repository-shutdown"));
         try {
             // Submit a runnable to terminate all sessions ...
             Future<Boolean> future = executor.submit(new Callable<Boolean>() {
@@ -1401,6 +1402,11 @@ public class JcrRepository implements org.modeshape.jcr.api.Repository {
             if (repositoryQueryManager != null) {
                 repositoryQueryManager.shutdown();
                 this.context().releaseThreadPool(indexingExecutor);
+            }
+
+            //Shutdown the text extractors
+            if (extractors != null) {
+                extractors.shutdown();
             }
 
             if (statistics != null) {

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrSession.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrSession.java
@@ -1008,7 +1008,7 @@ public class JcrSession implements Session {
         if (!keepChanges) {
             cache.clear();
         }
-        // Otherwise there is nothing to do, as all persistent changes are always immediately vislble to all sessions
+        // Otherwise there is nothing to do, as all persistent changes are always immediately visible to all sessions
         // using that same workspace
     }
 
@@ -1437,6 +1437,34 @@ public class JcrSession implements Session {
         } catch (WorkspaceNotFoundException e) {
             throw new NoSuchWorkspaceException(JcrI18n.workspaceNameIsInvalid.text(repository().repositoryName(), workspaceName));
         }
+    }
+
+    /**
+     * Checks if the node given key is foreign by comparing the source key & workspace key against the same keys from this session's
+     * root. This method is used for reference resolving.
+     *
+     * @return true if the node key is considered foreign, false otherwise.
+     */
+    protected boolean isForeignKey(NodeKey key) {
+        if (key == null) {
+            return false;
+        }
+        String nodeWorkspaceKey = key.getWorkspaceKey();
+
+        NodeKey rootKey = cache().getRootKey();
+        boolean sameWorkspace = rootKey.getWorkspaceKey().equals(nodeWorkspaceKey);
+        boolean sameSource = rootKey.getSourceKey().equalsIgnoreCase(key.getSourceKey());
+        return !sameWorkspace || !sameSource;
+    }
+
+
+    /**
+     * Returns a string representing a node's identifier, based on whether the node is foreign or not.
+     *
+     * @see javax.jcr.Node#getIdentifier()
+     */
+    protected String nodeIdentifier( NodeKey key ) {
+        return isForeignKey(key) ? key.toString() : key.getIdentifier();
     }
 
     @Override

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/NodeNotFoundInParentException.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/NodeNotFoundInParentException.java
@@ -38,13 +38,8 @@ public class NodeNotFoundInParentException extends NodeNotFoundException {
      */
     public NodeNotFoundInParentException( NodeKey key,
                                           NodeKey parentKey ) {
-        super(key);
+        super(key, "Cannot locate child node: " + key + " within parent: " + parentKey);
         this.parentKey = parentKey;
-    }
-
-    @Override
-    public String toString() {
-        return super.toString();
     }
 
     /**

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/RepositoryCache.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/RepositoryCache.java
@@ -220,7 +220,10 @@ public class RepositoryCache implements Observable {
             String workspaceName = changeSet.getWorkspaceName();
             if (workspaceName != null) {
                 for (WorkspaceCache cache : workspaces()) {
-                    cache.notify(changeSet);
+                    if (!cache.getWorkspaceName().equalsIgnoreCase(workspaceName)) {
+                        //the workspace which triggered the event should've already processed the changeset, so we don't want to do it
+                        cache.notify(changeSet);
+                    }
                 }
             } else {
                 // Look for changes to the workspaces ...

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/document/WritableSessionCache.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/document/WritableSessionCache.java
@@ -358,6 +358,7 @@ public class WritableSessionCache extends AbstractSessionCache {
 
             } catch (NotSupportedException err) {
                 // No nested transactions are supported ...
+                return;
             } catch (SecurityException err) {
                 // No privilege to commit ...
                 throw new SystemFailureException(err);
@@ -366,6 +367,7 @@ public class WritableSessionCache extends AbstractSessionCache {
                 throw new SystemFailureException(err);
             } catch (RollbackException err) {
                 // Couldn't be committed, but the txn is already rolled back ...
+                return;
             } catch (HeuristicMixedException err) {
             } catch (HeuristicRollbackException err) {
                 // Rollback has occurred ...
@@ -482,6 +484,7 @@ public class WritableSessionCache extends AbstractSessionCache {
 
             } catch (NotSupportedException err) {
                 // No nested transactions are supported ...
+                return;
             } catch (SecurityException err) {
                 // No privilege to commit ...
                 throw new SystemFailureException(err);
@@ -490,6 +493,7 @@ public class WritableSessionCache extends AbstractSessionCache {
                 throw new SystemFailureException(err);
             } catch (RollbackException err) {
                 // Couldn't be committed, but the txn is already rolled back ...
+                return;
             } catch (HeuristicMixedException err) {
             } catch (HeuristicRollbackException err) {
                 // Rollback has occurred ...
@@ -596,6 +600,7 @@ public class WritableSessionCache extends AbstractSessionCache {
 
             } catch (NotSupportedException err) {
                 // No nested transactions are supported ...
+                return;
             } catch (SecurityException err) {
                 // No privilege to commit ...
                 throw new SystemFailureException(err);
@@ -604,6 +609,7 @@ public class WritableSessionCache extends AbstractSessionCache {
                 throw new SystemFailureException(err);
             } catch (RollbackException err) {
                 // Couldn't be committed, but the txn is already rolled back ...
+                return;
             } catch (HeuristicMixedException err) {
             } catch (HeuristicRollbackException err) {
                 // Rollback has occurred ...

--- a/modeshape-jcr/src/test/java/org/modeshape/jcr/TestingEnvironment.java
+++ b/modeshape-jcr/src/test/java/org/modeshape/jcr/TestingEnvironment.java
@@ -41,12 +41,19 @@ public class TestingEnvironment extends LocalEnvironment {
     private final CacheLoaderConfig cacheLoaderConfiguration;
 
     public TestingEnvironment() {
-        super(DummyTransactionManagerLookup.class);
-        this.cacheLoaderConfiguration = null;
+        this(null, DummyTransactionManagerLookup.class);
+    }
+
+    public TestingEnvironment(Class<? extends TransactionManagerLookup> transactionManagerLookup) {
+        this(null, transactionManagerLookup);
     }
 
     public TestingEnvironment( CacheLoaderConfig cacheLoaderConfiguration ) {
-        super(DummyTransactionManagerLookup.class);
+        this(cacheLoaderConfiguration, DummyTransactionManagerLookup.class);
+    }
+
+    public TestingEnvironment(CacheLoaderConfig cacheLoaderConfiguration, Class<? extends TransactionManagerLookup> transactionManagerLookup) {
+        super(transactionManagerLookup);
         this.cacheLoaderConfiguration = cacheLoaderConfiguration;
     }
 

--- a/modeshape-jcr/src/test/java/org/modeshape/jcr/TestingUtil.java
+++ b/modeshape-jcr/src/test/java/org/modeshape/jcr/TestingUtil.java
@@ -77,11 +77,11 @@ public class TestingUtil {
             if (repository.getState() != State.RUNNING) return Collections.emptySet();
             // Rollback any open transactions ...
             TransactionManager txnMgr = repository.runningState().txnManager();
-            if (txnMgr != null) {
+            if (txnMgr != null && txnMgr.getTransaction() != null) {
                 try {
                     txnMgr.rollback();
                 } catch (Throwable t) {
-                    // don't care
+                   log.warn(t, JcrI18n.errorKillingRepository, repository.getName(), t.getMessage());
                 }
             }
 
@@ -89,7 +89,7 @@ public class TestingUtil {
             Collection<Cache<?, ?>> caches = repository.caches();
 
             // First shut down the repository ...
-            repository.shutdown().get(20, TimeUnit.SECONDS);
+            repository.shutdown().get();
 
             // Get the caches and kill them ...
             Set<CacheContainer> cacheContainers = new HashSet<CacheContainer>();

--- a/modeshape-schematic/src/main/java/org/infinispan/schematic/internal/SchematicEntryLiteral.java
+++ b/modeshape-schematic/src/main/java/org/infinispan/schematic/internal/SchematicEntryLiteral.java
@@ -110,6 +110,8 @@ public class SchematicEntryLiteral implements SchematicEntry, DeltaAware {
     public SchematicEntryLiteral copyForWrite() {
         try {
             SchematicEntryLiteral clone = (SchematicEntryLiteral)super.clone();
+            //TODO author=Horia Chiorean date=7/20/12 description=MODE-1546 - This is not efficient and should be handled differently
+            //clone.value = (MutableDocument)value.clone();
             clone.proxy = proxy;
             clone.copied = true;
             return clone;


### PR DESCRIPTION
- fixed the dispatching of workspace events if a transaction fails
- JcrObservationManager: cleaned up some multi-threaded code and improved performance in some cases by not retrieving nodes from the schematic db 
- TextExtractors - added a way to shut them down and shutdown the executor
- updated the creation of Executors, so that they use NamedThreadFactory
