### PR TITLE
MODE-1617 - Fixed the lack of persistence for created/deleted workspaces

### DIFF
--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/RepositoryCache.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/RepositoryCache.java
@@ -217,6 +217,8 @@ public class RepositoryCache implements Observable {
                 EditableDocument editable = entry.editDocumentContent();
                 PropertyFactory propFactory = context.getPropertyFactory();
                 translator.setProperty(editable, propFactory.create(name("workspaces"), workspaceNames), null);
+                //we need to update the cache immediately, so the changes are persisted
+                database.replace(systemMetadataKeyStr, editable, entry.getMetadata());
             }
         }
     }


### PR DESCRIPTION
The problem was caused by fact that we weren't updating the database and the edited schematic entry was a clone of the real one, which was never persisted back.

The solution was to update the entry in the database.
