### PR TITLE
MODE-1817 Corrected logic of concurrent removals

### DIFF
--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/document/WritableSessionCache.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/document/WritableSessionCache.java
@@ -1115,8 +1115,12 @@ public class WritableSessionCache extends AbstractSessionCache {
             Set<NodeKey> referrers = new HashSet<NodeKey>();
             for (NodeKey removedKey : removedNodes) {
                 // we need the current document from the documentStore, because this differs from what's persisted
-                Document doc = documentStore.get(removedKey.toString()).getContentAsDocument();
-                referrers.addAll(translator.getReferrers(doc, ReferenceType.STRONG));
+                SchematicEntry entry = documentStore.get(removedKey.toString());
+                if (entry != null) {
+                    // The entry hasn't yet been removed by another (concurrent) session ...
+                    Document doc = documentStore.get(removedKey.toString()).getContentAsDocument();
+                    referrers.addAll(translator.getReferrers(doc, ReferenceType.STRONG));
+                }
             }
             // check referential integrity ...
             referrers.removeAll(removedNodes);

--- a/modeshape-schematic/src/main/java/org/infinispan/schematic/internal/CacheSchematicDb.java
+++ b/modeshape-schematic/src/main/java/org/infinispan/schematic/internal/CacheSchematicDb.java
@@ -345,7 +345,8 @@ public class CacheSchematicDb implements SchematicDb {
 
     @Override
     public SchematicEntry remove( String key ) {
-        return removedResult(key, store.remove(key));
+        SchematicEntry existing = store.remove(key);
+        return existing == null ? null : removedResult(key, existing);
     }
 
     @Override


### PR DESCRIPTION
Added a relatively-simple test case that replicated the exact exception using my hypothesized scenario. The test creates separate threads to concurrently remove a specific node and (after synchronizing on a CyclicBarrier) save their changes. Thus, the transient state of each Session does not see the uncommitted transient state of the other Session, but both sessions are saved roughly the same time (in different threads so different transactions are used). But since both need to acquire the lock on the same parent node, only one session will proceed first to successfully remove the node. When the second session proceeds, it no accepts the fact that the node was already removed and proceeds accordingly.

(ACID transactions FTW!)

The fix was pretty simple: be aware that attempting to remove an entry in the cache may return null if the entry does not exist (i.e., was recently removed).
