### PR TITLE
MODE-1720 Corrected how REFERENCE properties are set

### DIFF
--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/AbstractJcrNode.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/AbstractJcrNode.java
@@ -1074,7 +1074,7 @@ abstract class AbstractJcrNode extends AbstractJcrItem implements Node {
             newChild = mutable().createChild(cache, desiredKey, childName, ptProp);
         }
 
-        //Check if the child node is referenceable
+        // Check if the child node is referenceable
         if (capabilities.getNodeType(childPrimaryNodeTypeName).isNodeType(JcrMixLexicon.REFERENCEABLE)) {
             newChild.setProperty(cache, propFactory.create(JcrLexicon.UUID, session.nodeIdentifier(newChild.getKey())));
         }

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/ExecutionContext.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/ExecutionContext.java
@@ -142,6 +142,27 @@ public class ExecutionContext implements ThreadPoolFactory, Cloneable {
     }
 
     /**
+     * Create a copy of the supplied execution context, but use the supplied {@link ValueFactories} instead.
+     * 
+     * @param original the original
+     * @param valueFactories the values factory
+     * @throws IllegalArgumentException if the original or access control context are is null
+     */
+    protected ExecutionContext( ExecutionContext original,
+                                ValueFactories valueFactories ) {
+        CheckArg.isNotNull(original, "original");
+        CheckArg.isNotNull(valueFactories, "valueFactories");
+        this.securityContext = original.getSecurityContext();
+        this.namespaceRegistry = original.getNamespaceRegistry();
+        this.valueFactories = valueFactories;
+        this.propertyFactory = new BasicPropertyFactory(this.valueFactories);
+        this.threadPools = original.getThreadPoolFactory();
+        this.data = original.getData();
+        this.processId = original.getProcessId();
+        this.binaryStore = original.getBinaryStore();
+    }
+
+    /**
      * Create an instance of the execution context by supplying all parameters.
      * 
      * @param securityContext the security context, or null if there is no associated authenticated user
@@ -373,6 +394,18 @@ public class ExecutionContext implements ThreadPoolFactory, Cloneable {
      */
     public ExecutionContext with( SecurityContext securityContext ) {
         return new ExecutionContext(this, securityContext);
+    }
+
+    /**
+     * Create an {@link ExecutionContext} that is the same as this context, but which uses the supplied value factories.
+     * 
+     * @param valueFactories the new value factories to use; may be null
+     * @return the execution context that is identical with this execution context, but with a different reference factory; never
+     *         null
+     * @throws IllegalArgumentException if the <code>referenceFactory</code> is null
+     */
+    protected ExecutionContext with( ValueFactories valueFactories ) {
+        return new ExecutionContext(this, valueFactories);
     }
 
     /**

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrSession.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrSession.java
@@ -26,12 +26,16 @@ package org.modeshape.jcr;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.math.BigDecimal;
+import java.net.URI;
 import java.security.AccessControlException;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
+import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.TimeUnit;
@@ -83,8 +87,10 @@ import org.modeshape.jcr.cache.SessionCache;
 import org.modeshape.jcr.cache.SessionCache.SaveContext;
 import org.modeshape.jcr.cache.WorkspaceNotFoundException;
 import org.modeshape.jcr.cache.WrappedException;
+import org.modeshape.jcr.query.model.TypeSystem;
 import org.modeshape.jcr.security.AuthorizationProvider;
 import org.modeshape.jcr.security.SecurityContext;
+import org.modeshape.jcr.value.BinaryFactory;
 import org.modeshape.jcr.value.DateTimeFactory;
 import org.modeshape.jcr.value.Name;
 import org.modeshape.jcr.value.NameFactory;
@@ -93,9 +99,14 @@ import org.modeshape.jcr.value.Path;
 import org.modeshape.jcr.value.Path.Segment;
 import org.modeshape.jcr.value.PathFactory;
 import org.modeshape.jcr.value.PropertyFactory;
+import org.modeshape.jcr.value.PropertyType;
 import org.modeshape.jcr.value.Reference;
 import org.modeshape.jcr.value.ReferenceFactory;
 import org.modeshape.jcr.value.UuidFactory;
+import org.modeshape.jcr.value.ValueFactories;
+import org.modeshape.jcr.value.ValueFactory;
+import org.modeshape.jcr.value.ValueTypeSystem;
+import org.modeshape.jcr.value.basic.DelegateReferenceFactory;
 import org.modeshape.jcr.value.basic.LocalNamespaceRegistry;
 import org.xml.sax.ContentHandler;
 import org.xml.sax.InputSource;
@@ -109,6 +120,7 @@ import org.xml.sax.helpers.XMLReaderFactory;
  */
 public class JcrSession implements Session {
 
+    private static final int UUID_LENGTH = UUID.randomUUID().toString().length();
     private static final String[] NO_ATTRIBUTES_NAMES = new String[] {};
 
     protected final JcrRepository repository;
@@ -135,14 +147,17 @@ public class JcrSession implements Session {
         this.repository = repository;
 
         // Create an execution context for this session that uses a local namespace registry ...
+        // (The order of these operations is critical!)
+        context = context.with(new SessionValueFactories(context.getValueFactories()));
         final NamespaceRegistry globalNamespaceRegistry = context.getNamespaceRegistry(); // thread-safe!
         final LocalNamespaceRegistry localRegistry = new LocalNamespaceRegistry(globalNamespaceRegistry); // not-thread-safe!
-        this.context = context.with(localRegistry);
+        context = context.with(localRegistry);
+        this.context = context.with(new SessionValueFactories(context.getValueFactories()));
         this.sessionRegistry = new JcrNamespaceRegistry(Behavior.SESSION, localRegistry, globalNamespaceRegistry, this);
         this.workspace = new JcrWorkspace(this, workspaceName);
 
         // Create the session cache ...
-        this.cache = repository.repositoryCache().createSession(context, workspaceName, readOnly);
+        this.cache = repository.repositoryCache().createSession(this.context, workspaceName, readOnly);
         this.rootNode = new JcrRootNode(this, this.cache.getRootKey());
         this.jcrNodes.put(this.rootNode.key(), this.rootNode);
         this.sessionAttributes = sessionAttributes != null ? sessionAttributes : Collections.<String, Object>emptyMap();
@@ -1745,5 +1760,173 @@ public class JcrSession implements Session {
                 node.setProperty(cache, propertyFactory.create(JcrLexicon.ETAG, etagValue));
             }
         }
+    }
+
+    protected String convertNodeIdentifierToNodeKeyString( String identifier ) {
+        // Most nodes will likely be UUIDs, which we need to prepend the root node's system and workspace keys ...
+        if (identifier.length() == UUID_LENGTH) {
+            try {
+                UUID.fromString(identifier);
+                return rootNode.key().withId(identifier).toString();
+            } catch (IllegalArgumentException e) {
+                // It's not a valid UUID, so continue ...
+            }
+        }
+        return identifier;
+    }
+
+    /**
+     * This is a special {@link ValueFactories} implementation that has specialized {@link ReferenceFactory} implementations that
+     * are aware of and can convert {@link Node#getIdentifier()} values to proper REFERENCE values.
+     * 
+     * @see JcrSession#JcrSession(JcrRepository, String, ExecutionContext, Map, boolean)
+     */
+    protected class SessionValueFactories implements ValueFactories {
+        private final ValueFactories delegate;
+        private final ReferenceFactory referenceFactory;
+        private final ReferenceFactory weakReferenceFactory;
+        private final TypeSystem typeSystem;
+
+        protected SessionValueFactories( ValueFactories factories ) {
+            this.delegate = factories;
+            this.referenceFactory = new DelegateReferenceFactory(this.delegate.getReferenceFactory()) {
+                @Override
+                public Reference create( String value ) throws org.modeshape.jcr.value.ValueFormatException {
+                    String newValue = convertNodeIdentifierToNodeKeyString(value);
+                    return delegate.create(newValue);
+                }
+            };
+            this.weakReferenceFactory = new DelegateReferenceFactory(this.delegate.getWeakReferenceFactory()) {
+                @Override
+                public Reference create( String value ) throws org.modeshape.jcr.value.ValueFormatException {
+                    String newValue = convertNodeIdentifierToNodeKeyString(value);
+                    return delegate.create(newValue);
+                }
+            };
+            this.typeSystem = new ValueTypeSystem(this);
+        }
+
+        @Override
+        public ReferenceFactory getReferenceFactory() {
+            return referenceFactory;
+        }
+
+        @Override
+        public ReferenceFactory getWeakReferenceFactory() {
+            return weakReferenceFactory;
+        }
+
+        @Override
+        public Iterator<ValueFactory<?>> iterator() {
+            final Iterator<ValueFactory<?>> original = this.delegate.iterator();
+            final ReferenceFactory originalRefFactory = this.delegate.getReferenceFactory();
+            final ReferenceFactory originalWeakRefFactory = this.delegate.getWeakReferenceFactory();
+            return new Iterator<ValueFactory<?>>() {
+                @Override
+                public boolean hasNext() {
+                    return original.hasNext();
+                }
+
+                @Override
+                public ValueFactory<?> next() {
+                    ValueFactory<?> result = original.next();
+                    if (result == originalRefFactory) return getReferenceFactory();
+                    if (result == originalWeakRefFactory) return getWeakReferenceFactory();
+                    return result;
+                }
+
+                @Override
+                public void remove() {
+                    throw new UnsupportedOperationException();
+                }
+            };
+        }
+
+        @Override
+        public TypeSystem getTypeSystem() {
+            return this.typeSystem;
+        }
+
+        @Override
+        public ValueFactory<?> getValueFactory( PropertyType type ) {
+            switch (type) {
+                case REFERENCE:
+                    return referenceFactory;
+                case WEAKREFERENCE:
+                    return weakReferenceFactory;
+                default:
+                    return delegate.getValueFactory(type);
+            }
+        }
+
+        @Override
+        public ValueFactory<?> getValueFactory( Object prototype ) {
+            if (prototype instanceof Reference) {
+                Reference ref = (Reference)prototype;
+                return ref.isWeak() ? weakReferenceFactory : referenceFactory;
+            }
+            return delegate.getValueFactory(prototype);
+        }
+
+        @Override
+        public ValueFactory<String> getStringFactory() {
+            return delegate.getStringFactory();
+        }
+
+        @Override
+        public BinaryFactory getBinaryFactory() {
+            return delegate.getBinaryFactory();
+        }
+
+        @Override
+        public ValueFactory<Long> getLongFactory() {
+            return delegate.getLongFactory();
+        }
+
+        @Override
+        public ValueFactory<Double> getDoubleFactory() {
+            return delegate.getDoubleFactory();
+        }
+
+        @Override
+        public ValueFactory<BigDecimal> getDecimalFactory() {
+            return delegate.getDecimalFactory();
+        }
+
+        @Override
+        public DateTimeFactory getDateFactory() {
+            return delegate.getDateFactory();
+        }
+
+        @Override
+        public ValueFactory<Boolean> getBooleanFactory() {
+            return delegate.getBooleanFactory();
+        }
+
+        @Override
+        public NameFactory getNameFactory() {
+            return delegate.getNameFactory();
+        }
+
+        @Override
+        public PathFactory getPathFactory() {
+            return delegate.getPathFactory();
+        }
+
+        @Override
+        public ValueFactory<URI> getUriFactory() {
+            return delegate.getUriFactory();
+        }
+
+        @Override
+        public UuidFactory getUuidFactory() {
+            return delegate.getUuidFactory();
+        }
+
+        @Override
+        public ValueFactory<Object> getObjectFactory() {
+            return delegate.getObjectFactory();
+        }
+
     }
 }

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/NodeKey.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/NodeKey.java
@@ -133,6 +133,15 @@ public final class NodeKey implements Serializable, Comparable<NodeKey> {
     }
 
     /**
+     * Get the multi-character string that precedes the identifier part of this key.
+     * 
+     * @return the identifier prefix; never null and always contains at least one character
+     */
+    public String getIdentifierPrefix() {
+        return key.substring(0, IDENTIFIER_START_INDEX);
+    }
+
+    /**
      * Get the multi-character key representing the JCR identifier of a node, which is usually a UUID.
      * 
      * @return the JCR identifier for the node; never null and always contains at least one character

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/value/basic/AbstractObjectValueFactory.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/value/basic/AbstractObjectValueFactory.java
@@ -1,0 +1,86 @@
+/*
+ * ModeShape (http://www.modeshape.org)
+ * See the COPYRIGHT.txt file distributed with this work for information
+ * regarding copyright ownership.  Some portions may be licensed
+ * to Red Hat, Inc. under one or more contributor license agreements.
+ * See the AUTHORS.txt file in the distribution for a full listing of 
+ * individual contributors. 
+ *
+ * ModeShape is free software. Unless otherwise indicated, all code in ModeShape
+ * is licensed to you under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * ModeShape is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.modeshape.jcr.value.basic;
+
+import java.io.InputStream;
+import java.math.BigDecimal;
+import java.net.URI;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.UUID;
+import javax.jcr.RepositoryException;
+import org.modeshape.common.annotation.Immutable;
+import org.modeshape.jcr.api.value.DateTime;
+import org.modeshape.jcr.cache.NodeKey;
+import org.modeshape.jcr.value.BinaryValue;
+import org.modeshape.jcr.value.Name;
+import org.modeshape.jcr.value.Path;
+import org.modeshape.jcr.value.Reference;
+import org.modeshape.jcr.value.ValueFactory;
+
+/**
+ * Abstract {@link ValueFactory}.
+ * 
+ * @param <T> the property type
+ */
+@Immutable
+public abstract class AbstractObjectValueFactory<T> implements ValueFactory<T> {
+
+    protected AbstractObjectValueFactory() {
+    }
+
+    @Override
+    public T create( Object value ) {
+        if (value == null) return null;
+        if (value instanceof String) return create((String)value);
+        if (value instanceof Integer) return create(((Integer)value).intValue());
+        if (value instanceof Long) return create(((Long)value).longValue());
+        if (value instanceof Double) return create(((Double)value).doubleValue());
+        if (value instanceof Float) return create(((Float)value).floatValue());
+        if (value instanceof Boolean) return create(((Boolean)value).booleanValue());
+        if (value instanceof BigDecimal) return create((BigDecimal)value);
+        if (value instanceof DateTime) return create((DateTime)value);
+        if (value instanceof Calendar) return create((Calendar)value);
+        if (value instanceof Date) return create((Date)value);
+        if (value instanceof Name) return create((Name)value);
+        if (value instanceof Path) return create((Path)value);
+        if (value instanceof Path.Segment) return create((Path.Segment)value);
+        if (value instanceof Reference) return create((Reference)value);
+        if (value instanceof NodeKey) return create((NodeKey)value);
+        if (value instanceof UUID) return create((UUID)value);
+        if (value instanceof URI) return create((URI)value);
+        if (value instanceof BinaryValue) return create((BinaryValue)value);
+        if (value instanceof javax.jcr.Binary) {
+            javax.jcr.Binary jcrBinary = (javax.jcr.Binary)value;
+            try {
+                return create(jcrBinary.getStream());
+            } catch (RepositoryException e) {
+                throw new RuntimeException(e);
+            }
+        }
+        if (value instanceof byte[]) return create((byte[])value);
+        if (value instanceof InputStream) return create((InputStream)value);
+        return create(value.toString());
+    }
+}

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/value/basic/AbstractValueFactory.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/value/basic/AbstractValueFactory.java
@@ -23,14 +23,12 @@
  */
 package org.modeshape.jcr.value.basic;
 
