### PR TITLE
MODE-1615 Changed WorkspaceCache to use in-memory Infinispan cache

### DIFF
--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/bus/RepositoryChangeBus.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/bus/RepositoryChangeBus.java
@@ -84,6 +84,7 @@ public final class RepositoryChangeBus implements ChangeBus {
 
     @Override
     public void shutdown() {
+        shutdown = true;
         try {
             listenersLock.writeLock().lock();
             listeners.clear();
@@ -97,7 +98,7 @@ public final class RepositoryChangeBus implements ChangeBus {
     private void stopWork() {
         executor.shutdown();
         for (Future<?> worker : workers) {
-            worker.cancel(true);
+            if (!worker.isDone()) worker.cancel(true);
         }
         workers.clear();
     }

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/document/LazyCachedNode.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/document/LazyCachedNode.java
@@ -23,6 +23,7 @@
  */
 package org.modeshape.jcr.cache.document;
 
+import java.io.Serializable;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
@@ -54,16 +55,18 @@ import org.modeshape.jcr.value.Property;
  * externally each instance appears to be immutable and invariant.
  */
 @Immutable
-public class LazyCachedNode implements CachedNode {
+public class LazyCachedNode implements CachedNode, Serializable {
+
+    private static final long serialVersionUID = 1L;
 
     private final NodeKey key;
     private Document document;
-    private Map<Name, Property> properties;
-    private NodeKey parent;
-    private Set<NodeKey> additionalParents;
-    private ChildReference parentReferenceToSelf;
-    private boolean propertiesFullyLoaded = false;
-    private ChildReferences childReferences;
+    private transient Map<Name, Property> properties;
+    private transient NodeKey parent;
+    private transient Set<NodeKey> additionalParents;
+    private transient ChildReference parentReferenceToSelf;
+    private transient boolean propertiesFullyLoaded = false;
+    private transient ChildReferences childReferences;
 
     public LazyCachedNode( NodeKey key ) {
         this.key = key;

--- a/modeshape-jcr/src/main/resources/org/modeshape/jcr/default-workspace-cache-config.xml
+++ b/modeshape-jcr/src/main/resources/org/modeshape/jcr/default-workspace-cache-config.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<infinispan
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="urn:infinispan:config:5.1 http://www.infinispan.org/schemas/infinispan-config-5.1.xsd"
+        xmlns="urn:infinispan:config:5.1">
+
+    <global/>
+    
+    <!--
+      Define the configuration for each workspace cache. This configuration will be used if there is no "namedCache"
+      definition for the workspace name. Note that the names of caches following the convention 
+      "{repositoryName}/{workspaceName}".
+    -->
+    <default>
+
+        <!-- Local in-memory caches with no persistence. -->
+        <clustering mode="LOCAL"/>
+
+        <!-- No more that 10K entries per cache, with LIRS eviction. -->
+        <eviction maxEntries="10000" strategy="LIRS"/>
+
+        <!-- Expire entries after 120 seconds or after 60 seconds of not being used (whichever comes first). -->
+        <expiration lifespan="120000" maxIdle="60000"/>  
+          
+    </default>
+    
+</infinispan>

--- a/modeshape-jcr/src/main/resources/org/modeshape/jcr/repository-config-schema.json
+++ b/modeshape-jcr/src/main/resources/org/modeshape/jcr/repository-config-schema.json
@@ -189,6 +189,10 @@
                     "default" : true,
                     "description" : "Specifies whether users can create additional workspaces beyond the predefined, system, and default workspaces. The default value is 'true'."
                 },
+                "cacheConfiguration" : {
+                    "type" : "string",
+                    "description" : "The location of the file defining the Infinispan configuration for the repository's workspace caches. If a file could not be found (on the thread context classloader, on the application's classpath, or on the system classpath), then the name is used to look in JNDI for an Infinispan CacheContainer instance. If no such container is found, then a value of 'org/modeshape/jcr/deafult-workspace-cache-config.xml' is used, which is the default configuration provided by ModeShape."
+                },
                 "description" : {
                     "type" : "string",
                     "description" : "The optional description of this section of the configuration. It is unused by ModeShape."

--- a/modeshape-jcr/src/test/java/org/modeshape/jcr/RepositoryConfigurationTest.java
+++ b/modeshape-jcr/src/test/java/org/modeshape/jcr/RepositoryConfigurationTest.java
@@ -266,6 +266,23 @@ public class RepositoryConfigurationTest {
         assertNotNull(clusteringConfiguration.getDocument());
     }
 
+    @Test
+    public void shouldAllowWorkspaceCacheContainerToBeConfigured() throws Exception {
+        String cacheContainer = "my-container";
+
+        RepositoryConfiguration config = RepositoryConfiguration.read("{ \"name\" : \"foo\", \"workspaces\" : {\"cacheConfiguration\":\""
+                                                                      + cacheContainer + "\"} }");
+        System.out.println(config.validate());
+        assertThat(config.validate().hasProblems(), is(false));
+        assertEquals(cacheContainer, config.getWorkspaceCacheConfiguration());
+
+        config = RepositoryConfiguration.read("{ 'name' : 'foo', 'workspaces' : { 'cacheConfiguration' : '" + cacheContainer
+                                              + "' } }");
+        System.out.println(config.validate());
+        assertThat(config.validate().hasProblems(), is(false));
+        assertEquals(cacheContainer, config.getWorkspaceCacheConfiguration());
+    }
+
     protected RepositoryConfiguration assertValid( RepositoryConfiguration config ) {
         Problems results = config.validate();
         assertThat(results.toString(), results.hasProblems(), is(false));

--- a/modeshape-jcr/src/test/java/org/modeshape/jcr/cache/document/AbstractSessionCacheTest.java
+++ b/modeshape-jcr/src/test/java/org/modeshape/jcr/cache/document/AbstractSessionCacheTest.java
@@ -23,8 +23,11 @@
  */
 package org.modeshape.jcr.cache.document;
 
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 import javax.transaction.TransactionManager;
 import org.modeshape.jcr.ExecutionContext;
+import org.modeshape.jcr.cache.CachedNode;
 import org.modeshape.jcr.cache.NodeCache;
 import org.modeshape.jcr.cache.NodeKey;
 import org.modeshape.jcr.cache.SessionCache;
@@ -49,7 +52,8 @@ public abstract class AbstractSessionCacheTest extends AbstractNodeCacheTest {
     @Override
     protected NodeCache createCache() {
         listener = new PrintingChangeSetListener();
-        workspaceCache = new WorkspaceCache(context, "repo", "ws", database(), 100L, ROOT_KEY_WS1, listener);
+        ConcurrentMap<NodeKey, CachedNode> nodeCache = new ConcurrentHashMap<NodeKey, CachedNode>();
+        workspaceCache = new WorkspaceCache(context, "repo", "ws", database(), 100L, ROOT_KEY_WS1, nodeCache, listener);
         loadJsonDocuments(resource(resourceNameForWorkspaceContentDocument()));
         session1 = createSessionCache(context, workspaceCache);
         session2 = createSessionCache(context, workspaceCache);

--- a/modeshape-jcr/src/test/java/org/modeshape/jcr/cache/document/WorkspaceCacheTest.java
+++ b/modeshape-jcr/src/test/java/org/modeshape/jcr/cache/document/WorkspaceCacheTest.java
@@ -23,13 +23,18 @@
  */
 package org.modeshape.jcr.cache.document;
 
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import org.modeshape.jcr.cache.CachedNode;
 import org.modeshape.jcr.cache.NodeCache;
+import org.modeshape.jcr.cache.NodeKey;
 
 public class WorkspaceCacheTest extends AbstractNodeCacheTest {
 
     @Override
     protected NodeCache createCache() {
-        WorkspaceCache workspaceCache = new WorkspaceCache(context, "repo", "ws", database(), 100L, ROOT_KEY_WS1, null);
+        ConcurrentMap<NodeKey, CachedNode> nodeCache = new ConcurrentHashMap<NodeKey, CachedNode>();
+        WorkspaceCache workspaceCache = new WorkspaceCache(context, "repo", "ws", database(), 100L, ROOT_KEY_WS1, nodeCache, null);
         loadJsonDocuments(resource(resourceNameForWorkspaceContentDocument()));
         return workspaceCache;
     }


### PR DESCRIPTION
The Infinispan cache uses eviction and expiration to limit the size of each workspace cache. Also, the RepositoryConfiguration (and the JSON schema) were changed to allow overriding the defaults of the workspace cache configuration parameters. (Tuning will likely be necessary, since the cache size is highly a function of the number and size of the nodes.)

This pull-request is currently for review only; there still is an error being logged by Infinispan during the JcrWritingTest.

See below for an description of the relevant changes.
