### PR TITLE
MODE-1747 Changed default configuration for workspace caches

### DIFF
--- a/modeshape-jcr/src/main/resources/org/modeshape/jcr/default-workspace-cache-config.xml
+++ b/modeshape-jcr/src/main/resources/org/modeshape/jcr/default-workspace-cache-config.xml
@@ -4,7 +4,9 @@
         xsi:schemaLocation="urn:infinispan:config:5.1 http://www.infinispan.org/schemas/infinispan-config-5.1.xsd"
         xmlns="urn:infinispan:config:5.1">
 
-    <global/>
+    <global>
+        <globalJmxStatistics enabled="false" allowDuplicateDomains="true"/>
+    </global>
     
     <!--
       Define the configuration for each workspace cache. This configuration will be used if there is no "namedCache"


### PR DESCRIPTION
Changed the default (built-in) configuration for a repository's in-memory workspace caches (on top of the Infinispan cache used for content) to better work with Infinispan 5.2.

The default can always be overridden in a repository's JSON configuration file.
