### PR TITLE
MODE-1721 Corrected Session.move under same parent when no SNS are allowed

### DIFF
--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrSession.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrSession.java
@@ -864,7 +864,8 @@ public class JcrSession implements Session {
         }
 
         // check whether the parent definition allows children which match the source
-        destParentNode.validateChildNodeDefinition(srcNode.name(), srcNode.getPrimaryTypeName(), true);
+        final Name newChildName = destPath.getLastSegment().getName();
+        destParentNode.validateChildNodeDefinition(newChildName, srcNode.getPrimaryTypeName(), true);
 
         // We already checked whether the supplied destination path is below the supplied source path, but this isn't
         // sufficient if any of the ancestors are shared nodes. Therefore, check whether the destination node
@@ -893,7 +894,7 @@ public class JcrSession implements Session {
                 mutableSrcParent.renameChild(sessionCache, srcNode.key(), destPath.getLastSegment().getName());
             } else {
                 // It is a move from one parent to another ...
-                mutableSrcParent.moveChild(sessionCache, srcNode.key(), mutableDestParent, destPath.getLastSegment().getName());
+                mutableSrcParent.moveChild(sessionCache, srcNode.key(), mutableDestParent, newChildName);
             }
         } catch (NodeNotFoundException e) {
             // Not expected ...


### PR DESCRIPTION
Moving a child node to a different name would not work if the child node definition does not allow same-name-sibling nodes. A simple fix to the JcrSession.move method fixed the problem. A new test case verifies the behavior is now correct.
