### PR TITLE
MODE-1821 - Fixed the inconsistency which can occur when creating SNS simultaneously from multiple threads. 

### DIFF
--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrSession.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrSession.java
@@ -74,6 +74,7 @@ import org.modeshape.jcr.api.monitor.DurationMetric;
 import org.modeshape.jcr.api.monitor.ValueMetric;
 import org.modeshape.jcr.cache.CachedNode;
 import org.modeshape.jcr.cache.ChildReference;
+import org.modeshape.jcr.cache.ChildReferences;
 import org.modeshape.jcr.cache.DocumentAlreadyExistsException;
 import org.modeshape.jcr.cache.DocumentNotFoundException;
 import org.modeshape.jcr.cache.MutableCachedNode;
@@ -1828,6 +1829,48 @@ public class JcrSession implements org.modeshape.jcr.api.Session {
                 // and create this value by simply concatenating the SHA-1 hash of each BINARY value ...
                 String etagValue = node.getEtag(cache);
                 node.setProperty(cache, propertyFactory.create(JcrLexicon.ETAG, etagValue));
+            }
+        }
+
+        @Override
+        public void processAfterLocking( MutableCachedNode modifiedNode,
+                                         SaveContext context ) throws RepositoryException {
+            MutableCachedNode.NodeChanges changes = modifiedNode.getNodeChanges();
+
+            Set<Name> childrenNames = new HashSet<Name>(changes.appendedChildren().values());
+            childrenNames.addAll(changes.renamedChildren().values());
+
+            if (!childrenNames.isEmpty()) {
+                //look at the information that was already persisted to determine whether some other thread has already created
+                //a child with the same name
+                NodeCache wsCache = repository().workspaceCache(workspaceName());
+                CachedNode persistentNode = wsCache.getNode(modifiedNode.getKey());
+                AbstractJcrNode modifiedNodeJcr = jcrNodes.get(modifiedNode.getKey());
+                assert modifiedNodeJcr != null;
+
+                //process appended children
+                for (Name childName : childrenNames) {
+                    ChildReferences persistedChildReferences = persistentNode.getChildReferences(wsCache);
+                    int existingChildrenWithSameName = persistedChildReferences.getChildCount(childName);
+                    if (existingChildrenWithSameName == 0) {
+                        continue;
+                    }
+                    JcrNodeDefinition childNodeDefinition = nodeTypeCapabilities.findChildNodeDefinition(modifiedNodeJcr.getPrimaryTypeName(),
+                                                                                                         modifiedNodeJcr.getMixinTypeNames(),
+                                                                                                         childName,
+                                                                                                         null,
+                                                                                                         existingChildrenWithSameName + 1,
+                                                                                                         true);
+                    if (childNodeDefinition == null) {
+                        //we weren't able to find a definition which allows SNS for this name, but we need to make sure that the node
+                        //that already exists (persisted) isn't the one that's being changed
+                        NodeKey persistedChildKey = persistedChildReferences.getChild(childName).getKey();
+                        if (!changes.appendedChildren().containsKey(persistedChildKey) && !changes.renamedChildren().containsKey(persistedChildKey)) {
+                            //SNS are not allowed and there's already a child with this name throw ItemExistsException per 7.1.4 of 1.0.1 spec
+                            throw new ItemExistsException(JcrI18n.noSnsDefinitionForNode.text(childName, workspaceName()));
+                        }
+                    }
+                }
             }
         }
     }

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/MutableCachedNode.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/MutableCachedNode.java
@@ -24,6 +24,7 @@
 package org.modeshape.jcr.cache;
 
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 import org.modeshape.jcr.value.Name;
@@ -345,6 +346,7 @@ public interface MutableCachedNode extends CachedNode {
      * Returns a set with the keys of the children which have been removed for this node.
      * 
      * @return a <code>Set&lt;{@link NodeKey}></code>, never null
+     * @deprecated use {@link org.modeshape.jcr.cache.MutableCachedNode.NodeChanges#removedChildren()}
      */
     public Set<NodeKey> removedChildren();
 
@@ -368,4 +370,122 @@ public interface MutableCachedNode extends CachedNode {
      * @param queryable a {@code boolean}.
      */
     public void setQueryable(boolean queryable);
+
+    /**
+     * Returns an object encapsulating all the different changes that this session node contains.
+     *
+     * @return a {@code non-null} {@link NodeChanges} object.
+     */
+    public NodeChanges getNodeChanges();
+
+    /**
+     * Interface which exposes all the changes that have occurred on a {@link MutableCachedNode} instance
+     */
+    public interface NodeChanges {
+        /**
+         * Returns a set with the names of the properties that have changed. This includes new/modified properties.
+         *
+         * @return a {@code non-null} Set
+         */
+        Set<Name> changedPropertyNames();
+
+        /**
+         * Returns a set with the names of the properties that have been removed.
+         *
+         * @return a {@code non-null} Set
+         */
+        public Set<Name> removedPropertyNames();
+
+        /**
+         * Returns a set with the names of the mixins that have been added.
+         *
+         * @return a {@code non-null} Set
+         */
+        public Set<Name> addedMixins();
+        /**
+         * Returns a set with the names of the mixins that have been removed.
+         *
+         * @return a {@code non-null} Set
+         */
+        public Set<Name> removedMixins();
+
+        /**
+         * Returns the [childKey, childName] pairs of the children that have been appended (at the end).
+         *
+         * @return a {@code non-null} Map
+         */
+        public LinkedHashMap<NodeKey, Name> appendedChildren();
+
+        /**
+         * Returns the set of children that have been removed
+         *
+         * @return a {@code non-null} Set
+         */
+        public Set<NodeKey> removedChildren();
+
+        /**
+         * Returns the [childKey, childName] pairs of the children that have been renamed, where "childName" represents the new
+         * name after the rename.
+         *
+         * @return a {@code non-null} Map
+         */
+        public Map<NodeKey, Name> renamedChildren();
+
+        /**
+         * Returns the [insertBeforeChildKey, [childKey, childName]] structure of the children that been inserted before another
+         * existing child. This is normally caused due to reorderings
+         *
+         * @return a {@code non-null} Map
+         */
+        public Map<NodeKey, LinkedHashMap<NodeKey, Name>> childrenInsertedBefore();
+
+        /**
+         * Returns the set of parents that have been added
+         *
+         * @return a {@code non-null} Set
+         */
+        public Set<NodeKey> addedParents();
+
+        /**
+         * Returns the set of parents that have been removed
+         *
+         * @return a {@code non-null} Set
+         */
+        public Set<NodeKey> removedParents();
+
+        /**
+         * Returns the node key of the new primary parent, in case it has changed.
+         *
+         * @return either the {@link NodeKey} of the new primary parent or {@code null}
+         */
+        public NodeKey newPrimaryParent();
+
+        /**
+         * Returns a set of node keys with the weak referrers that have been added.
+         *
+         * @return a {@code non-null} Set
+         */
+        public Set<NodeKey> addedWeakReferrers();
+
+        /**
+         * Returns a set of node keys with the weak referrers that have been removed.
+         *
+         * @return a {@code non-null} Set
+         */
+        public Set<NodeKey> removedWeakReferrers();
+
+        /**
+         * Returns a set of node keys with the strong referrers that have been added.
+         *
+         * @return a {@code non-null} Set
+         */
+        public Set<NodeKey> addedStrongReferrers();
+
+        /**
+         * Returns a set of node keys with the strong referrers that have been removed.
+         *
+         * @return a {@code non-null} Set
+         */
+        public Set<NodeKey> removedStrongReferrers();
+    }
 }

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/SessionCache.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/SessionCache.java
@@ -24,6 +24,7 @@
 package org.modeshape.jcr.cache;
 
 import java.util.Set;
+import javax.jcr.RepositoryException;
 import org.modeshape.jcr.ExecutionContext;
 import org.modeshape.jcr.api.value.DateTime;
 
@@ -70,6 +71,21 @@ public interface SessionCache extends NodeCache {
          */
         void process( MutableCachedNode modifiedOrNewNode,
                       SaveContext context ) throws Exception;
+
+        /**
+         * Process the supplied existing node prior to saving the changes but only after the entry corresponding to the key of the node
+         * has been locked in Infinispan. Note that locking in Infinispan does not occur always, but only if the
+         * {@link org.infinispan.transaction.LockingMode#PESSIMISTIC} flag is enabled.
+         *
+         * This method should be implemented as optimal as possible and should only be needed in multi-threaded scenarios where
+         * concurrent modifications may break consistency.
+         *
+         * @param modifiedNode the mutable node that was changed in this session; never null
+         * @param context the context of the save operation; never null
+         * @throws RepositoryException if there is a problem during the processing
+         */
+        void processAfterLocking( MutableCachedNode modifiedNode,
+                                  SaveContext context ) throws Exception;
     }
 
     /**

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/document/SessionNode.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/document/SessionNode.java
@@ -1194,12 +1194,8 @@ public class SessionNode implements MutableCachedNode {
         return result;
     }
 
-    /**
-     * Returns an object encapsulating all the different changes that this session node contains.
-     * 
-     * @return a {@code non-null} {@link NodeChanges} object.
-     */
     @SuppressWarnings( "synthetic-access" )
+    @Override
     public NodeChanges getNodeChanges() {
         return new NodeChanges();
     }
@@ -1318,38 +1314,26 @@ public class SessionNode implements MutableCachedNode {
      * Value object which contains an "abbreviated" view of the changes that this session node has registered in its internal
      * state.
      */
-    public class NodeChanges {
+    private class NodeChanges implements MutableCachedNode.NodeChanges {
         private NodeChanges() {
             // this is not mean to be created from the outside
         }
 
-        /**
-         * Returns a set with the names of the properties that have changed. This includes new/modified properties.
-         * 
-         * @return a {@code non-null} Set
-         */
+        @Override
         public Set<Name> changedPropertyNames() {
             Set<Name> result = new HashSet<Name>();
             result.addAll(changedProperties().keySet());
             return result;
         }
 
-        /**
-         * Returns a set with the names of the properties that have been removed.
-         * 
-         * @return a {@code non-null} Set
-         */
+        @Override
         public Set<Name> removedPropertyNames() {
             Set<Name> result = new HashSet<Name>();
             result.addAll(changedProperties().keySet());
             return result;
         }
 
-        /**
-         * Returns a set with the names of the mixins that have been added.
-         * 
-         * @return a {@code non-null} Set
-         */
+        @Override
         public Set<Name> addedMixins() {
             Set<Name> result = new HashSet<Name>();
             MixinChanges mixinChanges = mixinChanges(false);
@@ -1357,14 +1341,9 @@ public class SessionNode implements MutableCachedNode {
                 result.addAll(mixinChanges.getAdded());
             }
             return result;
-
         }
 
-        /**
-         * Returns a set with the names of the mixins that have been removed.
-         * 
-         * @return a {@code non-null} Set
-         */
+        @Override
         public Set<Name> removedMixins() {
             Set<Name> result = new HashSet<Name>();
             MixinChanges mixinChanges = mixinChanges(false);
@@ -1372,14 +1351,9 @@ public class SessionNode implements MutableCachedNode {
                 result.addAll(mixinChanges.getRemoved());
             }
             return result;
-
         }
 
-        /**
-         * Returns the [childKey, childName] pairs of the children that have been appended (at the end).
-         * 
-         * @return a {@code non-null} Map
-         */
+        @Override
         public LinkedHashMap<NodeKey, Name> appendedChildren() {
             LinkedHashMap<NodeKey, Name> result = new LinkedHashMap<NodeKey, Name>();
             MutableChildReferences appendedChildReferences = appended(false);
@@ -1391,34 +1365,21 @@ public class SessionNode implements MutableCachedNode {
             return result;
         }
 
-        /**
-         * Returns the set of children that have been removed
-         * 
-         * @return a {@code non-null} Set
-         */
+        @Override
         public Set<NodeKey> removedChildren() {
             Set<NodeKey> result = new HashSet<NodeKey>();
             result.addAll(changedChildren().getRemovals());
             return result;
         }
 
-        /**
-         * Returns the [childKey, childName] pairs of the children that have been renamed.
-         * 
-         * @return a {@code non-null} Map
-         */
+        @Override
         public Map<NodeKey, Name> renamedChildren() {
             Map<NodeKey, Name> result = new HashMap<NodeKey, Name>();
             result.putAll(changedChildren().getNewNames());
             return result;
         }
 
-        /**
-         * Returns the [insertBeforeChildKey, [childKey, childName]] structure of the children that been inserted before another
-         * existing child. This is normally caused due to reorderings
-         * 
-         * @return a {@code non-null} Map
-         */
+        @Override
         public Map<NodeKey, LinkedHashMap<NodeKey, Name>> childrenInsertedBefore() {
             Map<NodeKey, LinkedHashMap<NodeKey, Name>> result = new HashMap<NodeKey, LinkedHashMap<NodeKey, Name>>();
 
@@ -1436,11 +1397,7 @@ public class SessionNode implements MutableCachedNode {
             return result;
         }
 
-        /**
-         * Returns the set of parents that have been added
-         * 
-         * @return a {@code non-null} Set
-         */
+        @Override
         public Set<NodeKey> addedParents() {
             Set<NodeKey> result = new HashSet<NodeKey>();
             if (additionalParents() != null) {
@@ -1449,11 +1406,7 @@ public class SessionNode implements MutableCachedNode {
             return result;
         }
 
-        /**
-         * Returns the set of parents that have been removed
-         * 
-         * @return a {@code non-null} Set
-         */
+        @Override
         public Set<NodeKey> removedParents() {
             Set<NodeKey> result = new HashSet<NodeKey>();
             if (additionalParents() != null) {
@@ -1462,20 +1415,12 @@ public class SessionNode implements MutableCachedNode {
             return result;
         }
 
-        /**
-         * Returns the node key of the new primary parent, in case it has changed.
-         * 
-         * @return either the {@link NodeKey} of the new primary parent or {@code null}
-         */
+        @Override
         public NodeKey newPrimaryParent() {
             return newParent();
         }
 
-        /**
-         * Returns a set of node keys with the weak referrers that have been added.
-         * 
-         * @return a {@code non-null} Set
-         */
+        @Override
         public Set<NodeKey> addedWeakReferrers() {
             Set<NodeKey> result = new HashSet<NodeKey>();
             ReferrerChanges referrerChanges = referrerChanges(false);
@@ -1485,11 +1430,7 @@ public class SessionNode implements MutableCachedNode {
             return result;
         }
 
-        /**
-         * Returns a set of node keys with the weak referrers that have been removed.
-         * 
-         * @return a {@code non-null} Set
-         */
+        @Override
         public Set<NodeKey> removedWeakReferrers() {
             Set<NodeKey> result = new HashSet<NodeKey>();
             ReferrerChanges referrerChanges = referrerChanges(false);
@@ -1499,11 +1440,7 @@ public class SessionNode implements MutableCachedNode {
             return result;
         }
 
-        /**
-         * Returns a set of node keys with the strong referrers that have been added.
-         * 
-         * @return a {@code non-null} Set
-         */
+        @Override
         public Set<NodeKey> addedStrongReferrers() {
             Set<NodeKey> result = new HashSet<NodeKey>();
             ReferrerChanges referrerChanges = referrerChanges(false);
@@ -1513,11 +1450,7 @@ public class SessionNode implements MutableCachedNode {
             return result;
         }
 
-        /**
-         * Returns a set of node keys with the strong referrers that have been removed.
-         * 
-         * @return a {@code non-null} Set
-         */
+        @Override
         public Set<NodeKey> removedStrongReferrers() {
             Set<NodeKey> result = new HashSet<NodeKey>();
             ReferrerChanges referrerChanges = referrerChanges(false);

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/document/WorkspaceCache.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/document/WorkspaceCache.java
@@ -163,6 +163,12 @@ public class WorkspaceCache implements DocumentCache, ChangeSetListener {
         return sourceKey;
     }
 
+    final void purge(Iterable<NodeKey> nodeKeys) {
+        for (NodeKey nodeKey : nodeKeys) {
+            this.nodesByKey.remove(nodeKey);
+        }
+    }
+
     @Override
     public NodeKey getRootKey() {
         checkNotClosed();

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/federation/FederatedDocumentStore.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/federation/FederatedDocumentStore.java
@@ -42,6 +42,7 @@ import org.modeshape.common.logging.Logger;
 import org.modeshape.common.util.StringUtil;
 import org.modeshape.jcr.Connectors;
 import org.modeshape.jcr.JcrI18n;
+import org.modeshape.jcr.cache.MutableCachedNode;
 import org.modeshape.jcr.cache.NodeKey;
 import org.modeshape.jcr.cache.document.DocumentStore;
 import org.modeshape.jcr.cache.document.DocumentTranslator;
@@ -148,7 +149,7 @@ public class FederatedDocumentStore implements DocumentStore {
                 checkConnectorIsWritable(connector);
                 EditableDocument editableDocument = replaceNodeKeysWithDocumentIds(document);
                 String documentId = documentIdFromNodeKey(key);
-                SessionNode.NodeChanges nodeChanges = sessionNode.getNodeChanges();
+                MutableCachedNode.NodeChanges nodeChanges = sessionNode.getNodeChanges();
                 DocumentChanges documentChanges = createDocumentChanges(nodeChanges,
                                                                         connector.getSourceName(),
                                                                         editableDocument,
@@ -158,7 +159,7 @@ public class FederatedDocumentStore implements DocumentStore {
         }
     }
 
-    private DocumentChanges createDocumentChanges( SessionNode.NodeChanges nodeChanges,
+    private DocumentChanges createDocumentChanges( MutableCachedNode.NodeChanges nodeChanges,
                                                    String sourceName,
                                                    EditableDocument editableDocument,
                                                    String documentId ) {

--- a/modeshape-jcr/src/test/java/org/modeshape/jcr/ConcurrentWriteTest.java
+++ b/modeshape-jcr/src/test/java/org/modeshape/jcr/ConcurrentWriteTest.java
@@ -23,9 +23,6 @@
  */
 package org.modeshape.jcr;
 
-import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.fail;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
@@ -33,12 +30,12 @@ import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.ReentrantLock;
+import javax.jcr.ItemExistsException;
 import javax.jcr.Node;
 import javax.jcr.NodeIterator;
 import javax.jcr.Repository;
 import javax.jcr.RepositoryException;
 import javax.jcr.Session;
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.modeshape.common.FixFor;
@@ -47,15 +44,15 @@ import org.modeshape.common.annotation.ThreadSafe;
 import org.modeshape.common.util.CheckArg;
 import org.modeshape.common.util.StringUtil;
 import org.modeshape.jcr.api.JcrTools;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
 
 public class ConcurrentWriteTest extends SingleUseAbstractTest {
 
     @Override
     @Before
     public void beforeEach() throws Exception {
-        // super.beforeEach();
-        // FileUtil.delete("target/persistent_repository");
-        //
         startRepositoryWithConfiguration(getClass().getClassLoader()
                                                    .getResourceAsStream("config/repo-config-concurrent-tests.json"));
         tools = new JcrTools();
@@ -64,17 +61,8 @@ public class ConcurrentWriteTest extends SingleUseAbstractTest {
         repository.runningState().txnManager().setTransactionTimeout(500);
     }
 
-    @After
-    @Override
-    public void afterEach() throws Exception {
-        super.afterEach();
-        // FileUtil.delete("target/persistent_repository");
-    }
-
     /**
      * Create a session, obtain the root node, and close the session. Do this 500x using 16 threads.
-     * 
-     * @throws Exception
      */
     @Test
     public void shouldAllowMultipleThreadsToConcurrentlyGetRootNode() throws Exception {
@@ -89,8 +77,6 @@ public class ConcurrentWriteTest extends SingleUseAbstractTest {
     /**
      * Create a session, add a single node under the root, and close the session. Do this twice using 2 threads. Then verify that
      * there are 2 children under the root (except for the "/jcr:system" node).
-     * 
-     * @throws Exception
      */
     @FixFor( "MODE-1734" )
     @Test
@@ -104,8 +90,6 @@ public class ConcurrentWriteTest extends SingleUseAbstractTest {
     /**
      * Create a session, add a single node under the root, and close the session. Do this 500x using 16 threads. Then verify that
      * there are 500 children under the root (except for the "/jcr:system" node).
-     * 
-     * @throws Exception
      */
     @FixFor( "MODE-1734" )
     @Test
@@ -144,7 +128,6 @@ public class ConcurrentWriteTest extends SingleUseAbstractTest {
     @FixFor( "MODE-1739" )
     @Test
     public void shouldAllowMultipleThreadsToConcurrentlyModifySameNodesInDifferentOrder() throws Exception {
-        print = true;
         // Create several nodes right under the root ...
         final int numNodes = 3;
         runOnce(new CreateSubgraph("/", "node", numNodes, 2), false);
@@ -181,6 +164,40 @@ public class ConcurrentWriteTest extends SingleUseAbstractTest {
         runConcurrently(numThreads, numThreads, operation);
 
         verify(new NumberOfChildren(0, "node"));
+    }
+
+    @FixFor( "MODE-1821" )
+    @Test
+    public void shouldFailIfSNSAreNotSupported() throws Exception {
+        session.workspace().getNodeTypeManager().registerNodeTypes(resourceStream("cnd/no_sns.cnd"), true);
+
+        Node testRoot = session.getRootNode().addNode("/testRoot", "test:nodeWithoutSNS");
+        testRoot.addNode("childA", "nt:unstructured");
+        session.save();
+
+        try {
+            testRoot.addNode("childA", "nt:unstructured");
+            fail("Same name sibling are not supported, an exception should've been thrown");
+        } catch (ItemExistsException ex) {
+            // this is expected since this is not allowed.
+        }
+
+        // Now run two threads that are timed very carefully ...
+        int numThreads = 2;
+        final CyclicBarrier barrier = new CyclicBarrier(numThreads);
+        Operation operation = new Operation() {
+            @Override
+            public void run( Session session ) throws Exception {
+                Node testRoot = session.getNode("/testRoot");
+                testRoot.addNode("childB", "nt:unstructured");
+                barrier.await();
+                // one of the saves should fail but it doesn't
+                session.save();
+            }
+        };
+
+        run(2, numThreads, 1, operation);
+        verify(new NumberOfChildren(2, "testRoot"));
     }
 
     /**
@@ -449,28 +466,28 @@ public class ConcurrentWriteTest extends SingleUseAbstractTest {
         Thread[] threads = new Thread[numberOfConcurrentClients];
         for (int i = 0; i != numberOfConcurrentClients; ++i) {
             sessions[i] = repository.login();
-            final int index = i;
-            final String threadName = "RepoClient" + (index + 1);
+            final String threadName = "RepoClient" + (i + 1);
             Runnable runnable = new Runnable() {
                 @Override
                 public void run() {
                     try {
-                        // printMessage("Initializing thread '" + threadName + '"');
+                        printMessage("Initializing thread '" + threadName + '"');
 
                         // Block until all threads are ready to start ...
                         startLatch.await();
 
-                        // printMessage("Starting thread '" + threadName + '"');
+                        printMessage("Starting thread '" + threadName + '"');
 
                         // Perform the operation as many times as requested ...
                         int repeatCount = 1;
                         while (true) {
                             int operationNumber = actualOperationCount.getAndIncrement();
+
                             if (operationNumber > totalNumberOfOperations) break;
 
                             ++repeatCount;
                             Session session = null;
-                            // printMessage("Running operation " + repeatCount + " in thread '" + threadName + '"');
+                            printMessage("Running operation " + repeatCount + " in thread '" + threadName + '"');
                             try {
                                 // Create the session ...
                                 session = repository.login();
@@ -494,7 +511,7 @@ public class ConcurrentWriteTest extends SingleUseAbstractTest {
                         e.printStackTrace();
                     } finally {
                         // Thread is done, so count it down ...
-                        // printMessage("Completing thread '" + threadName + '"');
+                        printMessage("Completing thread '" + threadName + '"');
                         completionLatch.countDown();
                     }
                 }
@@ -529,7 +546,8 @@ public class ConcurrentWriteTest extends SingleUseAbstractTest {
         assertThat(actualOperationCount.get() > totalNumberOfOperations, is(true));
 
         // Verify there are no errors ...
-        if (problems.size() != numberOfErrorsExpected) {
+        int problemsCount = problems.size();
+        if (problemsCount != numberOfErrorsExpected) {
             if (numberOfConcurrentClients == 1) {
                 // Just one thread, so rethrow the exception ...
                 Throwable t = problems.getFirstException();
@@ -540,6 +558,8 @@ public class ConcurrentWriteTest extends SingleUseAbstractTest {
                     throw (Error)t;
                 }
                 throw (Exception)t;
+            } else if (problemsCount == 0 && numberOfErrorsExpected > 0) {
+                fail(numberOfErrorsExpected + " errors expected, but none occurred");
             }
             // Otherwise, multiple clients so log the set of them ...
             fail(problems.toString());

--- a/modeshape-jcr/src/test/resources/cnd/no_sns.cnd
+++ b/modeshape-jcr/src/test/resources/cnd/no_sns.cnd
@@ -1,0 +1,7 @@
+<mix = "http://www.jcp.org/jcr/mix/1.0">
+<mode = "http://www.modeshape.org/1.0">
+<test = "http://www.modeshape.org/test/1.0">
+
+[test:nodeWithoutSNS]
++ * (nt:base)
+

--- a/modeshape-jcr/src/test/resources/config/infinispan-concurrent-persistent.xml
+++ b/modeshape-jcr/src/test/resources/config/infinispan-concurrent-persistent.xml
@@ -11,18 +11,5 @@
                 transactionManagerLookupClass="org.infinispan.transaction.lookup.GenericTransactionManagerLookup"
                 transactionMode="TRANSACTIONAL"
                 lockingMode="PESSIMISTIC"/>
-        <!--loaders
-                passivation="false"
-                shared="false"
-                preload="false">
-            <loader
-                    class="org.infinispan.loaders.file.FileCacheStore"
-                    fetchPersistentState="false"
-                    purgeOnStartup="false">
-                <properties>
-                    <property name="location" value="target/persistent_repository/store"/>
-                </properties>
-            </loader>
-        </loaders-->
     </namedCache>
 </infinispan>


### PR DESCRIPTION
The solution was to add an additional method to JcrSession#PreSave and which is executed only after Infinispan locks are obtained on the changed nodes. For this to work however, Infinispan must be configured in PESSIMISTIC mode.

In working this, another problem showed up: stale information (nodes) leaking from the workspace cache, which is shared among all sessions of a WS. To work around this, the solution was to always purge the workspace cache after locks are obtained.

This PR should be merged in 3.1.x and cherry-picked in master.
