### PR TITLE
MODE-1596 - Fixed refreshing of node types at startup, when "projectNodeTypes" is enabled and there's a system workspace coupled to a JPA (persistent) source.

### DIFF
--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrEngine.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrEngine.java
@@ -679,7 +679,7 @@ public class JcrEngine extends ModeShapeEngine implements Repositories {
             }
 
             logger().info(JcrI18n.registeringNodeTypesDefinedInConfiguration, repositoryName);
-            repository.getRepositoryTypeManager().registerNodeTypes(nodeTypesSubgraph, nodeTypesNode.getLocation(), false, true);
+            repository.getRepositoryTypeManager().registerNodeTypes(nodeTypesSubgraph, nodeTypesNode.getLocation(), false, !needToRefreshSubgraph);
             logger().info(JcrI18n.completedRegisteringNodeTypesDefinedInConfiguration, repositoryName);
         }
 


### PR DESCRIPTION
The problem was caused by an invalid boolean flag that caused any updates in the node type definitions to be ignored.
