### PR TITLE
MODE-1751 - Updated the algorithm via which nodes update their referrers as result to changes in reference properties.

### DIFF
--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrSession.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrSession.java
@@ -1664,14 +1664,14 @@ public class JcrSession implements org.modeshape.jcr.api.Session {
                                                                context.getTime());
                     }
 
-                    // Now update the node as if it's checked in (with the exception of the predecessors...
+                    // Now update the node as if it's checked in (with the exception of the predecessors...)
                     Reference historyRef = referenceFactory.create(historyKey, true);
                     Reference baseVersionRef = referenceFactory.create(baseVersionKey, true);
                     node.setProperty(cache, propertyFactory.create(JcrLexicon.IS_CHECKED_OUT, Boolean.TRUE));
-                    node.setProperty(cache, propertyFactory.create(JcrLexicon.VERSION_HISTORY, historyRef));
-                    node.setProperty(cache, propertyFactory.create(JcrLexicon.BASE_VERSION, baseVersionRef));
+                    node.setReference(cache, propertyFactory.create(JcrLexicon.VERSION_HISTORY, historyRef), systemContent.cache());
+                    node.setReference(cache, propertyFactory.create(JcrLexicon.BASE_VERSION, baseVersionRef), systemContent.cache());
                     // JSR 283 - 15.1
-                    node.setProperty(cache, propertyFactory.create(JcrLexicon.PREDECESSORS, new Object[] {baseVersionRef}));
+                    node.setReference(cache, propertyFactory.create(JcrLexicon.PREDECESSORS, new Object[] {baseVersionRef}), systemContent.cache());
                 }
             }
 

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/MutableCachedNode.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/MutableCachedNode.java
@@ -95,6 +95,19 @@ public interface MutableCachedNode extends CachedNode {
                       Property property );
 
     /**
+     * Sets a property of type reference in the case when there's an active system cache and the property is a reference
+     * towards a transient node from the system cache.
+     *
+     * @param cache the cache to which this node belongs; may not be null
+     * @param property the property; may not be null
+     * @param systemCache an existing system cache which contains transient nodes towards which the property points.
+     * @throws NodeNotFoundException if this node no longer exists
+     */
+    void setReference(SessionCache cache,
+                      Property property,
+                      SessionCache systemCache);
+
+    /**
      * Set the given property only if it has not been set previously and therefore appear as changed.
      * 
      * @param cache the cache to which this node belongs; may not be null

--- a/modeshape-jcr/src/test/java/org/modeshape/jcr/JcrNodeTest.java
+++ b/modeshape-jcr/src/test/java/org/modeshape/jcr/JcrNodeTest.java
@@ -23,23 +23,23 @@
  */
 package org.modeshape.jcr;
 
+import java.util.HashSet;
+import java.util.Set;
+import javax.jcr.ImportUUIDBehavior;
 import javax.jcr.Node;
 import javax.jcr.NodeIterator;
 import javax.jcr.Property;
 import javax.jcr.PropertyIterator;
-import static org.hamcrest.core.Is.is;
-import static org.hamcrest.core.IsNull.notNullValue;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
-import javax.jcr.ImportUUIDBehavior;
 import org.junit.AfterClass;
-import static org.junit.Assert.assertTrue;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.modeshape.common.FixFor;
-import java.util.HashSet;
-import java.util.Set;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsNull.notNullValue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 
 public class JcrNodeTest extends MultiUseAbstractTest {
 
@@ -205,5 +205,24 @@ public class JcrNodeTest extends MultiUseAbstractTest {
         Node referenceableCar2 = session.getNode("/Cars/referenceableCar2");
         uuid = referenceableCar2.getProperty(JcrLexicon.UUID.getString()).getString();
         assertEquals(referenceableCar2.getIdentifier(), uuid);
+    }
+
+    @Test
+    @FixFor( "MODE-1751" )
+    public void shouldNotCauseReferentialIntegrityExceptionWhenSameReferrerUpdatedMultipleTimes() throws Exception {
+        Node nodeA = session.getRootNode().addNode("nodeA");
+        nodeA.addMixin("mix:referenceable");
+        Node nodeB = session.getRootNode().addNode("nodeB");
+        nodeB.setProperty("nodeA", session.getValueFactory().createValue(nodeA, false));
+        session.save();
+
+        nodeB.setProperty("nodeA", session.getValueFactory().createValue(nodeA, false));
+        session.save();
+
+        nodeB.remove();
+        session.save();
+
+        nodeA.remove();
+        session.save();
     }
 }


### PR DESCRIPTION
The change was needed because the previous version of the code did not take into account "no-op" updates to the same property, which resulted in turn, into an erroneous increase in the reference count.

Fixing this issue exposed another "hidden" bug: there is a very rare case, when within a transient session, references towards nodes in another ongoing transient session are created. This is the case when a node is made versionable. The bug was exposed by the TCK _VersionHistoryTest_. To fix this issue, the _MutableNode_ interface was updated to handle this particular case.
