### PR TITLE
MODE-1740 Change hashCode and equals methods to handle not-yet-set IDs

### DIFF
--- a/extensions/modeshape-connector-store-jpa/src/main/java/org/modeshape/connector/store/jpa/model/common/ChangeLogEntity.java
+++ b/extensions/modeshape-connector-store-jpa/src/main/java/org/modeshape/connector/store/jpa/model/common/ChangeLogEntity.java
@@ -55,7 +55,7 @@ public class ChangeLogEntity {
     @Id
     @GeneratedValue( strategy = GenerationType.AUTO )
     @Column( name = "ID", updatable = false )
-    private long id;
+    private Long id;
 
     @Column( name = "USERNAME", updatable = false, nullable = false, length = 64, unique = false )
     private String username;
@@ -83,7 +83,7 @@ public class ChangeLogEntity {
     /**
      * @return id
      */
-    public long getId() {
+    public Long getId() {
         return id;
     }
 
@@ -135,7 +135,7 @@ public class ChangeLogEntity {
         if (obj == this) return true;
         if (obj instanceof ChangeLogEntity) {
             ChangeLogEntity that = (ChangeLogEntity)obj;
-            return id == that.id;
+            return id != null && that.id!=null && id.equals(that.id);
         }
         return false;
     }

--- a/extensions/modeshape-connector-store-jpa/src/main/java/org/modeshape/connector/store/jpa/model/common/NamespaceEntity.java
+++ b/extensions/modeshape-connector-store-jpa/src/main/java/org/modeshape/connector/store/jpa/model/common/NamespaceEntity.java
@@ -54,7 +54,7 @@ public class NamespaceEntity implements Serializable {
 
     @Id
     @GeneratedValue( strategy = GenerationType.AUTO )
-    private long id;
+    private Long id;
 
     @Column( name = "URI", nullable = true, unique = false, length = 512, updatable = false )
     private String uri;
@@ -75,14 +75,14 @@ public class NamespaceEntity implements Serializable {
     /**
      * @return id
      */
-    public long getId() {
+    public Long getId() {
         return id;
     }
 
     /**
      * @param id Sets id to the specified value.
      */
-    public void setId( long id ) {
+    public void setId( Long id ) {
         this.id = id;
     }
 
@@ -120,7 +120,8 @@ public class NamespaceEntity implements Serializable {
         if (obj == this) return true;
         if (obj instanceof NamespaceEntity) {
             NamespaceEntity that = (NamespaceEntity)obj;
-            if (this.id!=that.id) return false;
+            if (this.id==null || that.id == null) return false;
+            if (!this.id.equals(that.id)) return false;
             if (!this.uri.equals(that.uri)) return false;
             return true;
         }

--- a/extensions/modeshape-connector-store-jpa/src/main/java/org/modeshape/connector/store/jpa/model/common/WorkspaceEntity.java
+++ b/extensions/modeshape-connector-store-jpa/src/main/java/org/modeshape/connector/store/jpa/model/common/WorkspaceEntity.java
@@ -40,6 +40,7 @@ import javax.persistence.Query;
 import javax.persistence.Table;
 import org.hibernate.annotations.Index;
 import org.modeshape.common.util.CheckArg;
+import org.modeshape.common.util.HashCode;
 
 /**
  * A WorkspaceEntity represents a workspace that has been create in the store. WorkspaceEntity records are immutable and shared by
@@ -57,7 +58,7 @@ public class WorkspaceEntity implements Serializable {
 
     @Id
     @GeneratedValue( strategy = GenerationType.AUTO )
-    private long id;
+    private Long id;
 
     @Column( name = "NAME", nullable = false, unique = false, length = 128, updatable = false )
     private String name;
@@ -78,7 +79,7 @@ public class WorkspaceEntity implements Serializable {
     /**
      * @param id Sets id to the specified value.
      */
-    public void setId( long id ) {
+    public void setId( Long id ) {
         this.id = id;
     }
 
@@ -103,9 +104,7 @@ public class WorkspaceEntity implements Serializable {
      */
     @Override
     public int hashCode() {
-    	int hash = 0;
-		hash += (this.getId() != null ? this.getId().hashCode() : 0);
-		return hash;
+    	return  HashCode.compute(id);
     }
 
     /**
@@ -118,7 +117,8 @@ public class WorkspaceEntity implements Serializable {
         if (obj == this) return true;
         if (obj instanceof WorkspaceEntity) {
             WorkspaceEntity that = (WorkspaceEntity)obj;
-            if (this.id != that.id) return false;
+            if (this.id==null || that.id == null) return false;
+            if (!this.id.equals(that.id)) return false;
             if (!this.name.equals(that.name)) return false;
             return true;
         }

--- a/extensions/modeshape-connector-store-jpa/src/main/java/org/modeshape/connector/store/jpa/model/simple/SubgraphQueryEntity.java
+++ b/extensions/modeshape-connector-store-jpa/src/main/java/org/modeshape/connector/store/jpa/model/simple/SubgraphQueryEntity.java
@@ -41,7 +41,7 @@ public class SubgraphQueryEntity implements Serializable {
     @Id
     @GeneratedValue( strategy = GenerationType.AUTO )
     @Column( name = "ID", updatable = false )
-    private long id;
+    private Long id;
 
     @Column( name = "WORKSPACE_ID", nullable = false )
     private Long workspaceId;
@@ -58,7 +58,7 @@ public class SubgraphQueryEntity implements Serializable {
     /**
      * @return id
      */
-    public long getId() {
+    public Long getId() {
         return id;
     }
 


### PR DESCRIPTION
These changes correct the hashCode and equals methods on three Entity classes so that these methods work when the entity IDs (which are configured to be automatically set by JPA) have not yet been set.

https://issues.jboss.org/browse/MODE-1740
