### PR TITLE
MODE-1800 - Added the node primary type as information to the newDocumentId() method, giving connector implementations an additional piece of information.

### DIFF
--- a/modeshape-jcr/src/main/java/org/modeshape/connector/filesystem/FileSystemConnector.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/connector/filesystem/FileSystemConnector.java
@@ -539,7 +539,8 @@ public class FileSystemConnector extends Connector {
 
     @Override
     public String newDocumentId( String parentId,
-                                 Name newDocumentName ) {
+                                 Name newDocumentName,
+                                 Name newDocumentPrimaryType ) {
         return parentId + DELIMITER + newDocumentName.getString();
     }
 

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/AbstractJcrNode.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/AbstractJcrNode.java
@@ -1052,7 +1052,7 @@ abstract class AbstractJcrNode extends AbstractJcrItem implements Node {
 
         //If there isn't a desired key, check if the document store doesn't require a certain key format (this is especially used by federation)
         if (desiredKey == null) {
-            String documentStoreKey = session().repository().documentStore().newDocumentKey(key().toString(), childName);
+            String documentStoreKey = session().repository().documentStore().newDocumentKey(key().toString(), childName, childPrimaryNodeTypeName);
             if (documentStoreKey != null) {
                 desiredKey = new NodeKey(documentStoreKey);
             }

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/document/DocumentStore.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/document/DocumentStore.java
@@ -75,13 +75,16 @@ public interface DocumentStore {
     /**
      * Generates a new key which will be assigned to a new child document when it is being added to its parent.
      *
+     *
      * @param parentKey a {@code non-null} {@link String}, the key of the existing parent
-     * @param documentName {@code non-null} {@link Name}, the name of the new child document.
+     * @param documentName {@code non-null} {@link org.modeshape.jcr.value.Name}, the name of the new child document.
+     * @param documentPrimaryType {@code non-null} {@link org.modeshape.jcr.value.Name}, the name of the primary type of the new child document
      * @return a {@link String} which will be assigned as key to the new child, or {@code null} indicating that no preferred key
      * is to be used. If this is the case, the repository will assign a random key.
      */
     public String newDocumentKey( String parentKey,
-                                  Name documentName );
+                                  Name documentName,
+                                  Name documentPrimaryType );
 
     /**
      * Return whether {@link #prepareDocumentsForUpdate(Collection)} should be called before updating the documents.

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/document/LocalDocumentStore.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/document/LocalDocumentStore.java
@@ -79,7 +79,8 @@ public class LocalDocumentStore implements DocumentStore {
 
     @Override
     public String newDocumentKey( String parentKey,
-                                  Name documentName ) {
+                                  Name documentName,
+                                  Name documentPrimaryType ) {
         //the local store doesn't generate explicit keys for new nodes
         return null;
     }

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/federation/FederatedDocumentStore.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/federation/FederatedDocumentStore.java
@@ -103,14 +103,15 @@ public class FederatedDocumentStore implements DocumentStore {
 
     @Override
     public String newDocumentKey( String parentKey,
-                                  Name documentName ) {
+                                  Name documentName,
+                                  Name documentPrimaryType ) {
         if (isLocalSource(parentKey)) {
-            return localStore().newDocumentKey(parentKey, documentName);
+            return localStore().newDocumentKey(parentKey, documentName, null);
         }
         Connector connector = connectors.getConnectorForSourceKey(sourceKey(parentKey));
         if (connector != null) {
             String parentDocumentId = documentIdFromNodeKey(parentKey);
-            String newChildId = connector.newDocumentId(parentDocumentId, documentName);
+            String newChildId = connector.newDocumentId(parentDocumentId, documentName, documentPrimaryType);
             if (!StringUtil.isBlank(newChildId)) {
                 return documentIdToNodeKey(connector.getSourceName(), newChildId).toString();
             }

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/federation/spi/Connector.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/federation/spi/Connector.java
@@ -384,14 +384,16 @@ public abstract class Connector {
      *
      * @param parentId a {@code non-null} {@link String} which represents the identifier of the parent under which the new document
      * will be created.
-     * @param newDocumentName a {@code non-null} {@link Name} which represents the name that will be given to the child document
+     * @param newDocumentName a {@code non-null} {@link org.modeshape.jcr.value.Name} which represents the name that will be given to the child document
+     * @param newDocumentPrimaryType a {@code non-null} {@link org.modeshape.jcr.value.Name} which represents the child document's primary type.
      * @return either a {@code non-null} {@link String} which will be assigned as the new identifier, or {@code null} which means
      * that no "special" id format is required. In this last case, the repository will auto-generate a random id.
      *
      * @throws org.modeshape.jcr.cache.DocumentStoreException if the connector is readonly.
      */
     public abstract String newDocumentId( String parentId,
-                                          Name newDocumentName );
+                                          Name newDocumentName,
+                                          Name newDocumentPrimaryType );
 
     /**
      * Utility method that checks whether the field with the supplied name is set.

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/federation/spi/ReadOnlyConnector.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/federation/spi/ReadOnlyConnector.java
@@ -59,7 +59,8 @@ public abstract class ReadOnlyConnector extends Connector {
 
     @Override
     public String newDocumentId( String parentId,
-                                 Name newDocumentName ) {
+                                 Name newDocumentName,
+                                 Name newDocumentPrimaryType ) {
         throw new DocumentStoreException(JcrI18n.connectorIsReadOnly.text(getSourceName(), newDocumentName));
     }
 }

--- a/modeshape-jcr/src/test/java/org/modeshape/connector/mock/MockConnector.java
+++ b/modeshape-jcr/src/test/java/org/modeshape/connector/mock/MockConnector.java
@@ -207,7 +207,8 @@ public class MockConnector extends Connector implements Pageable {
 
     @Override
     public String newDocumentId( String parentId,
-                                 Name newDocumentName ) {
+                                 Name newDocumentName,
+                                 Name newDocumentPrimaryType ) {
         return null;
     }
 


### PR DESCRIPTION
Should be merged into 3.1.x and cherry-picked into master.
