### PR TITLE
MODE-1630 Corrected the build of the WebDAV tests

### DIFF
--- a/web/modeshape-web-jcr-webdav-war/pom.xml
+++ b/web/modeshape-web-jcr-webdav-war/pom.xml
@@ -74,6 +74,11 @@
                 <directory>src/main/resources</directory>
             </resource>
         </resources>
+        <testResources>
+            <testResource>
+                <directory>src/test/webapp</directory>
+            </testResource>
+        </testResources>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -81,9 +86,16 @@
                 <executions>
                     <execution>
                         <id>test-jar</id>
-                        <phase>non-existant</phase>
+                        <goals>
+                            <goal>test-jar</goal>
+                        </goals>
                     </execution>
                 </executions>
+                <configuration>
+                    <archive>
+                        <manifestFile>target/test-classes/META-INF/MANIFEST.MF</manifestFile>
+                    </archive>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.codehaus.cargo</groupId>

--- a/web/modeshape-web-jcr-webdav-war/src/test/webapp/META-INF/MANIFEST.MF
+++ b/web/modeshape-web-jcr-webdav-war/src/test/webapp/META-INF/MANIFEST.MF
@@ -1,0 +1,2 @@
+Manifest-Version: 1.0
+Class-Path: 

--- a/web/modeshape-webdav-war/pom.xml
+++ b/web/modeshape-webdav-war/pom.xml
@@ -59,6 +59,14 @@
                 <directory>src/main/resources</directory>
             </resource>
         </resources>
+        <testResources>
+            <testResource>
+                <directory>src/test/resources</directory>
+            </testResource>
+            <testResource>
+                <directory>src/test/webapp</directory>
+            </testResource>
+        </testResources>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -66,9 +74,16 @@
                 <executions>
                     <execution>
                         <id>test-jar</id>
-                        <phase>non-existant</phase>
+                        <goals>
+                            <goal>test-jar</goal>
+                        </goals>
                     </execution>
                 </executions>
+                <configuration>
+                    <archive>
+                        <manifestFile>target/test-classes/META-INF/MANIFEST.MF</manifestFile>
+                    </archive>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.codehaus.cargo</groupId>

--- a/web/modeshape-webdav-war/src/test/webapp/META-INF/MANIFEST.MF
+++ b/web/modeshape-webdav-war/src/test/webapp/META-INF/MANIFEST.MF
@@ -1,0 +1,2 @@
+Manifest-Version: 1.0
+Class-Path: 


### PR DESCRIPTION
When there was no `~/.m2/repository`, the build would not succeed because of missing test JAR dependencies in the WebDAV test modules (since the test classes are reused). Fixing the POMs corrected the issue.
