### PR TITLE
MODE-1770 Added PESSIMISTIC locking to the default, in-memory Infinispan configuration

### DIFF
--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/LocalEnvironment.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/LocalEnvironment.java
@@ -39,6 +39,7 @@ import org.infinispan.configuration.global.GlobalConfigurationBuilder;
 import org.infinispan.manager.CacheContainer;
 import org.infinispan.manager.DefaultCacheManager;
 import org.infinispan.manager.EmbeddedCacheManager;
+import org.infinispan.transaction.LockingMode;
 import org.infinispan.transaction.TransactionMode;
 import org.infinispan.transaction.lookup.GenericTransactionManagerLookup;
 import org.infinispan.transaction.lookup.TransactionManagerLookup;
@@ -217,6 +218,7 @@ public class LocalEnvironment implements Environment {
         ConfigurationBuilder configurationBuilder = new ConfigurationBuilder();
         configurationBuilder.transaction().transactionMode(TransactionMode.TRANSACTIONAL);
         configurationBuilder.transaction().transactionManagerLookup(transactionManagerLookupInstance());
+        configurationBuilder.transaction().lockingMode(LockingMode.PESSIMISTIC);
         return configurationBuilder.build();
     }
 


### PR DESCRIPTION
The LocalEnvironment class and its [createDefaultConfiguration()](https://github.com/ModeShape/modeshape/blob/db418d6163830608c4a8e764c33f820f374c5a56/modeshape-jcr/src/main/java/org/modeshape/jcr/LocalEnvironment.java#L216) method are used to create the default cache configurations for in-memory content. This method does set up the transactional behavior, but does not set the locking. Therefore, I think it is prudent to add code to this method that sets up the LockingMode of PESSIMISTIC.

Verified that this has no negative effect on the tests.

This should be merged onto '3.1.x' and cherry-picked onto 'master'.
