### PR TITLE
MODE-1795 Importing XML should map default XML namespace

### DIFF
--- a/modeshape-jcr-api/src/main/java/org/modeshape/jcr/api/NamespaceRegistry.java
+++ b/modeshape-jcr-api/src/main/java/org/modeshape/jcr/api/NamespaceRegistry.java
@@ -23,7 +23,9 @@
  */
 package org.modeshape.jcr.api;
 
+import javax.jcr.AccessDeniedException;
 import javax.jcr.RepositoryException;
+import javax.jcr.UnsupportedRepositoryOperationException;
 
 /**
  * An extension of JCR 2.0's {@link javax.jcr.NamespaceRegistry} interface, with a few ModeShape-specific enhancements.
@@ -47,5 +49,18 @@ public interface NamespaceRegistry extends javax.jcr.NamespaceRegistry {
      * @throws RepositoryException if another error occurs.
      */
     boolean isRegisteredUri( String uri ) throws RepositoryException;
+
+    /**
+     * Get the prefix for a registered namespace with the supplied URI or, if no such namespace is registered, register it with a
+     * generated prefix and return that prefix.
+     * 
+     * @param uri The URI of the namespace; may not be null
+     * @return the prefix of the already-registered namespace, or the newly-generated prefix if no such namespace was registered
+     * @throws UnsupportedRepositoryOperationException if this repository does not support namespace registry changes.
+     * @throws AccessDeniedException if the current session does not have sufficent access to register the namespace.
+     * @throws RepositoryException if another error occurs.
+     */
+    public String registerNamespace( String uri )
+        throws UnsupportedRepositoryOperationException, AccessDeniedException, RepositoryException;
 
 }

--- a/modeshape-jcr/src/test/java/org/modeshape/jcr/ImportExportTest.java
+++ b/modeshape-jcr/src/test/java/org/modeshape/jcr/ImportExportTest.java
@@ -23,6 +23,21 @@
  */
 package org.modeshape.jcr;
 
+import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.assertNotNull;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsNot.not;
+import static org.hamcrest.core.IsNull.notNullValue;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
 import javax.jcr.ImportUUIDBehavior;
 import javax.jcr.ItemExistsException;
 import javax.jcr.Node;
@@ -32,27 +47,12 @@ import javax.jcr.RepositoryException;
 import javax.jcr.Session;
 import javax.jcr.Value;
 import javax.jcr.nodetype.ConstraintViolationException;
-import static junit.framework.Assert.assertEquals;
-import static junit.framework.Assert.assertNotNull;
-import static org.hamcrest.core.Is.is;
-import static org.hamcrest.core.IsNot.not;
-import static org.hamcrest.core.IsNull.notNullValue;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.modeshape.common.FixFor;
 import org.modeshape.jcr.api.Binary;
 import org.modeshape.jcr.api.JcrTools;
 import org.modeshape.jcr.value.Path;
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
 
 /**
  * Tests of round-trip importing/exporting of repository content.
@@ -66,7 +66,7 @@ public class ImportExportTest extends SingleUseAbstractTest {
 
     private static final String BAD_CHARACTER_STRING = "Test & <Test>*";
 
-    private String expectedIdentifier ="e41075cb-a09a-4910-87b1-90ce8b4ca9dd";
+    private String expectedIdentifier = "e41075cb-a09a-4910-87b1-90ce8b4ca9dd";
 
     private void testImportExport( String sourcePath,
                                    String targetPath,
@@ -969,7 +969,7 @@ public class ImportExportTest extends SingleUseAbstractTest {
         JcrTools tools = new JcrTools();
 
         File binaryFile = new File("src/test/resources/io/binary.pdf");
-        assert(binaryFile.exists() && binaryFile.isFile());
+        assert (binaryFile.exists() && binaryFile.isFile());
 
         File outputFile = File.createTempFile("modeshape_import_export_" + System.currentTimeMillis(), "_test");
         outputFile.deleteOnExit();
@@ -1006,6 +1006,18 @@ public class ImportExportTest extends SingleUseAbstractTest {
         assertNode("/drools:repository/drools:tag_area", "nt:folder");
         assertNode("/drools:repository/drools:state_area", "nt:folder");
         assertNode("/drools:repository/drools.package.migrated", "nt:folder");
+    }
+
+    @FixFor( "MODE-1795" )
+    @Test
+    public void shouldBeAbleToImportXmlFileThatUsesDefaultNamespaceWithNonBlankUri() throws Exception {
+        session.importXML("/",
+                          resourceStream("io/simple-document-view-with-default-namespace.xml"),
+                          ImportUUIDBehavior.IMPORT_UUID_CREATE_NEW);
+
+        // Get the prefix for the namespace used in the imported file ...
+        String prefix = session.getWorkspace().getNamespaceRegistry().getPrefix("http://www.ns.com");
+        assertNode("/" + prefix + ":childNode", "nt:unstructured");
     }
 
     // ----------------------------------------------------------------------------------------------------------------

--- a/modeshape-jcr/src/test/resources/io/simple-document-view-with-default-namespace.xml
+++ b/modeshape-jcr/src/test/resources/io/simple-document-view-with-default-namespace.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<jcr:root xmlns="http://www.ns.com" xmlns:jcr="http://www.jcp.org/jcr/1.0">
+    <childNode jcr:primaryType="nt:unstructured"/>
+</jcr:root>


### PR DESCRIPTION
When importing XML, any XML namespaces should be used, even if the prefix for the XML namespace matches an existing namespace prefix. Per Section 11.1 of the JSR-283 specification, an existing JCR namespace should be used if its URL matches the XML namespace URI. If there is no existing JCR namespace matching the XML namespace URI, then the namespace should be registered using the XML namespace prefix if not already used or a generated prefix if the XML namespace prefix is already used.

A new unit test case was added to verify the behavior.

This pull request should be merged onto the '3.1.x' branch and cherry-picked to the 'master' branch. See the [related pull-request](https://github.com/ModeShape/modeshape/pull/680) for the changes to the '2.x' branch.
