### PR TITLE
MODE-1830 Corrected the purging of workspace caches in a cluster

### DIFF
--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/change/RecordingChanges.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/change/RecordingChanges.java
@@ -268,13 +268,20 @@ public class RecordingChanges implements Changes, ChangeSet {
           .append(getTimestamp())
           .append(" with user data = ")
           .append(userData)
-          .append(" in repository ").append(repositoryKey)
-          .append(" and workspace ").append(workspaceName)
+          .append(" in repository ")
+          .append(repositoryKey)
+          .append(" and workspace ")
+          .append(workspaceName)
           .append("\n");
 
         for (Change change : this) {
             sb.append("  ").append(change).append("\n");
         }
+        sb.append("changed " + nodeKeys.size() + " nodes:\n");
+        for (NodeKey key : nodeKeys) {
+            sb.append("  ").append(key).append("\n");
+        }
+
         return sb.toString();
     }
 }

--- a/modeshape-jcr/src/test/resources/config/clustered-repo-config-ispn.xml
+++ b/modeshape-jcr/src/test/resources/config/clustered-repo-config-ispn.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<infinispan xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:infinispan:config:5.1 http://www.infinispan.org/schemas/infinispan-config-5.1.xsd" xmlns="urn:infinispan:config:5.1">
+
+    <global>
+        <!-- Defines the global settings shared by all caches -->
+        <globalJmxStatistics enabled="false"/>
+
+        <transport clusterName="modeshape-cluster">
+          <!-- Use the property below to point to a specific JGroups configuration file on your classpath -->
+          <properties>
+             <property name="configurationFile" value="jgroups-tcp.xml" />
+          </properties>
+        </transport>
+    </global>
+
+    <namedCache name="repo_cache">
+        <clustering mode="replication">
+            <stateTransfer fetchInMemoryState="true" timeout="20000" />
+            <sync />
+        </clustering>
+        <locking isolationLevel="READ_COMMITTED" writeSkewCheck="false" lockAcquisitionTimeout="4000"/>
+        <transaction transactionMode="TRANSACTIONAL" lockingMode="PESSIMISTIC" />
+    </namedCache>
+
+</infinispan>

--- a/modeshape-jcr/src/test/resources/config/clustered-repo-config.json
+++ b/modeshape-jcr/src/test/resources/config/clustered-repo-config.json
@@ -6,9 +6,10 @@
         "allowCreation" : true
     },
     "storage" : {
-        "transactionManagerLookup" : "org.infinispan.transaction.lookup.DummyTransactionManagerLookup"
+        "cacheName" : "repo_cache",
+        "cacheConfiguration" : "config/clustered-repo-config-ispn.xml",
     },
     "clustering" : {
-        "clusterName" : "modeshape"
+        "clusterName" : "modeshape-cluster"
     }
 }


### PR DESCRIPTION
_This should be merged into the '3.1.x' branch and cherry-picked into the 'master' branch._

Before this fix, when a change was made via a WritableSessionCache, any changes persisted to the store were also used to directly purge any previously-cached node representations from the corresponding WorkspaceCache. Thus, when the RepositoryCache received the changes, it simply forwarding them to all workspaces except the one in which the changes originated.

However, in a clustered environment, the changes originate on one process and are sent to all other processes. The logic described above works fine in the same process in which the changes originated, but it doesn't correctly propagate the changes in the other processes.

The fix was pretty simple: determine if the changes came from the same process. If so, the use the current logic. If not, always forward the changes to all WorkspaceCache instances.

I also modified the ClusteredRepositoryTest to look in process A for nodes changed in process B. This failed before the logic was fixed, and now works with the fix.
