### PR TITLE
MODE-1648 Added several Maven BOMs for ModeShape clients

### DIFF
--- a/boms/README.md
+++ b/boms/README.md
@@ -1,0 +1,11 @@
+ModeShape provides a number of Maven Bills of Material (BOMs) that make it easier to use ModeShape as a dependency in your own applications. These artifacts specify versions for all of ModeShape's components and dependencies, ensuring you always get a compatible stack.
+
+== ModeShape BOMs ==
+
+The following BOMs are available:
+
+* `modeshape-bom-embedded` - Use this when your applications or components embed ModeShape and explicitly manage ModeShape's lifecycle. This is often what you'll want in Java SE applications, libraries, or even web applications deployed to containers other than JBoss AS7.
+* `modeshape-bom-jbossas` - Use this in web applications or services that are to be deployed to JBoss AS7 instances that have ModeShape installed as a service. Your applications never manage the ModeShape lifecycle, but instead just look up one of the repository instances already running within AS7. Therefore, your applications only need access to the JCR API, ModeShape's public API, the Java Transaction API (JTA), and (optionally) the Java Servlet API (used for servlet-based authentication). All these dependences have a scope of `provided` since
+they are provided by the ModeShape installation in AS7.
+* `modeshape-bom-api` - Use this when your applications or components only depend upon the public APIs that ModeShape provides and uses, namely the JCR API, ModeShape's public API, the Java Transaction API (JTA), and the Java Servlet API (used for servlet-based authentication). However, unlike `modeshape-bom-jbossas`, these dependences default to `compile` scope.
+* `modeshape-bom-remote-client` - Use this when your applications connect to a remote ModeShape server using one of ModeShape's clients libraries: the REST client library or the remote JDBC driver. Most of ModeShape's normal dependencies are not needed, since ModeShape is really running on a remote server.

--- a/boms/modeshape-bom-api/README.md
+++ b/boms/modeshape-bom-api/README.md
@@ -1,0 +1,51 @@
+This ModeShape BOM makes it easy for your applications and libraries that need to access only the JCR API, the ModeShape public API, the Java Transaction API (JTA), and the Java Servlet API. You might want to use this in a library that will be handed a Repository instance and will simply use that repository.
+
+== Usage ==
+
+Include the following in your POM file:
+
+    <project>
+      ...
+      <dependencyManagement>    
+        <dependencies>
+          <dependency>
+            <groupId>org.modeshape.bom</groupId>
+            <artifactId>modeshape-bom-api</artifactId>
+            <version>3.0.0.Final</version>
+            <type>pom</type>
+            <scope>import</scope>
+          </dependency>
+        </dependencies>
+      </dependencyManagement>
+      ...
+    </project>
+
+Obviously, you'll need to specify the correct ModeShape version. But note that this is the only place you'll need to specify a version, because the BOM provides a completely valid and consistent set of versions.
+
+This works like all other Maven BOMs by adding into the `dependencyManagement` section all of the dependency defaults for the ModeShape components and dependencies that your module _might_ need. Then, all you have to do is add an explicit dependency to your POM's `dependencies` section for each of ModeShape's components that your module _does_ use.
+
+For example, if your module uses the JCR API, the ModeShape public API (which is a small extension to the JCR API), and Java Transaction API, then simply define these dependencies:
+
+    <project>
+      ...
+      <dependencies>
+        ...
+        <dependency>
+          <groupId>javax.jcr</groupId>
+          <artifactId>jcr</artifactId>
+        </dependency>
+        <dependency>
+          <groupId>org.modeshape</groupId>
+          <artifactId>modeshape-jcr-api</artifactId>
+        </dependency>
+        <dependency>
+          <groupId>javax.transaction</groupId>
+          <artifactId>jta</artifactId>
+        </dependency>
+        ...
+      </dependencies>
+      ...
+    </project>
+
+Because the ModeShape BOM defines them as `provided`, they will not be included in the web archive for your application or service.
+

--- a/boms/modeshape-bom-api/pom.xml
+++ b/boms/modeshape-bom-api/pom.xml
@@ -1,0 +1,61 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <parent>
+        <groupId>org.modeshape.bom</groupId>
+        <artifactId>modeshape-bom-parent</artifactId>
+        <version>3.0-SNAPSHOT</version>
+    </parent>
+
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.modeshape.bom</groupId>
+    <artifactId>modeshape-bom-api</artifactId>
+    <version>3.0-SNAPSHOT</version>
+    <name>ModeShape BOM for public APIs</name>
+
+    <url>http://www.modeshape.org</url>
+    <packaging>pom</packaging>
+    <description>Bill of Material (BOM) for using ModeShapes public API</description>
+
+    <properties>
+      <!-- Version properties are inherited from parent -->
+    </properties>
+
+    <!--
+         This section defines the default dependency settings inherited by
+         child projects. Note that this section does not add dependencies, but
+         rather provide default settings.
+     -->
+    <dependencyManagement>
+        <dependencies>
+            <!-- Java Content Repository API -->
+            <dependency>
+                <groupId>javax.jcr</groupId>
+                <artifactId>jcr</artifactId>
+                <version>${jcr.version}</version>
+            </dependency>
+
+            <!-- ModeShape public API -->
+            <dependency>
+                <groupId>org.modeshape</groupId>
+                <artifactId>modeshape-jcr-api</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <!-- Transactions (JTA) public API -->
+            <dependency>
+                <groupId>javax.transaction</groupId>
+                <artifactId>jta</artifactId>
+                <version>${javax.jta.version}</version>
+            </dependency>
+
+            <!-- Servlet public API (for authentication)-->
+            <dependency>
+                <groupId>javax.servlet</groupId>
+                <artifactId>servlet-api</artifactId>
+                <version>${javax.servlet.version}</version>
+            </dependency>
+
+        </dependencies>
+    </dependencyManagement>
+</project>

