### PR TITLE
MODE-1827 - NullPointerException in RepositoryQueryManager

### DIFF
--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/RepositoryQueryManager.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/RepositoryQueryManager.java
@@ -355,7 +355,7 @@ class RepositoryQueryManager {
 
             // Look up the node and find the path ...
             node = cache.getNode(key);
-            if (!node.isQueryable(cache)) {
+            if (node == null || !node.isQueryable(cache)) {
                 continue;
             }
             nodePath = paths.getPath(node);


### PR DESCRIPTION
Null check in case the node no longer exist in the cache.