-import java.io.InputStream;
 import java.math.BigDecimal;
 import java.net.URI;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.Iterator;
 import java.util.UUID;
-import javax.jcr.RepositoryException;
 import org.modeshape.common.annotation.Immutable;
 import org.modeshape.common.text.TextDecoder;
 import org.modeshape.common.util.CheckArg;
@@ -51,7 +49,7 @@ import org.modeshape.jcr.value.ValueFormatException;
  * @param <T> the property type
  */
 @Immutable
-public abstract class AbstractValueFactory<T> implements ValueFactory<T> {
+public abstract class AbstractValueFactory<T> extends AbstractObjectValueFactory<T> {
 
     private final TextDecoder decoder;
     private final PropertyType propertyType;
@@ -95,40 +93,6 @@ public abstract class AbstractValueFactory<T> implements ValueFactory<T> {
     @Override
     public PropertyType getPropertyType() {
         return propertyType;
-    }
-
-    @Override
-    public T create( Object value ) {
-        if (value == null) return null;
-        if (value instanceof String) return create((String)value);
-        if (value instanceof Integer) return create(((Integer)value).intValue());
-        if (value instanceof Long) return create(((Long)value).longValue());
-        if (value instanceof Double) return create(((Double)value).doubleValue());
-        if (value instanceof Float) return create(((Float)value).floatValue());
-        if (value instanceof Boolean) return create(((Boolean)value).booleanValue());
-        if (value instanceof BigDecimal) return create((BigDecimal)value);
-        if (value instanceof DateTime) return create((DateTime)value);
-        if (value instanceof Calendar) return create((Calendar)value);
-        if (value instanceof Date) return create((Date)value);
-        if (value instanceof Name) return create((Name)value);
-        if (value instanceof Path) return create((Path)value);
-        if (value instanceof Path.Segment) return create((Path.Segment)value);
-        if (value instanceof Reference) return create((Reference)value);
-        if (value instanceof NodeKey) return create((NodeKey)value);
-        if (value instanceof UUID) return create((UUID)value);
-        if (value instanceof URI) return create((URI)value);
-        if (value instanceof BinaryValue) return create((BinaryValue)value);
-        if (value instanceof javax.jcr.Binary) {
-            javax.jcr.Binary jcrBinary = (javax.jcr.Binary)value;
-            try {
-                return create(jcrBinary.getStream());
-            } catch (RepositoryException e) {
-                throw new RuntimeException(e);
-            }
-        }
-        if (value instanceof byte[]) return create((byte[])value);
-        if (value instanceof InputStream) return create((InputStream)value);
-        return create(value.toString());
     }
 
     protected abstract T[] createEmptyArray( int length );

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/value/basic/DelegateReferenceFactory.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/value/basic/DelegateReferenceFactory.java
@@ -1,0 +1,293 @@
+/*
+ * ModeShape (http://www.modeshape.org)
+ * See the COPYRIGHT.txt file distributed with this work for information
+ * regarding copyright ownership.  Some portions may be licensed
+ * to Red Hat, Inc. under one or more contributor license agreements.
+ * See the AUTHORS.txt file in the distribution for a full listing of 
+ * individual contributors. 
+ *
+ * ModeShape is free software. Unless otherwise indicated, all code in ModeShape
+ * is licensed to you under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * ModeShape is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.modeshape.jcr.value.basic;
+
+import java.io.InputStream;
+import java.math.BigDecimal;
+import java.net.URI;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.Iterator;
+import java.util.UUID;
+import org.modeshape.common.annotation.Immutable;
+import org.modeshape.common.text.TextDecoder;
+import org.modeshape.jcr.api.value.DateTime;
+import org.modeshape.jcr.cache.NodeKey;
+import org.modeshape.jcr.value.BinaryValue;
+import org.modeshape.jcr.value.IoException;
+import org.modeshape.jcr.value.Name;
+import org.modeshape.jcr.value.Path;
+import org.modeshape.jcr.value.Path.Segment;
+import org.modeshape.jcr.value.PropertyType;
+import org.modeshape.jcr.value.Reference;
+import org.modeshape.jcr.value.ReferenceFactory;
+import org.modeshape.jcr.value.ValueFormatException;
+
+/**
+ * The delegating {@link ReferenceFactory} that wraps another. This is useful to extend and override a few methods.
+ */
+@Immutable
+public class DelegateReferenceFactory extends AbstractObjectValueFactory<Reference> implements ReferenceFactory {
+
+    protected final ReferenceFactory delegate;
+
+    public DelegateReferenceFactory( ReferenceFactory delegate ) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public Reference create( NodeKey value,
+                             boolean foreign ) throws ValueFormatException {
+        return delegate.create(value, foreign);
+    }
+
+    @Override
+    public Reference[] create( NodeKey[] value,
+                               boolean foreign ) throws ValueFormatException {
+        return delegate.create(value, foreign);
+    }
+
+    @Override
+    public PropertyType getPropertyType() {
+        return delegate.getPropertyType();
+    }
+
+    @Override
+    public Reference create( String value ) throws ValueFormatException {
+        return delegate.create(value);
+    }
+
+    @Override
+    public Reference create( String value,
+                             TextDecoder decoder ) throws ValueFormatException {
+        return delegate.create(value, decoder);
+    }
+
+    @Override
+    public Reference create( int value ) throws ValueFormatException {
+        return delegate.create(value);
+    }
+
+    @Override
+    public Reference create( long value ) throws ValueFormatException {
+        return delegate.create(value);
+    }
+
+    @Override
+    public Reference create( boolean value ) throws ValueFormatException {
+        return delegate.create(value);
+    }
+
+    @Override
+    public Reference create( float value ) throws ValueFormatException {
+        return delegate.create(value);
+    }
+
+    @Override
+    public Reference create( double value ) throws ValueFormatException {
+        return delegate.create(value);
+    }
+
+    @Override
+    public Reference create( BigDecimal value ) throws ValueFormatException {
+        return delegate.create(value);
+    }
+
+    @Override
+    public Reference create( Calendar value ) throws ValueFormatException {
+        return delegate.create(value);
+    }
+
+    @Override
+    public Reference create( Date value ) throws ValueFormatException {
+        return delegate.create(value);
+    }
+
+    @Override
+    public Reference create( DateTime value ) throws ValueFormatException {
+        return delegate.create(value);
+    }
+
+    @Override
+    public Reference create( Name value ) throws ValueFormatException {
+        return delegate.create(value);
+    }
+
+    @Override
+    public Reference create( Path value ) throws ValueFormatException {
+        return delegate.create(value);
+    }
+
+    @Override
+    public Reference create( Segment value ) throws ValueFormatException {
+        return delegate.create(value);
+    }
+
+    @Override
+    public Reference create( Reference value ) throws ValueFormatException {
+        return delegate.create(value);
+    }
+
+    @Override
+    public Reference create( URI value ) throws ValueFormatException {
+        return delegate.create(value);
+    }
+
+    @Override
+    public Reference create( UUID value ) throws ValueFormatException {
+        return delegate.create(value);
+    }
+
+    @Override
+    public Reference create( NodeKey value ) throws ValueFormatException {
+        return delegate.create(value);
+    }
+
+    @Override
+    public Reference create( byte[] value ) throws ValueFormatException {
+        return delegate.create(value);
+    }
+
+    @Override
+    public Reference create( BinaryValue value ) throws ValueFormatException, IoException {
+        return delegate.create(value);
+    }
+
+    @Override
+    public Reference create( InputStream stream ) throws ValueFormatException, IoException {
+        return delegate.create(stream);
+    }
+
+    @Override
+    public Reference[] create( String[] values ) throws ValueFormatException {
+        return delegate.create(values);
+    }
+
+    @Override
+    public Reference[] create( String[] values,
+                               TextDecoder decoder ) throws ValueFormatException {
+        return delegate.create(values, decoder);
+    }
+
+    @Override
+    public Reference[] create( int[] values ) throws ValueFormatException {
+        return delegate.create(values);
+    }
+
+    @Override
+    public Reference[] create( long[] values ) throws ValueFormatException {
+        return delegate.create(values);
+    }
+
+    @Override
+    public Reference[] create( boolean[] values ) throws ValueFormatException {
+        return delegate.create(values);
+    }
+
+    @Override
+    public Reference[] create( float[] values ) throws ValueFormatException {
+        return delegate.create(values);
+    }
+
+    @Override
+    public Reference[] create( double[] values ) throws ValueFormatException {
+        return delegate.create(values);
+    }
+
+    @Override
+    public Reference[] create( BigDecimal[] values ) throws ValueFormatException {
+        return delegate.create(values);
+    }
+
+    @Override
+    public Reference[] create( Calendar[] values ) throws ValueFormatException {
+        return delegate.create(values);
+    }
+
+    @Override
+    public Reference[] create( Date[] values ) throws ValueFormatException {
+        return delegate.create(values);
+    }
+
+    @Override
+    public Reference[] create( DateTime[] values ) throws ValueFormatException {
+        return delegate.create(values);
+    }
+
+    @Override
+    public Reference[] create( Name[] values ) throws ValueFormatException {
+        return delegate.create(values);
+    }
+
+    @Override
+    public Reference[] create( Path[] values ) throws ValueFormatException {
+        return delegate.create(values);
+    }
+
+    @Override
+    public Reference[] create( Reference[] values ) throws ValueFormatException {
+        return delegate.create(values);
+    }
+
+    @Override
+    public Reference[] create( URI[] values ) throws ValueFormatException {
+        return delegate.create(values);
+    }
+
+    @Override
+    public Reference[] create( UUID[] values ) throws ValueFormatException {
+        return delegate.create(values);
+    }
+
+    @Override
+    public Reference[] create( NodeKey[] value ) throws ValueFormatException {
+        return delegate.create(value);
+    }
+
+    @Override
+    public Reference[] create( byte[][] values ) throws ValueFormatException {
+        return delegate.create(values);
+    }
+
+    @Override
+    public Reference[] create( BinaryValue[] values ) throws ValueFormatException, IoException {
+        return delegate.create(values);
+    }
+
+    @Override
+    public Reference[] create( Object[] values ) throws ValueFormatException, IoException {
+        return delegate.create(values);
+    }
+
+    @Override
+    public Iterator<Reference> create( Iterator<?> values ) throws ValueFormatException, IoException {
+        return delegate.create(values);
+    }
+
+    @Override
+    public Iterable<Reference> create( Iterable<?> valueIterable ) throws ValueFormatException, IoException {
+        return delegate.create(valueIterable);
+    }
+
+}


### PR DESCRIPTION
When REFERENCE properties are set with Value objects created from node identifier strings, the values were not correctly being converted (internally) to NodeKey representations. The result was that the REFERENCE values were not usable. A new test case verifies this behavior.

The challenge was that the logic was using the ReferenceFactory (in the ValueFactories inside the Session's ExecutionContext) to perform the conversion. However, the conversion requires knowledge of the root NodeKey, of which the ReferenceFactory was not aware.

The fix was to give each Session a new ValueFactories object that wrapped the existing ValueFactories with specialized ReferenceFactory instances (for strong and weak references) that were aware of the session's root node NodeKey.