--- a/boms/modeshape-bom-embedded/README.md
+++ b/boms/modeshape-bom-embedded/README.md
@@ -1,0 +1,143 @@
+This ModeShape BOM makes it easy for your applications and libraries to embed ModeShape and explicitly manage ModeShape's lifecycle. This is typically what is used in the POM files of Java SE applications, libraries, and even web applications that are deployed to containers other than JBoss AS7. (There is a special BOM for deployments to JBoss AS7 that has ModeShape installed.)
+
+== Usage ==
+
+Include the following in your POM file:
+
+    <project>
+      ...
+      <dependencyManagement>    
+        <dependencies>
+          <dependency>
+            <groupId>org.modeshape.bom</groupId>
+            <artifactId>modeshape-bom-embedded</artifactId>
+            <version>3.0.0.Final</version>
+            <type>pom</type>
+            <scope>import</scope>
+          </dependency>
+        </dependencies>
+      </dependencyManagement>
+      ...
+    </project>
+
+Obviously, you'll need to specify the correct ModeShape version. But note that this is the only place you'll need to specify a version, because the BOM provides a completely valid and consistent set of versions.
+
+This works like all other Maven BOMs by adding into the `dependencyManagement` section all of the dependency defaults for the ModeShape components and dependencies that your module _might_ need. Then, all you have to do is add an explicit dependency to your POM's `dependencies` section for each of ModeShape's components that your module _does_ use, including any of the optional optional components (e.g., sequencers, MongoDB binary store, Infinispan cache stores, JTA implementation, JAAS implementation, etc.) that simply need to be on the classpath for ModeShape to find and use them.
+
+For example, if your module _explicitly_ uses the JCR API and needs to manually set up and manage a ModeShape engine, then simply define these dependencies:
+
+    <project>
+      ...
+      <dependencies>
+        ...
+        <dependency>
+          <groupId>javax.jcr</groupId>
+          <artifactId>jcr</artifactId>
+        </dependency>
+        <dependency>
+          <groupId>org.modeshape</groupId>
+          <artifactId>modeshape-jcr-api</artifactId>
+        </dependency>
+        <dependency>
+          <groupId>org.modeshape</groupId>
+          <artifactId>modeshape-jcr</artifactId>
+        </dependency>
+        ...
+      </dependencies>
+      ...
+    </project>
+
+You can also add any sequencers that ModeShape should find. Here's an example that adds in ModeShape's XSD sequencer:
+
+    <project>
+      ...
+      <dependencies>
+        ...
+        <dependency>
+          <groupId>org.modeshape</groupId>
+          <artifactId>modeshape-sequencer-xsd</artifactId>
+        </dependency>
+        ...
+      </dependencies>
+      ...
+    </project>
+
+You should do the same for the Infinispan cache stores, MongoDB driver, or other optional components. For example, if you're writing a Java SE application, you can even include the Java Transaction API (JTA) and a fully-functioning implementation:
+
+    <project>
+      ...
+      <dependencies>
+        ...
+        <dependency>
+          <groupId>javax.transaction</groupId>
+          <artifactId>jta</artifactId>
+        </dependency>
+        <dependency>
+          <groupId>org.jboss.jbossts</groupId>
+          <artifactId>jbossjta</artifactId>
+        </dependency>
+        ...
+      </dependencies>
+      ...
+    </project>
+
+ModeShape can use a variety of logging frameworks. If your application uses the JDK's logging framework, do not include any logging dependencies.
+
+If your application uses SLF4J, simply include the API, the binding JAR, and the logging implementation. For example, adding these dependencies would use Log4J via SLF4J, where both ModeShape and your application can use SLF4J.  to use a logging library, simply include *_one_* of the following dependencies:
+
+    <project>
+      ...
+      <dependencies>
+        ...
+        <dependency>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-api</artifactId>
+        </dependency>
+        <dependency>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-log4j12</artifactId>
+        </dependency>
+        <dependency>
+          <groupId>log4j</groupId>
+          <artifactId>log4j</artifactId>
+        </dependency>
+        ...
+      </dependencies>
+      ...
+    </project>
+
+If your application directly uses Log4J, then simply add that dependency:
+
+    <project>
+      ...
+      <dependencies>
+        ...
+        <dependency>
+          <groupId>log4j</groupId>
+          <artifactId>log4j</artifactId>
+        </dependency>
+        ...
+      </dependencies>
+      ...
+    </project>
+
+Or, if your application directly uses LogBack (which implements the SLF4J API), simply include the following dependencies:
+
+    <project>
+      ...
+      <dependencies>
+        ...
+        <dependency>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-api</artifactId>
+        </dependency>
+        <dependency>
+          <groupId>ch.qos.logback</groupId>
+          <artifactId>logback-classic</artifactId>
+          <version>${logback.version}</version>
+        </dependency>
+        ...
+      </dependencies>
+      ...
+    </project>
+

