### PR TITLE
MODE-1568 - Fixed the fact that surefire ignored the ipv4 or ipv6 profiles

### DIFF
--- a/modeshape-parent/pom.xml
+++ b/modeshape-parent/pom.xml
@@ -578,10 +578,7 @@
                         <include>**/*TestCase.java</include>
                         <include>**/*Test.java</include>
                     </includes>
-                    <!--
-                             excludes> <exclude>**/Abstract*TestCase.java</exclude>
-                             <exclude>**/Abstract*Test.java</exclude> </excludes -->
-                    <systemProperties>
+                    <systemProperties combine.children="append">
                         <property>
                             <name>java.io.tmpdir</name>
                             <value>${basedir}/target</value>


### PR DESCRIPTION
Actually, because of the fix for MODE-1555, any system properties from the parent .pom were ignored.
