### PR TITLE
MODE-1722 Fixed creation from CND of node types with URI property definitions

### DIFF
--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/PropertyTypeUtil.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/PropertyTypeUtil.java
@@ -115,7 +115,7 @@ public class PropertyTypeUtil {
             case UUID:
                 return PropertyType.STRING; // JCR treats UUID properties as strings
             case URI:
-                return PropertyType.STRING;
+                return PropertyType.URI;
             case PATH:
                 return PropertyType.PATH;
             case BOOLEAN:

--- a/modeshape-jcr/src/test/java/org/modeshape/jcr/JcrNodeTypesTest.java
+++ b/modeshape-jcr/src/test/java/org/modeshape/jcr/JcrNodeTypesTest.java
@@ -24,15 +24,21 @@
 
 package org.modeshape.jcr;
 
-import javax.jcr.NamespaceRegistry;
-import javax.jcr.RepositoryException;
 import static junit.framework.Assert.assertEquals;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+import javax.jcr.NamespaceRegistry;
+import javax.jcr.PropertyType;
+import javax.jcr.RepositoryException;
+import javax.jcr.nodetype.NodeType;
+import javax.jcr.nodetype.NodeTypeManager;
+import javax.jcr.nodetype.PropertyDefinition;
 import org.junit.Test;
 import org.modeshape.common.FixFor;
 
 /**
  * Unit test for the node-types feature, which allows initial cnd files to be pre-configured in a repository
- *
+ * 
  * @author Horia Chiorean (hchiorea@redhat.com)
  */
 public class JcrNodeTypesTest extends SingleUseAbstractTest {
@@ -46,8 +52,8 @@ public class JcrNodeTypesTest extends SingleUseAbstractTest {
 
     @Test
     public void shouldRegisterValidNodeTypesOnly() throws Exception {
-        startRepositoryWithConfiguration(getClass().getClassLoader().getResourceAsStream(
-                "config/repo-config-invalid-node-types.json"));
+        startRepositoryWithConfiguration(getClass().getClassLoader()
+                                                   .getResourceAsStream("config/repo-config-invalid-node-types.json"));
 
         validateNodesWithCustomTypes();
     }
@@ -61,6 +67,18 @@ public class JcrNodeTypesTest extends SingleUseAbstractTest {
         assertEquals("http://www.modeshape.org/examples/aircraft/1.0", namespaceRegistry.getURI("air"));
         assertEquals("http://www.test1.com", namespaceRegistry.getURI("test1"));
         assertEquals("http://www.test2.com", namespaceRegistry.getURI("test2"));
+    }
+
+    @Test
+    @FixFor( "MODE-1722" )
+    public void shouldRegisterNodeTypeWithUriPropertyType() throws Exception {
+        startRepository();
+        registerNodeTypes("cnd/nodetype-with-uri-property.cnd");
+        NodeTypeManager ntmgr = session.getWorkspace().getNodeTypeManager();
+        NodeType nt = ntmgr.getNodeType("ex:myNodeType");
+        PropertyDefinition uriPropDefn = nt.getDeclaredPropertyDefinitions()[0];
+        assertThat(uriPropDefn.getName(), is("ex:path"));
+        assertThat(uriPropDefn.getRequiredType(), is(PropertyType.URI));
     }
 
     private void validateNodesWithCustomTypes() throws RepositoryException {

--- a/modeshape-jcr/src/test/resources/cnd/nodetype-with-uri-property.cnd
+++ b/modeshape-jcr/src/test/resources/cnd/nodetype-with-uri-property.cnd
@@ -1,0 +1,6 @@
+<jcr='http://www.jcp.org/jcr/1.0'>
+<nt='http://www.jcp.org/jcr/nt/1.0'>
+<ex='http://www.example.com/test'>
+
+[ex:myNodeType] > nt:hierarchyNode
+ - ex:path (uri) mandatory


### PR DESCRIPTION
If a CND file contains a node type with a property definition that has a required type of URI, then this property definition was incorrectly being created with a type of STRING rather than URI. Added a test case to fail with this incorrect behavior, and then corrected the PropertyTypeUtil method that was determining the JCR property type from the string name. The new test and all other tests now pass.