--- a/boms/modeshape-bom-embedded/pom.xml
+++ b/boms/modeshape-bom-embedded/pom.xml
@@ -1,0 +1,677 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <parent>
+        <groupId>org.modeshape.bom</groupId>
+        <artifactId>modeshape-bom-parent</artifactId>
+        <version>3.0-SNAPSHOT</version>
+    </parent>
+
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.modeshape.bom</groupId>
+    <artifactId>modeshape-bom-embedded</artifactId>
+    <version>3.0-SNAPSHOT</version>
+    <name>ModeShape BOM for embedded usage</name>
+
+    <url>http://www.modeshape.org</url>
+    <packaging>pom</packaging>
+    <description>Bill of Material (BOM) for embedding ModeShape within JavaSE apps, libraries, and (non-AS7) web apps</description>
+
+    <properties>
+      <!-- Version properties are inherited from parent -->
+    </properties>
+
+    <!--
+         This section defines the default dependency settings inherited by
+         child projects. Note that this section does not add dependencies, but
+         rather provide default settings.
+     -->
+    <dependencyManagement>
+        <dependencies>
+
+            <!-- Public APIs from BOM -->
+            <dependency>
+                <groupId>org.modeshape.bom</groupId>
+                <artifactId>modeshape-bom-api</artifactId>
+                <version>${project.version}</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
+
+            <!-- ModeShape implementation components -->
+            <dependency>
+                <groupId>org.modeshape</groupId>
+                <artifactId>modeshape-common</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.modeshape</groupId>
+                <artifactId>modeshape-jcr</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.modeshape</groupId>
+                <artifactId>modeshape-schematic</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.modeshape</groupId>
+                <artifactId>modeshape-jcr-tck</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.modeshape</groupId>
+                <artifactId>modeshape-sequencer-ddl</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.modeshape</groupId>
+                <artifactId>modeshape-sequencer-images</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.modeshape</groupId>
+                <artifactId>modeshape-sequencer-java</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.modeshape</groupId>
+                <artifactId>modeshape-sequencer-mp3</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.modeshape</groupId>
+                <artifactId>modeshape-sequencer-msoffice</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.modeshape</groupId>
+                <artifactId>modeshape-sequencer-sramp</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.modeshape</groupId>
+                <artifactId>modeshape-sequencer-teiid</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.modeshape</groupId>
+                <artifactId>modeshape-sequencer-text</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.modeshape</groupId>
+                <artifactId>modeshape-sequencer-xml</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.modeshape</groupId>
+                <artifactId>modeshape-sequencer-xsd</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.modeshape</groupId>
+                <artifactId>modeshape-sequencer-wsdl</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.modeshape</groupId>
+                <artifactId>modeshape-sequencer-zip</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.modeshape</groupId>
+                <artifactId>modeshape-extractor-tika</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <!--
+                Infinispan
+            -->
+            <dependency>
+                <groupId>org.infinispan</groupId>
+                <artifactId>infinispan-core</artifactId>
+                <version>${infinispan.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.codehaus.woodstox</groupId>
+                        <artifactId>woodstox-core-asl</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.codehaus.woodstox</groupId>
+                        <artifactId>stax2-api</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>org.infinispan</groupId>
+                <artifactId>infinispan-lucene-directory</artifactId>
+                <version>${infinispan.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.infinispan</groupId>
+                <artifactId>infinispan-cachestore-bdbje</artifactId>
+                <version>${infinispan.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.infinispan</groupId>
+                <artifactId>infinispan-cachestore-jdbm</artifactId>
+                <version>${infinispan.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.infinispan</groupId>
+                <artifactId>infinispan-cachestore-jdbc</artifactId>
+                <version>${infinispan.version}</version>
+            </dependency>
+            <!--Required by infinispan-cachestore-jdbc -->
+            <dependency>
+                <groupId>c3p0</groupId>
+                <artifactId>c3p0</artifactId>
+                <version>${c3p0.version}</version>
+            </dependency>
+            
+            <!--
+                JGroups is used for the changes bus, but it's optional. Most of the times though, this will be in the classpath
+                because of ISPN.
+             -->
+            <dependency>
+                <groupId>org.jgroups</groupId>
+                <artifactId>jgroups</artifactId>
+                <version>${jgroups.version}</version>
+            </dependency>
+
+            <!-- Hibernate Search engine (does not use Hibernate Core or JPA!) -->
+            <dependency>
+                <groupId>org.hibernate</groupId>
+                <artifactId>hibernate-search-engine</artifactId>
+                <version>${hibernate.search.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.hibernate</groupId>
+                        <artifactId>hibernate-search-analyzers</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>org.hibernate</groupId>
+                <artifactId>hibernate-search-infinispan</artifactId>
+                <version>${hibernate.search.version}</version>
+            </dependency>
+            <dependency>
+              <!--
+              To force testing of Apache Avro integration with the version of Jackson used in AS 7.1
+              -->
+              <groupId>org.codehaus.jackson</groupId>
+              <artifactId>jackson-core-asl</artifactId>
+              <version>${hibernate.search.jackson-core-asl.version}</version>
+            </dependency>
+            <dependency>
+              <!--
+              To force testing of Apache Avro integration with the version of Jackson used in AS 7.1
+              -->
+              <groupId>org.codehaus.jackson</groupId>
+              <artifactId>jackson-mapper-asl</artifactId>
+              <version>${hibernate.search.jackson-mapper-asl.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.lucene</groupId>
+                <artifactId>lucene-core</artifactId>
+                <version>${lucene.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.lucene</groupId>
+                <artifactId>lucene-regex</artifactId>
+                <version>${lucene.regex.version}</version>
+            </dependency>
+            
+            <!-- Recommended JUnit version -->
+            <dependency>
+                <groupId>junit</groupId>
+                <artifactId>junit</artifactId>
+                <version>${junit.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>junit</groupId>
+                <artifactId>junit-dep</artifactId>
+                <version>${junit.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.modeshape</groupId>
+                <artifactId>modeshape-unit-test</artifactId>
+                <version>${project.version}</version>
+                <scope>test</scope>
+            </dependency>
+
+            <!--
+                Compatible logging modules.
+            -->
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-api</artifactId>
+                <version>${slf4j.api.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-log4j12</artifactId>
+                <version>${slf4j.log4j.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>log4j</groupId>
+                <artifactId>log4j</artifactId>
+                <version>${log4j.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>ch.qos.logback</groupId>
+                <artifactId>logback-classic</artifactId>
+                <version>${logback.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jboss.logging</groupId>
+                <artifactId>jboss-logging</artifactId>
+                <version>${jboss.logging.version}</version>
+            </dependency>
+            
+            <!--
+                Sequencers
+            -->
+
+            <!-- Eclipse JDT artifacts declare their dependencies using ranges. (yikes!)
+                 So we need to specify exact versions, and we can do that in a dependencyManagement section.
+                 Here are the dependencies showing the last combination that we could get working:
+                 +- org.eclipse.equinox:common:jar:3.3.0-v20070426:compile
+                     +- org.eclipse.jdt:core:jar:3.3.0-v_771:compile
+                     |  +- org.eclipse.core:resources:jar:3.3.0-v20070604:compile
+                     |  |  \- org.eclipse.core:expressions:jar:3.3.0-v20070606-0010:compile
+                     |  \- org.eclipse.core:runtime:jar:3.3.100-v20070530:compile
+                     |     +- org.eclipse:osgi:jar:3.3.0-v20070530:compile
+                     |     +- org.eclipse.core:jobs:jar:3.3.0-v20070423:compile
+                     |     +- org.eclipse.equinox:registry:jar:3.3.0-v20070522:compile
+                     |     +- org.eclipse.equinox:preferences:jar:3.2.100-v20070522:compile
+                     |     \- org.eclipse.core:contenttype:jar:3.2.100-v20070319:compile
+            -->
+            <!--Java sequencer-->
+            <dependency>
+                <groupId>org.eclipse.equinox</groupId>
+                <artifactId>common</artifactId>
+                <version>${eclipse.equinox.common.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.jdt</groupId>
+                <artifactId>core</artifactId>
+                <version>${eclipse.jdt.core.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.core</groupId>
+                <artifactId>resources</artifactId>
+                <version>${eclipse.core.resources.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.core</groupId>
+                <artifactId>expressions</artifactId>
+                <version>${eclipse.core.expressions.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.core</groupId>
+                <artifactId>runtime</artifactId>
+                <version>${eclipse.core.runtime.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse</groupId>
+                <artifactId>osgi</artifactId>
+                <version>${eclipse.osgi.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.core</groupId>
+                <artifactId>jobs</artifactId>
+                <version>${eclipse.core.jobs.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.equinox</groupId>
+                <artifactId>registry</artifactId>
+                <version>${eclipse.equinox.registry.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.equinox</groupId>
+                <artifactId>preferences</artifactId>
+                <version>${eclipse.equinox.preferences.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.core</groupId>
+                <artifactId>contenttype</artifactId>
+                <version>${eclipse.core.contenttype.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>javassist</groupId>
+                <artifactId>javassist</artifactId>
+                <version>${javaassist.version}</version>
+            </dependency>
+            <!--Mp3 sequencer-->
+            <dependency>
+                <groupId>org</groupId>
+                <artifactId>jaudiotagger</artifactId>
+                <version>${jaudiotagger.version}</version>
+            </dependency>
+            <!--MsOffice sequencer-->
+            <dependency>
+                <groupId>org.apache.poi</groupId>
+                <artifactId>poi</artifactId>
+                <version>${poi.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.poi</groupId>
+                <artifactId>poi-scratchpad</artifactId>
+                <version>${poi.version}</version>
+            </dependency>
+            <!--Teiid sequencer-->
+            <dependency>
+                <groupId>com.beust</groupId>
+                <artifactId>jcommander</artifactId>
+                <version>${jcommander.version}</version>
+            </dependency>
+            <!--WSDL sequencer-->
+            <dependency>
+                <groupId>wsdl4j</groupId>
+                <artifactId>wsdl4j</artifactId>
+                <version>${wsdl4j.version}</version>
+            </dependency>
+            <!--XSD sequencer-->
+            <dependency>
+                <groupId>org.eclipse.xsd</groupId>
+                <artifactId>xsd</artifactId>
+                <version>${eclipse.xsd.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.emf</groupId>
+                <artifactId>common</artifactId>
+                <version>${eclipse.emf.common.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.emf</groupId>
+                <artifactId>ecore</artifactId>
+                <version>${eclipse.emf.ecore.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.emf</groupId>
+                <artifactId>ecore-change</artifactId>
+                <version>${eclipse.emf.ecorechange.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.emf</groupId>
+                <artifactId>ecore-xmi</artifactId>
+                <version>${eclipse.emf.ecorexmi.version}</version>
+            </dependency>
+
+            <!--
+                TIKA text extractor
+            
+                This Tika dependency brings in a lot of 3rd party libraries. We'll exclude
+                most of them and only keep a few that are for Microsoft Office documents,
+                HTML, XML and PDF. When others are needed, they can simply be added to
+                an application's dependencies.
+                
+                Note that 'modeshape-jcr' excludes even more transitive dependencies, since it
+                only uses the MIME type detector functionality, whereas the 'modeshape-extractor-tika'
+                uses everything defined here.
+                -->
+            <dependency>
+                <groupId>org.apache.tika</groupId>
+                <artifactId>tika-parsers</artifactId>
+                <version>${tika.version}</version>
+                <exclusions>
+                    <!--
+                    The NetCDF and HDF files are often used in the scientific community, so we exclude this
+                    library (and the Commons HTTP Client library) by default.
+                    -->
+                    <exclusion>
+                        <groupId>edu.ucar</groupId>
+                        <artifactId>netcdf</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>commons-httpclient</groupId>
+                        <artifactId>commons-httpclient</artifactId>
+                    </exclusion>
+
+                    <!--
+                    Image metadata isn't often for text extraction,
+                    so exclude this library by default.
+                    -->
+                    <exclusion>
+                        <groupId>com.drewnoakes</groupId>
+                        <artifactId>metadata-extractor</artifactId>
+                    </exclusion>
+                    <!--
+                    RSS and Atom feeds aren't often used for text extraction,
+                    so exclude this library by default.
+                    -->
+                    <exclusion>
+                        <groupId>rome</groupId>
+                        <artifactId>rome</artifactId>
+                    </exclusion>
+                    <!--
+                    Boilerpipe HTML templates are likely not used,
+                    so exclude this library by default.
+                    -->
+                    <exclusion>
+                        <groupId>de.l3s.boilerpipe</groupId>
+                        <artifactId>boilerpipe</artifactId>
+                    </exclusion>
+                    <!-- 
+                    PDFBox declares the Bouncy Castle dependencies
+                    as optional, and Tika always depends on them to avoid
+                    problems with encrypted PDFs (see TIKA-370). 
+                    We exclude them by default. 
+                    -->
+                    <exclusion>
+                      <groupId>org.bouncycastle</groupId>
+                      <artifactId>bcmail-jdk15</artifactId>
+                    </exclusion>
+                    <exclusion>
+                      <groupId>org.bouncycastle</groupId>
+                      <artifactId>bcprov-jdk15</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            
+            <!--
+                Optional dependency when using the MongoDB binary store
+            -->
+            <dependency>
+                <groupId>org.mongodb</groupId>
+                <artifactId>mongo-java-driver</artifactId>
+                <version>${mongo.driver.version}</version>
+            </dependency>
+            
+            <!--
+               Optional/recommended JAAS implementation (PicketBox)
+               -->
+            <dependency>
+                <groupId>org.picketbox</groupId>
+                <artifactId>picketbox-bare</artifactId>
+                <version>${picketbox.version}</version>
+                <scope>test</scope>
+                <exclusions>
+                    <exclusion>
+                        <groupId>apache-xalan</groupId>
+                        <artifactId>xalan</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>apache-xalan</groupId>
+                        <artifactId>serializer</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>apache-xerces</groupId>
+                        <artifactId>xml-apis</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>apache-xerces</groupId>
+                        <artifactId>xercesImpl</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.hibernate</groupId>
+                        <artifactId>hibernate</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+
+            <!--
+                Optional/recommended JTA implementation
+            -->
+            <dependency>
+                <groupId>javax.transaction</groupId>
+                <artifactId>jta</artifactId>
+                <version>${javax.jta.version}</version>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.jboss.jbossts</groupId>
+                <artifactId>jbossjta</artifactId>
+                <version>${jbossjta.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <artifactId>commons-httpclient</artifactId>
+                        <groupId>commons-httpclient</groupId>
+                    </exclusion>
+                    <exclusion>
+                        <artifactId>ironjacamar-spec-api</artifactId>
+                        <groupId>org.jboss.ironjacamar</groupId>
+                    </exclusion>
+                    <exclusion>
+                        <artifactId>jboss-logging-spi</artifactId>
+                        <groupId>org.jboss.logging</groupId>
+                    </exclusion>
+                    <exclusion>
+                        <artifactId>jboss-logging</artifactId>
+                        <groupId>org.jboss.logging</groupId>
+                    </exclusion>
+                    <exclusion>
+                        <artifactId>jboss-logging-processor</artifactId>
+                        <groupId>org.jboss.logging</groupId>
+                    </exclusion>
+                    <exclusion>
+                        <artifactId>jboss-logging-generator</artifactId>
+                        <groupId>org.jboss.logging</groupId>
+                    </exclusion>
+                    <exclusion>
+                        <artifactId>jbossws-native-core</artifactId>
+                        <groupId>org.jboss.ws.native</groupId>
+                    </exclusion>
+                    <exclusion>
+                        <artifactId>emma</artifactId>
+                        <groupId>emma</groupId>
+                    </exclusion>
+                    <exclusion>
+                        <artifactId>emma_ant</artifactId>
+                        <groupId>emma</groupId>
+                    </exclusion>
+                    <exclusion>
+                        <artifactId>hornetq-core</artifactId>
+                        <groupId>org.hornetq</groupId>
+                    </exclusion>
+                    <exclusion>
+                        <artifactId>netty</artifactId>
+                        <groupId>org.jboss.netty</groupId>
+                    </exclusion>
+                    <exclusion>
+                        <artifactId>wrapper</artifactId>
+                        <groupId>tanukisoft</groupId>
+                    </exclusion>
+                    <exclusion>
+                        <artifactId>jacorb</artifactId>
+                        <groupId>jacorb</groupId>
+                    </exclusion>
+                    <exclusion>
+                        <artifactId>jfreechart</artifactId>
+                        <groupId>jfree</groupId>
+                    </exclusion>
+                    <exclusion>
+                        <artifactId>jboss-corba-ots-spi</artifactId>
+                        <groupId>org.jboss.integration</groupId>
+                    </exclusion>
+                    <exclusion>
+                        <artifactId>jboss-server-manager</artifactId>
+                        <groupId>org.jboss.jbossas</groupId>
+                    </exclusion>
+                    <exclusion>
+                        <artifactId>jboss-ejb-api_3.1_spec</artifactId>
+                        <groupId>org.jboss.spec.javax.ejb</groupId>
+                    </exclusion>
+                    <exclusion>
+                        <artifactId>jnp-client</artifactId>
+                        <groupId>org.jboss.naming</groupId>
+                    </exclusion>
+                    <exclusion>
+                        <artifactId>jboss-servlet-api_3.0_spec</artifactId>
+                        <groupId>org.jboss.spec.javax.servlet</groupId>
+                    </exclusion>
+                    <exclusion>
+                        <artifactId>jbossws-common</artifactId>
+                        <groupId>org.jboss.ws</groupId>
+                    </exclusion>
+                    <exclusion>
+                        <artifactId>jcl-over-slf4j</artifactId>
+                        <groupId>org.slf4j</groupId>
+                    </exclusion>
+                    <exclusion>
+                        <artifactId>stax-api</artifactId>
+                        <groupId>stax</groupId>
+                    </exclusion>
+                    <exclusion>
+                        <artifactId>idl</artifactId>
+                        <groupId>jacorb</groupId>
+                    </exclusion>
+                    <exclusion>
+                        <artifactId>jboss-logging-tools</artifactId>
+                        <groupId>org.jboss.logging</groupId>
+                    </exclusion>
+                    <exclusion>
+                        <artifactId>jboss-connector-api_1.5_spec</artifactId>
+                        <groupId>org.jboss.spec.javax.resource</groupId>
+                    </exclusion>
+                    <exclusion>
+                        <artifactId>jboss-transaction-spi</artifactId>
+                        <groupId>org.jboss.integration</groupId>
+                    </exclusion>
+                    <exclusion>
+                        <artifactId>jboss-remoting</artifactId>
+                        <groupId>org.jboss.remoting</groupId>
+                    </exclusion>
+                    <exclusion>
+                        <artifactId>slf4j-api</artifactId>
+                        <groupId>org.slf4j</groupId>
+                    </exclusion>
+                    <exclusion>
+                        <artifactId>dom4j</artifactId>
+                        <groupId>dom4j</groupId>
+                    </exclusion>
+                    <exclusion>
+                        <artifactId>commons-codec</artifactId>
+                        <groupId>commons-codec</groupId>
+                    </exclusion>
+                    <exclusion>
+                        <artifactId>jboss-logmanager</artifactId>
+                        <groupId>org.jboss.logmanager</groupId>
+                    </exclusion>
+                    <exclusion>
+                        <artifactId>hibernate-jpa-2.0-api</artifactId>
+                        <groupId>org.hibernate.javax.persistence</groupId>
+                    </exclusion>
+                    <exclusion>
+                        <artifactId>commons-logging</artifactId>
+                        <groupId>commons-logging</groupId>
+                    </exclusion>
+                    <exclusion>
+                        <artifactId>jcommon</artifactId>
+                        <groupId>jfree</groupId>
+                    </exclusion>
+                    <exclusion>
+                        <artifactId>jboss-transaction-api_1.1_spec</artifactId>
+                        <groupId>org.jboss.spec.javax.transaction</groupId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+
+        </dependencies>
+    </dependencyManagement>
+</project>

--- a/boms/modeshape-bom-jbossas/README.md
+++ b/boms/modeshape-bom-jbossas/README.md
@@ -1,0 +1,53 @@
+ModeShape can be installed into a JBoss AS7 installation, in which case all configuration and management of the repositories is done via standard AS7 tools and mechanisms. All your applications and services need to do is simply lookup one of the repositories and use it.
+
+This ModeShape BOM makes it easy for your web applications and services to add dependencies to the JCR API, the ModeShape public API and the Java Transaction API (JTA). (Note that this is similar to the `modeshape-bom-api` BOM, except that all of the dependencies are marked with a scope of `provided`.)
+
+== Usage ==
+
+Include the following in your POM file:
+
+    <project>
+      ...
+      <dependencyManagement>    
+        <dependencies>
+          <dependency>
+            <groupId>org.modeshape.bom</groupId>
+            <artifactId>modeshape-bom-jbossas</artifactId>
+            <version>3.0.0.Final</version>
+            <type>pom</type>
+            <scope>import</scope>
+          </dependency>
+        </dependencies>
+      </dependencyManagement>
+      ...
+    </project>
+
+Obviously, you'll need to specify the correct ModeShape version. But note that this is the only place you'll need to specify a version, because the BOM provides a completely valid and consistent set of versions.
+
+This works like all other Maven BOMs by adding into the `dependencyManagement` section all of the dependency defaults for the ModeShape components and dependencies that your module _might_ need. Then, all you have to do is add an explicit dependency to your POM's `dependencies` section for each of ModeShape's components that your module _does_ use, including JCR API, JTA, or ModeShape public API. If you need any other APIs, please use one of the Java EE6 BOMs provided by JBoss AS7.
+
+For example, if your module uses the JCR API, the ModeShape public API (which is a small extension to the JCR API), and Java Transaction API, then simply define these dependencies:
+
+    <project>
+      ...
+      <dependencies>
+        ...
+        <dependency>
+          <groupId>javax.jcr</groupId>
+          <artifactId>jcr</artifactId>
+        </dependency>
+        <dependency>
+          <groupId>org.modeshape</groupId>
+          <artifactId>modeshape-jcr-api</artifactId>
+        </dependency>
+        <dependency>
+          <groupId>javax.transaction</groupId>
+          <artifactId>jta</artifactId>
+        </dependency>
+        ...
+      </dependencies>
+      ...
+    </project>
+
+Because the ModeShape BOM defines them as `provided`, they will not be included in the web archive for your application or service.
+

--- a/boms/modeshape-bom-jbossas/pom.xml
+++ b/boms/modeshape-bom-jbossas/pom.xml
@@ -1,0 +1,88 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <parent>
+        <groupId>org.modeshape.bom</groupId>
+        <artifactId>modeshape-bom-parent</artifactId>
+        <version>3.0-SNAPSHOT</version>
+    </parent>
+
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.modeshape.bom</groupId>
+    <artifactId>modeshape-bom-jbossas</artifactId>
+    <version>3.0-SNAPSHOT</version>
+    <name>ModeShape BOM for usage within AS7</name>
+
+    <url>http://www.modeshape.org</url>
+    <packaging>pom</packaging>
+    <description>ModeShape and AS7 usage Bill of Material (BOM)</description>
+
+    <properties>
+      <!-- Version properties are inherited from parent -->
+    </properties>
+
+    <!--
+         This section defines the default dependency settings inherited by
+         child projects. Note that this section does not add dependencies, but
+         rather provide default settings.
+     -->
+    <dependencyManagement>
+        <dependencies>
+            <!-- All of these are 'provided' since they are already installed in AS7. -->
+            
+            <!-- Java Content Repository API -->
+            <dependency>
+                <groupId>javax.jcr</groupId>
+                <artifactId>jcr</artifactId>
+                <version>${jcr.version}</version>
+                <scope>provided</scope>
+            </dependency>
+
+            <!-- ModeShape public API -->
+            <dependency>
+                <groupId>org.modeshape</groupId>
+                <artifactId>modeshape-jcr-api</artifactId>
+                <version>${project.version}</version>
+                <scope>provided</scope>
+            </dependency>
+
+            <!-- Transactions (JTA) public API -->
+            <dependency>
+                <groupId>javax.transaction</groupId>
+                <artifactId>jta</artifactId>
+                <version>${javax.jta.version}</version>
+                <scope>provided</scope>
+            </dependency>
+
+            <!-- Servlet public API (for authentication)-->
+            <dependency>
+                <groupId>javax.servlet</groupId>
+                <artifactId>servlet-api</artifactId>
+                <version>${javax.servlet.version}</version>
+                <scope>provided</scope>
+            </dependency>
+
+            <!--
+                AS7-compatible logging modules.
+            -->
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-api</artifactId>
+                <version>${slf4j.api.version}</version>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
+                <groupId>log4j</groupId>
+                <artifactId>log4j</artifactId>
+                <version>${log4j.version}</version>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.jboss.logging</groupId>
+                <artifactId>jboss-logging</artifactId>
+                <version>${jboss.logging.version}</version>
+                <scope>provided</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+</project>

--- a/boms/modeshape-bom-parent/README.md
+++ b/boms/modeshape-bom-parent/README.md
@@ -1,0 +1,1 @@
+This is a parent POM for all of the other BOMs. It defines basic information and a number of properties that define the specific versions of dependencies referenced in the other BOMs.

--- a/boms/modeshape-bom-parent/pom.xml
+++ b/boms/modeshape-bom-parent/pom.xml
@@ -1,0 +1,107 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.modeshape.bom</groupId>
+    <artifactId>modeshape-bom-parent</artifactId>
+    <version>3.0-SNAPSHOT</version>
+    <name>ModeShape BOM Parent</name>
+
+    <url>http://www.modeshape.org</url>
+    <packaging>pom</packaging>
+    <description>ModeShape top-level Bill of Material (BOM)</description>
+    <inceptionYear>2008</inceptionYear>
+
+    <organization>
+        <name>JBoss, by Red Hat</name>
+        <url>http://www.jboss.org</url>
+    </organization>
+
+    <licenses>
+        <license>
+            <name>GNU Lesser General Public License</name>
+            <url>http://repository.jboss.org/licenses/lgpl-2.1.txt</url>
+            <!--url>http://www.gnu.org/licenses/lgpl.html</url-->
+            <distribution>repo</distribution>
+            <comments>A business-friendly OSS license</comments>
+        </license>
+    </licenses>
+
+    <properties>
+
+        <!-- Versions of non-ModeShape dependencies -->
+        <jcr.version>2.0</jcr.version>
+        <joda.time.version>1.6.2</joda.time.version>
+        <infinispan.version>5.1.2.FINAL</infinispan.version>
+        <c3p0.version>0.9.1.2</c3p0.version>  <!-- same as the one used by Infinispan's JDBC cache store -->
+        <jgroups.version>3.0.6.Final</jgroups.version> <!-- same as the one used by Infinispan -->
+        <hibernate.search.version>4.1.1.Final</hibernate.search.version>
+        <hibernate.search.jackson-mapper-asl.version>1.9.2</hibernate.search.jackson-mapper-asl.version>
+        <hibernate.search.jackson-core-asl.version>1.9.2</hibernate.search.jackson-core-asl.version>
+        <lucene.version>3.5.0</lucene.version>
+        <lucene.regex.version>3.0.3</lucene.regex.version>
+        <lucene.regex.jakarta.version>1.4</lucene.regex.jakarta.version>
+        <jbossjta.version>4.16.2.Final</jbossjta.version>
+        <picketbox.version>4.0.7.Final</picketbox.version>
+        <resteasy.version>2.3.2.Final</resteasy.version>
+        <jettison.version>1.1</jettison.version>
+        <httpclient.version>4.1.2</httpclient.version>
+        <mongo.driver.version>2.7.3</mongo.driver.version>
+        <embedmongo.version>1.25</embedmongo.version>
+        <tika.version>1.2</tika.version>
+        <javaassist.version>3.11.0.GA</javaassist.version>
+        <jaudiotagger.version>2.0.3</jaudiotagger.version>
+        <poi.version>3.8</poi.version>
+        <jcommander.version>1.5</jcommander.version>
+        <wsdl4j.version>1.6.2</wsdl4j.version>
+        <eclipse.equinox.common.version>3.3.0-v20070426</eclipse.equinox.common.version>
+        <eclipse.jdt.core.version>3.3.0-v_771</eclipse.jdt.core.version>
+        <eclipse.core.resources.version>3.3.0-v20070604</eclipse.core.resources.version>
+        <eclipse.core.expressions.version>3.3.0-v20070606-0010</eclipse.core.expressions.version>
+        <eclipse.core.runtime.version>3.3.100-v20070530</eclipse.core.runtime.version>
+        <eclipse.osgi.version>3.3.0-v20070530</eclipse.osgi.version>
+        <eclipse.core.jobs.version>3.3.0-v20070423</eclipse.core.jobs.version>
+        <eclipse.equinox.registry.version>3.3.0-v20070522</eclipse.equinox.registry.version>
+        <eclipse.equinox.preferences.version>3.2.100-v20070522</eclipse.equinox.preferences.version>
+        <eclipse.core.contenttype.version>3.2.100-v20070319</eclipse.core.contenttype.version>
+        <eclipse.xsd.version>2.2.3</eclipse.xsd.version>
+        <eclipse.emf.common.version>2.4.0</eclipse.emf.common.version>
+        <eclipse.emf.ecore.version>2.4.2</eclipse.emf.ecore.version>
+        <eclipse.emf.ecorechange.version>2.2.3</eclipse.emf.ecorechange.version>
+        <eclipse.emf.ecorexmi.version>2.4.1</eclipse.emf.ecorexmi.version>
+
+        <!-- Versions of JBoss AS dependencies -->
+        <jbossas-version>7.1.1.Final</jbossas-version>
+        <!--jbossas-version>7.2.0.Alpha1-SNAPSHOT</jbossas-version-->
+        <javax.connector-api.version>1.5</javax.connector-api.version>
+        <javax.jta.version>1.1</javax.jta.version>
+        <jbossas7.assembly.descriptor.version>71</jbossas7.assembly.descriptor.version>
+        <javax.servlet.version>2.5</javax.servlet.version>
+
+        <!-- Versions of non-ModeShape dependencies used for logging -->
+        <slf4j.api.version>1.6.1</slf4j.api.version>
+        <slf4j.log4j.version>1.6.1</slf4j.log4j.version>
+        <log4j.version>1.2.16</log4j.version>
+        <logback.version>0.9.29</logback.version>
+        <jboss.logging.version>3.1.0.CR2</jboss.logging.version>
+
+        <!-- Versions of non-ModeShape dependencies used for testing -->
+        <junit.version>4.10</junit.version>
+        <hamcrest.version>1.1</hamcrest.version>
+        <mockito.all.version>1.8.4</mockito.all.version>
+
+    </properties>
+
+    <!--
+         This section defines the default dependency settings inherited by
+         child projects. Note that this section does not add dependencies, but
+         rather provide default settings.
+     -->
+    <dependencyManagement>
+        <dependencies>
+          
+          <!-- Nothing is specified in the parent -->
+
+        </dependencies>
+    </dependencyManagement>
+</project>

--- a/boms/modeshape-bom-remote-client/README.md
+++ b/boms/modeshape-bom-remote-client/README.md
@@ -1,0 +1,47 @@
+This ModeShape BOM makes it easy for your applications and libraries to connect to a remote ModeShape repository, using either ModeShape's REST API or JDBC driver.
+
+== Usage ==
+
+Include the following in your POM file:
+
+    <project>
+      ...
+      <dependencyManagement>    
+        <dependencies>
+          <dependency>
+            <groupId>org.modeshape.bom</groupId>
+            <artifactId>modeshape-bom-remote-client</artifactId>
+            <version>3.0.0.Final</version>
+            <type>pom</type>
+            <scope>import</scope>
+          </dependency>
+        </dependencies>
+      </dependencyManagement>
+      ...
+    </project>
+
+Obviously, you'll need to specify the correct ModeShape version. But note that this is the only place you'll need to specify a version, because the BOM provides a completely valid and consistent set of versions.
+
+This works like all other Maven BOMs by adding into the `dependencyManagement` section all of the dependency defaults for the ModeShape components and dependencies that your module _might_ need. Then, all you have to do is add an explicit dependency to your POM's `dependencies` section for each of ModeShape's components that your module _does_ use.
+
+For example, if your module _explicitly_ uses ModeShape's REST client library, then simply define these dependencies:
+
+    <project>
+      ...
+      <dependencies>
+        ...
+        <dependency>
+            <groupId>org.modeshape</groupId>
+            <artifactId>modeshape-web-jcr-rest-client</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.modeshape</groupId>
+            <artifactId>modeshape-jdbc</artifactId>
+        </dependency>
+        ...
+      </dependencies>
+      ...
+    </project>
+
+There are quite a few other transitive dependencies of these components.
+

--- a/boms/modeshape-bom-remote-client/pom.xml
+++ b/boms/modeshape-bom-remote-client/pom.xml
@@ -1,0 +1,158 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <parent>
+        <groupId>org.modeshape.bom</groupId>
+        <artifactId>modeshape-bom-parent</artifactId>
+        <version>3.0-SNAPSHOT</version>
+    </parent>
+
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.modeshape.bom</groupId>
+    <artifactId>modeshape-bom-remote-client</artifactId>
+    <version>3.0-SNAPSHOT</version>
+    <name>BOM for using ModeShape's remote clients</name>
+
+    <url>http://www.modeshape.org</url>
+    <packaging>pom</packaging>
+    <description>Bill of Material (BOM) for applications using ModeShape's REST client or remote JDBC driver.</description>
+
+    <properties>
+      <!-- Version properties are inherited from parent -->
+    </properties>
+
+    <!--
+         This section defines the default dependency settings inherited by
+         child BOMs. Note that this section does not add dependencies, but
+         rather provide default settings.
+     -->
+    <dependencyManagement>
+        <dependencies>
+
+            <!-- ModeShape components -->
+            <dependency>
+                <groupId>org.modeshape</groupId>
+                <artifactId>modeshape-common</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.modeshape</groupId>
+                <artifactId>modeshape-web-jcr-rest-client</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.modeshape</groupId>
+                <artifactId>modeshape-jdbc</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <!--
+                Compatible logging modules.
+            -->
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-api</artifactId>
+                <version>${slf4j.api.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-log4j12</artifactId>
+                <version>${slf4j.log4j.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>log4j</groupId>
+                <artifactId>log4j</artifactId>
+                <version>${log4j.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>ch.qos.logback</groupId>
+                <artifactId>logback-classic</artifactId>
+                <version>${logback.version}</version>
+            </dependency>
+            
+            <!--
+               JAX-B implementation used by some modules particularly the REST client & service
+               -->
+            <dependency>
+                <groupId>com.sun.xml.bind</groupId>
+                <artifactId>jaxb-impl</artifactId>
+                <version>${sun.xml.bind.jaxbimpl.version}</version>
+                <scope>runtime</scope>
+            </dependency>
+            <!--
+               RESTEasy client dependencies
+            -->
+            <dependency>
+                <groupId>org.jboss.resteasy</groupId>
+                <artifactId>resteasy-jaxrs</artifactId>
+                <version>${resteasy.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.slf4j</groupId>
+                        <artifactId>slf4j-simple</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.slf4j</groupId>
+                        <artifactId>jcl-over-slf4j</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>org.jboss.resteasy</groupId>
+                <artifactId>resteasy-jaxb-provider</artifactId>
+                <version>${resteasy.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>com.sun.xml.bind</groupId>
+                        <artifactId>jaxb-impl</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>com.sun.xml.stream</groupId>
+                        <artifactId>stream.buffer</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>org.jboss.resteasy</groupId>
+                <artifactId>resteasy-jettison-provider</artifactId>
+                <version>${resteasy.version}</version>
+            </dependency>
+            <!-- Not needed on client??
+            <dependency>
+                <groupId>org.jboss.resteasy</groupId>
+                <artifactId>resteasy-multipart-provider</artifactId>
+                <version>${resteasy.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>com.sun.xml.bind</groupId>
+                        <artifactId>jaxb-impl</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>com.sun.xml.stream</groupId>
+                        <artifactId>stream.buffer</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            -->
+            <dependency>
+                <groupId>org.codehaus.jettison</groupId>
+                <artifactId>jettison</artifactId>
+                <version>${jettison.version}</version>
+                <exclusions>
+                    <!-- This results in duplicate stax-api jars. This is the older one.
+                         A newer is brought in by com.sun.xml.bind:jaxb-impl
+                    -->
+                    <exclusion>
+                        <groupId>stax</groupId>
+                        <artifactId>stax-api</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.httpcomponents</groupId>
+                <artifactId>httpclient</artifactId>
+                <version>${httpclient.version}</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,9 @@
 	<description>Builds the entire ModeShape distribution.</description>
 
 	<modules>
-        <!-- This must be first -->
+        <!-- Order is important -->
+
+        <!-- First these -->
         <module>modeshape-parent</module>
         <module>modeshape-assembly-descriptors</module>
         <!-- Order is important -->
@@ -37,6 +39,13 @@
           The JBoss AS7 subsystem needs the web components and (local) JDBC drivers.
         -->
         <module>deploy/jbossas</module>
+
+        <!-- Finally the BOMs -->
+        <module>boms/modeshape-bom-parent</module>
+        <module>boms/modeshape-bom-api</module>
+        <module>boms/modeshape-bom-jbossasg</module>
+        <module>boms/modeshape-bom-embedded</module>
+        <module>boms/modeshape-bom-remote-client</module>
     </modules>
 	<properties>
 		<rootDir>${project.basedir}</rootDir>


### PR DESCRIPTION
This commit adds several Maven BOMs that make it much easier for Maven-based applications and libraries to add the necessary ModeShape dependencies as a consistent stack with the correct versions of ModeShape components and third-party dependencies.

Unfortunately, I couldn't find a way to make the existing parent POM file extend or use these BOMs. Therefore, the parent BOM and existing parent POM both contain properties defining the versions of all dependencies. (Note that the BOMs should not extend the JBoss Parent POM, which our existing parent POM does. This is the major source of contention.) However, if may be able to figure out how to share the property definitions in a way that is transparent to clients that use the BOMs.

Note that these BOMs were tested by updating the example modules in the 'modeshape-examples' Git repository and the module in the 'modeshape-performance' Git repository that uses the latest (post-Beta4) release of ModeShape.
