### PR TITLE
MODE-1783 - Fixed the lack of constraint validation when updating properties

### DIFF
--- a/modeshape-jcr/src/test/resources/cnd/propertyWithConstraint.cnd
+++ b/modeshape-jcr/src/test/resources/cnd/propertyWithConstraint.cnd
@@ -1,0 +1,7 @@
+<jcr='http://www.jcp.org/jcr/1.0'>
+<nt='http://www.jcp.org/jcr/nt/1.0'>
+<mix='http://www.jcp.org/jcr/mix/1.0'>
+<test='http://tempuri.org/test'>
+
+[test:nodeType] > nt:hierarchyNode
+ - test:stringProp (string) mandatory < "\w"


### PR DESCRIPTION
This PR should be merged into 3.1.x and cherry-picked into master.
