### PR TITLE
MODE-1762 Added code to ensure the sequencers always close the Binary's stream

### DIFF
--- a/modeshape-jcr/src/main/java/org/modeshape/sequencer/cnd/CndSequencer.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/sequencer/cnd/CndSequencer.java
@@ -23,31 +23,59 @@
  */
 package org.modeshape.sequencer.cnd;
 
-
-import javax.jcr.*;
+import static org.modeshape.sequencer.cnd.CndSequencerLexicon.AUTO_CREATED;
+import static org.modeshape.sequencer.cnd.CndSequencerLexicon.AVAILABLE_QUERY_OPERATORS;
+import static org.modeshape.sequencer.cnd.CndSequencerLexicon.CHILD_NODE_DEFINITION;
+import static org.modeshape.sequencer.cnd.CndSequencerLexicon.DEFAULT_PRIMARY_TYPE;
+import static org.modeshape.sequencer.cnd.CndSequencerLexicon.DEFAULT_VALUES;
+import static org.modeshape.sequencer.cnd.CndSequencerLexicon.HAS_ORDERABLE_CHILD_NODES;
+import static org.modeshape.sequencer.cnd.CndSequencerLexicon.IS_ABSTRACT;
+import static org.modeshape.sequencer.cnd.CndSequencerLexicon.IS_FULL_TEXT_SEARCHABLE;
+import static org.modeshape.sequencer.cnd.CndSequencerLexicon.IS_MIXIN;
+import static org.modeshape.sequencer.cnd.CndSequencerLexicon.IS_QUERYABLE;
+import static org.modeshape.sequencer.cnd.CndSequencerLexicon.IS_QUERY_ORDERABLE;
+import static org.modeshape.sequencer.cnd.CndSequencerLexicon.MANDATORY;
+import static org.modeshape.sequencer.cnd.CndSequencerLexicon.MULTIPLE;
+import static org.modeshape.sequencer.cnd.CndSequencerLexicon.NAME;
+import static org.modeshape.sequencer.cnd.CndSequencerLexicon.NODE_TYPE;
+import static org.modeshape.sequencer.cnd.CndSequencerLexicon.NODE_TYPE_NAME;
+import static org.modeshape.sequencer.cnd.CndSequencerLexicon.ON_PARENT_VERSION;
+import static org.modeshape.sequencer.cnd.CndSequencerLexicon.PRIMARY_ITEM_NAME;
+import static org.modeshape.sequencer.cnd.CndSequencerLexicon.PROPERTY_DEFINITION;
+import static org.modeshape.sequencer.cnd.CndSequencerLexicon.PROTECTED;
+import static org.modeshape.sequencer.cnd.CndSequencerLexicon.REQUIRED_PRIMARY_TYPES;
+import static org.modeshape.sequencer.cnd.CndSequencerLexicon.REQUIRED_TYPE;
+import static org.modeshape.sequencer.cnd.CndSequencerLexicon.SAME_NAME_SIBLINGS;
+import static org.modeshape.sequencer.cnd.CndSequencerLexicon.SUPERTYPES;
+import static org.modeshape.sequencer.cnd.CndSequencerLexicon.VALUE_CONSTRAINTS;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.List;
+import javax.jcr.Binary;
+import javax.jcr.NamespaceRegistry;
+import javax.jcr.Node;
+import javax.jcr.Property;
+import javax.jcr.PropertyType;
+import javax.jcr.RepositoryException;
+import javax.jcr.Value;
 import javax.jcr.nodetype.NodeDefinition;
 import javax.jcr.nodetype.NodeTypeDefinition;
 import javax.jcr.nodetype.PropertyDefinition;
 import javax.jcr.version.OnParentVersionAction;
 import org.modeshape.common.collection.Problems;
 import org.modeshape.common.collection.SimpleProblems;
-import org.modeshape.common.util.CheckArg;
 import org.modeshape.common.logging.Logger;
