### PR TITLE
MODE-1795 Importing XML should map default XML namespace

### DIFF
--- a/modeshape-jcr-api/src/main/java/org/modeshape/jcr/api/NamespaceRegistry.java
+++ b/modeshape-jcr-api/src/main/java/org/modeshape/jcr/api/NamespaceRegistry.java
@@ -1,0 +1,48 @@
+/*
+ * ModeShape (http://www.modeshape.org)
+ * See the COPYRIGHT.txt file distributed with this work for information
+ * regarding copyright ownership.  Some portions may be licensed
+ * to Red Hat, Inc. under one or more contributor license agreements.
+ * See the AUTHORS.txt file in the distribution for a full listing of 
+ * individual contributors.
+ *
+ * ModeShape is free software. Unless otherwise indicated, all code in ModeShape
+ * is licensed to you under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ * 
+ * ModeShape is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.modeshape.jcr.api;
+
+import javax.jcr.AccessDeniedException;
+import javax.jcr.RepositoryException;
+import javax.jcr.UnsupportedRepositoryOperationException;
+
+/**
+ * An extension of JCR 2.0's {@link javax.jcr.NamespaceRegistry} interface, with a few ModeShape-specific enhancements.
+ */
+public interface NamespaceRegistry extends javax.jcr.NamespaceRegistry {
+
+    /**
+     * Get the prefix for a registered namespace with the supplied URI or, if no such namespace is registered, register it with a
+     * generated prefix and return that prefix.
+     * 
+     * @param uri The URI of the namespace; may not be null
+     * @return the prefix of the already-registered namespace, or the newly-generated prefix if no such namespace was registered
+     * @throws UnsupportedRepositoryOperationException if this repository does not support namespace registry changes.
+     * @throws AccessDeniedException if the current session does not have sufficent access to register the namespace.
+     * @throws RepositoryException if another error occurs.
+     */
+    public String registerNamespace( String uri )
+        throws UnsupportedRepositoryOperationException, AccessDeniedException, RepositoryException;
+
+}

--- a/modeshape-jcr/src/test/java/org/modeshape/jcr/ImportExportTest.java
+++ b/modeshape-jcr/src/test/java/org/modeshape/jcr/ImportExportTest.java
@@ -23,7 +23,6 @@
  */
 package org.modeshape.jcr;
 
-import javax.jcr.Binary;
 import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertNotNull;
 import static junit.framework.Assert.assertTrue;
@@ -43,6 +42,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import javax.jcr.Binary;
 import javax.jcr.Credentials;
 import javax.jcr.ImportUUIDBehavior;
 import javax.jcr.Node;
@@ -424,7 +424,7 @@ public class ImportExportTest {
         JcrTools tools = new JcrTools();
 
         File binaryFile = new File("src/test/resources/io/binary.pdf");
-        assert(binaryFile.exists() && binaryFile.isFile());
+        assert (binaryFile.exists() && binaryFile.isFile());
 
         File outputFile = File.createTempFile("modeshape_import_export_" + System.currentTimeMillis(), "_test");
         outputFile.deleteOnExit();
@@ -444,6 +444,18 @@ public class ImportExportTest {
         Binary binary = data.getBinary();
         assertNotNull(binary);
         assertEquals(binaryFile.length(), binary.getSize());
+    }
+
+    @FixFor( "MODE-1795" )
+    @Test
+    public void shouldBeAbleToImportXmlFileThatUsesDefaultNamespaceWithNonBlankUri() throws Exception {
+        importFile("/", "io/simple-document-view-with-default-namespace.xml", ImportUUIDBehavior.IMPORT_UUID_COLLISION_THROW);
+
+        // Get the prefix for the namespace used in the imported file ...
+        new JcrTools().printSubgraph(session.getRootNode(), 2);
+        String prefix = session.getWorkspace().getNamespaceRegistry().getPrefix("http://www.ns.com");
+        assertNotNull(session.getNode("/" + prefix + ":childNode"));
+        assertNotNull(session.getNode("/" + prefix + ":childNode").getPrimaryNodeType().getName(), is("nt:unstructured"));
     }
 
     protected void assertSameProperties( Node node1,

--- a/modeshape-jcr/src/test/resources/io/simple-document-view-with-default-namespace.xml
+++ b/modeshape-jcr/src/test/resources/io/simple-document-view-with-default-namespace.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<jcr:root xmlns="http://www.ns.com" xmlns:jcr="http://www.jcp.org/jcr/1.0">
+    <childNode jcr:primaryType="nt:unstructured"/>
+</jcr:root>


### PR DESCRIPTION
When importing XML, any XML namespaces should be used, even if the prefix for the XML namespace matches an existing namespace prefix. Per Section 11.1 of the JSR-283 specification, an existing JCR namespace should be used if its URL matches the XML namespace URI. If there is no existing JCR namespace matching the XML namespace URI, then the namespace should be registered using the XML namespace prefix if not already used or a generated prefix if the XML namespace prefix is already used.

A new unit test case was added to verify the behavior.

(See the [related pull-request](https://github.com/ModeShape/modeshape/pull/679) for the changes to the 'master' and '3.1.x' branch.)
