### PR TITLE
MODE-1601 EAP considers update to ISPN 5.1.6 and JGroups 3.0.12 (not 3.0.11)

### DIFF
--- a/modeshape-parent/pom.xml
+++ b/modeshape-parent/pom.xml
@@ -419,11 +419,11 @@
         </profile>
 
         <profile>
-            <id>ispn515</id>
+            <id>ispn516</id>
             <properties>
                 <!--The following versions are also used by AS7.2-->
-                <infinispan.version>5.1.5.FINAL</infinispan.version>
-                <jgroups.version>3.1.0.Final</jgroups.version>
+                <infinispan.version>5.1.6.FINAL</infinispan.version>
+                <jgroups.version>3.0.12.Final</jgroups.version>
             </properties>
         </profile>
     </profiles>


### PR DESCRIPTION
Updates the Maven profile used to verify the tests pass using Infinispan 5.1.6.FINAL and JGroups 3.0.12.Final, the same versions that are used in EAP 6.0.1.
