### PR TITLE
MODE-1624 Verified that VersionHistory.removeVersion works in 3.0

### DIFF
--- a/modeshape-jcr/src/test/java/org/modeshape/jcr/JcrVersioningTest.java
+++ b/modeshape-jcr/src/test/java/org/modeshape/jcr/JcrVersioningTest.java
@@ -36,8 +36,11 @@ import javax.jcr.Node;
 import javax.jcr.RepositoryException;
 import javax.jcr.Session;
 import javax.jcr.UnsupportedRepositoryOperationException;
+import javax.jcr.nodetype.ConstraintViolationException;
+import javax.jcr.version.Version;
 import javax.jcr.version.VersionException;
 import javax.jcr.version.VersionHistory;
+import javax.jcr.version.VersionIterator;
 import javax.jcr.version.VersionManager;
 import org.junit.Before;
 import org.junit.Test;
@@ -294,6 +297,148 @@ public class JcrVersioningTest extends SingleUseAbstractTest {
         assertThat(versionManager.isCheckedOut(child2.getPath()), is(false));
         child2.remove();
         session.save();
+    }
+
+    @FixFor( "MODE-1624" )
+    @Test
+    public void shouldAllowRemovingVersionFromVersionHistory() throws Exception {
+        print = false;
+
+        Node outerNode = session.getRootNode().addNode("outerFolder");
+        Node innerNode = outerNode.addNode("innerFolder");
+        Node fileNode = innerNode.addNode("testFile.dat");
+        fileNode.setProperty("jcr:mimeType", "text/plain");
+        fileNode.setProperty("jcr:data", "Original content");
+        session.save();
+
+        fileNode.addMixin("mix:versionable");
+        session.save();
+
+        // Make several changes ...
+        String path = fileNode.getPath();
+        for (int i = 2; i != 7; ++i) {
+            versionManager.checkout(path);
+            fileNode.setProperty("jcr:data", "Original content " + i);
+            session.save();
+            versionManager.checkin(path);
+        }
+
+        // Get the version history ...
+        VersionHistory history = versionManager.getVersionHistory(path);
+        if (print) System.out.println("Before: \n" + history);
+        assertThat(history, is(notNullValue()));
+        assertThat(history.getAllLinearVersions().getSize(), is(6L));
+
+        // Get the versions ...
+        VersionIterator iter = history.getAllLinearVersions();
+        Version v1 = iter.nextVersion();
+        Version v2 = iter.nextVersion();
+        Version v3 = iter.nextVersion();
+        Version v4 = iter.nextVersion();
+        Version v5 = iter.nextVersion();
+        Version v6 = iter.nextVersion();
+        assertThat(iter.hasNext(), is(false));
+        String versionName = v3.getName();
+        assertThat(v1, is(notNullValue()));
+        assertThat(v2, is(notNullValue()));
+        assertThat(v3, is(notNullValue()));
+        assertThat(v4, is(notNullValue()));
+        assertThat(v5, is(notNullValue()));
+        assertThat(v6, is(notNullValue()));
+
+        // Remove the 3rd version (that is, i=3) ...
+        history.removeVersion(versionName);
+
+        if (print) System.out.println("After (same history used to remove): \n" + history);
+        assertThat(history.getAllLinearVersions().getSize(), is(5L));
+
+        // Get the versions using the history node we already have ...
+        iter = history.getAllLinearVersions();
+        Version v1a = iter.nextVersion();
+        Version v2a = iter.nextVersion();
+        Version v4a = iter.nextVersion();
+        Version v5a = iter.nextVersion();
+        Version v6a = iter.nextVersion();
+        assertThat(iter.hasNext(), is(false));
+        assertThat(v1a.getName(), is(v1.getName()));
+        assertThat(v2a.getName(), is(v2.getName()));
+        assertThat(v4a.getName(), is(v4.getName()));
+        assertThat(v5a.getName(), is(v5.getName()));
+        assertThat(v6a.getName(), is(v6.getName()));
+
+        // Get the versions using a fresh history node ...
+        VersionHistory history2 = versionManager.getVersionHistory(path);
+        if (print) System.out.println("After (fresh history): \n" + history2);
+        assertThat(history.getAllLinearVersions().getSize(), is(5L));
+
+        iter = history2.getAllLinearVersions();
+        Version v1b = iter.nextVersion();
+        Version v2b = iter.nextVersion();
+        Version v4b = iter.nextVersion();
+        Version v5b = iter.nextVersion();
+        Version v6b = iter.nextVersion();
+        assertThat(iter.hasNext(), is(false));
+        assertThat(v1b.getName(), is(v1.getName()));
+        assertThat(v2b.getName(), is(v2.getName()));
+        assertThat(v4b.getName(), is(v4.getName()));
+        assertThat(v5b.getName(), is(v5.getName()));
+        assertThat(v6b.getName(), is(v6.getName()));
+    }
+
+    @FixFor( "MODE-1624" )
+    @Test
+    public void shouldAllowRemovingVersionFromVersionHistoryByRemovingVersionNode() throws Exception {
+        print = false;
+
+        Node outerNode = session.getRootNode().addNode("outerFolder");
+        Node innerNode = outerNode.addNode("innerFolder");
+        Node fileNode = innerNode.addNode("testFile.dat");
+        fileNode.setProperty("jcr:mimeType", "text/plain");
+        fileNode.setProperty("jcr:data", "Original content");
+        session.save();
+
+        fileNode.addMixin("mix:versionable");
+        session.save();
+
+        // Make several changes ...
+        String path = fileNode.getPath();
+        for (int i = 2; i != 7; ++i) {
+            versionManager.checkout(path);
+            fileNode.setProperty("jcr:data", "Original content " + i);
+            session.save();
+            versionManager.checkin(path);
+        }
+
+        // Get the version history ...
+        VersionHistory history = versionManager.getVersionHistory(path);
+        if (print) System.out.println("Before: \n" + history);
+        assertThat(history, is(notNullValue()));
+        assertThat(history.getAllLinearVersions().getSize(), is(6L));
+
+        // Get the versions ...
+        VersionIterator iter = history.getAllLinearVersions();
+        Version v1 = iter.nextVersion();
+        Version v2 = iter.nextVersion();
+        Version v3 = iter.nextVersion();
+        Version v4 = iter.nextVersion();
+        Version v5 = iter.nextVersion();
+        Version v6 = iter.nextVersion();
+        assertThat(iter.hasNext(), is(false));
+        assertThat(v1, is(notNullValue()));
+        assertThat(v2, is(notNullValue()));
+        assertThat(v3, is(notNullValue()));
+        assertThat(v4, is(notNullValue()));
+        assertThat(v5, is(notNullValue()));
+        assertThat(v6, is(notNullValue()));
+
+        // Remove the 3rd version (that is, i=3) ...
+        // history.removeVersion(versionName);
+        try {
+            v3.remove();
+            fail("Should not allow removing a protected node");
+        } catch (ConstraintViolationException e) {
+            // expected
+        }
     }
 
     private void registerNodeTypes( Session session,

--- a/modeshape-parent/pom.xml
+++ b/modeshape-parent/pom.xml
@@ -251,6 +251,7 @@
         <log4j.version>1.2.16</log4j.version>
         <jcr.version>2.0</jcr.version>
         <jackrabbit.jcr.tck.version>2.5.1</jackrabbit.jcr.tck.version>
+        <jackrabbit.lucene.version>3.6.0</jackrabbit.lucene.version>
         <jbossjta.version>4.16.2.Final</jbossjta.version>
         <picketbox.version>4.0.7.Final</picketbox.version>
         <byteman.version>1.5.1</byteman.version>

--- a/sandbox/modeshape-test-reference-impl/pom.xml
+++ b/sandbox/modeshape-test-reference-impl/pom.xml
@@ -62,6 +62,12 @@
             <groupId>log4j</groupId>
             <artifactId>log4j</artifactId>
         </dependency>
+        <!-- Override the Lucene version, since JR uses a more modern version -->
+        <dependency>
+            <groupId>org.apache.lucene</groupId>
+            <artifactId>lucene-core</artifactId>
+            <version>${jackrabbit.lucene.version}</version>
+        </dependency>
         <dependency>
             <groupId>org.apache.jackrabbit</groupId>
             <artifactId>jackrabbit-core</artifactId>
@@ -70,16 +76,16 @@
         </dependency>
     </dependencies>
     <build>
+        <testResources>
+            <testResource>
+                <directory>src/test/resources</directory>
+                <filtering>false</filtering>
+                <includes>
+                    <include>**/*</include>
+                </includes>
+            </testResource>
+        </testResources>
         <plugins>
-            <!-- Do not build any assemblies -->
-            <plugin>
-                <artifactId>maven-assembly-plugin</artifactId>
-                <inherited>false</inherited>
-                <configuration>
-                    <!-- we don't want to install any of these artifacts -->
-                    <attach>false</attach>
-                </configuration>
-            </plugin>
             <!-- Do not build any source JARs -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -106,6 +112,20 @@
                         <id>default-jar</id>
                         <!-- We don't want to run this -->
                         <phase>non-existant</phase>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <!--Disable bundle packaging because there aren't any sources-->
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>bundle-manifest</id>
+                        <phase>non-existant</phase>
+                        <goals>
+                            <goal>manifest</goal>
+                        </goals>
                     </execution>
                 </executions>
             </plugin>


### PR DESCRIPTION
Added several tests to explicitly test that it is possible to remove a version history. Only changes to test code were made.
