### PR TITLE
MODE-1655 Corrected namespace registration logic

### DIFF
--- a/modeshape-jcr/src/test/java/org/modeshape/jcr/JcrNamespaceRegistryTest.java
+++ b/modeshape-jcr/src/test/java/org/modeshape/jcr/JcrNamespaceRegistryTest.java
@@ -253,6 +253,11 @@ public class JcrNamespaceRegistryTest extends MultiUseAbstractTest {
         registry.unregisterNamespace(prefix);
     }
 
+    @Test( expected = NamespaceException.class )
+    public void shouldNotAllowRegisteringNamespaceWithPrefixThatIsNotValidName() throws Exception {
+        registry.registerNamespace("foo:", "http://example.com");
+    }
+
     @Test
     public void shouldRegisterNewPrefixWithNewUri() throws Exception {
         String prefix = "foo";


### PR DESCRIPTION
Added code that validates supplied namespace prefixes to see if they are valid JCR names. Also added a test case.
