### PR TITLE
MODE-1806 - Changed the way the projections are stored/removed 

### DIFF
--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/Connectors.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/Connectors.java
@@ -26,15 +26,11 @@ package org.modeshape.jcr;
 
 import java.io.IOException;
 import java.lang.reflect.Method;
-import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import javax.jcr.NamespaceRegistry;
 import javax.jcr.PathNotFoundException;
 import javax.jcr.RepositoryException;
@@ -70,6 +66,8 @@ import org.modeshape.jcr.value.PropertyFactory;
  */
 public class Connectors {
 
+    private static final Logger LOGGER = Logger.getLogger(Connectors.class);
+
     private final JcrRepository.RunningState repository;
     private final Logger logger;
 
@@ -86,14 +84,9 @@ public class Connectors {
     private Map<String, List<RepositoryConfiguration.ProjectionConfiguration>> preconfiguredProjections = new HashMap<String, List<RepositoryConfiguration.ProjectionConfiguration>>();
 
     /**
-     * A map of (externalNodeKey, Projection) instances holds the projections
+     * A map of (externalNodeKey, Projection) instances holds the existing projections in-memory
      */
     private Map<String, Projection> projections;
-
-    /**
-     * A set of (externalNodeKey) containing the keys of the projections that have been removed and should be cleaned up
-     */
-    private Set<String> removedProjections = new HashSet<String>();
 
     protected Connectors( JcrRepository.RunningState repository,
                        Collection<Component> components,
@@ -143,8 +136,7 @@ public class Connectors {
 
                     AbstractJcrNode node = session.getNode(repositoryPath);
                     //only create the projectionCfg if one doesn't exist with the same alias
-                    if (!projectionExists(alias, node.key().toString())) {
-                        checkRepositoryPathDoesNotExist(session, projectionCfg);
+                    if (!projectionExists(alias, node.key().toString()) && !projectedPathExists(session, projectionCfg)) {
                         federationManager.createProjection(repositoryPath, projectionCfg.getSourceName(),
                                                            projectionCfg.getExternalPath(),
                                                            alias);
@@ -156,13 +148,14 @@ public class Connectors {
         }
     }
 
-    private void checkRepositoryPathDoesNotExist( JcrSession session,
-                                                  RepositoryConfiguration.ProjectionConfiguration projection ) throws RepositoryException {
+    private boolean projectedPathExists( JcrSession session,
+                                         RepositoryConfiguration.ProjectionConfiguration projectionCfg ) throws RepositoryException {
         try {
-            session.getNode(projection.getProjectedPath());
-            throw new RepositoryException(JcrI18n.projectedPathPointsTowardsInternalNode.text(projection.getProjectedPath()));
+            session.getNode(projectionCfg.getProjectedPath());
+            LOGGER.warn(JcrI18n.projectedPathPointsTowardsInternalNode, projectionCfg, projectionCfg.getSourceName(), projectionCfg.getProjectedPath());
+            return true;
         } catch (PathNotFoundException e) {
-            //expected
+            return false;
         }
     }
 
@@ -182,15 +175,13 @@ public class Connectors {
 
         CachedNode systemNode = getSystemNode(systemSession);
         ChildReference federationNodeRef = systemNode.getChildReferences(systemSession).getChild(ModeShapeLexicon.FEDERATION);
-        this.projections = federationNodeRef != null ? storedProjections(systemSession,
-                                                                         federationNodeRef,
-                                                                         Collections.<String>emptySet())
+        this.projections = federationNodeRef != null ? loadStoredProjections(systemSession,
+                                                                             federationNodeRef)
                                                      : new HashMap<String, Projection>();
     }
 
-    private Map<String, Projection> storedProjections( SessionCache systemSession,
-                                                       ChildReference federationNodeRef,
-                                                       Set<String> projectionsToRemove ) {
+    private Map<String, Projection> loadStoredProjections( SessionCache systemSession,
+                                                           ChildReference federationNodeRef ) {
         CachedNode federationNode = systemSession.getNode(federationNodeRef.getKey());
         ChildReferences federationChildRefs = federationNode.getChildReferences(systemSession);
         //the stored projection mappings use SNS
@@ -204,10 +195,7 @@ public class Connectors {
             String externalNodeKey = projection.getProperty(ModeShapeLexicon.EXTERNAL_NODE_KEY, systemSession).getFirstValue()
                                                .toString();
             assert externalNodeKey != null;
-            if (projectionsToRemove.contains(externalNodeKey)) {
-                systemSession.destroy(projectionRefKey);
-                continue;
-            }
+
             String projectedNodeKey = projection.getProperty(ModeShapeLexicon.PROJECTED_NODE_KEY, systemSession).getFirstValue()
                                                 .toString();
             assert projectedNodeKey != null;
@@ -274,7 +262,46 @@ public class Connectors {
     public void addProjection( String externalNodeKey,
                                String projectedNodeKey,
                                String alias ) {
-        projections.put(externalNodeKey, new Projection(externalNodeKey, projectedNodeKey, alias));
+        Projection projection = new Projection(externalNodeKey, projectedNodeKey, alias);
+        projections.put(externalNodeKey, projection);
+        storeProjection(projection);
+    }
+
+    private void storeProjection( Projection projection ) {
+        PropertyFactory propertyFactory = repository.context().getPropertyFactory();
+
+        //we need to store the projection mappings so that we don't loose that information
+        SessionCache systemSession = repository.createSystemSession(repository.context(), false);
+        NodeKey systemNodeKey = getSystemNode(systemSession).getKey();
+        MutableCachedNode systemNode = systemSession.mutable(systemNodeKey);
+        ChildReference federationNodeRef = systemNode.getChildReferences(systemSession).getChild(ModeShapeLexicon.FEDERATION);
+
+        if (federationNodeRef == null) {
+            //there isn't a federation node present, so we need to add it
+            try {
+                Property primaryType = propertyFactory.create(JcrLexicon.PRIMARY_TYPE, ModeShapeLexicon.FEDERATION);
+                systemNode.createChild(systemSession, systemNodeKey.withId("mode:federation"),
+                                       ModeShapeLexicon.FEDERATION, primaryType);
+                systemSession.save();
+                federationNodeRef = systemNode.getChildReferences(systemSession).getChild(ModeShapeLexicon.FEDERATION);
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        NodeKey federationNodeKey = federationNodeRef.getKey();
+        MutableCachedNode federationNode = systemSession.mutable(federationNodeKey);
+
+        Property primaryType = propertyFactory.create(JcrLexicon.PRIMARY_TYPE, ModeShapeLexicon.PROJECTION);
+        Property externalNodeKeyProp = propertyFactory.create(ModeShapeLexicon.EXTERNAL_NODE_KEY, projection.getExternalNodeKey());
+
+        Property projectedNodeKeyProp = propertyFactory.create(ModeShapeLexicon.PROJECTED_NODE_KEY,
+                                                               projection.getProjectedNodeKey());
+        Property alias = propertyFactory.create(ModeShapeLexicon.PROJECTION_ALIAS, projection.getAlias());
+        federationNode.createChild(systemSession, federationNodeKey.withRandomId(), ModeShapeLexicon.PROJECTION,
+                                   primaryType, externalNodeKeyProp, projectedNodeKeyProp, alias);
+
+        systemSession.save();
     }
 
     /**
@@ -297,7 +324,8 @@ public class Connectors {
     public void externalNodeRemoved( String externalNodeKey ) {
         Projection removedProjection = projections.remove(externalNodeKey);
         if (removedProjection != null) {
-            removedProjections.add(externalNodeKey);
+            //the external node was the root of a projection, so we need to remove that projection
+            removeStoredProjection(externalNodeKey);
         }
     }
 
@@ -306,18 +334,46 @@ public class Connectors {
      *
      * @param internalNodeKey a {@code non-null} String
      */
-    public void internalNodeRemoved (String internalNodeKey) {
-        List<String> externalNodeKeysToRemove = new ArrayList<String>();
-        for (Projection projection : projections.values()) {
+    public void internalNodeRemoved( String internalNodeKey ) {
+        //identify all the projections which from this internal (aka. federated node) and remove them
+        for (Iterator<Map.Entry<String, Projection>> projectionsIt = projections.entrySet().iterator(); projectionsIt.hasNext();) {
+            Projection projection = projectionsIt.next().getValue();
             if (internalNodeKey.equalsIgnoreCase(projection.getProjectedNodeKey())) {
                 String externalNodeKey = projection.getExternalNodeKey();
-                externalNodeKeysToRemove.add(externalNodeKey);
-                removedProjections.add(externalNodeKey);
+                removeStoredProjection(externalNodeKey);
+                projectionsIt.remove();
             }
         }
+    }
 
-        for (String externalNodeKeyToRemove : externalNodeKeysToRemove) {
-            projections.remove(externalNodeKeyToRemove);
+    private void removeStoredProjection(String externalNodeKey) {
+        SessionCache systemSession = repository.createSystemSession(repository.context(), false);
+        NodeKey systemNodeKey = getSystemNode(systemSession).getKey();
+        MutableCachedNode systemNode = systemSession.mutable(systemNodeKey);
+        ChildReference federationNodeRef = systemNode.getChildReferences(systemSession).getChild(ModeShapeLexicon.FEDERATION);
+
+        //if we're removing a projection, one had to be stored previously, so there should be a federation node present
+        assert federationNodeRef != null;
+
+        NodeKey federationNodeKey = federationNodeRef.getKey();
+        MutableCachedNode federationNode = systemSession.mutable(federationNodeKey);
+        ChildReferences federationChildRefs = federationNode.getChildReferences(systemSession);
+
+        int projectionsCount = federationChildRefs.getChildCount(ModeShapeLexicon.PROJECTION);
+
+        for (int i = 1; i <= projectionsCount; i++) {
+            ChildReference projectionRef = federationChildRefs.getChild(ModeShapeLexicon.PROJECTION, i);
+            NodeKey projectionRefKey = projectionRef.getKey();
+            CachedNode storedProjection = systemSession.getNode(projectionRefKey);
+            String storedProjectionExternalNodeKey = storedProjection.getProperty(ModeShapeLexicon.EXTERNAL_NODE_KEY, systemSession).getFirstValue()
+                                                                     .toString();
+            assert storedProjectionExternalNodeKey != null;
+            if (storedProjectionExternalNodeKey.equals(externalNodeKey)) {
+                federationNode.removeChild(systemSession, projectionRefKey);
+                systemSession.destroy(projectionRefKey);
+                systemSession.save();
+                break;
+            }
         }
     }
 
@@ -443,12 +499,8 @@ public class Connectors {
         if (!initialized || !hasConnectors()) {
             return;
         }
-
-        storeProjections();
         shutdownConnectors();
-
         projections.clear();
-        removedProjections.clear();
     }
 
     private void shutdownConnectors() {
@@ -457,57 +509,6 @@ public class Connectors {
         }
         sourceKeyToConnectorMap.clear();
         sourceKeyToConnectorMap = null;
-    }
-
-    private void storeProjections() {
-        if (projections.isEmpty()) {
-            return;
-        }
-
-        PropertyFactory propertyFactory = repository.context().getPropertyFactory();
-
-        //we need to store the projection mappings so that we don't loose that information
-        SessionCache systemSession = repository.createSystemSession(repository.context(), false);
-        NodeKey systemNodeKey = getSystemNode(systemSession).getKey();
-        MutableCachedNode systemNode = systemSession.mutable(systemNodeKey);
-        ChildReference federationNodeRef = systemNode.getChildReferences(systemSession).getChild(ModeShapeLexicon.FEDERATION);
-
-        if (federationNodeRef == null) {
-            //there isn't a federation node present, so we need to add it
-            try {
-                Property primaryType = propertyFactory.create(JcrLexicon.PRIMARY_TYPE, ModeShapeLexicon.FEDERATION);
-                systemNode.createChild(systemSession, systemNodeKey.withId("mode:federation"),
-                                       ModeShapeLexicon.FEDERATION, primaryType);
-                systemSession.save();
-                federationNodeRef = systemNode.getChildReferences(systemSession).getChild(ModeShapeLexicon.FEDERATION);
-            } catch (Exception e) {
-                logger.debug("Cannot create federation node", e);
-                return;
-            }
-        }
-
-        //we need to remove from the current map the ones which are already stored
-        Map<String, Projection> existingStoredProjections = storedProjections(systemSession, federationNodeRef, this.removedProjections);
-        for (String storedExternalNodeKey : existingStoredProjections.keySet()) {
-            projections.remove(storedExternalNodeKey);
-        }
-
-        //the ones that remained in the map are new projection ids that we need to store
-        NodeKey federationNodeKey = federationNodeRef.getKey();
-        MutableCachedNode federationNode = systemSession.mutable(federationNodeKey);
-        //iterate the existing mapping and save
-        for (String externalNodeKey : projections.keySet()) {
-            Property primaryType = propertyFactory.create(JcrLexicon.PRIMARY_TYPE, ModeShapeLexicon.PROJECTION);
-            Property externalNodeKeyProp = propertyFactory.create(ModeShapeLexicon.EXTERNAL_NODE_KEY, externalNodeKey);
-
-            Projection projection = projections.get(externalNodeKey);
-            Property projectedNodeKeyProp = propertyFactory.create(ModeShapeLexicon.PROJECTED_NODE_KEY,
-                                                                   projection.getProjectedNodeKey());
-            Property alias = propertyFactory.create(ModeShapeLexicon.PROJECTION_ALIAS, projection.getAlias());
-            federationNode.createChild(systemSession, federationNodeKey.withRandomId(), ModeShapeLexicon.PROJECTION,
-                                       primaryType, externalNodeKeyProp, projectedNodeKeyProp, alias);
-        }
-        systemSession.save();
     }
 
     /**

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/RepositoryConfiguration.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/RepositoryConfiguration.java
@@ -2100,6 +2100,7 @@ public class RepositoryConfiguration {
         private final String workspaceName;
         private final String externalPath;
         private final String sourceName;
+        private final String pathExpression;
 
         private String projectedPath;
 
@@ -2113,6 +2114,7 @@ public class RepositoryConfiguration {
             Matcher expressionMatcher = PROJECTION_PATH_EXPRESSION_PATTERN.matcher(pathExpression);
             // should be validated by the repository schema
             if (expressionMatcher.matches()) {
+                this.pathExpression = pathExpression;
                 this.sourceName = sourceName;
                 workspaceName = expressionMatcher.group(1);
                 projectedPath = expressionMatcher.group(2);
@@ -2177,6 +2179,11 @@ public class RepositoryConfiguration {
          */
         public String getSourceName() {
             return sourceName;
+        }
+
+        @Override
+        public String toString() {
+            return pathExpression;
         }
     }
 

--- a/modeshape-jcr/src/main/resources/org/modeshape/jcr/JcrI18n.properties
+++ b/modeshape-jcr/src/main/resources/org/modeshape/jcr/JcrI18n.properties
@@ -443,7 +443,7 @@ repositoryNotFound = Could not load or find a ModeShape repository named '{0}' u
 federationNodeKeyDoesNotBelongToSource = The node key '{0}' does not belong to the '{1}' source. Only nodes from that source are allowed.
 invalidProjectionPath = The path '{0}' is not a valid projection path
 invalidProjectionExpression = The projection expression '{0}' does not match the expected format
-projectedPathPointsTowardsInternalNode = The projected path: '{0}' points towards an existing, internal node. You need to provide a name for the new projection by changing the path to '{0}'/<name>.
+projectedPathPointsTowardsInternalNode = Ignoring configured projection '{0}' for source '{1}' because the projected path '{2}' points towards an existing, internal node.
 
 reindexMissingNoIndexesExist = Re-indexing only missing indexes for repository {0}. Since no indexes exist, all content will be re-indexed.
 noReindex = Index rebuild mode for repository {0} is 'never' and there aren't any indexes. Any content which already exists will not be available to queries.

--- a/modeshape-jcr/src/test/java/org/modeshape/jcr/FederationConfigurationTest.java
+++ b/modeshape-jcr/src/test/java/org/modeshape/jcr/FederationConfigurationTest.java
@@ -27,13 +27,13 @@ import java.io.InputStream;
 import java.util.UUID;
 import javax.jcr.Node;
 import javax.jcr.NodeIterator;
-import javax.jcr.RepositoryException;
 import javax.jcr.Session;
 import org.junit.Test;
 import org.modeshape.common.FixFor;
 import org.modeshape.common.util.FileUtil;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsNull.notNullValue;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 
@@ -86,11 +86,14 @@ public class FederationConfigurationTest extends SingleUseAbstractTest {
         }
     }
 
-    @Test( expected = RepositoryException.class )
-    @FixFor( "MODE-1798" )
-    public void shouldNotAllowPreconfiguredProjectionIfAliasNotProvided() throws Exception {
-        //we expect this to fail because there is already an internal node that is supposed to be used as an alias as well
+    @Test
+    public void shouldIgnorePreconfiguredProjectionIfProjectedPathPointsTowardsInternalNode() throws Exception {
         startRepositoryWithConfiguration(resource("config/repo-config-filesystem-federation-invalid-alias.json"));
+        //check that there only the internal node + 1 child and that the projection has not been created
+        Session session = session();
+        Node federation = session.getNode("/federation");
+        assertEquals(1, federation.getNodes().getSize());
+        assertNotNull(session.getNode("/federation/fs"));
     }
 
     @Override


### PR DESCRIPTION
...so that the information is persisted each time into the repository. This way there shouldn't be any problems if the shutdown of the repository isn't orderly.

Also, if an internal node exists with a given alias, instead of raising an exception only a WARN will be logged.

Should be merged in 3.1.x and cherry-picked in master.
