### PR TITLE
MODE-1679 Corrected querying of REFERENCE properties

### DIFF
--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrSession.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrSession.java
@@ -1455,15 +1455,16 @@ public class JcrSession implements Session {
      * session's root. This method is used for reference resolving.
      * 
      * @param key the node key; may be null
+     * @param rootKey the key of the root node in the workspace; may not be null
      * @return true if the node key is considered foreign, false otherwise.
      */
-    protected boolean isForeignKey( NodeKey key ) {
+    public static boolean isForeignKey( NodeKey key,
+                                        NodeKey rootKey ) {
         if (key == null) {
             return false;
         }
         String nodeWorkspaceKey = key.getWorkspaceKey();
 
-        NodeKey rootKey = cache().getRootKey();
         boolean sameWorkspace = rootKey.getWorkspaceKey().equals(nodeWorkspaceKey);
         boolean sameSource = rootKey.getSourceKey().equalsIgnoreCase(key.getSourceKey());
         return !sameWorkspace || !sameSource;
@@ -1473,11 +1474,35 @@ public class JcrSession implements Session {
      * Returns a string representing a node's identifier, based on whether the node is foreign or not.
      * 
      * @param key the node key; may be null
+     * @param rootKey the key of the root node in the workspace; may not be null
      * @return the identifier for the node; never null
      * @see javax.jcr.Node#getIdentifier()
      */
-    protected String nodeIdentifier( NodeKey key ) {
-        return isForeignKey(key) ? key.toString() : key.getIdentifier();
+    public static String nodeIdentifier( NodeKey key,
+                                         NodeKey rootKey ) {
+        return isForeignKey(key, rootKey) ? key.toString() : key.getIdentifier();
+    }
+
+    /**
+     * Checks if the node given key is foreign by comparing the source key & workspace key against the same keys from this
+     * session's root. This method is used for reference resolving.
+     * 
+     * @param key the node key; may be null
+     * @return true if the node key is considered foreign, false otherwise.
+     */
+    protected final boolean isForeignKey( NodeKey key ) {
+        return isForeignKey(key, cache.getRootKey());
+    }
+
+    /**
+     * Returns a string representing a node's identifier, based on whether the node is foreign or not.
+     * 
+     * @param key the node key; may be null
+     * @return the identifier for the node; never null
+     * @see javax.jcr.Node#getIdentifier()
+     */
+    protected final String nodeIdentifier( NodeKey key ) {
+        return nodeIdentifier(key, cache.getRootKey());
     }
 
     @Override

--- a/modeshape-jcr/src/test/resources/cnd/notionalTypes.cnd
+++ b/modeshape-jcr/src/test/resources/cnd/notionalTypes.cnd
@@ -19,3 +19,5 @@
 - notion:stringPropertyWithDefault (string) = "default string value"
 - notion:booleanAutoCreatedPropertyWithDefault (boolean) = true autocreated
 - notion:stringAutoCreatedPropertyWithDefault (string) = "default string value" autocreated
+- notion:singleReference (reference)
+- notion:multipleReferences (reference) multiple


### PR DESCRIPTION
Reference properties were not being queried correctly: the tuple value of REFERENCE property was the string representation of the node key rather than the exposed identifier, so this corrects the BasicTupleCollector to properly process/generate the result set tuples for such properties. Additionally, multi-valued REFERENCE properties were not being joined properly, since the tuple contained the array of identifier strings and the join processing component was never looking for arrays.

A half-dozen new query tests were added to JcrQueryManagerTest that replicated all of these situations, including some of the more elementary queries that are involved in the joins and/or subqueries. Prior to these fixes, all of these tests failed. However, after the corrections were made, all of these tests pass.
