### PR TITLE
MODE-1656 Repositories are always calling Environment.shutdown

### DIFF
--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrRepository.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrRepository.java
@@ -1489,6 +1489,9 @@ public class JcrRepository implements org.modeshape.jcr.api.Repository {
             }
 
             this.context().terminateAllPools(30, TimeUnit.SECONDS);
+
+            // Shutdown the environment's resources.
+            this.environment().shutdown();
         }
 
         protected void bindIntoJndi() {


### PR DESCRIPTION
It is now the responsibility of the Environment implementations to know what to do when shutdown is called. The JBoss AS service does nothing, but the LocalEnvironment does attempt to shutdown all containers (though there is now a way to set a LocalEnvironment instance as being "shared", which means shutdown does nothing). The LocalEnvironment class can be extended for custom logic.

All unit and integration tests pass with these changes.
