### PR TITLE
MODE-1673 Changed the JSON response to always include the built-in fields

### DIFF
--- a/web/modeshape-web-jcr-rest-war/src/test/java/org/modeshape/web/jcr/rest/ModeShapeRestServiceTest.java
+++ b/web/modeshape-web-jcr-rest-war/src/test/java/org/modeshape/web/jcr/rest/ModeShapeRestServiceTest.java
@@ -379,6 +379,7 @@ public class ModeShapeRestServiceTest extends JcrResourcesTest {
         doPost("v2/post/multiple_nodes_request.json", itemsUrl()).isOk();
         doPut("v2/put/multiple_nodes_edit_request.json", itemsUrl()).isOk()
                                                                     .isJSONArrayLikeFile("v2/put/multiple_nodes_edit_response.json");
+        // System.out.println("*****  GET: \n" + doGet(itemsUrl(TEST_NODE)));
     }
 
     @Test
@@ -404,13 +405,15 @@ public class ModeShapeRestServiceTest extends JcrResourcesTest {
         Response response = doPost((String)null, itemsUrl(TEST_NODE)).isCreated();
         String id = response.hasNodeIdentifier();
         // Get by ID ...
-        doGet(nodesUrl(id)).isJSONObjectLike(response);
+        response = doGet(nodesUrl(id)).isJSONObjectLike(response);
+        // System.out.println("**** GET-BY-ID: \n" + response);
 
         // Update by ID ...
-        doPut(nodeWithBinaryProperty(), nodesUrl(id)).isOk().isJSONObjectLikeFile(
-                nodeBinaryPropertyAfterEdit());
+        response = doPut(nodeWithBinaryProperty(), nodesUrl(id)).isOk().isJSONObjectLikeFile(nodeBinaryPropertyAfterEdit());
+        // System.out.println("**** GET-BY-ID: \n" + response);
 
         // Delete by ID ...
-        doDelete(nodesUrl(id)).isDeleted();
+        response = doDelete(nodesUrl(id)).isDeleted();
+        // System.out.println("**** GET-BY-ID: \n" + response);
     }
 }

