### PR TITLE
MODE-1809 Corrected the processing of set queries, including unions

### DIFF
--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/query/process/ProcessingComponent.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/query/process/ProcessingComponent.java
@@ -81,7 +81,7 @@ public abstract class ProcessingComponent {
      * 
      * @return the column mappings; never null
      */
-    public final Columns getColumns() {
+    public Columns getColumns() {
         return columns;
     }
 
@@ -507,7 +507,7 @@ public abstract class ProcessingComponent {
         final Comparator<Location> typeComparator = Location.getComparator();
         if (numLocations == 1) {
             // We can do this a tad faster if we know there is only one Location object ...
-            final int locationIndex = columns.getColumnCount();
+            final int locationIndex = columns.getLocationStartIndexInTuple();
             return new Comparator<Object[]>() {
                 @Override
                 public int compare( Object[] tuple1,
@@ -518,7 +518,7 @@ public abstract class ProcessingComponent {
                 }
             };
         }
-        final int firstLocationIndex = columns.getColumnCount();
+        final int firstLocationIndex = columns.getLocationStartIndexInTuple();
         return new Comparator<Object[]>() {
             @Override
             public int compare( Object[] tuple1,

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/query/process/SetOperationComponent.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/query/process/SetOperationComponent.java
@@ -36,6 +36,7 @@ public abstract class SetOperationComponent extends ProcessingComponent {
 
     private final Iterable<ProcessingComponent> sources;
     protected final Comparator<Object[]> removeDuplicatesComparator;
+    private final Columns columns;
 
     protected SetOperationComponent( QueryContext context,
                                      Columns columns,
@@ -45,7 +46,9 @@ public abstract class SetOperationComponent extends ProcessingComponent {
         super(context, columns);
         assert unionCompatible(columns, sources);
         this.sources = wrapWithLocationOrdering(sources, alreadySorted);
-        this.removeDuplicatesComparator = all ? null : createSortComparator(context, columns);
+        // Use for sorting the columns that may have been wrapped with location ordering ...
+        this.columns = this.sources.iterator().next().getColumns();
+        this.removeDuplicatesComparator = all ? null : createSortComparator(context, this.columns);
     }
 
     protected static boolean unionCompatible( Columns columns,
@@ -54,6 +57,11 @@ public abstract class SetOperationComponent extends ProcessingComponent {
             if (!columns.isUnionCompatible(source.getColumns())) return false;
         }
         return true;
+    }
+
+    @Override
+    public Columns getColumns() {
+        return columns;
     }
 
     /**

--- a/modeshape-jcr/src/test/java/org/modeshape/jcr/JcrQueryManagerTest.java
+++ b/modeshape-jcr/src/test/java/org/modeshape/jcr/JcrQueryManagerTest.java
@@ -107,7 +107,7 @@ public class JcrQueryManagerTest extends MultiUseAbstractTest {
         "/jcr:system/mode:namespaces", "/jcr:system/mode:repository"};
 
     private static final String[] NON_INDEXED_SYSTEM_NODES_PATHS = new String[] {"/", "/jcr:system/mode:locks",
-            "/jcr:system/jcr:versionStorage"};
+        "/jcr:system/jcr:versionStorage"};
 
     private static final boolean WRITE_INDEXES_TO_FILE = false;
 
@@ -283,14 +283,16 @@ public class JcrQueryManagerTest extends MultiUseAbstractTest {
         JcrSession session = repository.login();
         try {
             NodeCache systemSession = repository.createSystemSession(session.context(), true);
-            totalSystemNodeCount = countAllNodesBelow(systemSession.getRootKey(), systemSession) - NON_INDEXED_SYSTEM_NODES_PATHS.length;
+            totalSystemNodeCount = countAllNodesBelow(systemSession.getRootKey(), systemSession)
+                                   - NON_INDEXED_SYSTEM_NODES_PATHS.length;
             totalNodeCount = totalSystemNodeCount + TOTAL_NON_SYSTEM_NODE_COUNT;
         } finally {
             session.logout();
         }
     }
 
-    private static int countAllNodesBelow( NodeKey nodeKey, NodeCache cache ) throws RepositoryException {
+    private static int countAllNodesBelow( NodeKey nodeKey,
+                                           NodeCache cache ) throws RepositoryException {
         int result = 1;
         CachedNode node = cache.getNode(nodeKey);
         ChildReferences childReferences = node.getChildReferences(cache);
@@ -1109,6 +1111,20 @@ public class JcrQueryManagerTest extends MultiUseAbstractTest {
         assertResultsHaveColumns(result, carColumnNames("car"));
     }
 
+    @FixFor( "MODE-1809" )
+    @Test
+    public void shouldBeAbleToCreateAndExecuteJcrSql2UnionOfQueriesWithJoins() throws RepositoryException {
+        String sql1 = "SELECT car.* from [car:Car] as car JOIN [nt:unstructured] as category ON ISDESCENDANTNODE(car,category) WHERE NAME(category) LIKE 'Utility'";
+        String sql2 = "SELECT car.* from [car:Car] as car JOIN [nt:unstructured] as category ON ISDESCENDANTNODE(car,category) WHERE NAME(category) LIKE 'Sports'";
+        String sql = sql1 + " UNION " + sql2;
+        Query query = session.getWorkspace().getQueryManager().createQuery(sql, Query.JCR_SQL2);
+        assertThat(query, is(notNullValue()));
+        QueryResult result = query.execute();
+        assertThat(result, is(notNullValue()));
+        assertResults(query, result, 7);
+        assertResultsHaveColumns(result, carColumnNames("car"));
+    }
+
     @Test
     public void shouldBeAbleToCreateAndExecuteJcrSql2QueryWithDescendantNodeJoinAndColumnsFromBothSidesOfJoin()
         throws RepositoryException {
@@ -1252,7 +1268,7 @@ public class JcrQueryManagerTest extends MultiUseAbstractTest {
         assertResultsHaveColumns(result, new String[] {"car.jcr:name", "category.jcr:primaryType"});
     }
 
-    @FixFor("MODE-1750")
+    @FixFor( "MODE-1750" )
     @Test
     public void shouldBeAbleToCreateAndExecuteJcrSql2QueryWithLeftOuterJoinOnNullCondition() throws RepositoryException {
         // given
@@ -1269,7 +1285,7 @@ public class JcrQueryManagerTest extends MultiUseAbstractTest {
         assertResultsHaveColumns(result, new String[] {"car1.jcr:name"});
     }
 
-    @FixFor("MODE-1750")
+    @FixFor( "MODE-1750" )
     @Test
     public void shouldBeAbleToCreateAndExecuteJcrSql2QueryWithRightOuterJoinOnNullCondition() throws RepositoryException {
         // given
@@ -1858,7 +1874,7 @@ public class JcrQueryManagerTest extends MultiUseAbstractTest {
 
     /**
      * Tests that the child nodes (but no grandchild nodes) are returned.
-     *
+     * 
      * @throws RepositoryException
      */
     @SuppressWarnings( "deprecation" )
@@ -1877,7 +1893,7 @@ public class JcrQueryManagerTest extends MultiUseAbstractTest {
 
     /**
      * Tests that the child nodes (but no grandchild nodes) are returned.
-     *
+     * 
      * @throws RepositoryException
      */
     @SuppressWarnings( "deprecation" )


### PR DESCRIPTION
The code was sorting and then removing duplicates in the tuples, but during pre-processing and planning, the internal structure of the tuples changed for certain kinds of queries (like unions with join) to add in node location information as additional columns. The removal of duplicates, however, was still incorrectly basing its access of the tuple values upon the smaller/earlier tuple structure. This cause various kinds of ClassCastExceptions.

Added a test case that replicated the originally reported problem, which after the fix now passes.
