### PR TITLE
MODE-1816 The jcr:mixinTypes properties should not need to be first in the JSON requests

### DIFF
--- a/modeshape-jcr/src/test/java/org/modeshape/connector/filesystem/FileSystemConnectorTest.java
+++ b/modeshape-jcr/src/test/java/org/modeshape/connector/filesystem/FileSystemConnectorTest.java
@@ -39,7 +39,6 @@ import org.modeshape.common.util.IoUtil;
 import org.modeshape.jcr.SingleUseAbstractTest;
 import org.modeshape.jcr.api.Session;
 import org.modeshape.jcr.api.federation.FederationManager;
-import org.modeshape.jcr.federation.spi.ConnectorException;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;

--- a/web/modeshape-web-jcr-rest-war/pom.xml
+++ b/web/modeshape-web-jcr-rest-war/pom.xml
@@ -35,6 +35,13 @@
             <artifactId>modeshape-jcr</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.modeshape</groupId>
+            <artifactId>modeshape-common</artifactId>
+            <type>test-jar</type>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
         </dependency>

--- a/web/modeshape-web-jcr-rest-war/src/test/java/org/modeshape/web/jcr/rest/ModeShapeRestServiceTest.java
+++ b/web/modeshape-web-jcr-rest-war/src/test/java/org/modeshape/web/jcr/rest/ModeShapeRestServiceTest.java
@@ -32,6 +32,7 @@ import java.io.ByteArrayOutputStream;
 import javax.ws.rs.core.MediaType;
 import org.junit.Ignore;
 import org.junit.Test;
+import org.modeshape.common.FixFor;
 import org.modeshape.common.util.IoUtil;
 import org.modeshape.web.jcr.rest.handler.RestBinaryHandler;
 
@@ -232,6 +233,14 @@ public class ModeShapeRestServiceTest extends JcrResourcesTest {
         return "v2/query/query_result_jcrSql2.json";
     }
 
+    protected String nodeWithMixinAfterPropsRequest() {
+        return "v2/post/node_with_mixin_after_props_request.json";
+    }
+
+    protected String nodeWithMixinAfterPropsResponse() {
+        return "v2/post/node_with_mixin_after_props_response.json";
+    }
+
     @Override
     @Ignore( "Ignored because the deprecated parameter isn't supported anymore" )
     public void shouldRetrieveRootNodeWhenDeprecatedDepthSet() throws Exception {
@@ -415,5 +424,13 @@ public class ModeShapeRestServiceTest extends JcrResourcesTest {
         // Delete by ID ...
         response = doDelete(nodesUrl(id)).isDeleted();
         // System.out.println("**** GET-BY-ID: \n" + response);
+    }
+
+    @Test
+    @FixFor( "MODE-1816" )
+    public void shouldAllowPostingNodeWithMixinAndPrimaryTypesPropertiesAfterProperties() throws Exception {
+        doPost(nodeWithMixinAfterPropsRequest(), itemsUrl(TEST_NODE)).isCreated()
+                                                                     .isJSONObjectLikeFile(nodeWithMixinAfterPropsResponse());
+        doGet(itemsUrl(TEST_NODE)).isOk().isJSONObjectLikeFile(nodeWithMixinAfterPropsResponse());
     }
 }

--- a/web/modeshape-web-jcr-rest-war/src/test/resources/v2/post/node_with_mixin_after_props_request.json
+++ b/web/modeshape-web-jcr-rest-war/src/test/resources/v2/post/node_with_mixin_after_props_request.json
@@ -1,0 +1,5 @@
+{
+    "jcr:title" : "This is a title",
+    "jcr:primaryType" : "nt:folder",
+    "jcr:mixinTypes":"mix:title"
+}

--- a/web/modeshape-web-jcr-rest-war/src/test/resources/v2/post/node_with_mixin_after_props_response.json
+++ b/web/modeshape-web-jcr-rest-war/src/test/resources/v2/post/node_with_mixin_after_props_response.json
@@ -1,0 +1,7 @@
+{
+    "self":"http://localhost:8090/resources/repo/default/items/testNode",
+    "up":"http://localhost:8090/resources/repo/default/items/",
+    "jcr:title" : "This is a title",
+    "jcr:primaryType" : "nt:folder",
+    "jcr:mixinTypes":"mix:title"
+}

--- a/web/modeshape-web-jcr-rest/src/main/java/org/modeshape/web/jcr/rest/handler/ItemHandler.java
+++ b/web/modeshape-web-jcr-rest/src/main/java/org/modeshape/web/jcr/rest/handler/ItemHandler.java
@@ -321,10 +321,16 @@ public class ItemHandler extends AbstractHandler {
             newNode = parentNode.addNode(nodeName);
         }
 
+        if (properties.has(MIXIN_TYPES_PROPERTY)) {
+            // Be sure to set this property first, before the other properties in case the other properties
+            // are defined only on one of the mixin types ...
+            setPropertyOnNode(newNode, MIXIN_TYPES_PROPERTY, properties.get(MIXIN_TYPES_PROPERTY));
+        }
+
         for (Iterator<?> iter = properties.keys(); iter.hasNext();) {
             String key = (String)iter.next();
 
-            if (PRIMARY_TYPE_PROPERTY.equals(key)) {
+            if (PRIMARY_TYPE_PROPERTY.equals(key) || MIXIN_TYPES_PROPERTY.equals(key)) {
                 continue;
             }
             setPropertyOnNode(newNode, key, properties.get(key));
@@ -607,10 +613,26 @@ public class ItemHandler extends AbstractHandler {
 
         changes.checkout(node);
 
+        // Change the primary type first ...
+        if (properties.has(PRIMARY_TYPE_PROPERTY)) {
+            String primaryType = properties.getString(PRIMARY_TYPE_PROPERTY);
+            primaryType = primaryType.trim();
+            if (primaryType.length() != 0 && !node.getPrimaryNodeType().getName().equals(primaryType)) {
+                node.setPrimaryType(primaryType);
+            }
+        }
+
+        if (properties.has(MIXIN_TYPES_PROPERTY)) {
+            // Next set the mixin types ...
+            Object mixinTypes = properties.get(MIXIN_TYPES_PROPERTY);
+            setPropertyOnNode(node, MIXIN_TYPES_PROPERTY, mixinTypes); // handles both string and array value forms
+        }
+
+        // Now set all the other properties ...
         for (Iterator<?> iter = properties.keys(); iter.hasNext();) {
             String key = (String)iter.next();
-            if (PRIMARY_TYPE_PROPERTY.equals(key) || CHILD_NODE_HOLDER.equals(key)) {
-                continue; // can't change the primary type
+            if (PRIMARY_TYPE_PROPERTY.equals(key) || MIXIN_TYPES_PROPERTY.equals(key) || CHILD_NODE_HOLDER.equals(key)) {
+                continue;
             }
             setPropertyOnNode(node, key, properties.get(key));
         }


### PR DESCRIPTION
Changed the logic of POST to set the "jcr:primaryType" first (if specified in the JSON), then the "jcr:mixinTypes" second (again, if specified in the JSON), and finally all of the other properties.

The PUT logic was modified similarly, including the ability to _change_ the primary type (this was added sometime since one of the earlier 3.0 releases).

Note that the "jcr:mixinTypes" value can be an array of strings (this is technically the correct representation) or a single string if just one mixin type is to be named. The latter does not technically match the semantics of the multi-valued "jcr:mixinTypes" property, but it is convenient to handle both cases.
