### PR TITLE
MODE-1581 Added support for including binary values in backups

### DIFF
--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrI18n.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrI18n.java
@@ -84,6 +84,7 @@ public final class JcrI18n {
     public static I18n problemsWritingDocumentToBackup;
     public static I18n problemsWritingBinaryToBackup;
     public static I18n problemsReadingBinaryFromBackup;
+    public static I18n problemsGettingBinaryKeysFromBinaryStore;
     public static I18n problemsRestoringBinaryFromBackup;
     public static I18n interruptedWhilePerformingBackup;
     public static I18n problemObtainingDocumentsToBackup;

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/value/binary/BinaryStore.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/value/binary/BinaryStore.java
@@ -30,8 +30,8 @@ import javax.jcr.RepositoryException;
 import org.modeshape.common.annotation.ThreadSafe;
 import org.modeshape.jcr.TextExtractors;
 import org.modeshape.jcr.api.mimetype.MimeTypeDetector;
-import org.modeshape.jcr.value.BinaryValue;
 import org.modeshape.jcr.value.BinaryKey;
+import org.modeshape.jcr.value.BinaryValue;
 
 /**
  * The basic interface for a store for Binary value objects. All binary values that are of a
@@ -62,7 +62,7 @@ public interface BinaryStore {
 
     /**
      * Set the text extractor that can be used for extracting text from binary content.
-     *
+     * 
      * @param textExtractors a non-null {@link TextExtractors} instance
      */
     void setTextExtractors( TextExtractors textExtractors );
@@ -89,8 +89,8 @@ public interface BinaryStore {
      * 
      * @param key the key to the binary content; never null
      * @return the input stream through which the content can be read, {@code never null}
-     * @throws BinaryStoreException if there is a problem reading the content from the store or if a valid, non-null {@link InputStream}
-     * cannot be returned for the given key.
+     * @throws BinaryStoreException if there is a problem reading the content from the store or if a valid, non-null
+     *         {@link InputStream} cannot be returned for the given key.
      */
     InputStream getInputStream( BinaryKey key ) throws BinaryStoreException;
 
@@ -98,7 +98,7 @@ public interface BinaryStore {
      * Mark the supplied binary keys as unused, but key them in quarantine until needed again (at which point they're removed from
      * quarantine) or until {@link #removeValuesUnusedLongerThan(long, TimeUnit)} is called. This method ignores any keys for
      * values not stored within this store.
-     *
+     * 
      * @param keys the keys for the binary values that are no longer needed
      * @throws BinaryStoreException if there is a problem marking any of the supplied binary values as unused
      */
@@ -106,7 +106,7 @@ public interface BinaryStore {
 
     /**
      * Remove binary values that have been {@link #markAsUnused(Iterable) unused} for at least the specified amount of time.
-     *
+     * 
      * @param minimumAge the minimum time that a binary value has been {@link #markAsUnused(Iterable) unused} before it can be
      *        removed; must be non-negative
      * @param unit the time unit for the minimum age; may not be null
@@ -116,16 +116,18 @@ public interface BinaryStore {
                                        TimeUnit unit ) throws BinaryStoreException;
 
     /**
-     * Get the text that can be extracted from this binary content. If text extraction isn't enabled (either full text search
-     * is not enabled or there aren't any configured extractors), this returns {@code null}
-     *
-     * <p>If extraction is enabled, this method may block until a text extractor has finished extracting the text.</p>
-     * <p>If there are any problems either with the binary value or during the extraction process, the exception will
-     * be logged and {@code null} is returned</p>
-     *
-     * In general, the implementation from {@link AbstractBinaryStore} should be enough and any custom {@link BinaryStore} implementations
-     * aren't expected to implement this.
-     *
+     * Get the text that can be extracted from this binary content. If text extraction isn't enabled (either full text search is
+     * not enabled or there aren't any configured extractors), this returns {@code null}
+     * <p>
+     * If extraction is enabled, this method may block until a text extractor has finished extracting the text.
+     * </p>
+     * <p>
+     * If there are any problems either with the binary value or during the extraction process, the exception will be logged and
+     * {@code null} is returned
+     * </p>
+     * In general, the implementation from {@link AbstractBinaryStore} should be enough and any custom {@link BinaryStore}
+     * implementations aren't expected to implement this.
+     * 
      * @param binary the binary content; may not be null
      * @return the extracted text, or null if none could be extracted
      * @throws BinaryStoreException if the binary content could not be accessed
@@ -146,23 +148,33 @@ public interface BinaryStore {
 
     /**
      * Stores the extracted text of a binary value into this store.
-     *
+     * 
      * @param source a {@code non-null} {@link BinaryValue} instance from which the text was extracted
      * @param extractedText a {@code non-null} and {@code non-blank} string representing the extracted text
      * @throws BinaryStoreException if the operation fails or if the extracted text cannot be stored for the given binary value
-     * (regardless of the reason)
+     *         (regardless of the reason)
      */
-    void storeExtractedText(BinaryValue source, String extractedText) throws BinaryStoreException;
+    void storeExtractedText( BinaryValue source,
+                             String extractedText ) throws BinaryStoreException;
 
     /**
-     * Returns the extracted text of a binary value, or {@code null} if such text hasn't been stored previously or if the
-     * binary value cannot be found in this store.
-     *
+     * Returns the extracted text of a binary value, or {@code null} if such text hasn't been stored previously or if the binary
+     * value cannot be found in this store.
+     * 
      * @param source a {@code non-null} {@link BinaryValue} instance from which the text was extracted
-     * @return a {@code String} representing the extracted text, or {@code null} if such text hasn't been stored in this
-     * store  previously.
+     * @return a {@code String} representing the extracted text, or {@code null} if such text hasn't been stored in this store
+     *         previously.
      * @throws BinaryStoreException if anything unexpected happens.
      */
-    String getExtractedText(BinaryValue source) throws BinaryStoreException;
+    String getExtractedText( BinaryValue source ) throws BinaryStoreException;
+
+    /**
+     * Obtain an iterable implementation containing all of the store's binary keys. The resulting iterator may be lazy, in the
+     * sense that it may determine additional {@link BinaryKey}s only as the iterator is used.
+     * 
+     * @return the iterable set of binary keys; never null
+     * @throws BinaryStoreException if anything unexpected happens.
+     */
+    Iterable<BinaryKey> getAllBinaryKeys() throws BinaryStoreException;
 
 }

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/value/binary/Database.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/value/binary/Database.java
@@ -28,6 +28,7 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.Set;
 import org.modeshape.common.util.StringUtil;
 import org.modeshape.jcr.value.BinaryKey;
 
@@ -303,6 +304,27 @@ public class Database {
                                               .build();
             sql.setString(1, text);
             sql.setString(2, key.toString());
+            return sql;
+        } catch (SQLException e) {
+            throw new BinaryStoreException(e);
+        }
+    }
+
+    /**
+     * Generates SQL statement for retrieving the binary keys in the store.
+     * 
+     * @param keys the container into which the keys should be placed
+     * @return executable SQL statement
+     * @throws BinaryStoreException
+     */
+    public PreparedStatement retrieveBinaryKeys( Set<BinaryKey> keys ) throws BinaryStoreException {
+        try {
+            PreparedStatement sql = sqlBuilder.select()
+                                              .columns("cid")
+                                              .from(tableName())
+                                              .where()
+                                              .condition("usage", sqlType.integer(), "=", "1")
+                                              .build();
             return sql;
         } catch (SQLException e) {
             throw new BinaryStoreException(e);

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/value/binary/DatabaseBinaryStore.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/value/binary/DatabaseBinaryStore.java
@@ -24,8 +24,14 @@
 package org.modeshape.jcr.value.binary;
 
 import java.io.InputStream;
-import java.sql.*;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
 import java.util.Date;
+import java.util.HashSet;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import javax.naming.InitialContext;
@@ -47,7 +53,7 @@ public class DatabaseBinaryStore extends AbstractBinaryStore {
     /** JDBC utility for working with the database. */
     private Database database;
 
-    //JDBC params
+    // JDBC params
     private final String driverClass;
     private final String connectionURL;
     private final String username;
@@ -56,14 +62,16 @@ public class DatabaseBinaryStore extends AbstractBinaryStore {
 
     /**
      * Create new store.
-     *
+     * 
      * @param driverClass JDBC driver class name
      * @param connectionURL database location
      * @param username database user name
      * @param password database password
      */
-    public DatabaseBinaryStore(String driverClass, String connectionURL, 
-            String username, String password) {
+    public DatabaseBinaryStore( String driverClass,
+                                String connectionURL,
+                                String username,
+                                String password ) {
         this.driverClass = driverClass;
         this.connectionURL = connectionURL;
         this.username = username;
@@ -71,12 +79,13 @@ public class DatabaseBinaryStore extends AbstractBinaryStore {
         this.datasourceJNDILocation = null;
         this.cache = TransientBinaryStore.get();
     }
+
     /**
      * Create new store that uses the JDBC DataSource in the given JNDI location.
-     *
+     * 
      * @param datasourceJNDILocation the JNDI name of the JDBC Data Source that should be used, or null
      */
-    public DatabaseBinaryStore(String datasourceJNDILocation) {
+    public DatabaseBinaryStore( String datasourceJNDILocation ) {
         this.driverClass = null;
         this.connectionURL = null;
         this.username = null;
@@ -85,22 +94,21 @@ public class DatabaseBinaryStore extends AbstractBinaryStore {
         this.cache = TransientBinaryStore.get();
     }
 
-
     @Override
     public BinaryValue storeValue( InputStream stream ) throws BinaryStoreException {
-        //store into temporary file system store and get SHA-1
+        // store into temporary file system store and get SHA-1
         BinaryValue temp = cache.storeValue(stream);
         try {
-            //prepare new binary key based on SHA-1
+            // prepare new binary key based on SHA-1
             BinaryKey key = new BinaryKey(temp.getKey().toString());
 
-            //check for duplicate content
+            // check for duplicate content
             InputStream content = this.getInputStream(key);
             if (content != null && getContentLength(content) > 0) {
                 return new StoredBinaryValue(this, key, temp.getSize());
             }
 
-            //store content
+            // store content
             try {
                 PreparedStatement sql = database.insertContentSQL(key, temp.getStream());
                 Database.execute(sql);
@@ -110,7 +118,7 @@ public class DatabaseBinaryStore extends AbstractBinaryStore {
                 throw new BinaryStoreException(e);
             }
         } finally {
-            //remove content from temp store
+            // remove content from temp store
             cache.markAsUnused(temp.getKey());
         }
     }
@@ -133,8 +141,9 @@ public class DatabaseBinaryStore extends AbstractBinaryStore {
     }
 
     @Override
-    public void removeValuesUnusedLongerThan(long minimumAge,  TimeUnit unit) throws BinaryStoreException {
-        //compute usage deadline (in past)
+    public void removeValuesUnusedLongerThan( long minimumAge,
+                                              TimeUnit unit ) throws BinaryStoreException {
+        // compute usage deadline (in past)
         long deadline = now() - unit.toMillis(minimumAge);
         PreparedStatement sql = database.removeExpiredContentSQL(deadline);
         Database.execute(sql);
@@ -150,7 +159,8 @@ public class DatabaseBinaryStore extends AbstractBinaryStore {
     }
 
     @Override
-    protected void storeMimeType(BinaryValue source, String mimeType) throws BinaryStoreException {
+    protected void storeMimeType( BinaryValue source,
+                                  String mimeType ) throws BinaryStoreException {
         PreparedStatement sql = database.updateMimeTypeSQL(source.getKey(), mimeType);
         Database.executeUpdate(sql);
     }
@@ -165,7 +175,8 @@ public class DatabaseBinaryStore extends AbstractBinaryStore {
     }
 
     @Override
-    public void storeExtractedText( BinaryValue source, String extractedText ) throws BinaryStoreException {
+    public void storeExtractedText( BinaryValue source,
+                                    String extractedText ) throws BinaryStoreException {
         PreparedStatement sql = database.updateExtTextSQL(source.getKey(), extractedText);
         Database.executeUpdate(sql);
     }
@@ -174,13 +185,14 @@ public class DatabaseBinaryStore extends AbstractBinaryStore {
     public void start() {
         super.start();
         try {
-            Connection connection = datasourceJNDILocation != null ?
-                DatabaseBinaryStore.connect(datasourceJNDILocation) :
-                DatabaseBinaryStore.connect(driverClass, connectionURL, username, password);
+            Connection connection = datasourceJNDILocation != null ? DatabaseBinaryStore.connect(datasourceJNDILocation) : DatabaseBinaryStore.connect(driverClass,
+                                                                                                                                                       connectionURL,
+                                                                                                                                                       username,
+                                                                                                                                                       password);
 
             // TODO: here we are making decision which kind of database we will talk to.
             // Right now, we just have one kind of utility, and no specializations for specific databases
-            //DatabaseMetaData metaData = connection.getMetaData();
+            // DatabaseMetaData metaData = connection.getMetaData();
             database = new Database(connection);
 
             if (!database.tableExists()) {
@@ -190,9 +202,21 @@ public class DatabaseBinaryStore extends AbstractBinaryStore {
             throw new RuntimeException(e);
         }
     }
-    
+
     protected Database doCreateDatabase( Connection connection ) throws BinaryStoreException {
         return new Database(connection);
+    }
+
+    @Override
+    public Iterable<BinaryKey> getAllBinaryKeys() throws BinaryStoreException {
+        Set<BinaryKey> keys = new HashSet<BinaryKey>();
+        try {
+            PreparedStatement sql = database.retrieveBinaryKeys(keys);
+            Database.execute(sql);
+            return keys;
+        } catch (Exception e) {
+            throw new BinaryStoreException(e);
+        }
     }
 
     @Override
@@ -205,7 +229,7 @@ public class DatabaseBinaryStore extends AbstractBinaryStore {
 
     /**
      * Current time.
-     *
+     * 
      * @return current time in milliseconds
      */
     private long now() {
@@ -215,11 +239,11 @@ public class DatabaseBinaryStore extends AbstractBinaryStore {
     /**
      * Determine length of the content.
      * 
-     * @param stream content 
+     * @param stream content
      * @return the length of the content in bytes.
-     * @throws BinaryStoreException 
+     * @throws BinaryStoreException
      */
-    private long getContentLength(InputStream stream) throws BinaryStoreException {
+    private long getContentLength( InputStream stream ) throws BinaryStoreException {
         AtomicLong length = new AtomicLong();
         SizeMeasuringInputStream ms = new SizeMeasuringInputStream(stream, length);
         try {
@@ -235,16 +259,16 @@ public class DatabaseBinaryStore extends AbstractBinaryStore {
 
     /**
      * Creates connection with a database using data source registered via JNDI.
-     *
+     * 
      * @param jndiName the JNDI location of the data source
      * @return connection to database
      * @throws BinaryStoreException
      */
-    private static Connection connect(String jndiName) throws BinaryStoreException {
+    private static Connection connect( String jndiName ) throws BinaryStoreException {
         DataSource dataSource = null;
         try {
             InitialContext context = new InitialContext();
-            dataSource = (DataSource) context.lookup(jndiName);
+            dataSource = (DataSource)context.lookup(jndiName);
         } catch (NamingException e) {
             throw new BinaryStoreException(e);
         }
@@ -262,7 +286,7 @@ public class DatabaseBinaryStore extends AbstractBinaryStore {
 
     /**
      * Creates connection to a database using driver, location and credentials.
-     *
+     * 
      * @param driverClass driver's class name
      * @param connectionURL database location
      * @param username database user name
@@ -270,8 +294,10 @@ public class DatabaseBinaryStore extends AbstractBinaryStore {
      * @return connection to a database.
      * @throws BinaryStoreException
      */
-    private static Connection connect(String driverClass, String connectionURL,
-            String username, String password) throws BinaryStoreException {
+    private static Connection connect( String driverClass,
+                                       String connectionURL,
+                                       String username,
+                                       String password ) throws BinaryStoreException {
         try {
             Class.forName(driverClass);
         } catch (Exception e) {

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/value/binary/InfinispanBinaryStore.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/value/binary/InfinispanBinaryStore.java
@@ -144,4 +144,9 @@ public class InfinispanBinaryStore extends AbstractBinaryStore {
                                     String extractedText ) /*throws BinaryStoreException*/{
         throw new UnsupportedOperationException("Not implemented");
     }
+
+    @Override
+    public Iterable<BinaryKey> getAllBinaryKeys() throws BinaryStoreException {
+        throw new BinaryStoreException("Not implemented");
+    }
 }

--- a/modeshape-jcr/src/main/resources/org/modeshape/jcr/JcrI18n.properties
+++ b/modeshape-jcr/src/main/resources/org/modeshape/jcr/JcrI18n.properties
@@ -73,6 +73,7 @@ existsAndMustBeWritableDirectory = The location "{0}" exists and is expected to 
 problemInitializingBackupArea = Error while initializing the backup area "{0}": {1}
 problemsWritingDocumentToBackup = Problems writing document "{0}" to backup: {1}
 problemsWritingBinaryToBackup = Problems writing binary value with SHA-1 "{0}" to backup {1}: {2}
+problemsGettingBinaryKeysFromBinaryStore = Problem getting the binary keys from the binary store in the "{0}" repository for the backup {1}: {2}
 problemsReadingBinaryFromBackup = Unable to read binary value {0} from backup for repository '{1}' at {2} - check permissions
 problemsRestoringBinaryFromBackup = Problems restoring binary value {0} from backup for repository '{1}' at {2}: {3}
 interruptedWhilePerformingBackup = Backup of '{0}' to {1} was interrupted and has been aborted: {2}

--- a/modeshape-jcr/src/test/java/org/modeshape/jcr/RepositoryRestoreTest.java
+++ b/modeshape-jcr/src/test/java/org/modeshape/jcr/RepositoryRestoreTest.java
@@ -57,10 +57,13 @@ public class RepositoryRestoreTest extends SingleUseAbstractTest {
     @Before
     @Override
     public void beforeEach() throws Exception {
-        super.beforeEach();
-        backupDirectory = new File("target/backupArea/repoBackups");
-        FileUtil.delete(backupDirectory);
+        File backupArea = new File("target/backupArea");
+        backupDirectory = new File(backupArea, "repoBackups");
+        FileUtil.delete(backupArea);
         backupDirectory.mkdirs();
+        new File(backupArea, "backRepo").mkdirs();
+        new File(backupArea, "restoreRepo").mkdirs();
+        super.beforeEach();
     }
 
     @Test


### PR DESCRIPTION
The BinaryStore interface was changed to provide a method that returns an Iterable over the store's BinaryKeys. This allows the BackupService to now include all of the binary values in the backup, and the values are included when restoring a repository from a backup.
