### PR TITLE
MODE-1828 - ConstraintViolationException when updating the definition of...

### DIFF
--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/RepositoryNodeTypeManager.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/RepositoryNodeTypeManager.java
@@ -970,6 +970,9 @@ class RepositoryNodeTypeManager implements ChangeSetListener {
         protected NodeTypes with( Collection<JcrNodeType> addedNodeTypes ) {
             if (addedNodeTypes.isEmpty()) return this;
             Collection<JcrNodeType> nodeTypes = new HashSet<JcrNodeType>(this.nodeTypes.values());
+            // if there are updated node types, remove them first (hashcode is based on name alone),
+            // else addAll() will ignore the changes.
+            nodeTypes.removeAll(addedNodeTypes);
             nodeTypes.addAll(addedNodeTypes);
             return new NodeTypes(this.context, nodeTypes, getVersion() + 1);
         }

--- a/modeshape-jcr/src/test/java/org/modeshape/jcr/JcrRepositoryTest.java
+++ b/modeshape-jcr/src/test/java/org/modeshape/jcr/JcrRepositoryTest.java
@@ -27,6 +27,7 @@ import static org.hamcrest.collection.IsArrayContaining.hasItemInArray;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsNull.notNullValue;
 import static org.hamcrest.core.IsNull.nullValue;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
@@ -724,6 +725,28 @@ public class JcrRepositoryTest extends AbstractTransactionalTest {
         } finally {
             session2.logout();
         }
+    }
+
+    @FixFor( "MODE-1828" )
+    @Test
+    public void shouldAllowNodeTypeChangeAfterWrite() throws Exception {
+        session = createSession();
+        session.workspace().getNodeTypeManager().registerNodeTypes(getClass().getResourceAsStream("/cnd/nodeTypeChange-initial.cnd"), true);
+
+        Node testRoot = session.getRootNode().addNode("/testRoot", "test:nodeTypeA");
+        testRoot.setProperty("fieldA", "foo");
+        session.save();
+
+        session.workspace().getNodeTypeManager().registerNodeTypes(getClass().getResourceAsStream("/cnd/nodeTypeChange-next.cnd"), true);
+
+        testRoot = session.getNode("/testRoot");
+        assertEquals("foo", testRoot.getProperty("fieldA").getString());
+        testRoot.setProperty("fieldB", "bar");
+        session.save();
+
+        testRoot = session.getNode("/testRoot");
+        assertEquals("foo", testRoot.getProperty("fieldA").getString());
+        assertEquals("bar", testRoot.getProperty("fieldB").getString());
     }
 
     @FixFor( "MODE-1525" )

--- a/modeshape-jcr/src/test/resources/cnd/nodeTypeChange-initial.cnd
+++ b/modeshape-jcr/src/test/resources/cnd/nodeTypeChange-initial.cnd
@@ -1,0 +1,7 @@
+<mix = "http://www.jcp.org/jcr/mix/1.0">
+<mode = "http://www.modeshape.org/1.0">
+<test = "http://www.modeshape.org/test/1.0">
+
+[test:nodeTypeA]
+- fieldA (STRING)
+

--- a/modeshape-jcr/src/test/resources/cnd/nodeTypeChange-next.cnd
+++ b/modeshape-jcr/src/test/resources/cnd/nodeTypeChange-next.cnd
@@ -1,0 +1,7 @@
+<mix = "http://www.jcp.org/jcr/mix/1.0">
+<mode = "http://www.modeshape.org/1.0">
+<test = "http://www.modeshape.org/test/1.0">
+
+[test:nodeTypeA]
+- fieldA (STRING)
+- fieldB (STRING)


### PR DESCRIPTION
... the same node in a session

Fix the issue by making sure that nodeTypes with the same name is actually updated properly in the cache.
