### PR TITLE
MODE-1585 - Fixed checkout of nodes when a federated source is used

### DIFF
--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrVersionManager.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrVersionManager.java
@@ -590,10 +590,8 @@ final class JcrVersionManager implements VersionManager {
         org.modeshape.graph.property.Property predecessors = propFactory.create(JcrLexicon.PREDECESSORS, newPreds);
 
         Graph graph = workspace().graph();
-        Location location = Location.create(node.uuid());
-        graph.set(isCheckedOut, predecessors, multiValuedProps).on(location).and();
-
-        cache().refreshProperties(location);
+        graph.set(isCheckedOut, predecessors, multiValuedProps).on(node.location()).and();
+        cache().refreshProperties(node.location());
     }
 
     /**


### PR DESCRIPTION
The problem was that an ID Location did not propagate to all sources taking part in the federation.  The fix was to use a path location instead.
