### PR TITLE
MODE-831 Removed logged errors and warnings when using WebDAV on OS X

### DIFF
--- a/web/modeshape-webdav/src/main/java/org/modeshape/webdav/methods/DoCopy.java
+++ b/web/modeshape-webdav/src/main/java/org/modeshape/webdav/methods/DoCopy.java
@@ -71,20 +71,20 @@ public class DoCopy extends AbstractMethod {
             }
             copyResource(transaction, req, resp);
         } catch (AccessDeniedException e) {
-            LOG.debug(e, "Access denied for "+path);
+            LOG.debug(e, "Access denied for " + path);
             resp.sendError(WebdavStatus.SC_FORBIDDEN);
         } catch (ObjectAlreadyExistsException e) {
-            LOG.debug(e, "Conflict for "+path);
+            LOG.debug(e, "Conflict for " + path);
             resp.sendError(WebdavStatus.SC_CONFLICT, req.getRequestURI());
         } catch (ObjectNotFoundException e) {
-            LOG.debug(e, "Not found for "+path);
+            LOG.debug(e, "Not found for " + path);
             resp.sendError(WebdavStatus.SC_NOT_FOUND, req.getRequestURI());
         } catch (WebdavException e) {
-            LOG.debug(e, "Error for "+path);
+            LOG.debug(e, "Error for " + path);
             resp.sendError(WebdavStatus.SC_INTERNAL_SERVER_ERROR);
         } finally {
             resourceLocks.unlockTemporaryLockedObjects(transaction, path, tempLockOwner);
-       }
+        }
     }
 
     /**
@@ -221,6 +221,10 @@ public class DoCopy extends AbstractMethod {
                        HttpServletResponse resp ) throws WebdavException, IOException {
 
         StoredObject sourceSo = store.getStoredObject(transaction, sourcePath);
+        if (sourceSo == null) {
+            resp.setStatus(WebdavStatus.SC_NOT_FOUND);
+            return;
+        }
         if (sourceSo.isResource()) {
             store.createResource(transaction, destinationPath);
             long resourceLength = store.setResourceContent(transaction,
@@ -279,6 +283,10 @@ public class DoCopy extends AbstractMethod {
                 children[i] = "/" + children[i];
                 try {
                     childSo = store.getStoredObject(transaction, (sourcePath + children[i]));
+                    if (childSo == null) {
+                        errorList.put(destinationPath + children[i], WebdavStatus.SC_NOT_FOUND);
+                        continue;
+                    }
                     if (childSo.isResource()) {
                         store.createResource(transaction, destinationPath + children[i]);
                         long resourceLength = store.setResourceContent(transaction,

--- a/web/modeshape-webdav/src/main/java/org/modeshape/webdav/methods/DoDelete.java
+++ b/web/modeshape-webdav/src/main/java/org/modeshape/webdav/methods/DoDelete.java
@@ -84,13 +84,13 @@ public class DoDelete extends AbstractMethod {
                 sendReport(req, resp, errorList);
             }
         } catch (AccessDeniedException e) {
-            LOG.debug(e, "Access denied for "+path);
+            LOG.debug(e, "Access denied for " + path);
             resp.sendError(WebdavStatus.SC_FORBIDDEN);
         } catch (ObjectAlreadyExistsException e) {
-            LOG.debug(e, "Conflict for "+path);
+            LOG.debug(e, "Conflict for " + path);
             resp.sendError(WebdavStatus.SC_NOT_FOUND, req.getRequestURI());
         } catch (WebdavException e) {
-            LOG.debug(e, "Error for "+path);
+            LOG.debug(e, "Error for " + path);
             resp.sendError(WebdavStatus.SC_INTERNAL_SERVER_ERROR);
         } finally {
             resourceLocks.unlockTemporaryLockedObjects(transaction, path, tempLockOwner);
@@ -156,6 +156,10 @@ public class DoDelete extends AbstractMethod {
             children[i] = "/" + children[i];
             try {
                 so = store.getStoredObject(transaction, path + children[i]);
+                if (so == null) {
+                    errorList.put(path + children[i], WebdavStatus.SC_NOT_FOUND);
+                    continue;
+                }
                 if (so.isResource()) {
                     store.removeObject(transaction, path + children[i]);
 

--- a/web/modeshape-webdav/src/main/java/org/modeshape/webdav/methods/DoGet.java
+++ b/web/modeshape-webdav/src/main/java/org/modeshape/webdav/methods/DoGet.java
@@ -54,6 +54,10 @@ public class DoGet extends DoHead {
 
         try {
             StoredObject so = store.getStoredObject(transaction, path);
+            if (so == null) {
+                resp.sendError(HttpServletResponse.SC_NOT_FOUND);
+                return;
+            }
             if (so.isNullResource()) {
                 String methodsAllowed = DeterminableMethod.determineMethodsAllowed(so);
                 resp.addHeader("Allow", methodsAllowed);

--- a/web/modeshape-webdav/src/main/java/org/modeshape/webdav/methods/DoLock.java
+++ b/web/modeshape-webdav/src/main/java/org/modeshape/webdav/methods/DoLock.java
@@ -200,12 +200,15 @@ public class DoLock extends AbstractMethod {
                 return;
             }
             nullSo = store.getStoredObject(transaction, path);
-            // define the newly created resource as null-resource
-            nullSo.setNullResource(true);
+            if (nullSo == null) {
+                resp.setStatus(WebdavStatus.SC_NOT_FOUND);
+            } else {
+                // define the newly created resource as null-resource
+                nullSo.setNullResource(true);
 
-            // Thats the locking itself
-            executeLock(transaction, req, resp);
-
+                // Thats the locking itself
+                executeLock(transaction, req, resp);
+            }
         } catch (LockFailedException e) {
             sendLockFailError(req, resp);
         } catch (WebdavException e) {

--- a/web/modeshape-webdav/src/main/java/org/modeshape/webdav/methods/DoPropfind.java
+++ b/web/modeshape-webdav/src/main/java/org/modeshape/webdav/methods/DoPropfind.java
@@ -167,7 +167,7 @@ public class DoPropfind extends AbstractMethod {
             } catch (AccessDeniedException e) {
                 resp.sendError(WebdavStatus.SC_FORBIDDEN);
             } catch (WebdavException e) {
-                LOG.warn(new TextI18n("Sending internal error!"));
+                LOG.warn(e, new TextI18n("Sending internal error!"));
                 resp.sendError(WebdavStatus.SC_INTERNAL_SERVER_ERROR);
             } catch (ServletException e) {
                 LOG.error(e, new TextI18n("Cannot create the xml document builder"));
@@ -250,6 +250,7 @@ public class DoPropfind extends AbstractMethod {
                                   String mimeType ) throws WebdavException {
 
         StoredObject so = store.getStoredObject(transaction, path);
+        if (so == null) return;
 
         boolean isFolder = so.isFolder();
         final String creationdate = creationDateFormat(so.getCreationDate());

--- a/web/modeshape-webdav/src/main/java/org/modeshape/webdav/methods/DoPut.java
+++ b/web/modeshape-webdav/src/main/java/org/modeshape/webdav/methods/DoPut.java
@@ -142,7 +142,9 @@ public class DoPut extends AbstractMethod {
                     long resourceLength = store.setResourceContent(transaction, path, req.getInputStream(), null, null);
 
                     so = store.getStoredObject(transaction, path);
-                    if (resourceLength != -1) {
+                    if (so == null) {
+                        resp.setStatus(WebdavStatus.SC_NOT_FOUND);
+                    } else if (resourceLength != -1) {
                         so.setResourceLength(resourceLength);
                     }
                     // Now lets report back what was actually saved

--- a/web/modeshape-webdav/src/main/java/org/modeshape/webdav/methods/DoUnlock.java
+++ b/web/modeshape-webdav/src/main/java/org/modeshape/webdav/methods/DoUnlock.java
@@ -67,11 +67,14 @@ public class DoUnlock extends DeterminableMethod {
 
                         if (resourceLocks.unlock(transaction, lockId, owner)) {
                             StoredObject so = store.getStoredObject(transaction, path);
-                            if (so.isNullResource()) {
-                                store.removeObject(transaction, path);
+                            if (so == null) {
+                                resp.setStatus(WebdavStatus.SC_NOT_FOUND);
+                            } else {
+                                if (so.isNullResource()) {
+                                    store.removeObject(transaction, path);
+                                }
+                                resp.setStatus(WebdavStatus.SC_NO_CONTENT);
                             }
-
-                            resp.setStatus(WebdavStatus.SC_NO_CONTENT);
                         } else {
                             LOG.trace("DoUnlock failure at " + lo.getPath());
                             resp.sendError(WebdavStatus.SC_METHOD_FAILURE);


### PR DESCRIPTION
Several errors and warnings were logged due to the fact that OS X routinely attempts to put "._DS_Store" files and other files that start with "._". (OS X uses these hidden files to store positions of icons and background images for the Finder, which is OS X's file system navigation UI.)

The code was changed to better handle the requests for files beginning with "._" (e.g., "._jcr:system"). Also, the DoPut, DoLock and several other related classes were modified to look for null references from the IWebStore.getStoredObject(...) method. The IWebStore implementations are allowed to return null, and in fact the LocalFileSystemWebStore does, but several of the Do\* classes were not properly handling this possibility. In all cases, a null stored object will result in an HTTP 404 error, signifying that the resource is not available. (This is in line with previous code that did correctly handle null stored object references.)
