### PR TITLE
MODE-1819 Changed how WorkspaceCache is used inside user transactions

### DIFF
--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrI18n.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrI18n.java
@@ -402,6 +402,7 @@ public final class JcrI18n {
 
     public static I18n failedWhileRollingBackDestroyToRuntimeError;
     public static I18n unexpectedException;
+    public static I18n errorDeterminingCurrentTransactionAssumingNone;
 
     public static I18n configurationError;
     public static I18n configurationWarning;

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/document/ReadOnlySessionCache.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/document/ReadOnlySessionCache.java
@@ -26,6 +26,7 @@ package org.modeshape.jcr.cache.document;
 import java.util.Collections;
 import java.util.Set;
 import org.modeshape.common.annotation.ThreadSafe;
+import org.modeshape.common.logging.Logger;
 import org.modeshape.jcr.ExecutionContext;
 import org.modeshape.jcr.cache.CachedNode;
 import org.modeshape.jcr.cache.NodeKey;
@@ -38,6 +39,8 @@ import org.modeshape.jcr.cache.SessionEnvironment;
 @ThreadSafe
 public class ReadOnlySessionCache extends AbstractSessionCache {
 
+    private static final Logger LOGGER = Logger.getLogger(ReadOnlySessionCache.class);
+
     public ReadOnlySessionCache( ExecutionContext context,
                                  WorkspaceCache workspaceCache,
                                  SessionEnvironment sessionContext ) {
@@ -45,8 +48,8 @@ public class ReadOnlySessionCache extends AbstractSessionCache {
     }
 
     @Override
-    public void clear() {
-        // do nothing, as we don't want to clear the shared workspace
+    protected Logger logger() {
+        return LOGGER;
     }
 
     @Override
@@ -65,7 +68,12 @@ public class ReadOnlySessionCache extends AbstractSessionCache {
     }
 
     @Override
-    public void clear( CachedNode node ) {
+    protected void doClear() {
+        // do nothing, as we don't want to clear the shared workspace
+    }
+
+    @Override
+    protected void doClear( CachedNode node ) {
         // do nothing
     }
 
@@ -110,10 +118,7 @@ public class ReadOnlySessionCache extends AbstractSessionCache {
     @Override
     public String toString() {
         StringBuilder sb = new StringBuilder();
-        sb.append("Session ")
-          .append(context().getId())
-          .append(" (readonly) to workspace '")
-          .append(workspaceCache.getWorkspaceName());
+        sb.append("Session ").append(context().getId()).append(" (readonly) to workspace '").append(workspaceName());
         return sb.toString();
     }
 

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/document/SessionNode.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/document/SessionNode.java
@@ -734,8 +734,8 @@ public class SessionNode implements MutableCachedNode {
 
     private void updateReferences( SessionCache cache,
                                    Name propertyName,
-                                   SessionCache systemCache) {
-        //first try to determine if there's old reference property with the same name so that old references can be removed
+                                   SessionCache systemCache ) {
+        // first try to determine if there's old reference property with the same name so that old references can be removed
         boolean oldPropertyWasReference = false;
         List<Reference> referencesToRemove = new ArrayList<Reference>();
         if (!isNew()) {
@@ -751,7 +751,7 @@ public class SessionNode implements MutableCachedNode {
             }
         }
 
-        //if the updated property is a reference, determine which are the references that need updating
+        // if the updated property is a reference, determine which are the references that need updating
         boolean updatedPropertyIsReference = false;
         List<Reference> referencesToAdd = new ArrayList<Reference>();
         Property property = changedProperties.get(propertyName);
@@ -759,19 +759,20 @@ public class SessionNode implements MutableCachedNode {
             updatedPropertyIsReference = true;
             for (Object referenceObject : property.getValuesAsArray()) {
                 assert referenceObject instanceof Reference;
-                Reference updatedReference = (Reference) referenceObject;
+                Reference updatedReference = (Reference)referenceObject;
                 if (referencesToRemove.contains(updatedReference)) {
-                    //the reference is already present on a property with the same name, so this is a no-op for that reference
-                    //therefore we remove it from the list of references that will be removed
+                    // the reference is already present on a property with the same name, so this is a no-op for that reference
+                    // therefore we remove it from the list of references that will be removed
                     referencesToRemove.remove(updatedReference);
                 } else {
-                    //this is a new reference (either via key or type)
+                    // this is a new reference (either via key or type)
                     referencesToAdd.add(updatedReference);
                 }
             }
         }
 
-        //if an existing reference property was just updated with the same value, it is a no-op so we should just remove it from the list of changed properties
+        // if an existing reference property was just updated with the same value, it is a no-op so we should just remove it from
+        // the list of changed properties
         if (referencesToRemove.isEmpty() && referencesToAdd.isEmpty() && oldPropertyWasReference && updatedPropertyIsReference) {
             changedProperties.remove(propertyName);
             return;
@@ -801,14 +802,13 @@ public class SessionNode implements MutableCachedNode {
                                          Iterator<?> referenceValuesIterator,
                                          boolean add ) {
 
-
         boolean isFrozenNode = JcrNtLexicon.FROZEN_NODE.equals(this.getPrimaryType(cache));
 
         while (referenceValuesIterator.hasNext()) {
             Object value = referenceValuesIterator.next();
             assert value instanceof Reference;
 
-            Reference reference = (Reference) value;
+            Reference reference = (Reference)value;
             NodeKey referredKey = nodeKeyFromReference(reference);
             boolean isWeak = reference.isWeak();
 
@@ -818,7 +818,8 @@ public class SessionNode implements MutableCachedNode {
             }
 
             SessionNode referredNode = null;
-            //first search for a referred node in the cache of the current session and if nothing is found, look in the system session
+            // first search for a referred node in the cache of the current session and if nothing is found, look in the system
+            // session
             if (cache.getNode(referredKey) != null) {
                 referredNode = writableSession(cache).mutable(referredKey);
             } else if (systemCache != null && systemCache.getNode(referredKey) != null) {
@@ -838,13 +839,13 @@ public class SessionNode implements MutableCachedNode {
         }
     }
 
-    private NodeKey nodeKeyFromReference(Reference reference) {
+    private NodeKey nodeKeyFromReference( Reference reference ) {
         if (reference instanceof NodeKeyReference) {
-           return  ((NodeKeyReference)reference).getNodeKey();
+            return ((NodeKeyReference)reference).getNodeKey();
         } else if (reference instanceof StringReference) {
             return new NodeKey(reference.getString());
         } else if (reference instanceof UuidReference) {
-            UuidReference uuidReference = (UuidReference) reference;
+            UuidReference uuidReference = (UuidReference)reference;
             return getKey().withId(uuidReference.getString());
         }
         throw new IllegalArgumentException("Unknown reference type: " + reference.getClass().getSimpleName());
@@ -1114,8 +1115,16 @@ public class SessionNode implements MutableCachedNode {
         // We need a mutable node in the session for the child, so that we can find changes in the parent ...
         cache.mutable(key);
 
-        // Now perform the rename ...
-        changedChildren.renameTo(key, newName);
+        // If the node was previously appended ...
+        MutableChildReferences appended = this.appended.get();
+        if (appended != null && appended.hasChild(key)) {
+            // Just remove and re-add with the new name ...
+            appended.remove(key);
+            appended.append(key, newName);
+        } else {
+            // Now perform the rename ...
+            changedChildren.renameTo(key, newName);
+        }
     }
 
     @Override
@@ -1207,7 +1216,7 @@ public class SessionNode implements MutableCachedNode {
             return isQueryable;
         }
         CachedNode persistedNode = nodeInWorkspace(session(cache));
-        //if the node does not exist yet, it is queryable by default
+        // if the node does not exist yet, it is queryable by default
         return persistedNode == null || persistedNode.isQueryable(cache);
     }
 

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/document/TransactionalWorkspaceCache.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/document/TransactionalWorkspaceCache.java
@@ -1,0 +1,76 @@
+/*
+ * ModeShape (http://www.modeshape.org)
+ * See the COPYRIGHT.txt file distributed with this work for information
+ * regarding copyright ownership.  Some portions may be licensed
+ * to Red Hat, Inc. under one or more contributor license agreements.
+ * See the AUTHORS.txt file in the distribution for a full listing of 
+ * individual contributors.
+ *
+ * ModeShape is free software. Unless otherwise indicated, all code in ModeShape
+ * is licensed to you under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ * 
+ * ModeShape is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.modeshape.jcr.cache.document;
+
+import java.util.concurrent.ConcurrentHashMap;
+import org.modeshape.jcr.cache.CachedNode;
+import org.modeshape.jcr.cache.NodeKey;
+import org.modeshape.jcr.cache.RepositoryCache;
+import org.modeshape.jcr.cache.change.ChangeSet;
+
+/**
+ * A special WorkspaceCache implementation that should be used by sessions running within user transactions.
+ * <p>
+ * Normally, each {@link RepositoryCache} instance has for each workspace a single WorkspaceCache instance shared by all sessions.
+ * However, in the event that a session is running within a user transaction, it is possible for the session (or other sessions
+ * that are also participating in the same user transaction) to persist node changes in the document store but to not commit the
+ * transaction. This means that no other transactions should see these persisted-but-not-committed node representations. Thus,
+ * these sessions running within a user transaction cannot share the common WorkspaceCache instance, lest any node representations
+ * persisted-but-not-committed be loaded into the WorkspaceCache (leaking transaction-scoped data outside of the transaction) or
+ * the shared WorkspaceCache instance has already-cached pre-modified representations of the persisted-but-not-committed nodes
+ * (transaction-scoped changes are not visible to the transaction).
+ * </p>
+ * <p>
+ * Therefore, such sessions running within user transactions need a transactionally-scoped WorkspaceCache instance. Because the
+ * ModeShape infrastructure is not set up to handle lots of WorkspaceCache instances, we only want one instance that is actually
+ * caching nodes. Therefore, the WorkspaceCache returned from this method will never cache any nodes and will always re-read the
+ * nodes from the document store.
+ * </p>
+ */
+class TransactionalWorkspaceCache extends WorkspaceCache {
+
+    private final WorkspaceCache sharedWorkspaceCache;
+
+    protected TransactionalWorkspaceCache( WorkspaceCache sharedWorkspaceCache ) {
+        // Use a new in-memory map for the transactional cache ...
+        super(sharedWorkspaceCache, new ConcurrentHashMap<NodeKey, CachedNode>(), null);
+        this.sharedWorkspaceCache = sharedWorkspaceCache;
+    }
+
+    @Override
+    public void changed( ChangeSet changes ) {
+        // Delegate to the shared ...
+        sharedWorkspaceCache.changed(changes);
+        // And then handle it ourselves ...
+        super.changed(changes);
+    }
+
+    @Override
+    public void notify( ChangeSet changeSet ) {
+        // Delegate to the shared ...
+        sharedWorkspaceCache.notify(changeSet);
+        // And then handle it ourselves ...
+        super.notify(changeSet);
+    }
+}

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/document/WorkspaceCache.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/document/WorkspaceCache.java
@@ -87,6 +87,24 @@ public class WorkspaceCache implements DocumentCache, ChangeSetListener {
         this.nodesByKey = cache;
     }
 
+    protected WorkspaceCache( WorkspaceCache original,
+                              ConcurrentMap<NodeKey, CachedNode> cache,
+                              ChangeSetListener changeSetListener ) {
+        this.context = original.context;
+        this.documentStore = original.documentStore;
+        this.changeSetListener = changeSetListener;
+        this.translator = original.translator;
+        this.rootKey = original.rootKey;
+        this.childReferenceForRoot = original.childReferenceForRoot;
+        this.repositoryKey = original.repositoryKey;
+        this.workspaceName = original.workspaceName;
+        this.workspaceKey = original.workspaceKey;
+        this.sourceKey = original.sourceKey;
+        this.pathFactory = original.pathFactory;
+        this.nameFactory = original.nameFactory;
+        this.nodesByKey = cache;
+    }
+
     public void setMinimumStringLengthForBinaryStorage( long largeValueSize ) {
         assert largeValueSize > -1;
         this.translator.setMinimumStringLengthForBinaryStorage(largeValueSize);
@@ -163,7 +181,7 @@ public class WorkspaceCache implements DocumentCache, ChangeSetListener {
         return sourceKey;
     }
 
-    final void purge(Iterable<NodeKey> nodeKeys) {
+    final void purge( Iterable<NodeKey> nodeKeys ) {
         for (NodeKey nodeKey : nodeKeys) {
             this.nodesByKey.remove(nodeKey);
         }

--- a/modeshape-jcr/src/main/resources/org/modeshape/jcr/JcrI18n.properties
+++ b/modeshape-jcr/src/main/resources/org/modeshape/jcr/JcrI18n.properties
@@ -387,6 +387,7 @@ nodeCreatedBySessionUsedExistingKey = This session tried to create node '{0}' (w
 
 failedWhileRollingBackDestroyToRuntimeError = '{1}' error caused rollback in SessionCache.destroy(), but this rollback encountered an error: {0}
 unexpectedException = Unexpected exception: {0}
+errorDeterminingCurrentTransactionAssumingNone = Error while trying to determine if there is an active user transaction while using the "{0}" workspace: {1}
 
 configurationError = Error at {0} : {1}
 configurationWarning = Warning at {0} : {1}

--- a/modeshape-jcr/src/test/java/org/modeshape/jcr/SingleUseAbstractTest.java
+++ b/modeshape-jcr/src/test/java/org/modeshape/jcr/SingleUseAbstractTest.java
@@ -116,6 +116,10 @@ public abstract class SingleUseAbstractTest extends AbstractJcrRepositoryTest {
         return session;
     }
 
+    protected Session newSession() throws RepositoryException {
+        return repository.login();
+    }
+
     protected Session jcrSession() {
         return session;
     }

--- a/modeshape-jcr/src/test/java/org/modeshape/jcr/TransactionsTest.java
+++ b/modeshape-jcr/src/test/java/org/modeshape/jcr/TransactionsTest.java
@@ -1,0 +1,186 @@
+/*
+ * ModeShape (http://www.modeshape.org)
+ * See the COPYRIGHT.txt file distributed with this work for information
+ * regarding copyright ownership.  Some portions may be licensed
+ * to Red Hat, Inc. under one or more contributor license agreements.
+ * See the AUTHORS.txt file in the distribution for a full listing of 
+ * individual contributors.
+ *
+ * ModeShape is free software. Unless otherwise indicated, all code in ModeShape
+ * is licensed to you under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ * 
+ * ModeShape is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.modeshape.jcr;
+
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsInstanceOf.instanceOf;
+import static org.hamcrest.core.IsNull.nullValue;
+import static org.junit.Assert.assertThat;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import javax.jcr.Node;
+import javax.jcr.NodeIterator;
+import javax.jcr.PathNotFoundException;
+import javax.jcr.Session;
+import javax.transaction.HeuristicMixedException;
+import javax.transaction.HeuristicRollbackException;
+import javax.transaction.NotSupportedException;
+import javax.transaction.RollbackException;
+import javax.transaction.SystemException;
+import org.junit.Test;
+
+public class TransactionsTest extends SingleUseAbstractTest {
+
+    private static final String MULTI_LINE_VALUE = "Line\t1\nLine 2\rLine 3\r\nLine 4";
+
+    protected void initializeData() throws Exception {
+        Node root = session.getRootNode();
+        Node a = root.addNode("a");
+        Node b = a.addNode("b");
+        Node c = b.addNode("c");
+        a.addMixin("mix:lockable");
+        a.setProperty("stringProperty", "value");
+
+        b.addMixin("mix:referenceable");
+        b.setProperty("booleanProperty", true);
+
+        c.setProperty("stringProperty", "value");
+        c.setProperty("multiLineProperty", MULTI_LINE_VALUE);
+        session.save();
+    }
+
+    @Test
+    public void shouldBeAbleToMoveNodeWithinUserTransaction() throws Exception {
+        startTransaction();
+        moveDocument("childX");
+        commitTransaction();
+    }
+
+    @Test
+    public void shouldBeAbleToMoveNodeOutsideOfUserTransaction() throws Exception {
+        moveDocument("childX");
+    }
+
+    @Test
+    public void shouldBeAbleToUseSeparateSessionsWithinSingleUserTransaction() throws Exception {
+        // We'll use separate threads, but we want to have them both do something specific at a given time,
+        // so we'll use a barrier ...
+        final CyclicBarrier barrier = new CyclicBarrier(2);
+
+        // The path at which we expect to find a node ...
+        final String path = "/childY/grandChildZ";
+
+        // Create a runnable to obtain a session and look for a particular node ...
+        final AtomicReference<Exception> separateThreadException = new AtomicReference<Exception>();
+        final AtomicReference<Node> separateThreadNode = new AtomicReference<Node>();
+        Runnable runnable = new Runnable() {
+            @Override
+            public void run() {
+                // Wait till we both get to the barrier ...
+                Session session = null;
+                try {
+                    barrier.await(20, TimeUnit.SECONDS);
+
+                    // Create a second session, which should NOT see the persisted-but-not-committed changes ...
+                    session = newSession();
+                    Node grandChild2 = session.getNode(path);
+                    separateThreadNode.set(grandChild2);
+
+                } catch (Exception err) {
+                    separateThreadException.set(err);
+                } finally {
+                    if (session != null) session.logout();
+                }
+            }
+        };
+
+        // Start another session in a separate thread that won't participate in our transaction ...
+        new Thread(runnable).start();
+
+        // Now start a transaction ...
+        startTransaction();
+
+        // Create first session and make some changes ...
+        Node node = session.getRootNode().addNode("childY");
+        node.setProperty("foo", "bar");
+        Node grandChild = node.addNode("grandChildZ");
+        assertThat(grandChild.getPath(), is(path));
+        session.save(); // persisted but not committed ...
+
+        // Use the same session to find the node ...
+        Node grandChild1 = session.getNode(path);
+        assertThat(grandChild.isSame(grandChild1), is(true));
+
+        // Sync up with the other thread ...
+        barrier.await();
+
+        // Create a second session, which should see the persisted-but-not-committed changes ...
+        Session session2 = newSession();
+        Node grandChild2 = session2.getNode(path);
+        assertThat(grandChild.isSame(grandChild2), is(true));
+        session2.logout();
+
+        // Commit the transaction ...
+        commitTransaction();
+
+        // Our other session should not have seen the node and should have gotten a PathNotFoundException ...
+        assertThat(separateThreadNode.get(), is(nullValue()));
+        assertThat(separateThreadException.get(), is(instanceOf(PathNotFoundException.class)));
+
+        // It should now be visible outside of the transaction ...
+        Session session3 = newSession();
+        Node grandChild3 = session3.getNode(path);
+        assertThat(grandChild.isSame(grandChild3), is(true));
+        session3.logout();
+    }
+
+    protected void startTransaction() throws NotSupportedException, SystemException {
+        session.getRepository().transactionManager().begin();
+    }
+
+    protected void commitTransaction()
+        throws SystemException, SecurityException, IllegalStateException, RollbackException, HeuristicMixedException,
+        HeuristicRollbackException {
+        session.getRepository().transactionManager().commit();
+    }
+
+    protected void rollbackTransaction() throws SystemException, SecurityException, IllegalStateException {
+        session.getRepository().transactionManager().rollback();
+    }
+
+    public void moveDocument( String nodeName ) throws Exception {
+        Node section = session.getRootNode().addNode(nodeName);
+        section.setProperty("name", nodeName);
+
+        section.addNode("temppath");
+        session.save();
+
+        String srcAbsPath = "/" + nodeName + "/temppath";
+        String destAbsPath = "/" + nodeName + "/20130104";
+
+        session.move(srcAbsPath, destAbsPath);
+        session.save();
+
+        NodeIterator nitr = section.getNodes();
+
+        if (print) {
+            System.err.println("Child Nodes of " + nodeName + " are:");
+            while (nitr.hasNext()) {
+                Node n = nitr.nextNode();
+                System.err.println("  Node: " + n.getName());
+            }
+        }
+    }
+}

--- a/modeshape-jcr/src/test/java/org/modeshape/jcr/cache/document/ReadOnlySessionCacheTest.java
+++ b/modeshape-jcr/src/test/java/org/modeshape/jcr/cache/document/ReadOnlySessionCacheTest.java
@@ -25,6 +25,8 @@ package org.modeshape.jcr.cache.document;
 
 import org.modeshape.jcr.ExecutionContext;
 import org.modeshape.jcr.cache.SessionCache;
+import org.modeshape.jcr.cache.SessionEnvironment;
+import org.modeshape.jcr.txn.Transactions;
 
 /**
  * Tests that operate against a {@link ReadOnlySessionCache}.
@@ -34,6 +36,11 @@ public class ReadOnlySessionCacheTest extends AbstractSessionCacheTest {
     @Override
     protected SessionCache createSessionCache( ExecutionContext context,
                                                WorkspaceCache cache ) {
-        return new ReadOnlySessionCache(context, workspaceCache, null);
+        return new ReadOnlySessionCache(context, workspaceCache, new SessionEnvironment() {
+            @Override
+            public Transactions getTransactions() {
+                return null;
+            }
+        });
     }
 }


### PR DESCRIPTION
_This should be merged into '3.1.x' and cherry-picked into 'master'._

Added a new specialization of WorkspaceCache called TransactionWorkspaceCache that is used in place of WorkspaceCache any time a ReadOnlySessionCache or WritableSessionCache is used during the scope of a running user transaction.

Normally, each RepositoryCache instance has for each workspace a single WorkspaceCache instance shared by all sessions. However, in the case of a session is running within a user transaction, it is possible for the session (or other sessions that are also participating in the same user transaction) to persist node changes in the document store but to not commit the transaction. This means that such persisted-but-not-committed node representations should be visible to the sessions running within the transaction but should not be visible to sessions outside of the transaction. Because the shared WorkspaceCache lazily loads the requested nodes using the transactional scope of the requestor, this means that the WorkspaceCache may load these persisted-but-not-committed node representations and make them available to other sessions (outside the transaction boundary) and thereby leaking transactionally-scoped data. Similarly, a WorkspaceCache that already has the persisted-and-committed node representations from other sessions will expose those already-cached forms to sessions running within the transaction, thereby causing some of the sessions in the same user transaction to not see the transactionally-scoped (e.g., persisted-but-not-committed) changes.

Therefore, such sessions running within user transactions need a transactionally-scoped WorkspaceCache instance rather than sharing the commont WorkspaceCache instance. However, the ModeShape infrastructure is not set up to handle lots of WorkspaceCache instances for the same workspace, so we have to be careful about any transaction-specific caches.

This new design changes the AbstractSessionCache to maintain the original reference to the real (shared) WorkspaceCache, but to also have another WorkspaceCache reference that may change (depending upon whether there is a current user transaction) to a transient TransactionalWorkspaceCache instance specific to the transaction.

Originally, I tried to have the TransactionalWorkspaceCache do no caching whatsoever, but this caused problems within the WritableSessionCache's persistChanges logic, which needs access to the persisted representation of the node prior to when each changed node was actually changed. So, the TWC simply uses an in-memory ConcurrentHashMap. (The alternative was to use another Infinispan cache such as the one used for the shared workspace caches, but this would dramatically increase the complexity of the system and would require an additional cache container configured with different settings than the normal workspace caches and to use a different naming convention.)

Several new test cases were added to verify that multiple sessions within the same user transaction do indeed all see the same transactionally-scoped data, while other sessions that are outside of the user transaction do indeed not see any of the transactionally-scoped changes until commit occurs.
