### PR TITLE
MODE-1777 Allow for long-running tests to be skipped during normal builds

### DIFF
--- a/modeshape-jcr/src/test/java/org/modeshape/jcr/AbstractJcrRepositoryTest.java
+++ b/modeshape-jcr/src/test/java/org/modeshape/jcr/AbstractJcrRepositoryTest.java
@@ -41,6 +41,7 @@ import javax.jcr.PropertyIterator;
 import javax.jcr.RepositoryException;
 import javax.jcr.Value;
 import javax.jcr.nodetype.NodeType;
+import org.junit.Assume;
 import org.junit.Before;
 import org.modeshape.common.statistic.Stopwatch;
 import org.modeshape.common.util.StringUtil;
@@ -49,6 +50,24 @@ import org.modeshape.jcr.value.Path;
 import org.modeshape.jcr.value.Path.Segment;
 
 public abstract class AbstractJcrRepositoryTest extends AbstractTransactionalTest {
+
+    /**
+     * The value of the "skipLongRunningTests" system property. To use in long-running unit tests that don't have to
+     * be run during developer builds, simply include the following line as the first line in the tests:
+     *
+     * <pre>
+     *    thisLongRunningTestCanBeSkipped();
+     * </pre>
+     */
+    private static final boolean SKIP_LONG_RUNNING_TESTS = Boolean.getBoolean("skipLongRunningTests");
+
+    /**
+     * Signal that the test is long running and can be skipped when the "skipLongRunningTests" environment property
+     * is set to "true".
+     */
+    protected void thisLongRunningTestCanBeSkipped() {
+        Assume.assumeTrue(!SKIP_LONG_RUNNING_TESTS);
+    }
 
     protected boolean print;
 

--- a/modeshape-parent/pom.xml
+++ b/modeshape-parent/pom.xml
@@ -194,7 +194,6 @@
     </contributors>
 
     <properties>
-
         <!-- Used to define the JCR Descriptor value -->
         <jcr.repository.vendor>${project.organization.name}</jcr.repository.vendor>
         <jcr.repository.name>ModeShape</jcr.repository.name>
@@ -430,6 +429,19 @@
             ###################################################################
         -->
 
+        <!-- This profile is active unless the '-DskipLongRunningTests=<boolean>' is specified. -->
+        <profile>
+            <id>skipLongRunningTestsProfile</id>
+            <activation>
+                <property>
+                    <name>!skipLongRunningTests</name>
+                </property>
+            </activation>
+            <properties combine.children="overwrite">
+                <skipLongRunningTests>true</skipLongRunningTests>
+            </properties>
+        </profile>
+
         <!--
               The default test environment is H2
           -->
@@ -646,6 +658,10 @@
                         <property>
                             <name>java.net.preferIPv6Addresses</name>
                             <value>${jgroups.preferIpv6}</value>
+                        </property>
+                        <property>
+                            <name>skipLongRunningTests</name>
+                            <value>${skipLongRunningTests}</value>
                         </property>
                     </systemProperties>
                     <argLine>-Xmx1024M ${debug.argline} -XX:MaxPermSize=256M</argLine>

--- a/pom.xml
+++ b/pom.xml
@@ -59,6 +59,7 @@
 	</properties>
 
 	<profiles>
+
 		<!-- 
 		  This profile is used to run the build plus the JCR TCK tests
 			and must be activated manually, as in "mvn ... -Pjcr-tck ..."

--- a/sequencers/modeshape-sequencer-teiid/src/test/java/org/modeshape/sequencer/teiid/VdbSequencerTest.java
+++ b/sequencers/modeshape-sequencer-teiid/src/test/java/org/modeshape/sequencer/teiid/VdbSequencerTest.java
@@ -425,6 +425,8 @@ public class VdbSequencerTest extends AbstractSequencerTest {
 
     @Test
     public void shouldSequenceVdbBqtVdb() throws Exception {
+        thisLongRunningTestCanBeSkipped();
+
         createNodeWithContentFromFile("vdb/BqtVdb.vdb", "vdb/BqtVdb.vdb");
         Node outputNode = getOutputNode(this.rootNode, "vdbs/BqtVdb.vdb", 60);
         assertNotNull(outputNode);

--- a/sequencers/modeshape-sequencer-teiid/src/test/java/org/modeshape/sequencer/teiid/model/ModelSequencerTest.java
+++ b/sequencers/modeshape-sequencer-teiid/src/test/java/org/modeshape/sequencer/teiid/model/ModelSequencerTest.java
@@ -623,6 +623,8 @@ public class ModelSequencerTest extends AbstractSequencerTest {
 
     @Test
     public void shouldNotSequenceXmlDocumentModelForEmployees() throws Exception {
+        thisLongRunningTestCanBeSkipped();
+
         createNodeWithContentFromFile("EmpDoc.xmi", "model/QuickEmployees/EmpDoc.xmi");
         Node outputNode = getOutputNode(this.rootNode, "models/EmpDoc.xmi");
         assertNull(outputNode);


### PR DESCRIPTION
**_This is a work in progress and not ready to be merged._**

Attempt to skip run long running tests for development but to always run them during assembly (and other full profiles). This doesn't yet work.
