### PR TITLE
MODE-1591 Upgraded the JCR Tests to 2.5.1

### DIFF
--- a/modeshape-jcr/pom.xml
+++ b/modeshape-jcr/pom.xml
@@ -219,23 +219,13 @@
                                 <property>
                                     <name>known.issues</name>
                                     <value>
-                                        <!--// TODO author=Randall Hauch date=7/2/12 description=https://issues.apache.org/jira/browse/JCR-3370 -->
-                                        org.apache.jackrabbit.test.api.ShareableNodeTest#testGetPath
-                                        <!--// TODO author=Randall Hauch date=7/2/12 description=https://issues.apache.org/jira/browse/JCR-3371-->
-                                        org.apache.jackrabbit.test.api.ShareableNodeTest#testRemoveMixin
-                                        <!--// TODO author=Randall Hauch date=7/9/12 description=https://issues.apache.org/jira/browse/JCR-3380-->
-                                        org.apache.jackrabbit.test.api.ShareableNodeTest#testMoveShareableNode
-                                        org.apache.jackrabbit.test.api.ShareableNodeTest#testTransientMoveShareableNode
-                                        org.apache.jackrabbit.test.api.ShareableNodeTest#testModifyDescendantAndSave
-                                        org.apache.jackrabbit.test.api.ShareableNodeTest#testModifyDescendantAndRemoveShareAndSave
-                                        <!--// TODO author=Horia Chiorean date=7/16/12 description=https://issues.apache.org/jira/browse/JCR-3376-->
-                                        org.apache.jackrabbit.test.api.query.SQLPathTest#testChildAxisRoot
-                                        <!--// TODO author=Randall Hauch date=5/17/12 description=https://issues.apache.org/jira/browse/JCR-3313-->
-                                        org.apache.jackrabbit.test.api.query.qom.ColumnTest#testExpandColumnsForNodeType
                                         <!--// TODO author=Randall Hauch date=5/17/12 description=https://issues.apache.org/jira/browse/MODE-1095-->
                                         org.apache.jackrabbit.test.api.query.qom.OrderingTest#testMultipleSelectors
-                                        <!--// TODO author=Horia Chiorean date=4/19/12 description=https://issues.apache.org/jira/browse/JCR-2666-->
-                                        org.apache.jackrabbit.test.api.version.RestoreTest#testRestoreNameJcr2
+                                        <!--// TODO author=Randall Hauch date=7/10/12 description=https://issues.apache.org/jira/browse/MODE-1552-->
+                                        org.apache.jackrabbit.test.api.ShareableNodeTest#testModifyDescendantAndSave
+                                        org.apache.jackrabbit.test.api.ShareableNodeTest#testModifyDescendantAndRemoveShareAndSave
+                                        <!--// TODO author=Randall Hauch date=8/16/12 description=https://issues.apache.org/jira/browse/MODE-1599-->
+                                        org.apache.jackrabbit.test.api.query.qom.ColumnTest#testExpandColumnsForNodeType
                                     </value>
                                 </property>
                             </systemProperties>

--- a/modeshape-parent/pom.xml
+++ b/modeshape-parent/pom.xml
@@ -221,7 +221,7 @@
         <slf4j.log4j.version>1.6.1</slf4j.log4j.version>
         <log4j.version>1.2.16</log4j.version>
         <jcr.version>2.0</jcr.version>
-        <jackrabbit.jcr.tck.version>2.5.0</jackrabbit.jcr.tck.version>
+        <jackrabbit.jcr.tck.version>2.5.1</jackrabbit.jcr.tck.version>
         <picketbox.version>4.0.7.Final</picketbox.version>
         <byteman.version>1.5.1</byteman.version>
         <lucene.version>3.5.0</lucene.version>


### PR DESCRIPTION
Upgraded the JCR tests to 2.5.1, and removed all of the remaining "known.issues" in the 'modeshape-jcr/pom.xml' (except for the 3 remaining issues with ModeShape code).
