### PR TITLE
MODE-1775 Improved the Session.getNodeByIdentifier() method

### DIFF
--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/AbstractJcrNode.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/AbstractJcrNode.java
@@ -556,6 +556,10 @@ abstract class AbstractJcrNode extends AbstractJcrItem implements Node {
         return false;
     }
 
+    boolean isSystem() {
+        return false;
+    }
+
     final JcrValue valueFrom( int propertyType,
                               Object value ) {
         return new JcrValue(context().getValueFactories(), propertyType, value);
@@ -991,7 +995,6 @@ abstract class AbstractJcrNode extends AbstractJcrItem implements Node {
      * Adds the a new node with the given primary type (if specified) at the given relative path with the given UUID (if
      * specified).
      * 
-     *
      * @param childName the name for the new node; may not be null
      * @param childPrimaryNodeTypeName the desired primary type for the new node; null value indicates that the default primary
      *        type from the appropriate definition for this node should be used
@@ -1553,7 +1556,6 @@ abstract class AbstractJcrNode extends AbstractJcrItem implements Node {
     }
 
     /**
-     *
      * @param name the name of the property; may not be null
      * @param value the value of the property; may not be null
      * @param skipReferenceValidation indicates whether constraints on REFERENCE properties should be enforced
@@ -1596,12 +1598,12 @@ abstract class AbstractJcrNode extends AbstractJcrItem implements Node {
             if (existing.getDefinition().getRequiredType() == value.getType()) {
                 // The new value's type and the existing type are the same, so just delegate to the existing JCR property ...
                 try {
-                    //set the property via the public method, so that additional checks are performed
+                    // set the property via the public method, so that additional checks are performed
                     existing.setValue(value);
                 } catch (VersionException e) {
                     if (skipVersioningValidation) {
-                        //the node is checked in, but we should ignore that, so set the property via the protected method
-                        ((JcrSingleValueProperty) existing).setValue(value);
+                        // the node is checked in, but we should ignore that, so set the property via the protected method
+                        ((JcrSingleValueProperty)existing).setValue(value);
                     } else {
                         throw e;
                     }

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrSystemNode.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrSystemNode.java
@@ -28,17 +28,18 @@ import javax.jcr.nodetype.ConstraintViolationException;
 import org.modeshape.jcr.cache.NodeKey;
 
 /**
- *
+ * A Node implementation that is used to represent all nodes within the "/jcr:system" subgraph.
  */
 public class JcrSystemNode extends JcrNode {
 
-    /**
-     * @param session
-     * @param nodeKey
-     */
     JcrSystemNode( JcrSession session,
                    NodeKey nodeKey ) {
         super(session, nodeKey);
+    }
+
+    @Override
+    boolean isSystem() {
+        return true;
     }
 
     @Override

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrVersionHistoryNode.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrVersionHistoryNode.java
@@ -356,7 +356,7 @@ final class JcrVersionHistoryNode extends JcrSystemNode implements VersionHistor
 
     @Override
     public VersionIterator getAllLinearVersions() throws RepositoryException {
-        AbstractJcrNode existingNode = session().getNodeByIdentifier(getVersionableIdentifier());
+        AbstractJcrNode existingNode = session().getNonSystemNodeByIdentifier(getVersionableIdentifier());
         if (existingNode == null) return getAllVersions();
 
         assert existingNode.isNodeType(JcrMixLexicon.VERSIONABLE);
@@ -382,8 +382,8 @@ final class JcrVersionHistoryNode extends JcrSystemNode implements VersionHistor
         try {
             StringBuilder sb = new StringBuilder();
             String versionableId = getVersionableIdentifier();
-            sb.append("Version history for " + session.getNodeByIdentifier(versionableId).location() + " (" + versionableId
-                      + ") stored at " + location() + ":\n");
+            sb.append("Version history for " + session.getNonSystemNodeByIdentifier(versionableId).location() + " ("
+                      + versionableId + ") stored at " + location() + ":\n");
             VersionIterator iter = getAllLinearVersions();
             while (iter.hasNext()) {
                 Version v = iter.nextVersion();

--- a/modeshape-jcr/src/test/java/org/modeshape/jcr/JcrVersioningTest.java
+++ b/modeshape-jcr/src/test/java/org/modeshape/jcr/JcrVersioningTest.java
@@ -441,6 +441,26 @@ public class JcrVersioningTest extends SingleUseAbstractTest {
         }
     }
 
+    @SuppressWarnings( "deprecation" )
+    @Test
+    @FixFor( "MODE-1775" )
+    public void shouldFindVersionNodeByIdentifierAndByUuid() throws Exception {
+        registerNodeTypes(session, "cnd/versioning.cnd");
+
+        // Set up parent node and check it in ...
+        Node parent = session.getRootNode().addNode("versionableNode", "ver:versionable");
+        parent.setProperty("versionProp", "v");
+        parent.setProperty("copyProp", "c");
+        parent.setProperty("ignoreProp", "i");
+        session.save();
+        Version version = versionManager.checkin(parent.getPath());
+
+        // Now look for the version node by identifier, using the different ways to get an identifier ...
+        assertThat(session.getNodeByIdentifier(version.getIdentifier()), is((Node)version));
+        assertThat(session.getNodeByIdentifier(version.getProperty("jcr:uuid").getString()), is((Node)version));
+        assertThat(session.getNodeByUUID(version.getProperty("jcr:uuid").getString()), is((Node)version));
+    }
+
     private void registerNodeTypes( Session session,
                                     String resourcePathToCnd ) throws Exception {
         NodeTypeManager nodeTypes = (NodeTypeManager)session.getWorkspace().getNodeTypeManager();


### PR DESCRIPTION
Improved the method used to look up nodes by string identifier. The logic is now:
- If the identifier is a full node key, use it to look up the node with that key; if not found, continue
- Look for the node in the workspace content, using a key that is the same as the root node key except with the supplied identifier part; if not found, continue
- Look for the node in the system workspace content, using a key that is the same as the "/jcr:system" node except with the supplied identifier part; if not found, throw the ItemNotFoundException from step #2.

The method previously just did steps 1 and 2, so step 3 is what was added. A new test case verifies that the change fixes the original problem.
