### PR TITLE
MODE-1758 No longer skipping the two TCK tests that had bugs

### DIFF
--- a/modeshape-jcr/pom.xml
+++ b/modeshape-jcr/pom.xml
@@ -291,10 +291,6 @@
                                         of the form "package#method". One per line. For example:
                                         org.apache.jackrabbit.test.api.ShareableNodeTest#testModifyDescendantAndSave
                                         -->
-                                        <!-- See https://issues.apache.org/jira/browse/JCR-3493 -->
-                                        org.apache.jackrabbit.test.api.query.qom.EquiJoinConditionTest#testRightOuterJoin1
-                                        <!-- See https://issues.apache.org/jira/browse/JCR-3493 -->
-                                        org.apache.jackrabbit.test.api.query.qom.EquiJoinConditionTest#testLeftOuterJoin2
                                     </value>
                                 </property>
                             </systemProperties>

--- a/modeshape-parent/pom.xml
+++ b/modeshape-parent/pom.xml
@@ -252,7 +252,7 @@
         <slf4j.log4j.version>1.6.1</slf4j.log4j.version>
         <log4j.version>1.2.16</log4j.version>
         <jcr.version>2.0</jcr.version>
-        <jackrabbit.jcr.tck.version>2.5.1</jackrabbit.jcr.tck.version>
+        <jackrabbit.jcr.tck.version>2.6.0</jackrabbit.jcr.tck.version>
         <jackrabbit.lucene.version>3.6.0</jackrabbit.lucene.version>
         <jbossjta.version>4.16.2.Final</jbossjta.version>
         <atomikos.version>3.8.0</atomikos.version>


### PR DESCRIPTION
The two OUTER JOIN tests were fixed in Jackrabbit Tests 2.6.0, so we are no longer skipping these tests.
