### PR TITLE
MODE-1816 REST v2 responses base property representations on number of values

### DIFF
--- a/web/modeshape-web-jcr-rest-war/src/test/resources/v2/post/node_with_mixin_after_props_response.json
+++ b/web/modeshape-web-jcr-rest-war/src/test/resources/v2/post/node_with_mixin_after_props_response.json
@@ -1,7 +1,7 @@
 {
     "self":"http://localhost:8090/resources/repo/default/items/testNode",
     "up":"http://localhost:8090/resources/repo/default/items/",
-    "jcr:title" : "This is a title",
     "jcr:primaryType" : "nt:folder",
-    "jcr:mixinTypes":"mix:title"
+    "jcr:mixinTypes": ["mix:title"],
+    "jcr:title" : "This is a title"
 }

--- a/web/modeshape-web-jcr-rest-war/src/test/resources/v2/post/node_with_mixin_response.json
+++ b/web/modeshape-web-jcr-rest-war/src/test/resources/v2/post/node_with_mixin_response.json
@@ -2,7 +2,7 @@
     "self":"http://localhost:8090/resources/repo/default/items/testNode",
     "up":"http://localhost:8090/resources/repo/default/items/",
     "jcr:primaryType":"nt:unstructured",
-    "jcr:mixinTypes":"mix:referenceable",
+    "jcr:mixinTypes": ["mix:referenceable"],
     "jcr:uuid":"470b66a4-c9d8-401f-a2d0-e0a1aca13922"
 }
 

--- a/web/modeshape-web-jcr-rest-war/src/test/resources/v2/put/node_with_mixin.json
+++ b/web/modeshape-web-jcr-rest-war/src/test/resources/v2/put/node_with_mixin.json
@@ -3,7 +3,7 @@
     "up":"http://localhost:8090/resources/repo/default/items/",
     "jcr:primaryType":"nt:unstructured",
     "testProperty":"testValue",
-    "jcr:mixinTypes":"mix:referenceable",
+    "jcr:mixinTypes":["mix:referenceable"],
     "jcr:uuid":"3c7829e8-05f1-4976-aa4e-6bdb300e6951"
 }
 

--- a/web/modeshape-web-jcr-rest/src/main/java/org/modeshape/web/jcr/rest/handler/AbstractHandler.java
+++ b/web/modeshape-web-jcr-rest/src/main/java/org/modeshape/web/jcr/rest/handler/AbstractHandler.java
@@ -255,6 +255,7 @@ public abstract class AbstractHandler {
         List<String> values = restPropertyValues(property, baseUrl, session);
         String url = RestHelper.urlFrom(baseUrl, ITEMS_METHOD_NAME, property.getPath());
         String parentUrl = RestHelper.urlFrom(baseUrl, ITEMS_METHOD_NAME, property.getParent().getPath());
-        return new RestProperty(property.getName(), url, parentUrl, values);
+        boolean multiValued = property.isMultiple();
+        return new RestProperty(property.getName(), url, parentUrl, values, multiValued);
     }
 }

--- a/web/modeshape-web-jcr-rest/src/main/java/org/modeshape/web/jcr/rest/model/RestProperty.java
+++ b/web/modeshape-web-jcr-rest/src/main/java/org/modeshape/web/jcr/rest/model/RestProperty.java
@@ -24,34 +24,38 @@
 
 package org.modeshape.web.jcr.rest.model;
 
-import org.codehaus.jettison.json.JSONException;
-import org.codehaus.jettison.json.JSONObject;
 import java.util.Collections;
 import java.util.List;
+import org.codehaus.jettison.json.JSONException;
+import org.codehaus.jettison.json.JSONObject;
 
 /**
  * A REST representation of the {@link javax.jcr.Property}
- *
+ * 
  * @author Horia Chiorean (hchiorea@redhat.com)
  */
 public final class RestProperty extends RestItem {
 
     private final List<String> values;
+    private final boolean multiValued;
 
     /**
      * Creates a new rest property instance.
-     *
+     * 
      * @param name a {@code non-null} string, the name of the property
      * @param url a {@code non-null} string, the absolute url to this property
      * @param parentUrl a {@code non-null} string, the absolute url to this property's parent
      * @param values a list of possible values for the property, may be {@code null}
+     * @param multiValued true if this property is a multi-valued property
      */
     public RestProperty( String name,
                          String url,
                          String parentUrl,
-                         List<String> values ) {
+                         List<String> values,
+                         boolean multiValued ) {
         super(name, url, parentUrl);
         this.values = values != null ? values : Collections.<String>emptyList();
+        this.multiValued = multiValued;
     }
 
     List<String> getValues() {
@@ -63,7 +67,7 @@ public final class RestProperty extends RestItem {
     }
 
     boolean isMultiValue() {
-        return values.size() > 1;
+        return multiValued;
     }
 
     @Override


### PR DESCRIPTION
The response should base the field value for a given property based upon whether that JCR property is single-valued or multi-valued, not upon the number of values. If multi-valued, then the field value should be an array (even if there is just one item). Version 1 of the REST API already works this way, but the version 2 was changed.

Note that it is still possible for property representations in requests to use a single value (rather than an array) when setting a multi-value to a single value, or the more conventional practice of using an array to set a multi-valued array. The latter is obviously required when setting the mutli-valued property to 0 or 2+ values.

Several of the expected results were incorrect and have been changed.
