### PR TITLE
MODE-1461 General JDK7 compile compatibility

### DIFF
--- a/modeshape-common/src/main/java/org/modeshape/common/util/HashCode.java
+++ b/modeshape-common/src/main/java/org/modeshape/common/util/HashCode.java
@@ -43,7 +43,7 @@ public class HashCode {
      * @return the hash code
      */
     public static int compute( Object... objects ) {
-        return compute(0, objects);
+        return _compute(0, objects);
     }
 
     /**
@@ -53,8 +53,8 @@ public class HashCode {
      * @param objects the objects that should be used to compute the hash code
      * @return the hash code
      */
-    protected static int compute( int seed,
-                                  Object... objects ) {
+    protected static int _compute(int seed,
+                                  Object... objects) {
         if (objects == null || objects.length == 0) {
             return seed * HashCode.PRIME;
         }

--- a/modeshape-common/src/test/java/org/modeshape/common/util/HashCodeTest.java
+++ b/modeshape-common/src/test/java/org/modeshape/common/util/HashCodeTest.java
@@ -36,9 +36,9 @@ public class HashCodeTest {
 
     @Test
     public void shouldComputeHashCodeForOnePrimitive() {
-        assertThat(HashCode.compute(1), is(not(0)));
+        assertThat(HashCode._compute(1), is(not(0)));
         assertThat(HashCode.compute((long)8), is(not(0)));
-        assertThat(HashCode.compute((short)3), is(not(0)));
+        assertThat(HashCode._compute((short) 3), is(not(0)));
         assertThat(HashCode.compute(1.0f), is(not(0)));
         assertThat(HashCode.compute(1.0d), is(not(0)));
         assertThat(HashCode.compute(true), is(not(0)));
@@ -46,9 +46,9 @@ public class HashCodeTest {
 
     @Test
     public void shouldComputeHashCodeForMultiplePrimitives() {
-        assertThat(HashCode.compute(1, 2, 3), is(not(0)));
+        assertThat(HashCode._compute(1, 2, 3), is(not(0)));
         assertThat(HashCode.compute((long)8, (long)22, 33), is(not(0)));
-        assertThat(HashCode.compute((short)3, (long)22, true), is(not(0)));
+        assertThat(HashCode._compute((short) 3, (long) 22, true), is(not(0)));
     }
 
     @Test

--- a/modeshape-jdbc-local/src/main/java/org/modeshape/jdbc/JcrConnection.java
+++ b/modeshape-jdbc-local/src/main/java/org/modeshape/jdbc/JcrConnection.java
@@ -43,6 +43,7 @@ import java.sql.Struct;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
+import java.util.concurrent.Executor;
 import javax.jcr.Repository;
 import javax.jcr.RepositoryException;
 import javax.jcr.nodetype.NodeType;
@@ -684,4 +685,45 @@ public class JcrConnection implements Connection {
         return getRepositoryDelegate().unwrap(iface);
     }
 
+    /**
+     * {@inheritDoc}
+     *
+     * @see java.sql.Connection#setSchema(String)
+     */
+    public void setSchema(String schema) throws SQLException {
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see java.sql.Connection#getSchema()
+     */
+    public String getSchema() throws SQLException {
+        return null;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see java.sql.Connection#abort(java.util.concurrent.Executor)
+     */
+    public void abort(Executor executor) throws SQLException {
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see java.sql.Connection#setNetworkTimeout(java.util.concurrent.Executor, int)
+     */
+    public void setNetworkTimeout(Executor executor, int milliseconds) throws SQLException {
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see java.sql.Connection#getNetworkTimeout()
+     */
+    public int getNetworkTimeout() throws SQLException {
+        return 0;
+    }
 }

--- a/modeshape-jdbc-local/src/main/java/org/modeshape/jdbc/JcrMetaData.java
+++ b/modeshape-jdbc-local/src/main/java/org/modeshape/jdbc/JcrMetaData.java
@@ -102,6 +102,24 @@ public class JcrMetaData implements DatabaseMetaData {
 
     /**
      * {@inheritDoc}
+     *
+     * @see java.sql.DatabaseMetaData#getPseudoColumns(String, String, String, String)
+     */
+    public ResultSet getPseudoColumns(String catalog, String schemaPattern, String tableNamePattern, String columnNamePattern) throws SQLException {
+        return new JcrResultSet();
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see java.sql.DatabaseMetaData#generatedKeyAlwaysReturned()
+     */
+    public boolean generatedKeyAlwaysReturned() throws SQLException {
+        return true;
+    }
+
+    /**
+     * {@inheritDoc}
      * 
      * @see java.sql.DatabaseMetaData#getDriverMajorVersion()
      */

--- a/modeshape-jdbc-local/src/main/java/org/modeshape/jdbc/JcrResultSet.java
+++ b/modeshape-jdbc-local/src/main/java/org/modeshape/jdbc/JcrResultSet.java
@@ -961,6 +961,24 @@ public class JcrResultSet implements ResultSet {
 
     /**
      * {@inheritDoc}
+     *
+     * @see java.sql.ResultSet#getObject(int, Class)
+     */
+    public <T> T getObject(int columnIndex, Class<T> type) throws SQLException {
+        throw new SQLFeatureNotSupportedException();
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see java.sql.ResultSet#getObject(String, Class)
+     */
+    public <T> T getObject(String columnLabel, Class<T> type) throws SQLException {
+        throw new SQLFeatureNotSupportedException();
+    }
+
+    /**
+     * {@inheritDoc}
      * 
      * @see java.sql.ResultSet#getRef(int)
      */

--- a/modeshape-jdbc-local/src/main/java/org/modeshape/jdbc/JcrStatement.java
+++ b/modeshape-jdbc-local/src/main/java/org/modeshape/jdbc/JcrStatement.java
@@ -603,4 +603,20 @@ class JcrStatement implements Statement {
         return iface.cast(this);
     }
 
+    /**
+     * {@inheritDoc}
+     *
+     * @see java.sql.Statement#closeOnCompletion()
+     */
+    public void closeOnCompletion() throws SQLException {
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see java.sql.Statement#isCloseOnCompletion()
+     */
+    public boolean isCloseOnCompletion() throws SQLException {
+        return true;
+    }
 }

--- a/modeshape-jdbc-local/src/main/java/org/modeshape/jdbc/LocalJcrDriver.java
+++ b/modeshape-jdbc-local/src/main/java/org/modeshape/jdbc/LocalJcrDriver.java
@@ -23,10 +23,7 @@
  */
 package org.modeshape.jdbc;
 
-import java.sql.Connection;
-import java.sql.DriverManager;
-import java.sql.DriverPropertyInfo;
-import java.sql.SQLException;
+import java.sql.*;
 import java.util.Properties;
 import java.util.Set;
 import javax.jcr.Repository;
@@ -249,6 +246,15 @@ public class LocalJcrDriver implements java.sql.Driver {
 
     protected final DriverInfo getDriverInfo() {
         return driverInfo;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see java.sql.Driver#getParentLogger() 
+     */
+    public java.util.logging.Logger getParentLogger() throws SQLFeatureNotSupportedException {
+        throw new SQLFeatureNotSupportedException();
     }
 
     /**

--- a/modeshape-jdbc-local/src/test/java/org/modeshape/jdbc/JcrResultSetTest.java
+++ b/modeshape-jdbc-local/src/test/java/org/modeshape/jdbc/JcrResultSetTest.java
@@ -35,6 +35,7 @@ import java.sql.SQLException;
 import java.sql.SQLFeatureNotSupportedException;
 import java.util.Calendar;
 import java.util.GregorianCalendar;
+import java.util.Map;
 import java.util.TimeZone;
 
 import javax.jcr.query.QueryResult;
@@ -1070,7 +1071,7 @@ public class JcrResultSetTest {
      */
     @Test( expected = SQLFeatureNotSupportedException.class )
     public void featureNotSupportedCallingGetObjectIdxMap() throws SQLException {
-        resultSet.getObject(1, null);
+        resultSet.getObject(1, (Map)null);
     }
 
     /**
@@ -1078,7 +1079,23 @@ public class JcrResultSetTest {
      */
     @Test( expected = SQLFeatureNotSupportedException.class )
     public void featureNotSupportedCallingGetObjectColNameMap() throws SQLException {
-        resultSet.getObject("colname", null);
+        resultSet.getObject("colname", (Map)null);
+    }
+
+    /**
+     * @throws SQLException
+     */
+    @Test( expected = SQLFeatureNotSupportedException.class )
+    public void featureNotSupportedCallingGetObjectIdxClass() throws SQLException {
+        resultSet.getObject(1, (Class<?>)null);
+    }
+
+    /**
+     * @throws SQLException
+     */
+    @Test( expected = SQLFeatureNotSupportedException.class )
+    public void featureNotSupportedCallingGetObjectColNameClass() throws SQLException {
+        resultSet.getObject("colname", (Class<?>)null);
     }
 
     /**


### PR DESCRIPTION
Needed extension of the JDBC impl:
JcrMetaData.getPseudoColumns - returns empty set
JcrMetaData.generatedKeyAlwaysReturned - returns true
JcrConnection.setSchema - noop
JcrConnection.getSchema - noop
JcrConnection.abort(...) - noop
JcrConnection.setNetworkTimeout - noop
JcrConnection.getNetworkTimeout - return always 0
JcrStatement.closeOnCompletion - noop
JcrStatement.isCloseOnCompletion - return true
JcrResultSet.getObject(int columnIndex, Class<T> type) - throws unsupported
JcrResultSet.getObject(String columnLabel, Class<T> type) - throws unsupported
LocalJcrDriver.getParentLogger - throws unsupported (ModeShape Logger API needs to be extended for support that)
