### PR TITLE
Fix and test case for MODE-1824

### DIFF
--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/query/process/QueryResultColumns.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/query/process/QueryResultColumns.java
@@ -246,6 +246,19 @@ public class QueryResultColumns implements Columns {
                     String columnNameWithSelector = column.selectorName() + "." + columnNameWithoutSelector;
                     columnIndex = wrappedAround.columnIndexForName(columnNameWithSelector);
                 }
+                // if column index is still null, lookup the column index by property name.
+                if (columnIndex == null) {
+                  columnNameWithoutSelector = column.getPropertyName();
+                  if (columnNameWithoutSelector.startsWith(selectorName + ".")
+                      && columnNameWithoutSelector.length() > (selectorName.length() + 1)) {
+                    columnNameWithoutSelector = columnNameWithoutSelector.substring(selectorName.length() + 1);
+                  }
+                  columnIndex = wrappedAround.columnIndexForName(columnNameWithoutSelector);
+                  if (columnIndex == null) {
+                    String columnNameWithSelector = column.selectorName() + "." + columnNameWithoutSelector;
+                    columnIndex = wrappedAround.columnIndexForName(columnNameWithSelector);
+                  }
+                }
             }
             assert columnIndex != null;
             columnIndexByColumnName.put(columnName, columnIndex);


### PR DESCRIPTION
https://issues.jboss.org/browse/MODE-1824

Queries requesting for 2 columns against two joined selectors using QueryObjectModelFactory will fail at QueryResultColumns.java line 254 
