### PR TITLE
MODE-1761 Added debug and trace logging to sequencing operations

### DIFF
--- a/modeshape-jcr/src/test/resources/log4j.properties
+++ b/modeshape-jcr/src/test/resources/log4j.properties
@@ -15,6 +15,7 @@ log4j.logger.org.apache.jackrabbit.test=WARN
 log4j.logger.org.modeshape.jcr.tck=WARN
 log4j.logger.org.modeshape.jcr.ModeShapeTckTest=WARN
 #log4j.logger.org.modeshape.jcr.query=TRACE
+#log4j.logger.org.modeshape.jcr.sequencing=DEBUG
 
 # This line turns on detailed log messages 
 #log4j.logger.org.modeshape=DEBUG


### PR DESCRIPTION
Added debug logging for 'org.modeshape.jcr.sequencing' that outputs the initialization of each sequencer (with valid path expressions) and each invocation of a sequencer.

Added more trace logging for 'org.modeshape.jcr.sequencing' that outputs very details messages describing the various activities (and exit points) of sequencing.

Note that unconventional log names were used to make it easier to enable and disale all logging for sequencing.