+import org.modeshape.common.util.CheckArg;
 import org.modeshape.jcr.CndImporter;
 import org.modeshape.jcr.ExecutionContext;
 import org.modeshape.jcr.JcrLexicon;
 import org.modeshape.jcr.api.nodetype.NodeTypeManager;
 import org.modeshape.jcr.api.sequencer.Sequencer;
-import static org.modeshape.sequencer.cnd.CndSequencerLexicon.*;
 import org.modeshape.jcr.value.NamespaceRegistry.Namespace;
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.List;
-
 
 /**
  * A sequencer of CND files.
- *
+ * 
  * @author Horia Chiorean
  */
 public class CndSequencer extends Sequencer {
@@ -56,24 +84,34 @@ public class CndSequencer extends Sequencer {
     private static final Logger LOGGER = Logger.getLogger(CndSequencer.class);
 
     @Override
-    public void initialize( NamespaceRegistry registry, NodeTypeManager nodeTypeManager ) throws RepositoryException, IOException {
+    public void initialize( NamespaceRegistry registry,
+                            NodeTypeManager nodeTypeManager ) throws RepositoryException, IOException {
         super.registerNodeTypes("sequencer-cnd.cnd", nodeTypeManager, true);
     }
 
     @Override
-    public boolean execute( Property inputProperty, Node outputNode, Context context ) throws Exception {
+    public boolean execute( Property inputProperty,
+                            Node outputNode,
+                            Context context ) throws Exception {
         Binary binaryValue = inputProperty.getBinary();
         CheckArg.isNotNull(binaryValue, "binary");
 
-        //if the output is jcr:system/jcr:nodeTypes import via the NodeTypeManager
+        // if the output is jcr:system/jcr:nodeTypes import via the NodeTypeManager
         if (outputIsSystemNodeTypes(outputNode, binaryValue)) {
             return true;
         }
 
-        CndImporter cndImporter = importNodesFromCND(binaryValue.getStream());
-        if (cndImporter == null) {
-            return false;
+        CndImporter cndImporter = null;
+        InputStream stream = binaryValue.getStream();
+        try {
+            cndImporter = importNodesFromCND(stream);
+            if (cndImporter == null) {
+                return false;
+            }
+        } finally {
+            stream.close();
         }
+        assert cndImporter != null;
 
         registerImportedNamespaces(outputNode, cndImporter);
         processNodeTypeDefinitions(outputNode, cndImporter);
@@ -81,7 +119,8 @@ public class CndSequencer extends Sequencer {
         return true;
     }
 
-    private void processNodeTypeDefinitions( Node outputNode, CndImporter cndImporter ) throws RepositoryException {
+    private void processNodeTypeDefinitions( Node outputNode,
+                                             CndImporter cndImporter ) throws RepositoryException {
         List<NodeTypeDefinition> importedNodeTypes = cndImporter.getNodeTypeDefinitions();
 
         for (NodeTypeDefinition nodeTypeDefinition : importedNodeTypes) {
@@ -89,7 +128,8 @@ public class CndSequencer extends Sequencer {
         }
     }
 
-    private void registerImportedNamespaces( Node outputNode, CndImporter cndImporter ) throws RepositoryException {
+    private void registerImportedNamespaces( Node outputNode,
+                                             CndImporter cndImporter ) throws RepositoryException {
         NamespaceRegistry namespaceRegistry = outputNode.getSession().getWorkspace().getNamespaceRegistry();
         for (Namespace namespace : cndImporter.getNamespaces()) {
             super.registerNamespace(namespace.getPrefix(), namespace.getNamespaceUri(), namespaceRegistry);
@@ -109,7 +149,8 @@ public class CndSequencer extends Sequencer {
         return cndImporter;
     }
 
-    private boolean outputIsSystemNodeTypes( Node outputNode, Binary binaryValue ) throws RepositoryException, IOException {
+    private boolean outputIsSystemNodeTypes( Node outputNode,
+                                             Binary binaryValue ) throws RepositoryException, IOException {
         String systemNodesPath = JcrLexicon.SYSTEM.getString() + "/" + JcrLexicon.NODE_TYPES.getString();
         if (outputNode.getPath().contains(systemNodesPath)) {
             NodeTypeManager nodeTypeManager = (NodeTypeManager)outputNode.getSession().getWorkspace().getNodeTypeManager();
@@ -119,7 +160,8 @@ public class CndSequencer extends Sequencer {
         return false;
     }
 
-    private void storeNodeTypeDefinition( Node outputNode, NodeTypeDefinition nodeTypeDefinition ) throws RepositoryException {
+    private void storeNodeTypeDefinition( Node outputNode,
+                                          NodeTypeDefinition nodeTypeDefinition ) throws RepositoryException {
         Node nodeTypeNode = processNodeTypeDefinition(outputNode, nodeTypeDefinition);
 
         PropertyDefinition[] declaredPropertyDefinitions = nodeTypeDefinition.getDeclaredPropertyDefinitions();
@@ -137,7 +179,8 @@ public class CndSequencer extends Sequencer {
         }
     }
 
-    private void processChildNodeDefinition( Node nodeTypeNode, NodeDefinition childNodeDefinition ) throws RepositoryException {
+    private void processChildNodeDefinition( Node nodeTypeNode,
+                                             NodeDefinition childNodeDefinition ) throws RepositoryException {
         Node childNode = nodeTypeNode.addNode(CHILD_NODE_DEFINITION, CHILD_NODE_DEFINITION);
 
         if (!RESIDUAL_ITEM_NAME.equals(childNodeDefinition.getName())) {
@@ -154,7 +197,8 @@ public class CndSequencer extends Sequencer {
         childNode.setProperty(DEFAULT_PRIMARY_TYPE, childNodeDefinition.getDefaultPrimaryTypeName());
     }
 
-    private void processPropertyDefinition( Node nodeTypeNode, PropertyDefinition propertyDefinition ) throws RepositoryException {
+    private void processPropertyDefinition( Node nodeTypeNode,
+                                            PropertyDefinition propertyDefinition ) throws RepositoryException {
         Node propertyDefinitionNode = nodeTypeNode.addNode(PROPERTY_DEFINITION, PROPERTY_DEFINITION);
 
         if (!RESIDUAL_ITEM_NAME.equals(propertyDefinition.getName())) {
@@ -164,10 +208,13 @@ public class CndSequencer extends Sequencer {
         propertyDefinitionNode.setProperty(MANDATORY, propertyDefinition.isMandatory());
         propertyDefinitionNode.setProperty(MULTIPLE, propertyDefinition.isMultiple());
         propertyDefinitionNode.setProperty(PROTECTED, propertyDefinition.isProtected());
-        propertyDefinitionNode.setProperty(ON_PARENT_VERSION, OnParentVersionAction.nameFromValue(propertyDefinition.getOnParentVersion()));
-        propertyDefinitionNode.setProperty(REQUIRED_TYPE, PropertyType.nameFromValue(propertyDefinition.getRequiredType()).toUpperCase());
-        String[] availableQueryOperators = propertyDefinition.getAvailableQueryOperators();       
-        propertyDefinitionNode.setProperty(AVAILABLE_QUERY_OPERATORS, availableQueryOperators != null ? availableQueryOperators : new String[0]);
+        propertyDefinitionNode.setProperty(ON_PARENT_VERSION,
+                                           OnParentVersionAction.nameFromValue(propertyDefinition.getOnParentVersion()));
+        propertyDefinitionNode.setProperty(REQUIRED_TYPE, PropertyType.nameFromValue(propertyDefinition.getRequiredType())
+                                                                      .toUpperCase());
+        String[] availableQueryOperators = propertyDefinition.getAvailableQueryOperators();
+        propertyDefinitionNode.setProperty(AVAILABLE_QUERY_OPERATORS,
+                                           availableQueryOperators != null ? availableQueryOperators : new String[0]);
         Value[] defaultValues = propertyDefinition.getDefaultValues();
         propertyDefinitionNode.setProperty(DEFAULT_VALUES, defaultValues != null ? defaultValues : new Value[0]);
         String[] valueConstraints = propertyDefinition.getValueConstraints();
@@ -176,7 +223,8 @@ public class CndSequencer extends Sequencer {
         propertyDefinitionNode.setProperty(IS_QUERY_ORDERABLE, propertyDefinition.isQueryOrderable());
     }
 
-    private Node processNodeTypeDefinition( Node outputNode, NodeTypeDefinition nodeTypeDefinition ) throws RepositoryException {
+    private Node processNodeTypeDefinition( Node outputNode,
+                                            NodeTypeDefinition nodeTypeDefinition ) throws RepositoryException {
         Node nodeTypeNode = outputNode.addNode(nodeTypeDefinition.getName(), NODE_TYPE);
 
         nodeTypeNode.setProperty(IS_MIXIN, nodeTypeDefinition.isMixin());

--- a/sequencers/modeshape-sequencer-ddl/src/main/java/org/modeshape/sequencer/ddl/DdlSequencer.java
+++ b/sequencers/modeshape-sequencer-ddl/src/main/java/org/modeshape/sequencer/ddl/DdlSequencer.java
@@ -24,6 +24,7 @@
 package org.modeshape.sequencer.ddl;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.util.ArrayList;
@@ -42,10 +43,10 @@ import javax.jcr.RepositoryException;
 import javax.jcr.Value;
 import javax.jcr.ValueFactory;
 import org.modeshape.common.annotation.NotThreadSafe;
+import org.modeshape.common.logging.Logger;
 import org.modeshape.common.text.ParsingException;
 import org.modeshape.common.util.CheckArg;
 import org.modeshape.common.util.IoUtil;
-import org.modeshape.common.logging.Logger;
 import org.modeshape.jcr.api.JcrConstants;
 import org.modeshape.jcr.api.nodetype.NodeTypeManager;
 import org.modeshape.jcr.api.sequencer.Sequencer;
@@ -189,15 +190,18 @@ public class DdlSequencer extends Sequencer {
 
         // Perform the parsing
         final AstNode rootNode;
+        DdlParsers parsers = createParsers(getParserList());
+        InputStream stream = ddlContent.getStream();
         try {
-            DdlParsers parsers = createParsers(getParserList());
-            rootNode = parsers.parse(IoUtil.read(ddlContent.getStream()), fileName);
+            rootNode = parsers.parse(IoUtil.read(stream), fileName);
         } catch (ParsingException e) {
             LOGGER.error(e, DdlSequencerI18n.errorParsingDdlContent, e.getLocalizedMessage());
             return false;
         } catch (IOException e) {
             LOGGER.error(e, DdlSequencerI18n.errorSequencingDdlContent, e.getLocalizedMessage());
             return false;
+        } finally {
+            stream.close();
         }
 
         Queue<AstNode> queue = new LinkedList<AstNode>();

--- a/sequencers/modeshape-sequencer-java/src/main/java/org/modeshape/sequencer/javafile/JavaFileSequencer.java
+++ b/sequencers/modeshape-sequencer-java/src/main/java/org/modeshape/sequencer/javafile/JavaFileSequencer.java
@@ -23,42 +23,54 @@
  */
 package org.modeshape.sequencer.javafile;
 
-import javax.jcr.*;
+import java.io.IOException;
+import java.io.InputStream;
+import javax.jcr.Binary;
+import javax.jcr.NamespaceRegistry;
+import javax.jcr.Node;
+import javax.jcr.Property;
+import javax.jcr.RepositoryException;
 import org.modeshape.common.util.CheckArg;
 import org.modeshape.jcr.api.nodetype.NodeTypeManager;
 import org.modeshape.jcr.api.sequencer.Sequencer;
 import org.modeshape.sequencer.classfile.ClassFileSequencer;
 import org.modeshape.sequencer.javafile.metadata.JavaMetadata;
-import java.io.IOException;
 
 /**
  * Sequencer which handles java source files.
  * 
- * @author  ?
+ * @author ?
  * @author Horia Chiorean
  */
 public class JavaFileSequencer extends Sequencer {
-    
+
     private static final SourceFileRecorder DEFAULT_SOURCE_FILE_RECORDER = new ClassSourceFileRecorder();
     private SourceFileRecorder sourceFileRecorder = DEFAULT_SOURCE_FILE_RECORDER;
 
     @Override
-    public void initialize( NamespaceRegistry registry, NodeTypeManager nodeTypeManager ) throws RepositoryException, IOException {
-        String classFileCnd = "/" + ClassFileSequencer.class.getPackage().getName().replaceAll("\\.","/") + "/sequencer-classfile.cnd";
+    public void initialize( NamespaceRegistry registry,
+                            NodeTypeManager nodeTypeManager ) throws RepositoryException, IOException {
+        String classFileCnd = "/" + ClassFileSequencer.class.getPackage().getName().replaceAll("\\.", "/")
+                              + "/sequencer-classfile.cnd";
         registerNodeTypes(classFileCnd, nodeTypeManager, true);
     }
 
     @Override
-    public boolean execute( Property inputProperty, Node outputNode, Context context ) throws Exception {
+    public boolean execute( Property inputProperty,
+                            Node outputNode,
+                            Context context ) throws Exception {
         Binary binaryValue = inputProperty.getBinary();
         CheckArg.isNotNull(binaryValue, "binary");
+        InputStream stream = binaryValue.getStream();
         try {
-            JavaMetadata javaMetadata = JavaMetadata.instance(binaryValue.getStream(), JavaMetadataUtil.length(binaryValue.getStream()), null);
+            JavaMetadata javaMetadata = JavaMetadata.instance(stream, binaryValue.getSize(), null);
             sourceFileRecorder.record(context, outputNode, javaMetadata);
             return true;
         } catch (Exception ex) {
             getLogger().error(ex, "Error sequencing file");
             return false;
+        } finally {
+            stream.close();
         }
     }
 
@@ -67,7 +79,8 @@ public class JavaFileSequencer extends Sequencer {
      * the custom {@link SourceFileRecorder} class prior to ensure that the new value represents a valid implementation.
      * 
      * @param sourceFileRecorderClassName the fully-qualified class name of the new custom class file recorder implementation;
-     *        null indicates that {@link org.modeshape.sequencer.javafile.ClassSourceFileRecorder the class file recorder} should be used.
+     *        null indicates that {@link org.modeshape.sequencer.javafile.ClassSourceFileRecorder the class file recorder} should
+     *        be used.
      * @throws ClassNotFoundException if the the class for the {@code SourceFileRecorder} implementation cannot be located
      * @throws IllegalAccessException if the row factory class or its nullary constructor is not accessible.
      * @throws InstantiationException if the row factory represents an abstract class, an interface, an array class, a primitive

--- a/sequencers/modeshape-sequencer-mp3/src/main/java/org/modeshape/sequencer/mp3/Mp3MetadataSequencer.java
+++ b/sequencers/modeshape-sequencer-mp3/src/main/java/org/modeshape/sequencer/mp3/Mp3MetadataSequencer.java
@@ -30,6 +30,7 @@ import static org.modeshape.sequencer.mp3.Mp3MetadataLexicon.METADATA_NODE;
 import static org.modeshape.sequencer.mp3.Mp3MetadataLexicon.TITLE;
 import static org.modeshape.sequencer.mp3.Mp3MetadataLexicon.YEAR;
 import java.io.IOException;
+import java.io.InputStream;
 import javax.jcr.Binary;
 import javax.jcr.NamespaceRegistry;
 import javax.jcr.Node;
@@ -77,7 +78,13 @@ public class Mp3MetadataSequencer extends Sequencer {
         Binary binaryValue = inputProperty.getBinary();
         CheckArg.isNotNull(binaryValue, "binary");
         try {
-            Mp3Metadata metadata = Mp3Metadata.instance(binaryValue.getStream());
+            Mp3Metadata metadata = null;
+            InputStream stream = binaryValue.getStream();
+            try {
+                metadata = Mp3Metadata.instance(stream);
+            } finally {
+                stream.close();
+            }
             Node sequencedNode = outputNode;
             if (outputNode.isNew()) {
                 outputNode.setPrimaryType(METADATA_NODE);

--- a/sequencers/modeshape-sequencer-msoffice/src/main/java/org/modeshape/sequencer/msoffice/MSOfficeMetadataSequencer.java
+++ b/sequencers/modeshape-sequencer-msoffice/src/main/java/org/modeshape/sequencer/msoffice/MSOfficeMetadataSequencer.java
@@ -149,18 +149,33 @@ public class MSOfficeMetadataSequencer extends Sequencer {
 
         sequencedNode.setProperty(JCR_MIME_TYPE, mimeType);
         if (isPowerpoint(mimeType)) {
-            sequencePowerpoint(sequencedNode, context.valueFactory(), binaryValue.getStream());
-            return true;
+            InputStream stream = binaryValue.getStream();
+            try {
+                sequencePowerpoint(sequencedNode, context.valueFactory(), stream);
+                return true;
+            } finally {
+                stream.close();
+            }
         }
 
         if (isWord(mimeType)) {
-            sequenceWord(sequencedNode, context.valueFactory(), binaryValue.getStream());
-            return true;
+            InputStream stream = binaryValue.getStream();
+            try {
+                sequenceWord(sequencedNode, context.valueFactory(), binaryValue.getStream());
+                return true;
+            } finally {
+                stream.close();
+            }
         }
 
         if (isExcel(mimeType)) {
-            sequenceExcel(sequencedNode, context.valueFactory(), binaryValue.getStream());
-            return true;
+            InputStream stream = binaryValue.getStream();
+            try {
+                sequenceExcel(sequencedNode, context.valueFactory(), binaryValue.getStream());
+                return true;
+            } finally {
+                stream.close();
+            }
         }
 
         getLogger().warn("Unknown mimetype: {0} for microsoft office", mimeType);

--- a/sequencers/modeshape-sequencer-wsdl/src/main/java/org/modeshape/sequencer/wsdl/WsdlSequencer.java
+++ b/sequencers/modeshape-sequencer-wsdl/src/main/java/org/modeshape/sequencer/wsdl/WsdlSequencer.java
@@ -26,6 +26,7 @@ package org.modeshape.sequencer.wsdl;
 
 import static org.modeshape.sequencer.wsdl.WsdlLexicon.WSDL_DOCUMENT;
 import java.io.IOException;
+import java.io.InputStream;
 import javax.jcr.Binary;
 import javax.jcr.NamespaceRegistry;
 import javax.jcr.Node;
@@ -70,7 +71,12 @@ public class WsdlSequencer extends AbstractSrampSequencer {
         }
 
         String baseUri = inputProperty.getParent().getPath();
-        new Wsdl11Reader(context, baseUri).read(binaryValue.getStream(), outputNode);
+        InputStream stream = binaryValue.getStream();
+        try {
+            new Wsdl11Reader(context, baseUri).read(stream, outputNode);
+        } finally {
+            stream.close();
+        }
         return true;
     }
 }

--- a/sequencers/modeshape-sequencer-xml/src/main/java/org/modeshape/sequencer/xml/XmlSequencer.java
+++ b/sequencers/modeshape-sequencer-xml/src/main/java/org/modeshape/sequencer/xml/XmlSequencer.java
@@ -24,6 +24,7 @@
 package org.modeshape.sequencer.xml;
 
 import java.io.IOException;
+import java.io.InputStream;
 import javax.jcr.Binary;
 import javax.jcr.NamespaceRegistry;
 import javax.jcr.Node;
@@ -127,7 +128,12 @@ public class XmlSequencer extends Sequencer {
         // Prevent the resolving of DTD entities into fully-qualified URIS
         setFeature(reader, RESOLVE_DTD_URIS_FEATURE, false);
         // Parse XML document
-        reader.parse(new InputSource(binaryValue.getStream()));
+        InputStream stream = binaryValue.getStream();
+        try {
+            reader.parse(new InputSource(stream));
+        } finally {
+            stream.close();
+        }
         return true;
     }
 

--- a/sequencers/modeshape-sequencer-xsd/src/main/java/org/modeshape/sequencer/xsd/XsdSequencer.java
+++ b/sequencers/modeshape-sequencer-xsd/src/main/java/org/modeshape/sequencer/xsd/XsdSequencer.java
@@ -26,6 +26,7 @@ package org.modeshape.sequencer.xsd;
 
 import static org.modeshape.sequencer.xsd.XsdLexicon.SCHEMA_DOCUMENT;
 import java.io.IOException;
+import java.io.InputStream;
 import javax.jcr.Binary;
 import javax.jcr.NamespaceRegistry;
 import javax.jcr.Node;
@@ -74,7 +75,12 @@ public class XsdSequencer extends AbstractSrampSequencer {
         } else {
             outputNode = outputNode.addNode(SCHEMA_DOCUMENT, SCHEMA_DOCUMENT);
         }
-        new XsdReader(context).read(binaryValue.getStream(), outputNode);
+        InputStream stream = binaryValue.getStream();
+        try {
+            new XsdReader(context).read(stream, outputNode);
+        } finally {
+            stream.close();
+        }
         return true;
     }
 }

--- a/web/modeshape-web-jcr-rest/src/main/java/org/modeshape/web/jcr/rest/ModeShapeRestService.java
+++ b/web/modeshape-web-jcr-rest/src/main/java/org/modeshape/web/jcr/rest/ModeShapeRestService.java
@@ -24,6 +24,7 @@
 
 package org.modeshape.web.jcr.rest;
 
+import java.io.IOException;
 import java.io.InputStream;
 import javax.jcr.Binary;
 import javax.jcr.Property;
@@ -219,9 +220,18 @@ public final class ModeShapeRestService {
          * https://issues.jboss.org/browse/RESTEASY-741 so we need to be aware that with the current version the stream won't be
          * closed.
          */
-        Response.ResponseBuilder responseBuilder = Response.ok(binary.getStream(), mimeType);
-        responseBuilder.header("Content-Disposition", contentDisposition);
-        return responseBuilder.build();
+        InputStream stream = binary.getStream();
+        try {
+            Response.ResponseBuilder responseBuilder = Response.ok(stream, mimeType);
+            responseBuilder.header("Content-Disposition", contentDisposition);
+            return responseBuilder.build();
+        } finally {
+            try {
+                stream.close();
+            } catch (IOException e) {
+                throw new RepositoryException(e);
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
Our Binary values always return a stream that closes itself when fully-read.
However, if any of the sequencers do not read the entire stream (e.g.,
intentionally or if they experience an exception while processing),
the stream might not be closed.

These changes ensure that the stream is always closed. All sequencer
implementations where checked, and only those that were not always
closing the stream in a finally block were modified/corrected.

All tests pass with these changes.

(Note that this is for the '3.1.x' branch; there is a separate [pull-request](https://github.com/ModeShape/modeshape/pull/653) for the 'master' branch changes.)
