### PR TITLE
MODE-1811 - Fixed the InfinispanBinaryStore not being able to load a class from modeshape-jcr, by making that class available in the AS 7.1.1 kit to the org.infinispan.main module.

### DIFF
--- a/deploy/jbossas/kit/jboss-as71/modules/org/infinispan/main/module.xml
+++ b/deploy/jbossas/kit/jboss-as71/modules/org/infinispan/main/module.xml
@@ -23,7 +23,12 @@
 <module xmlns="urn:jboss:module:1.1" name="org.infinispan">
     <resources>
         <resource-root path="infinispan-core-${infinispan.version}.jar"/>
+        <!--
+            The following artifacts and paths are hacks necessary for AS 7.1.1 and ISPN 5.1.x, which need to be able to access
+            classes from the ModeShape module.
+        -->
         <resource-root path="modeshape-schematic-${project.version}.jar" />
+        <resource-root path="classes" />
     </resources>
 
     <dependencies>

--- a/modeshape-assembly-descriptors/src/main/resources/assemblies/jbossas-71-distribution.xml
+++ b/modeshape-assembly-descriptors/src/main/resources/assemblies/jbossas-71-distribution.xml
@@ -43,6 +43,17 @@
             <outputDirectory>standalone/deployments/modeshape-cmis.war</outputDirectory>
         </fileSet>
 
+        <!--
+         TODO author=Horia Chiorean date=2/14/13 description=MODE-1811 - Hack to allow Infinispan to access a classes from modeshape
+     -->
+        <fileSet>
+            <directory>../modeshape-jcr/${project.build.outputDirectory}</directory>
+            <includes>
+                <include>**/Metadata.class</include>
+            </includes>
+            <outputDirectory>modules/org/infinispan/main/classes</outputDirectory>
+        </fileSet>
+
     </fileSets>
 	
 	<dependencySets>
@@ -257,7 +268,7 @@
         </dependencySet>
 
         <!--
-            //TODO author=Horia Chiorean date=6/22/12 description=MODE-1534 - This is a temporary workaround because of the schematic Module for Infinispan
+            TODO author=Horia Chiorean date=6/22/12 description=MODE-1534 - This is a temporary workaround because of the schematic Module for Infinispan
         -->
 		<dependencySet>
             <useProjectArtifact>false</useProjectArtifact>


### PR DESCRIPTION
Should be merged in 3.1.x and cherry-picked in master.