--- a/web/modeshape-web-jcr-rest/src/main/java/org/modeshape/web/jcr/rest/handler/AbstractHandler.java
+++ b/web/modeshape-web-jcr-rest/src/main/java/org/modeshape/web/jcr/rest/handler/AbstractHandler.java
@@ -38,7 +38,7 @@ public abstract class AbstractHandler {
     /**
      * The name of the custom property which will contain the node id
      */
-    public static final String NODE_ID_CUSTOM_PROPERTY = "id";
+    public static final String NODE_ID_CUSTOM_PROPERTY = RestNode.ID_FIELD_NAME;
 
     /**
      * Name to be used when the workspace name is empty string as {@code "//"} is not a valid path.
@@ -226,9 +226,7 @@ public abstract class AbstractHandler {
                                                                                                                     ITEMS_METHOD_NAME,
                                                                                                                     node.getParent()
                                                                                                                         .getPath());
-
-        RestNode restNode = new RestNode(node.getName(), nodeUrl, parentUrl);
-        restNode.addCustomProperty(NODE_ID_CUSTOM_PROPERTY, node.getIdentifier());
+        RestNode restNode = new RestNode(node.getName(), node.getIdentifier(), nodeUrl, parentUrl);
 
         // add the properties
         for (PropertyIterator propertyIterator = node.getProperties(); propertyIterator.hasNext();) {
@@ -244,9 +242,8 @@ public abstract class AbstractHandler {
                 restChild = createRestNode(session, childNode, baseUrl, depth - 1);
             } else {
                 String childUrl = RestHelper.urlFrom(baseUrl, ITEMS_METHOD_NAME, childNode.getPath());
-                restChild = new RestNode(nodeName(childNode), childUrl, nodeUrl);
+                restChild = new RestNode(nodeName(childNode), childNode.getIdentifier(), childUrl, nodeUrl);
             }
-            restChild.addCustomProperty(NODE_ID_CUSTOM_PROPERTY, childNode.getIdentifier());
             restNode.addChild(restChild);
         }
         return restNode;

--- a/web/modeshape-web-jcr-rest/src/main/java/org/modeshape/web/jcr/rest/model/RestNode.java
+++ b/web/modeshape-web-jcr-rest/src/main/java/org/modeshape/web/jcr/rest/model/RestNode.java
@@ -24,35 +24,51 @@
 
 package org.modeshape.web.jcr.rest.model;
 
-import org.codehaus.jettison.json.JSONException;
-import org.codehaus.jettison.json.JSONObject;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.TreeMap;
+import org.codehaus.jettison.json.JSONException;
+import org.codehaus.jettison.json.JSONObject;
+import org.modeshape.common.collection.Collections;
 
 /**
  * A REST representation of a {@link javax.jcr.Node}
- *
+ * 
  * @author Horia Chiorean (hchiorea@redhat.com)
  */
 public final class RestNode extends RestItem {
 
+    public static final String SELF_FIELD_NAME = "self";
+    public static final String UP_FIELD_NAME = "up";
+    public static final String ID_FIELD_NAME = "id";
+    public static final String CHILDREN_FIELD_NAME = "children";
+
+    private static final Set<String> RESERVED_FIELD_NAMES = Collections.unmodifiableSet(SELF_FIELD_NAME,
+                                                                                        UP_FIELD_NAME,
+                                                                                        ID_FIELD_NAME,
+                                                                                        CHILDREN_FIELD_NAME);
+
     private final List<RestProperty> jcrProperties;
     private final List<RestNode> children;
     private final Map<String, String> customProperties;
+    protected final String id;
 
     /**
      * Creates a new rest node
-     *
+     * 
      * @param name a {@code non-null} string, representing the name
+     * @param id the node identifier
      * @param url a {@code non-null} string, representing the url to this node
      * @param parentUrl a {@code non-null} string, representing the url to this node's parent
      */
     public RestNode( String name,
+                     String id,
                      String url,
                      String parentUrl ) {
         super(name, url, parentUrl);
+        this.id = id;
         jcrProperties = new ArrayList<RestProperty>();
         children = new ArrayList<RestNode>();
         customProperties = new TreeMap<String, String>();
@@ -60,7 +76,7 @@ public final class RestNode extends RestItem {
 
     /**
      * Adds a new child to this node.
-     *
+     * 
      * @param child a {@code non-null} {@link RestNode}
      * @return this rest node.
      */
@@ -71,7 +87,7 @@ public final class RestNode extends RestItem {
 
     /**
      * Adds a new jcr property to this node.
-     *
+     * 
      * @param property a {@code non-null} {@link RestProperty}
      * @return this rest node.
      */
@@ -82,11 +98,13 @@ public final class RestNode extends RestItem {
 
     /**
      * Adds a custom property to this node, meaning a property which is not among the standard JCR properties
+     * 
      * @param name a {@code non-null} String, representing the name of the custom property
      * @param value a {@code non-null} String, representing the value of the custom property
      * @return this instance, with the custom property added
      */
-    public RestNode addCustomProperty (String name, String value)  {
+    public RestNode addCustomProperty( String name,
+                                       String value ) {
         customProperties.put(name, value);
         return this;
     }
@@ -94,29 +112,38 @@ public final class RestNode extends RestItem {
     @Override
     public JSONObject toJSON() throws JSONException {
         JSONObject node = new JSONObject();
-        node.put("self", url);
-        node.put("up", parentUrl);
+
+        // do these first so that they appear first in the JSON ...
+        node.put(SELF_FIELD_NAME, url);
+        node.put(UP_FIELD_NAME, parentUrl);
+        node.put(ID_FIELD_NAME, id);
 
         addCustomProperties(node);
         addJcrProperties(node);
         addChildren(node);
+
         return node;
     }
 
+    private boolean isReservedField( String fieldName ) {
+        return RESERVED_FIELD_NAMES.contains(fieldName);
+    }
+
     private void addChildren( JSONObject node ) throws JSONException {
-        //children
+        // children
         if (!children.isEmpty()) {
             JSONObject children = new JSONObject();
             for (RestNode child : this.children) {
                 children.put(child.name, child.toJSON());
             }
-            node.put("children", children);
+            node.put(CHILDREN_FIELD_NAME, children);
         }
     }
 
     private void addJcrProperties( JSONObject node ) throws JSONException {
-        //properties
+        // properties
         for (RestProperty restProperty : jcrProperties) {
+            if (isReservedField(restProperty.name)) continue; // skip
             if (restProperty.isMultiValue()) {
                 node.put(restProperty.name, restProperty.getValues());
             } else if (restProperty.getValue() != null) {
@@ -126,8 +153,9 @@ public final class RestNode extends RestItem {
     }
 
     private void addCustomProperties( JSONObject node ) throws JSONException {
-        //custom properties
+        // custom properties
         for (String customPropertyName : customProperties.keySet()) {
+            if (isReservedField(customPropertyName)) continue; // skip
             node.put(customPropertyName, customProperties.get(customPropertyName));
         }
     }


### PR DESCRIPTION
If a node contains properties with names that match the built-in fields (e.g., "self", "up", "id", and "children"), the code previously overwrote the built-in fields with the property values. This change prevents that. Obviously this means that some properties might not be represented, but this is acceptable given that a big best-practice of JCR is to always use namespaces for properties.
