### PR TITLE
MODE-1286 Added Git connector module for AS7

### DIFF
--- a/deploy/jbossas/kit/jboss-as71/modules/org/modeshape/connector/git/main/module.xml
+++ b/deploy/jbossas/kit/jboss-as71/modules/org/modeshape/connector/git/main/module.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2010, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+<module xmlns="urn:jboss:module:1.1" name="org.modeshape.connector.git">
+    <resources>
+        <resource-root path="modeshape-connector-git-${project.version}.jar" />
+        <resource-root path="org.eclipse.jgit-${jgit.version}.jar" />
+        <resource-root path="jsch-${jgit.jsch.version}.jar" />
+    </resources>
+
+    <dependencies>
+        <module name="org.modeshape"/>
+    </dependencies>
+
+</module>

--- a/deploy/jbossas/kit/jboss-as72/modules/org/modeshape/connector/git/main/module.xml
+++ b/deploy/jbossas/kit/jboss-as72/modules/org/modeshape/connector/git/main/module.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2010, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+<module xmlns="urn:jboss:module:1.1" name="org.modeshape.connector.git">
+    <resources>
+        <resource-root path="modeshape-connector-git-${project.version}.jar" />
+        <resource-root path="org.eclipse.jgit-${jgit.version}.jar" />
+        <resource-root path="jsch-${jgit.jsch.version}.jar" />
+    </resources>
+
+    <dependencies>
+        <module name="org.modeshape"/>
+    </dependencies>
+
+</module>

--- a/modeshape-assembly-descriptors/src/main/resources/assemblies/jbossas-71-distribution.xml
+++ b/modeshape-assembly-descriptors/src/main/resources/assemblies/jbossas-71-distribution.xml
@@ -112,6 +112,17 @@
             </includes>
         </dependencySet>
 
+        <!--Connectors-->
+        <dependencySet>
+            <useProjectArtifact>false</useProjectArtifact>
+            <outputDirectory>modules/org/modeshape/connector/git/main</outputDirectory>
+            <includes>
+                <include>org.modeshape:modeshape-connector-git:jar</include>
+                <include>org.eclipse.jgit:org.eclipse.jgit:jar</include>
+                <include>com.jcraft:jsch:jar</include>
+            </includes>
+        </dependencySet>
+
         <!--Sequencers-->
         <dependencySet>
             <useProjectArtifact>false</useProjectArtifact>

--- a/modeshape-assembly-descriptors/src/main/resources/assemblies/jbossas-72-distribution.xml
+++ b/modeshape-assembly-descriptors/src/main/resources/assemblies/jbossas-72-distribution.xml
@@ -113,6 +113,17 @@
             </includes>
         </dependencySet>
 
+        <!--Connectors-->
+        <dependencySet>
+            <useProjectArtifact>false</useProjectArtifact>
+            <outputDirectory>modules/org/modeshape/connector/git/main</outputDirectory>
+            <includes>
+                <include>org.modeshape:modeshape-connector-git:jar</include>
+                <include>org.eclipse.jgit:org.eclipse.jgit:jar</include>
+                <include>com.jcraft:jsch:jar</include>
+            </includes>
+        </dependencySet>
+
         <!--Sequencers-->
         <dependencySet>
             <useProjectArtifact>false</useProjectArtifact>

--- a/modeshape-distribution/pom.xml
+++ b/modeshape-distribution/pom.xml
@@ -47,6 +47,11 @@
 
         <dependency>
             <groupId>org.modeshape</groupId>
+            <artifactId>modeshape-connector-git</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.modeshape</groupId>
             <artifactId>modeshape-sequencer-images</artifactId>
         </dependency>
 

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/RepositoryConfiguration.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/RepositoryConfiguration.java
@@ -677,11 +677,14 @@ public class RepositoryConfiguration {
         SEQUENCER_ALIASES = Collections.unmodifiableMap(aliases);
 
         String fileSystemConnector = FileSystemConnector.class.getName();
+        String gitConnector = "org.modeshape.connector.git.GitConnector";
 
         aliases = new HashMap<String, String>();
         aliases.put("files", fileSystemConnector);
         aliases.put("filesystem", fileSystemConnector);
         aliases.put("filesystemconnector", fileSystemConnector);
+        aliases.put("git", gitConnector);
+        aliases.put("gitconnector", gitConnector);
 
         CONNECTOR_ALIASES = Collections.unmodifiableMap(aliases);
 

--- a/modeshape-parent/pom.xml
+++ b/modeshape-parent/pom.xml
@@ -307,6 +307,7 @@
         <json.simple.version>1.1</json.simple.version>
         <logback.version>0.9.29</logback.version>
         <jgit.version>2.1.0.201209190230-r</jgit.version>
+        <jgit.jsch.version>0.1.44-1</jgit.jsch.version>
         <eclipse.equinox.common.version>3.3.0-v20070426</eclipse.equinox.common.version>
         <eclipse.jdt.core.version>3.3.0-v_771</eclipse.jdt.core.version>
         <eclipse.core.resources.version>3.3.0-v20070604</eclipse.core.resources.version>
@@ -726,6 +727,11 @@
             <dependency>
                 <groupId>org.modeshape</groupId>
                 <artifactId>modeshape-jcr-tck</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.modeshape</groupId>
+                <artifactId>modeshape-connector-git</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>


### PR DESCRIPTION
Added the files that produce the AS7 module for the Git connector and include this module in the ModeShape AS7 assemblies.

Note that this connector module (and other connectors) will need to be referenced in the configuration of the connector, in the same way that the sequencer configurations have to specify the sequencer module.

This also adds the "git" and "gitconnector" aliases to the RepositoryConfiguration class.
