### PR TITLE
MODE-1789

### DIFF
--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrI18n.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrI18n.java
@@ -458,7 +458,8 @@ public final class JcrI18n {
 
     public static I18n federationNodeKeyDoesNotBelongToSource;
     public static I18n invalidProjectionPath;
-
+    public static I18n invalidProjectionExpression;
+    
     static {
         try {
             I18n.initialize(JcrI18n.class);

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/RepositoryConfiguration.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/RepositoryConfiguration.java
@@ -2020,7 +2020,7 @@ public class RepositoryConfiguration {
                 	}
                 	externalPath = expressionMatcher.group(7);
                 }else{
-                	throw new IllegalStateException("No match found!");
+                	throw new IllegalStateException(JcrI18n.invalidProjectionExpression.text(pathExpression));
                 }
             }
 

--- a/modeshape-jcr/src/main/resources/org/modeshape/jcr/JcrI18n.properties
+++ b/modeshape-jcr/src/main/resources/org/modeshape/jcr/JcrI18n.properties
@@ -441,3 +441,5 @@ repositoryNotFound = Could not load or find a ModeShape repository named '{0}' u
 
 federationNodeKeyDoesNotBelongToSource = The node key '{0}' does not belong to the '{1}' source. Only nodes from that source are allowed.
 invalidProjectionPath = The path '{0}' is not a valid projection path
+invalidProjectionExpression = The projection expression '{0}' does not match the expected format
+


### PR DESCRIPTION
Execute `match()` not only when assertions are enabled
