### PR TITLE
MODE-1613- Fixed caching of node paths (via parentReferenceToSelf) in the case of SNS.

### DIFF
--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/document/WritableSessionCache.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/document/WritableSessionCache.java
@@ -774,8 +774,7 @@ public class WritableSessionCache extends AbstractSessionCache {
                         // The node has moved (either within the same parent or to another parent) ...
                         Path oldPath = workspacePaths.getPath(persisted);
                         NodeKey oldParentKey = persisted.getParentKey(workspaceCache);
-                        if (!oldParentKey.equals(newParent) || !additionalParents.isEmpty()) {
-                            // Don't need to change the doc, since we've moved within the same parent ...
+                        if (!oldParentKey.equals(newParent) || (additionalParents != null && !additionalParents.isEmpty())) {
                             translator.setParents(doc, node.newParent(), oldParentKey, additionalParents);
                         }
                         // Generate a move even either way ...


### PR DESCRIPTION
The solution was to check that the parent of the actual cached children reference isn't stale.
