### PR TITLE
MODE-1461 Corrected JavaDoc of 1.7-related JDBC methods are valid when compiled with 1.6

### DIFF
--- a/modeshape-jdbc-local/src/main/java/org/modeshape/jdbc/JcrConnection.java
+++ b/modeshape-jdbc-local/src/main/java/org/modeshape/jdbc/JcrConnection.java
@@ -101,32 +101,17 @@ public class JcrConnection implements Connection {
         }
     }
 
-    /**
-     * {@inheritDoc}
-     * 
-     * @see java.sql.Connection#isReadOnly()
-     */
     @Override
     public boolean isReadOnly() throws SQLException {
         notClosed();
         return true; // always read-only
     }
 
-    /**
-     * {@inheritDoc}
-     * 
-     * @see java.sql.Connection#setReadOnly(boolean)
-     */
     @Override
     public void setReadOnly( boolean readOnly ) throws SQLException {
         notClosed();
     }
 
-    /**
-     * {@inheritDoc}
-     * 
-     * @see java.sql.Connection#isValid(int)
-     */
     @Override
     public boolean isValid( int timeout ) throws SQLException {
         if (closed) return false;
@@ -138,11 +123,6 @@ public class JcrConnection implements Connection {
         }
     }
 
-    /**
-     * {@inheritDoc}
-     * 
-     * @see java.sql.Connection#close()
-     */
     @Override
     public void close() {
         if (!closed) {
@@ -155,11 +135,6 @@ public class JcrConnection implements Connection {
         }
     }
 
-    /**
-     * {@inheritDoc}
-     * 
-     * @see java.sql.Connection#isClosed()
-     */
     @Override
     public boolean isClosed() {
         return closed;
@@ -169,11 +144,6 @@ public class JcrConnection implements Connection {
         if (isClosed()) throw new SQLException(JdbcLocalI18n.connectionIsClosed.text());
     }
 
-    /**
-     * {@inheritDoc}
-     * 
-     * @see java.sql.Connection#commit()
-     */
     @Override
     public void commit() throws SQLException {
         notClosed();
@@ -184,11 +154,6 @@ public class JcrConnection implements Connection {
         }
     }
 
-    /**
-     * {@inheritDoc}
-     * 
-     * @see java.sql.Connection#rollback()
-     */
     @Override
     public void rollback() throws SQLException {
         notClosed();
@@ -199,157 +164,82 @@ public class JcrConnection implements Connection {
         }
     }
 
-    /**
-     * {@inheritDoc}
-     * 
-     * @see java.sql.Connection#rollback(java.sql.Savepoint)
-     */
     @Override
     public void rollback( Savepoint savepoint ) throws SQLException {
         throw new SQLFeatureNotSupportedException();
     }
 
-    /**
-     * {@inheritDoc}
-     * 
-     * @see java.sql.Connection#clearWarnings()
-     */
     @Override
     public void clearWarnings() throws SQLException {
         notClosed();
         warning = null;
     }
 
-    /**
-     * {@inheritDoc}
-     * 
-     * @see java.sql.Connection#getWarnings()
-     */
     @Override
     public SQLWarning getWarnings() throws SQLException {
         notClosed();
         return warning;
     }
 
-    /**
-     * {@inheritDoc}
-     * 
-     * @see java.sql.Connection#getAutoCommit()
-     */
     @Override
     public boolean getAutoCommit() throws SQLException {
         notClosed();
         return autoCommit;
     }
 
-    /**
-     * {@inheritDoc}
-     * 
-     * @see java.sql.Connection#setAutoCommit(boolean)
-     */
     @Override
     public void setAutoCommit( boolean autoCommit ) throws SQLException {
         notClosed();
         this.autoCommit = autoCommit;
     }
 
-    /**
-     * {@inheritDoc}
-     * 
-     * @see java.sql.Connection#getTransactionIsolation()
-     */
     @Override
     public int getTransactionIsolation() throws SQLException {
         notClosed();
         return Connection.TRANSACTION_READ_COMMITTED;
     }
 
-    /**
-     * {@inheritDoc}
-     * 
-     * @see java.sql.Connection#setTransactionIsolation(int)
-     */
     @Override
     public void setTransactionIsolation( int level ) throws SQLException {
         notClosed();
         // silently ignore
     }
 
-    /**
-     * {@inheritDoc}
-     * 
-     * @see java.sql.Connection#setSavepoint()
-     */
     @Override
     public Savepoint setSavepoint() throws SQLException {
         throw new SQLFeatureNotSupportedException();
     }
 
-    /**
-     * {@inheritDoc}
-     * 
-     * @see java.sql.Connection#setSavepoint(java.lang.String)
-     */
     @Override
     public Savepoint setSavepoint( String name ) throws SQLException {
         throw new SQLFeatureNotSupportedException();
     }
 
-    /**
-     * {@inheritDoc}
-     * 
-     * @see java.sql.Connection#releaseSavepoint(java.sql.Savepoint)
-     */
     @Override
     public void releaseSavepoint( Savepoint savepoint ) throws SQLException {
         throw new SQLFeatureNotSupportedException();
     }
 
-    /**
-     * {@inheritDoc}
-     * 
-     * @see java.sql.Connection#getCatalog()
-     */
     @Override
     public String getCatalog() {
         return this.info().getRepositoryName();
     }
 
-    /**
-     * {@inheritDoc}
-     * 
-     * @see java.sql.Connection#setCatalog(java.lang.String)
-     */
     @Override
     public void setCatalog( String catalog ) {
         // silently ignore
     }
 
-    /**
-     * {@inheritDoc}
-     * 
-     * @see java.sql.Connection#getClientInfo()
-     */
     @Override
     public Properties getClientInfo() /*throws SQLException*/{
         return clientInfo;
     }
 
-    /**
-     * {@inheritDoc}
-     * 
-     * @see java.sql.Connection#getClientInfo(java.lang.String)
-     */
     @Override
     public String getClientInfo( String name ) /*throws SQLException*/{
         return clientInfo.getProperty(name);
     }
 
-    /**
-     * {@inheritDoc}
-     * 
-     * @see java.sql.Connection#setClientInfo(java.util.Properties)
-     */
     @Override
     public void setClientInfo( Properties properties ) throws SQLClientInfoException {
         Map<String, ClientInfoStatus> status = new HashMap<String, ClientInfoStatus>();
@@ -373,11 +263,6 @@ public class JcrConnection implements Connection {
         }
     }
 
-    /**
-     * {@inheritDoc}
-     * 
-     * @see java.sql.Connection#setClientInfo(java.lang.String, java.lang.String)
-     */
     @Override
     public void setClientInfo( String name,
                                String value ) throws SQLClientInfoException {
@@ -386,31 +271,16 @@ public class JcrConnection implements Connection {
         setClientInfo(properties);
     }
 
-    /**
-     * {@inheritDoc}
-     * 
-     * @see java.sql.Connection#getHoldability()
-     */
     @Override
     public int getHoldability() throws SQLException {
         throw new SQLFeatureNotSupportedException();
     }
 
-    /**
-     * {@inheritDoc}
-     * 
-     * @see java.sql.Connection#setHoldability(int)
-     */
     @Override
     public void setHoldability( int holdability ) throws SQLException {
         throw new SQLFeatureNotSupportedException();
     }
 
-    /**
-     * {@inheritDoc}
-     * 
-     * @see java.sql.Connection#getMetaData()
-     */
     @Override
     public DatabaseMetaData getMetaData() throws SQLException {
         notClosed();
@@ -424,22 +294,11 @@ public class JcrConnection implements Connection {
         return metadata;
     }
 
-    /**
-     * Retrieves the type map associated with this Connection object. The type map contains entries for undefined types. This
-     * method always returns an empty map since it is not possible to add entries to this type map {@inheritDoc}
-     * 
-     * @see java.sql.Connection#getTypeMap()
-     */
     @Override
     public Map<String, Class<?>> getTypeMap() {
         return new HashMap<String, Class<?>>(1);
     }
 
-    /**
-     * {@inheritDoc}
-     * 
-     * @see java.sql.Connection#setTypeMap(java.util.Map)
-     */
     @Override
     public void setTypeMap( Map<String, Class<?>> map ) throws SQLException {
         throw new SQLFeatureNotSupportedException();
@@ -458,33 +317,18 @@ public class JcrConnection implements Connection {
         return sql;
     }
 
-    /**
-     * {@inheritDoc}
-     * 
-     * @see java.sql.Connection#createStatement()
-     */
     @SuppressWarnings( "unused" )
     @Override
     public Statement createStatement() throws SQLException {
         return new JcrStatement(this);
     }
 
-    /**
-     * {@inheritDoc}
-     * 
-     * @see java.sql.Connection#createStatement(int, int)
-     */
     @Override
     public Statement createStatement( int resultSetType,
                                       int resultSetConcurrency ) throws SQLException {
         throw new SQLFeatureNotSupportedException();
     }
 
-    /**
-     * {@inheritDoc}
-     * 
-     * @see java.sql.Connection#createStatement(int, int, int)
-     */
     @Override
     public Statement createStatement( int resultSetType,
                                       int resultSetConcurrency,
@@ -492,54 +336,29 @@ public class JcrConnection implements Connection {
         throw new SQLFeatureNotSupportedException();
     }
 
-    /**
-     * {@inheritDoc}
-     * 
-     * @see java.sql.Connection#prepareStatement(java.lang.String)
-     */
     @Override
     public PreparedStatement prepareStatement( String sql ) throws SQLException {
         throw new SQLFeatureNotSupportedException();
     }
 
-    /**
-     * {@inheritDoc}
-     * 
-     * @see java.sql.Connection#prepareStatement(java.lang.String, int)
-     */
     @Override
     public PreparedStatement prepareStatement( String sql,
                                                int autoGeneratedKeys ) throws SQLException {
         throw new SQLFeatureNotSupportedException();
     }
 
-    /**
-     * {@inheritDoc}
-     * 
-     * @see java.sql.Connection#prepareStatement(java.lang.String, int[])
-     */
     @Override
     public PreparedStatement prepareStatement( String sql,
                                                int[] columnIndexes ) throws SQLException {
         throw new SQLFeatureNotSupportedException();
     }
 
-    /**
-     * {@inheritDoc}
-     * 
-     * @see java.sql.Connection#prepareStatement(java.lang.String, java.lang.String[])
-     */
     @Override
     public PreparedStatement prepareStatement( String sql,
                                                String[] columnNames ) throws SQLException {
         throw new SQLFeatureNotSupportedException();
     }
 
-    /**
-     * {@inheritDoc}
-     * 
-     * @see java.sql.Connection#prepareStatement(java.lang.String, int, int)
-     */
     @Override
     public PreparedStatement prepareStatement( String sql,
                                                int resultSetType,
@@ -547,11 +366,6 @@ public class JcrConnection implements Connection {
         throw new SQLFeatureNotSupportedException();
     }
 
-    /**
-     * {@inheritDoc}
-     * 
-     * @see java.sql.Connection#prepareStatement(java.lang.String, int, int, int)
-     */
     @Override
     public PreparedStatement prepareStatement( String sql,
                                                int resultSetType,
@@ -560,21 +374,11 @@ public class JcrConnection implements Connection {
         throw new SQLFeatureNotSupportedException();
     }
 
-    /**
-     * {@inheritDoc}
-     * 
-     * @see java.sql.Connection#prepareCall(java.lang.String)
-     */
     @Override
     public CallableStatement prepareCall( String sql ) throws SQLException {
         throw new SQLFeatureNotSupportedException();
     }
 
-    /**
-     * {@inheritDoc}
-     * 
-     * @see java.sql.Connection#prepareCall(java.lang.String, int, int)
-     */
     @Override
     public CallableStatement prepareCall( String sql,
                                           int resultSetType,
@@ -582,11 +386,6 @@ public class JcrConnection implements Connection {
         throw new SQLFeatureNotSupportedException();
     }
 
-    /**
-     * {@inheritDoc}
-     * 
-     * @see java.sql.Connection#prepareCall(java.lang.String, int, int, int)
-     */
     @Override
     public CallableStatement prepareCall( String sql,
                                           int resultSetType,
@@ -595,66 +394,36 @@ public class JcrConnection implements Connection {
         throw new SQLFeatureNotSupportedException();
     }
 
-    /**
-     * {@inheritDoc}
-     * 
-     * @see java.sql.Connection#createArrayOf(java.lang.String, java.lang.Object[])
-     */
     @Override
     public Array createArrayOf( String typeName,
                                 Object[] elements ) throws SQLException {
         throw new SQLFeatureNotSupportedException();
     }
 
-    /**
-     * {@inheritDoc}
-     * 
-     * @see java.sql.Connection#createBlob()
-     */
     @Override
     public Blob createBlob() throws SQLException {
         notClosed();
         throw new SQLFeatureNotSupportedException();
     }
 
-    /**
-     * {@inheritDoc}
-     * 
-     * @see java.sql.Connection#createClob()
-     */
     @Override
     public Clob createClob() throws SQLException {
         notClosed();
         throw new SQLFeatureNotSupportedException();
     }
 
-    /**
-     * {@inheritDoc}
-     * 
-     * @see java.sql.Connection#createNClob()
-     */
     @Override
     public NClob createNClob() throws SQLException {
         notClosed();
         throw new SQLFeatureNotSupportedException();
     }
 
-    /**
-     * {@inheritDoc}
-     * 
-     * @see java.sql.Connection#createSQLXML()
-     */
     @Override
     public SQLXML createSQLXML() throws SQLException {
         notClosed();
         throw new SQLFeatureNotSupportedException();
     }
 
-    /**
-     * {@inheritDoc}
-     * 
-     * @see java.sql.Connection#createStruct(java.lang.String, java.lang.Object[])
-     */
     @Override
     public Struct createStruct( String typeName,
                                 Object[] attributes ) throws SQLException {
@@ -662,21 +431,11 @@ public class JcrConnection implements Connection {
         throw new SQLFeatureNotSupportedException();
     }
 
-    /**
-     * {@inheritDoc}
-     * 
-     * @see java.sql.Wrapper#isWrapperFor(java.lang.Class)
-     */
     @Override
     public boolean isWrapperFor( Class<?> iface ) /*throws SQLException*/{
         return iface.isInstance(this) || this.getRepositoryDelegate().isWrapperFor(iface);
     }
 
-    /**
-     * {@inheritDoc}
-     * 
-     * @see java.sql.Wrapper#unwrap(java.lang.Class)
-     */
     @Override
     public <T> T unwrap( Class<T> iface ) throws SQLException {
         if (isWrapperFor(iface)) {
@@ -686,43 +445,72 @@ public class JcrConnection implements Connection {
     }
 
     /**
-     * {@inheritDoc}
-     *
-     * @see java.sql.Connection#setSchema(String)
+     * Sets the given schema name to access. If the driver does not support schemas, it will silently ignore this request. Calling
+     * setSchema has no effect on previously created or prepared Statement objects. It is implementation defined whether a DBMS
+     * prepare operation takes place immediately when the Connection method prepareStatement or prepareCall is invoked. For
+     * maximum portability, setSchema should be called before a Statement is created or prepared.
+     * 
+     * @param schema - the name of a schema in which to work
+     * @throws SQLException - if a database access error occurs or this method is called on a closed connection
      */
-    public void setSchema(String schema) throws SQLException {
+    // TODO: JDK 1.7 - add @Override and remove JavaDoc
+    public void setSchema( String schema ) throws SQLException {
     }
 
     /**
-     * {@inheritDoc}
-     *
-     * @see java.sql.Connection#getSchema()
+     * Retrieves this Connection object's current schema name.
+     * 
+     * @return the current schema name or null if there is none
+     * @throws SQLException - if a database access error occurs or this method is called on a closed connection
      */
+    // TODO: JDK 1.7 - add @Override
     public String getSchema() throws SQLException {
         return null;
     }
 
     /**
-     * {@inheritDoc}
-     *
-     * @see java.sql.Connection#abort(java.util.concurrent.Executor)
+     * Terminates an open connection.
+     * <p>
+     * <em>Note:</em> This method is part of the JDBC API in JDK 1.7.
+     * </p>
+     * 
+     * @param executor The {@link Executor} implementation which will be used by <code>abort</code>.
      */
-    public void abort(Executor executor) throws SQLException {
+    // TODO: JDK 1.7 - add @Override
+    public void abort( Executor executor ) /*throws SQLException*/{
     }
 
     /**
-     * {@inheritDoc}
-     *
-     * @see java.sql.Connection#setNetworkTimeout(java.util.concurrent.Executor, int)
+     * This method is not implemented and always throws {@link SQLFeatureNotSupportedException}.
+     * <p>
+     * <em>Note:</em> This method is part of the JDBC API in JDK 1.7.
+     * </p>
+     * 
+     * @param executor The <code>Executor</code> implementation which will be used by <code>setNetworkTimeout</code>.
+     * @param milliseconds The time in milliseconds to wait for the database operation to complete. If the JDBC driver does not
+     *        support milliseconds, the JDBC driver will round the value up to the nearest second. If the timeout period expires
+     *        before the operation completes, a SQLException will be thrown. A value of 0 indicates that there is not timeout for
+     *        database operations.
+     * @throws SQLException
+     * @exception SQLFeatureNotSupportedException if the JDBC driver does not support this method
      */
-    public void setNetworkTimeout(Executor executor, int milliseconds) throws SQLException {
+    // TODO: JDK 1.7 - add @Override
+    public void setNetworkTimeout( Executor executor,
+                                   int milliseconds ) throws SQLException {
+        throw new SQLFeatureNotSupportedException();
     }
 
     /**
-     * {@inheritDoc}
-     *
-     * @see java.sql.Connection#getNetworkTimeout()
+     * This method is not implemented and always throws {@link SQLFeatureNotSupportedException}.
+     * <p>
+     * <em>Note:</em> This method is part of the JDBC API in JDK 1.7.
+     * </p>
+     * 
+     * @return the timeout
+     * @throws SQLException
+     * @exception SQLFeatureNotSupportedException if the JDBC driver does not support this method
      */
+    // TODO: JDK 1.7 - add @Override
     public int getNetworkTimeout() throws SQLException {
         return 0;
     }

--- a/modeshape-jdbc-local/src/main/java/org/modeshape/jdbc/JcrMetaData.java
+++ b/modeshape-jdbc-local/src/main/java/org/modeshape/jdbc/JcrMetaData.java
@@ -101,19 +101,36 @@ public class JcrMetaData implements DatabaseMetaData {
     }
 
     /**
-     * {@inheritDoc}
-     *
-     * @see java.sql.DatabaseMetaData#getPseudoColumns(String, String, String, String)
+     * This method always returns an emtpy result set. *
+     * <p>
+     * <em>Note:</em> This method is part of the JDBC API in JDK 1.7.
+     * </p>
+     * 
+     * @param catalog
+     * @param schemaPattern
+     * @param tableNamePattern
+     * @param columnNamePattern
+     * @return the pseudo columns
+     * @throws SQLException
      */
-    public ResultSet getPseudoColumns(String catalog, String schemaPattern, String tableNamePattern, String columnNamePattern) throws SQLException {
+    // TODO: JDK 1.7 - add @Override and remove JavaDoc
+    public ResultSet getPseudoColumns( String catalog,
+                                       String schemaPattern,
+                                       String tableNamePattern,
+                                       String columnNamePattern ) throws SQLException {
         return new JcrResultSet();
     }
 
     /**
-     * {@inheritDoc}
-     *
-     * @see java.sql.DatabaseMetaData#generatedKeyAlwaysReturned()
+     * This method always returns true. *
+     * <p>
+     * <em>Note:</em> This method is part of the JDBC API in JDK 1.7.
+     * </p>
+     * 
+     * @return true
+     * @throws SQLException
      */
+    // TODO: JDK 1.7 - add @Override and remove JavaDoc
     public boolean generatedKeyAlwaysReturned() throws SQLException {
         return true;
     }
@@ -440,7 +457,7 @@ public class JcrMetaData implements DatabaseMetaData {
                                  String tableNamePattern,
                                  String columnNamePattern ) throws SQLException {
         LocalJcrDriver.logger.debug("getcolumns: " + catalog + ":" + schemaPattern + ":" + tableNamePattern + ":"
-                                              + columnNamePattern);
+                                    + columnNamePattern);
 
         // Get all tables if tableNamePattern is null
         if (tableNamePattern == null) tableNamePattern = WILDCARD;
@@ -607,11 +624,14 @@ public class JcrMetaData implements DatabaseMetaData {
 
                     JcrType jcrtype = JcrType.typeInfo(propDefn.getRequiredType());
 
-                    Integer nullable = propDefn
-                            .isMandatory() ? ResultsMetadataConstants.NULL_TYPES.NOT_NULL : ResultsMetadataConstants.NULL_TYPES.NULLABLE;
+                    Integer nullable = propDefn.isMandatory() ? ResultsMetadataConstants.NULL_TYPES.NOT_NULL : ResultsMetadataConstants.NULL_TYPES.NULLABLE;
 
-                    List<Object> currentRow = loadCurrentRow(type.getName(), propDefn.getName(), jcrtype, nullable,
-                                                             propDefn.isMandatory(), ordinal);
+                    List<Object> currentRow = loadCurrentRow(type.getName(),
+                                                             propDefn.getName(),
+                                                             jcrtype,
+                                                             nullable,
+                                                             propDefn.isMandatory(),
+                                                             ordinal);
 
                     // add the current row to the list of records.
                     records.add(currentRow);
@@ -621,8 +641,12 @@ public class JcrMetaData implements DatabaseMetaData {
                 // if columns where added and if Teiid Support is requested, then add the mode:properties to the list of columns
                 if (ordinal > 0 && this.connection.getRepositoryDelegate().getConnectionInfo().isTeiidSupport()) {
                     if (this.connection.getRepositoryDelegate().getConnectionInfo().isTeiidSupport()) {
-                        List<Object> currentRow = loadCurrentRow(type.getName(), "mode:properties", JcrType.typeInfo(
-                                PropertyType.STRING), ResultsMetadataConstants.NULL_TYPES.NULLABLE, false, ordinal);
+                        List<Object> currentRow = loadCurrentRow(type.getName(),
+                                                                 "mode:properties",
+                                                                 JcrType.typeInfo(PropertyType.STRING),
+                                                                 ResultsMetadataConstants.NULL_TYPES.NULLABLE,
+                                                                 false,
+                                                                 ordinal);
 
                         records.add(currentRow);
                     }
@@ -1496,8 +1520,7 @@ public class JcrMetaData implements DatabaseMetaData {
                                 String tableNamePattern,
                                 String[] types ) throws SQLException {
 
-        LocalJcrDriver.logger.debug("getTables: " + catalog + ":" + schemaPattern + ":" + tableNamePattern + ":"
-                                              + types);
+        LocalJcrDriver.logger.debug("getTables: " + catalog + ":" + schemaPattern + ":" + tableNamePattern + ":" + types);
 
         // Get all tables if tableNamePattern is null
         if (tableNamePattern == null) {

--- a/modeshape-jdbc-local/src/main/java/org/modeshape/jdbc/JcrResultSet.java
+++ b/modeshape-jdbc-local/src/main/java/org/modeshape/jdbc/JcrResultSet.java
@@ -960,19 +960,35 @@ public class JcrResultSet implements ResultSet {
     }
 
     /**
-     * {@inheritDoc}
-     *
-     * @see java.sql.ResultSet#getObject(int, Class)
+     * This method always throws {@link SQLFeatureNotSupportedException}.
+     * <p>
+     * <em>Note:</em> This method is part of the JDBC API in JDK 1.7.
+     * </p>
+     * 
+     * @param columnIndex
+     * @param type
+     * @param <T> the type class
+     * @return the object
+     * @throws SQLException
      */
+    // TODO: JDK 1.7 - add @Override and remove JavaDoc
     public <T> T getObject(int columnIndex, Class<T> type) throws SQLException {
         throw new SQLFeatureNotSupportedException();
     }
 
     /**
-     * {@inheritDoc}
-     *
-     * @see java.sql.ResultSet#getObject(String, Class)
+     * This method always throws {@link SQLFeatureNotSupportedException}.
+     * <p>
+     * <em>Note:</em> This method is part of the JDBC API in JDK 1.7.
+     * </p>
+     * 
+     * @param columnLabel
+     * @param type
+     * @param <T> the type class
+     * @return the object
+     * @throws SQLException
      */
+    // TODO: JDK 1.7 - add @Override and remove JavaDoc
     public <T> T getObject(String columnLabel, Class<T> type) throws SQLException {
         throw new SQLFeatureNotSupportedException();
     }

--- a/modeshape-jdbc-local/src/main/java/org/modeshape/jdbc/JcrStatement.java
+++ b/modeshape-jdbc-local/src/main/java/org/modeshape/jdbc/JcrStatement.java
@@ -604,18 +604,27 @@ class JcrStatement implements Statement {
     }
 
     /**
-     * {@inheritDoc}
-     *
-     * @see java.sql.Statement#closeOnCompletion()
+     * This method does nothing.
+     * <p>
+     * <em>Note:</em> This method is part of the JDBC API in JDK 1.7.
+     * </p>
+     * 
+     * @throws SQLException
      */
+    // TODO: JDK 1.7 - add @Override and remove JavaDoc
     public void closeOnCompletion() throws SQLException {
     }
 
     /**
-     * {@inheritDoc}
-     *
-     * @see java.sql.Statement#isCloseOnCompletion()
+     * This method always returns <code>true</code>
+     * <p>
+     * <em>Note:</em> This method is part of the JDBC API in JDK 1.7.
+     * </p>
+     * 
+     * @return true
+     * @throws SQLException
      */
+    // TODO: JDK 1.7 - add @Override and remove JavaDoc
     public boolean isCloseOnCompletion() throws SQLException {
         return true;
     }

--- a/modeshape-jdbc-local/src/main/java/org/modeshape/jdbc/LocalJcrDriver.java
+++ b/modeshape-jdbc-local/src/main/java/org/modeshape/jdbc/LocalJcrDriver.java
@@ -23,7 +23,11 @@
  */
 package org.modeshape.jdbc;
 
-import java.sql.*;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.DriverPropertyInfo;
+import java.sql.SQLException;
+import java.sql.SQLFeatureNotSupportedException;
 import java.util.Properties;
 import java.util.Set;
 import javax.jcr.Repository;
@@ -249,10 +253,15 @@ public class LocalJcrDriver implements java.sql.Driver {
     }
 
     /**
-     * {@inheritDoc}
-     *
-     * @see java.sql.Driver#getParentLogger() 
+     * This method always throws {@link SQLFeatureNotSupportedException}.
+     * <p>
+     * <em>Note:</em> This method is part of the JDBC API in JDK 1.7.
+     * </p>
+     * 
+     * @return the parent logger
+     * @throws SQLFeatureNotSupportedException
      */
+    // TODO: JDK 1.7 - add @Override and remove JavaDoc
     public java.util.logging.Logger getParentLogger() throws SQLFeatureNotSupportedException {
         throw new SQLFeatureNotSupportedException();
     }

--- a/modeshape-jdbc-local/src/test/java/org/modeshape/jdbc/JcrResultSetTest.java
+++ b/modeshape-jdbc-local/src/test/java/org/modeshape/jdbc/JcrResultSetTest.java
@@ -1071,7 +1071,7 @@ public class JcrResultSetTest {
      */
     @Test( expected = SQLFeatureNotSupportedException.class )
     public void featureNotSupportedCallingGetObjectIdxMap() throws SQLException {
-        resultSet.getObject(1, (Map)null);
+        resultSet.getObject(1, (Map<String,Class<?>>)null);
     }
 
     /**
@@ -1079,7 +1079,7 @@ public class JcrResultSetTest {
      */
     @Test( expected = SQLFeatureNotSupportedException.class )
     public void featureNotSupportedCallingGetObjectColNameMap() throws SQLException {
-        resultSet.getObject("colname", (Map)null);
+        resultSet.getObject("colname", (Map<String,Class<?>>)null);
     }
 
     /**


### PR DESCRIPTION
The previous JavaDoc used {@inheritDoc} JavaDoc annotation to link to the interfaces in the JDBC API. However, when building with JDK 1.6, these methods are not available. So the JavaDoc was changed to something that should be valid in 1.6 and 1.7, and added a TODO to add the @Override when we move to 1.7.
