### PR TITLE
MODE-1844 - Improved error handling & recovery during startup, so that an exception does not leave the repository in inconsistent state

### DIFF
--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrRepository.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrRepository.java
@@ -65,8 +65,10 @@ import javax.naming.InitialContext;
 import javax.naming.NamingException;
 import javax.naming.NoInitialContextException;
 import javax.security.auth.login.LoginContext;
+import javax.transaction.NotSupportedException;
 import javax.transaction.Status;
 import javax.transaction.Synchronization;
+import javax.transaction.SystemException;
 import javax.transaction.Transaction;
 import javax.transaction.TransactionManager;
 import org.hibernate.search.backend.TransactionContext;
@@ -114,11 +116,6 @@ import org.modeshape.jcr.cache.SessionEnvironment;
 import org.modeshape.jcr.cache.SessionEnvironment.Monitor;
 import org.modeshape.jcr.cache.SessionEnvironment.MonitorFactory;
 import org.modeshape.jcr.cache.WorkspaceNotFoundException;
-import org.modeshape.jcr.cache.change.Change;
-import org.modeshape.jcr.cache.change.ChangeSet;
-import org.modeshape.jcr.cache.change.ChangeSetListener;
-import org.modeshape.jcr.cache.change.WorkspaceAdded;
-import org.modeshape.jcr.cache.change.WorkspaceRemoved;
 import org.modeshape.jcr.cache.document.DocumentStore;
 import org.modeshape.jcr.cache.document.LocalDocumentStore;
 import org.modeshape.jcr.cache.document.TransactionalWorkspaceCaches;
@@ -339,7 +336,7 @@ public class JcrRepository implements org.modeshape.jcr.api.Repository {
                 this.runningState.set(new RunningState(oldState, configChanges));
 
                 // Handle a few special cases that the running state doesn't really handle itself ...
-                if (!configChanges.storageChanged && configChanges.predefinedWorkspacesChanged) workspacesChanged();
+                if (!configChanges.storageChanged && configChanges.predefinedWorkspacesChanged) refreshWorkspaces();
                 if (configChanges.nameChanged) repositoryNameChanged();
             }
             logger.debug("Applied changes to '{0}' repository configuration: {1} --> {2}", repositoryName, changes, config);
@@ -360,27 +357,17 @@ public class JcrRepository implements org.modeshape.jcr.api.Repository {
                 this.state.set(State.STARTING);
                 state = new RunningState();
                 this.runningState.compareAndSet(null, state);
-                workspacesChanged();
+                state.completeInitialization();
                 this.state.set(State.RUNNING);
                 state.postInitialize();
             }
             return state;
-        } catch (IOException e) {
-            // Only way to get exception is because we tried to create the running state (e.g., it was not running when we
-            // entered)
+        } catch (Exception e) {
+            //we should set the state to NOT_RUNNING regardless of the error/exception that occurs
             this.state.set(State.NOT_RUNNING);
             throw e;
-        } catch (NamingException e) {
-            // Only way to get exception is because we tried to create the running state (e.g., it was not running when we
-            // entered)
-            this.state.set(State.NOT_RUNNING);
-            throw e;
-        } catch (RuntimeException e) {
-            // Only way to get exception is because we tried to create the running state (e.g., it was not running when we
-            // entered)
-            this.state.set(State.NOT_RUNNING);
-            throw e;
-        } finally {
+        }
+        finally {
             stateLock.unlock();
         }
     }
@@ -588,8 +575,6 @@ public class JcrRepository implements org.modeshape.jcr.api.Repository {
     }
 
     /**
-     * {@inheritDoc}
-     * 
      * @throws IllegalArgumentException if <code>credentials</code> is not <code>null</code> but:
      *         <ul>
      *         <li>provides neither a <code>getLoginContext()</code> nor a <code>getAccessControlContext()</code> method and is
@@ -857,7 +842,7 @@ public class JcrRepository implements org.modeshape.jcr.api.Repository {
         return valueFor(valueFactories, PropertyType.BOOLEAN, value);
     }
 
-    protected void workspacesChanged() {
+    protected void refreshWorkspaces() {
         RunningState running = runningState();
         if (running != null) {
             Set<String> workspaceNames = running.repositoryCache().getWorkspaceNames();
@@ -892,33 +877,11 @@ public class JcrRepository implements org.modeshape.jcr.api.Repository {
         return caches;
     }
 
-    protected class WorkspaceListener implements ChangeSetListener {
-        @Override
-        public void notify( ChangeSet changeSet ) {
-
-            if (changeSet == null || !repositoryCache().getKey().equals(changeSet.getRepositoryKey())) return;
-            String workspaceName = changeSet.getWorkspaceName();
-            if (workspaceName == null) {
-                // Look for changes to the workspaces ...
-                boolean changed = false;
-                for (Change change : changeSet) {
-                    if (change instanceof WorkspaceAdded) {
-                        changed = true;
-                    } else if (change instanceof WorkspaceRemoved) {
-                        changed = true;
-                    }
-                }
-                if (changed) workspacesChanged();
-            }
-        }
-    }
-
     @Immutable
     protected class RunningState {
 
         private final RepositoryConfiguration config;
         private final DocumentStore documentStore;
-        private final RepositoryCache cache;
         private final AuthenticationProviders authenticators;
         private final Credentials anonymousCredentialsIfSuppliedCredentialsFail;
         private final String defaultWorkspaceName;
@@ -956,7 +919,8 @@ public class JcrRepository implements org.modeshape.jcr.api.Repository {
         private final RepositoryConfiguration.IndexRebuildOptions indexRebuildOptions;
         private final List<ScheduledFuture<?>> gcProcesses = new ArrayList<ScheduledFuture<?>>();
 
-        private Transaction runningTransaction;
+        private Transaction existingUserTransaction;
+        private RepositoryCache cache;
 
         protected RunningState() throws Exception {
             this(null, null);
@@ -999,239 +963,247 @@ public class JcrRepository implements org.modeshape.jcr.api.Repository {
                 this.defaultWorkspaceName = config.getDefaultWorkspaceName();
             }
 
-            if (other != null) {
-                if (change.storageChanged) {
-                    // Can't change where we're storing the content while we're running, so take effect upon next startup
-                    logger.warn(JcrI18n.storageRelatedConfigurationChangesWillTakeEffectAfterShutdown, getName());
-                }
-                if (change.binaryStorageChanged) {
-                    // Can't change where we're storing the content while we're running, so take effect upon next startup
-                    logger.warn(JcrI18n.storageRelatedConfigurationChangesWillTakeEffectAfterShutdown, getName());
-                }
-                // reuse the existing storage-related components ...
-                this.cache = other.cache;
-                this.context = other.context;
-                this.connectors = other.connectors;
-                this.documentStore = other.documentStore;
-                this.txnMgr = documentStore.transactionManager();
-                validateTransactionsEnabled();
-                MonitorFactory monitorFactory = new RepositoryMonitorFactory(this);
-                this.transactions = createTransactions(config.getTransactionMode(), monitorFactory, this.txnMgr);
-                // suspend any potential existing transaction, so that the initialization is "atomic"
-                runningTransaction = this.transactions.suspend();
-                if (change.largeValueChanged) {
-                    // We can update the value used in the repository cache dynamically ...
-                    BinaryStorage binaryStorage = config.getBinaryStorage();
-                    this.cache.setLargeStringLength(binaryStorage.getMinimumBinarySizeInBytes());
-                    this.context.getBinaryStore().setMinimumBinarySizeInBytes(binaryStorage.getMinimumBinarySizeInBytes());
-                }
-                if (change.workspacesChanged) {
-                    // Make sure that all the predefined workspaces are available ...
-                    for (String workspaceName : config.getPredefinedWorkspaceNames()) {
-                        this.cache.createWorkspace(workspaceName);
-                    }
-                }
-                this.mimeTypeDetector = new MimeTypeDetectors(other.config.environment());
-                this.binaryStore = other.binaryStore;
-                this.internalWorkerContext = other.internalWorkerContext;
-                this.nodeTypes = other.nodeTypes.with(this, true, true);
-                this.lockManager = other.lockManager.with(this);
-                this.cache.register(this.lockManager);
-                other.cache.unregister(other.lockManager);
-                this.persistentRegistry = other.persistentRegistry;
-                this.changeDispatchingQueue = other.changeDispatchingQueue;
-                this.changeBus = other.changeBus;
-            } else {
-                // find the Schematic database and Infinispan Cache ...
-                CacheContainer container = config.getContentCacheContainer();
-                String cacheName = config.getCacheName();
-                List<Component> connectorComponents = config.getFederation().getConnectors();
-                Map<String, List<RepositoryConfiguration.ProjectionConfiguration>> preconfiguredProjectionsByWorkspace = config.getFederation()
-                                                                                                                               .getProjectionsByWorkspace();
-                this.connectors = new Connectors(this, connectorComponents, preconfiguredProjectionsByWorkspace);
-                logger.debug("Loading cache '{0}' from cache container {1}", cacheName, container);
-                SchematicDb database = Schematic.get(container, cacheName);
-                this.documentStore = connectors.hasConnectors() ? new FederatedDocumentStore(connectors, database) : new LocalDocumentStore(
-                                                                                                                                            database);
-                // this.documentStore = new LocalDocumentStore(database);
-                this.txnMgr = this.documentStore.transactionManager();
-                validateTransactionsEnabled();
-                MonitorFactory monitorFactory = new RepositoryMonitorFactory(this);
-                this.transactions = createTransactions(config.getTransactionMode(), monitorFactory, this.txnMgr);
-                // suspend any potential existing transaction, so that the initialization is "atomic"
-                runningTransaction = this.transactions.suspend();
-
-                // Set up the binary store ...
-                BinaryStorage binaryStorageConfig = config.getBinaryStorage();
-                binaryStore = binaryStorageConfig.getBinaryStore();
-                binaryStore.start();
-                tempContext = tempContext.with(binaryStore);
-
-                // Now create the registry implementation and the execution context that uses it ...
-                this.persistentRegistry = new SystemNamespaceRegistry(this);
-                this.mimeTypeDetector = new MimeTypeDetectors(this.config.environment());
-                this.context = tempContext.with(persistentRegistry);
-                this.persistentRegistry.setContext(this.context);
-                this.internalWorkerContext = this.context.with(new InternalSecurityContext(INTERNAL_WORKER_USERNAME));
-
-                // Create the event bus
-                this.changeDispatchingQueue = this.context().getCachedTreadPool("modeshape-event-dispatcher");
-                this.changeBus = createBus(config.getClustering(), this.changeDispatchingQueue, systemWorkspaceName(), false);
-                this.changeBus.start();
-
-                // Set up the repository cache ...
-                final SessionEnvironment sessionEnv = new RepositorySessionEnvironment(this.transactions);
-                CacheContainer workspaceCacheContainer = this.config.getWorkspaceContentCacheContainer();
-                this.cache = new RepositoryCache(context, documentStore, config, systemContentInitializer, sessionEnv, changeBus,
-                                                 workspaceCacheContainer);
-
-                // Set up the node type manager ...
-                this.nodeTypes = new RepositoryNodeTypeManager(this, true, true);
-                this.cache.register(this.nodeTypes);
-
-                // Set up the lock manager ...
-                this.lockManager = new RepositoryLockManager(this);
-                this.cache.register(this.lockManager);
-
-                // Set up the unused binary value listener ...
-                this.cache.register(new BinaryUsageChangeSetListener(binaryStore));
-
-                // Refresh several of the components information from the repository cache ...
-                this.persistentRegistry.refreshFromSystem();
-                this.lockManager.refreshFromSystem();
-                if (!this.nodeTypes.refreshFromSystem()) {
-                    try {
-                        // Read in the built-in node types ...
-                        CndImporter importer = new CndImporter(context, true);
-                        importer.importBuiltIns(new SimpleProblems());
-                        this.nodeTypes.registerNodeTypes(importer.getNodeTypeDefinitions(), false, true, true);
-                    } catch (RepositoryException re) {
-                        throw new IllegalStateException("Could not load node type definition files", re);
-                    } catch (IOException ioe) {
-                        throw new IllegalStateException("Could not access node type definition files", ioe);
-                    }
-                }
-                // Add the built-ins, ensuring we overwrite any badly-initialized values ...
-                this.persistentRegistry.register(JcrNamespaceRegistry.STANDARD_BUILT_IN_NAMESPACES_BY_PREFIX);
-
-                // Record the number of workspaces that are available/predefined ...
-                this.statistics.set(ValueMetric.WORKSPACE_COUNT, cache.getWorkspaceNames().size());
-            }
-
-            this.useXaSessions = this.transactions instanceof SynchronizedTransactions;
-
-            if (other != null && !change.securityChanged) {
-                this.authenticators = other.authenticators;
-                this.anonymousCredentialsIfSuppliedCredentialsFail = other.anonymousCredentialsIfSuppliedCredentialsFail;
-            } else {
-                // Set up the security ...
-                AtomicBoolean useAnonymouOnFailedLogins = new AtomicBoolean();
-                this.authenticators = createAuthenticationProviders(useAnonymouOnFailedLogins);
-                this.anonymousCredentialsIfSuppliedCredentialsFail = useAnonymouOnFailedLogins.get() ? new AnonymousCredentials() : null;
-            }
-
-            if (other != null && !change.extractorsChanged) {
-                this.extractors = new TextExtractors(this, other.config.getQuery().getTextExtracting());
-            } else {
-                this.extractors = new TextExtractors(this, config.getQuery().getTextExtracting());
-            }
-            this.binaryStore.setMimeTypeDetector(this.mimeTypeDetector);
-            this.binaryStore.setTextExtractors(this.extractors);
-
-            if (other != null && !change.sequencingChanged) {
-                this.sequencingQueue = other.sequencingQueue;
-                this.sequencers = other.sequencers.with(this);
-                if (!sequencers.isEmpty()) this.cache.register(this.sequencers);
-                this.cache.unregister(other.sequencers);
-            } else {
-                // There are changes to the sequencers ...
-                Sequencers.WorkQueue queue = null;
-                List<Component> sequencerComponents = config.getSequencing().getSequencers();
-                if (sequencerComponents.isEmpty()) {
-                    // There are no sequencers ...
-                    this.sequencingQueue = null;
-                    this.sequencers = new Sequencers(this, sequencerComponents, cache.getWorkspaceNames(), queue);
-                } else {
-                    // Create an in-memory queue of sequencing work items ...
-                    String threadPoolName = config.getSequencing().getThreadPoolName();
-                    this.sequencingQueue = this.context.getThreadPool(threadPoolName);
-                    queue = new Sequencers.WorkQueue() {
-                        @SuppressWarnings( "synthetic-access" )
-                        @Override
-                        public void submit( final SequencingWorkItem work ) {
-                            sequencingQueue.execute(new SequencingRunner(JcrRepository.this, work));
-                        }
-                    };
-                    this.sequencers = new Sequencers(this, sequencerComponents, cache.getWorkspaceNames(), queue);
-                    this.cache.register(this.sequencers);
-                }
-            }
-
-            if (other != null && !change.indexingChanged) {
-                this.indexingExecutor = other.indexingExecutor;
-                this.queryParsers = other.queryParsers;
-            } else {
-                String indexThreadPoolName = config.getQuery().getThreadPoolName();
-                this.indexingExecutor = this.context.getThreadPool(indexThreadPoolName);
-                this.queryParsers = new QueryParsers(new JcrSql2QueryParser(), new XPathQueryParser(),
-                                                     new FullTextSearchParser(), new JcrSqlQueryParser(), new JcrQomQueryParser());
-            }
-            QuerySystem query = config.getQuery();
-            if (query.queriesEnabled()) {
-                // The query system is enabled ...
-                Properties backendProps = query.getIndexingBackendProperties();
-                Properties indexingProps = query.getIndexingProperties();
-                Properties indexStorageProps = query.getIndexStorageProperties();
-                this.repositoryQueryManager = new RepositoryQueryManager(this, config.getQuery(), indexingExecutor, backendProps,
-                                                                         indexingProps, indexStorageProps);
-                this.indexRebuildOptions = query.getIndexRebuildOptions();
-            } else {
-                this.repositoryQueryManager = new RepositoryDisabledQueryManager(this, config.getQuery());
-                this.indexRebuildOptions = null;
-                logger.debug("Queries have been DISABLED for the '{0}' repository. Nothing will be indexed, and all queries will return empty results.",
-                             repositoryName());
-            }
-
-            // Check that we have parsers for all the required languages ...
-            assert this.queryParsers.getParserFor(Query.XPATH) != null;
-            assert this.queryParsers.getParserFor(Query.SQL) != null;
-            assert this.queryParsers.getParserFor(Query.JCR_SQL2) != null;
-            assert this.queryParsers.getParserFor(Query.JCR_JQOM) != null;
-            assert this.queryParsers.getParserFor(QueryLanguage.SEARCH) != null;
-
-            if (other != null && !change.jndiChanged) {
-                // The repository is already registered (or not registered)
-                this.jndiName = other.jndiName;
-            } else {
-                // The JNDI location has changed, so register the new one ...
-                this.jndiName = config.getJndiName();
-                bindIntoJndi();
-
-                // And unregister the old name ...
+            try {
                 if (other != null) {
-                    other.unbindFromJndi();
+                    if (change.storageChanged) {
+                        // Can't change where we're storing the content while we're running, so take effect upon next startup
+                        logger.warn(JcrI18n.storageRelatedConfigurationChangesWillTakeEffectAfterShutdown, getName());
+                    }
+                    if (change.binaryStorageChanged) {
+                        // Can't change where we're storing the content while we're running, so take effect upon next startup
+                        logger.warn(JcrI18n.storageRelatedConfigurationChangesWillTakeEffectAfterShutdown, getName());
+                    }
+                    // reuse the existing storage-related components ...
+                    this.cache = other.cache;
+                    this.context = other.context;
+                    this.connectors = other.connectors;
+                    this.documentStore = other.documentStore;
+                    this.txnMgr = documentStore.transactionManager();
+
+                    MonitorFactory monitorFactory = new RepositoryMonitorFactory(this);
+                    this.transactions = createTransactions(config.getTransactionMode(), monitorFactory, this.txnMgr);
+
+                    suspendExistingUserTransaction();
+
+                    if (change.largeValueChanged) {
+                        // We can update the value used in the repository cache dynamically ...
+                        BinaryStorage binaryStorage = config.getBinaryStorage();
+                        this.cache.setLargeStringLength(binaryStorage.getMinimumBinarySizeInBytes());
+                        this.context.getBinaryStore().setMinimumBinarySizeInBytes(binaryStorage.getMinimumBinarySizeInBytes());
+                    }
+                    if (change.workspacesChanged) {
+                        // Make sure that all the predefined workspaces are available ...
+                        for (String workspaceName : config.getPredefinedWorkspaceNames()) {
+                            this.cache.createWorkspace(workspaceName);
+                        }
+                    }
+                    this.mimeTypeDetector = new MimeTypeDetectors(other.config.environment());
+                    this.binaryStore = other.binaryStore;
+                    this.internalWorkerContext = other.internalWorkerContext;
+                    this.nodeTypes = other.nodeTypes.with(this, true, true);
+                    this.lockManager = other.lockManager.with(this);
+                    this.cache.register(this.lockManager);
+                    other.cache.unregister(other.lockManager);
+                    this.persistentRegistry = other.persistentRegistry;
+                    this.changeDispatchingQueue = other.changeDispatchingQueue;
+                    this.changeBus = other.changeBus;
+                } else {
+                    // find the Schematic database and Infinispan Cache ...
+                    CacheContainer container = config.getContentCacheContainer();
+                    String cacheName = config.getCacheName();
+                    List<Component> connectorComponents = config.getFederation().getConnectors();
+                    Map<String, List<RepositoryConfiguration.ProjectionConfiguration>> preconfiguredProjectionsByWorkspace = config.getFederation()
+                                                                                                                                   .getProjectionsByWorkspace();
+                    this.connectors = new Connectors(this, connectorComponents, preconfiguredProjectionsByWorkspace);
+                    logger.debug("Loading cache '{0}' from cache container {1}", cacheName, container);
+                    SchematicDb database = Schematic.get(container, cacheName);
+                    this.documentStore = connectors.hasConnectors() ? new FederatedDocumentStore(connectors, database) : new LocalDocumentStore(
+                                                                                                                                                database);
+                    // this.documentStore = new LocalDocumentStore(database);
+                    this.txnMgr = this.documentStore.transactionManager();
+                    MonitorFactory monitorFactory = new RepositoryMonitorFactory(this);
+                    this.transactions = createTransactions(config.getTransactionMode(), monitorFactory, this.txnMgr);
+
+                    suspendExistingUserTransaction();
+
+                    // Set up the binary store ...
+                    BinaryStorage binaryStorageConfig = config.getBinaryStorage();
+                    binaryStore = binaryStorageConfig.getBinaryStore();
+                    binaryStore.start();
+                    tempContext = tempContext.with(binaryStore);
+
+                    // Now create the registry implementation and the execution context that uses it ...
+                    this.persistentRegistry = new SystemNamespaceRegistry(this);
+                    this.mimeTypeDetector = new MimeTypeDetectors(this.config.environment());
+                    this.context = tempContext.with(persistentRegistry);
+                    this.persistentRegistry.setContext(this.context);
+                    this.internalWorkerContext = this.context.with(new InternalSecurityContext(INTERNAL_WORKER_USERNAME));
+
+                    // Create the event bus
+                    this.changeDispatchingQueue = this.context().getCachedTreadPool("modeshape-event-dispatcher");
+                    this.changeBus = createBus(config.getClustering(), this.changeDispatchingQueue, systemWorkspaceName(), false);
+                    this.changeBus.start();
+
+                    // Set up the repository cache ...
+                    final SessionEnvironment sessionEnv = new RepositorySessionEnvironment(this.transactions);
+                    CacheContainer workspaceCacheContainer = this.config.getWorkspaceContentCacheContainer();
+                    this.cache = new RepositoryCache(context, documentStore, config, systemContentInitializer, sessionEnv, changeBus,
+                                                     workspaceCacheContainer);
+
+                    // Set up the node type manager ...
+                    this.nodeTypes = new RepositoryNodeTypeManager(this, true, true);
+                    this.cache.register(this.nodeTypes);
+
+                    // Set up the lock manager ...
+                    this.lockManager = new RepositoryLockManager(this);
+                    this.cache.register(this.lockManager);
+
+                    // Set up the unused binary value listener ...
+                    this.cache.register(new BinaryUsageChangeSetListener(binaryStore));
+
+                    // Refresh several of the components information from the repository cache ...
+                    this.persistentRegistry.refreshFromSystem();
+                    this.lockManager.refreshFromSystem();
+                    if (!this.nodeTypes.refreshFromSystem()) {
+                        try {
+                            // Read in the built-in node types ...
+                            CndImporter importer = new CndImporter(context, true);
+                            importer.importBuiltIns(new SimpleProblems());
+                            this.nodeTypes.registerNodeTypes(importer.getNodeTypeDefinitions(), false, true, true);
+                        } catch (RepositoryException re) {
+                            throw new IllegalStateException("Could not load node type definition files", re);
+                        } catch (IOException ioe) {
+                            throw new IllegalStateException("Could not access node type definition files", ioe);
+                        }
+                    }
+                    // Add the built-ins, ensuring we overwrite any badly-initialized values ...
+                    this.persistentRegistry.register(JcrNamespaceRegistry.STANDARD_BUILT_IN_NAMESPACES_BY_PREFIX);
+
+                    // Record the number of workspaces that are available/predefined ...
+                    this.statistics.set(ValueMetric.WORKSPACE_COUNT, cache.getWorkspaceNames().size());
                 }
-            }
 
-            // Set up the backup service and executor ...
-            this.backupService = new BackupService(this);
+                this.useXaSessions = this.transactions instanceof SynchronizedTransactions;
 
-            // Set up the initial content importer
-            this.initialContentImporter = new InitialContentImporter(config.getInitialContent(), this);
+                if (other != null && !change.securityChanged) {
+                    this.authenticators = other.authenticators;
+                    this.anonymousCredentialsIfSuppliedCredentialsFail = other.anonymousCredentialsIfSuppliedCredentialsFail;
+                } else {
+                    // Set up the security ...
+                    AtomicBoolean useAnonymouOnFailedLogins = new AtomicBoolean();
+                    this.authenticators = createAuthenticationProviders(useAnonymouOnFailedLogins);
+                    this.anonymousCredentialsIfSuppliedCredentialsFail = useAnonymouOnFailedLogins.get() ? new AnonymousCredentials() : null;
+                }
 
-            // Set up the node types importer
-            this.nodeTypesImporter = new NodeTypesImporter(config.getNodeTypes(), this);
-        }
+                if (other != null && !change.extractorsChanged) {
+                    this.extractors = new TextExtractors(this, other.config.getQuery().getTextExtracting());
+                } else {
+                    this.extractors = new TextExtractors(this, config.getQuery().getTextExtracting());
+                }
+                this.binaryStore.setMimeTypeDetector(this.mimeTypeDetector);
+                this.binaryStore.setTextExtractors(this.extractors);
 
-        private void validateTransactionsEnabled() {
-            if (txnMgr == null) {
-                throw new IllegalStateException(JcrI18n.repositoryCannotBeStartedWithoutTransactionalSupport.text(getName()));
+                if (other != null && !change.sequencingChanged) {
+                    this.sequencingQueue = other.sequencingQueue;
+                    this.sequencers = other.sequencers.with(this);
+                    if (!sequencers.isEmpty()) this.cache.register(this.sequencers);
+                    this.cache.unregister(other.sequencers);
+                } else {
+                    // There are changes to the sequencers ...
+                    Sequencers.WorkQueue queue = null;
+                    List<Component> sequencerComponents = config.getSequencing().getSequencers();
+                    if (sequencerComponents.isEmpty()) {
+                        // There are no sequencers ...
+                        this.sequencingQueue = null;
+                        this.sequencers = new Sequencers(this, sequencerComponents, cache.getWorkspaceNames(), queue);
+                    } else {
+                        // Create an in-memory queue of sequencing work items ...
+                        String threadPoolName = config.getSequencing().getThreadPoolName();
+                        this.sequencingQueue = this.context.getThreadPool(threadPoolName);
+                        queue = new Sequencers.WorkQueue() {
+                            @SuppressWarnings( "synthetic-access" )
+                            @Override
+                            public void submit( final SequencingWorkItem work ) {
+                                sequencingQueue.execute(new SequencingRunner(JcrRepository.this, work));
+                            }
+                        };
+                        this.sequencers = new Sequencers(this, sequencerComponents, cache.getWorkspaceNames(), queue);
+                        this.cache.register(this.sequencers);
+                    }
+                }
+
+                if (other != null && !change.indexingChanged) {
+                    this.indexingExecutor = other.indexingExecutor;
+                    this.queryParsers = other.queryParsers;
+                } else {
+                    String indexThreadPoolName = config.getQuery().getThreadPoolName();
+                    this.indexingExecutor = this.context.getThreadPool(indexThreadPoolName);
+                    this.queryParsers = new QueryParsers(new JcrSql2QueryParser(), new XPathQueryParser(),
+                                                         new FullTextSearchParser(), new JcrSqlQueryParser(), new JcrQomQueryParser());
+                }
+                QuerySystem query = config.getQuery();
+                if (query.queriesEnabled()) {
+                    // The query system is enabled ...
+                    Properties backendProps = query.getIndexingBackendProperties();
+                    Properties indexingProps = query.getIndexingProperties();
+                    Properties indexStorageProps = query.getIndexStorageProperties();
+                    this.repositoryQueryManager = new RepositoryQueryManager(this, config.getQuery(), indexingExecutor, backendProps,
+                                                                             indexingProps, indexStorageProps);
+                    this.indexRebuildOptions = query.getIndexRebuildOptions();
+                } else {
+                    this.repositoryQueryManager = new RepositoryDisabledQueryManager(this, config.getQuery());
+                    this.indexRebuildOptions = null;
+                    logger.debug("Queries have been DISABLED for the '{0}' repository. Nothing will be indexed, and all queries will return empty results.",
+                                 repositoryName());
+                }
+
+                // Check that we have parsers for all the required languages ...
+                assert this.queryParsers.getParserFor(Query.XPATH) != null;
+                assert this.queryParsers.getParserFor(Query.SQL) != null;
+                assert this.queryParsers.getParserFor(Query.JCR_SQL2) != null;
+                assert this.queryParsers.getParserFor(Query.JCR_JQOM) != null;
+                assert this.queryParsers.getParserFor(QueryLanguage.SEARCH) != null;
+
+                if (other != null && !change.jndiChanged) {
+                    // The repository is already registered (or not registered)
+                    this.jndiName = other.jndiName;
+                } else {
+                    // The JNDI location has changed, so register the new one ...
+                    this.jndiName = config.getJndiName();
+                    bindIntoJndi();
+
+                    // And unregister the old name ...
+                    if (other != null) {
+                        other.unbindFromJndi();
+                    }
+                }
+
+                // Set up the backup service and executor ...
+                this.backupService = new BackupService(this);
+
+                // Set up the initial content importer
+                this.initialContentImporter = new InitialContentImporter(config.getInitialContent(), this);
+
+                // Set up the node types importer
+                this.nodeTypesImporter = new NodeTypesImporter(config.getNodeTypes(), this);
+            } catch (Throwable t) {
+                //remove the document that was written as part of the initialization procedure
+                if (cache != null) {
+                    cache.rollbackRepositoryInfo();
+                }
+                //resume any user transaction that may have been suspended earlier
+                resumeExistingUserTransaction();
+                throw (t instanceof Exception) ? (Exception) t : new RuntimeException(t);
             }
         }
 
         protected Transactions createTransactions( TransactionMode mode,
                                                    MonitorFactory monitorFactory,
                                                    TransactionManager txnMgr ) {
+            if (txnMgr == null) {
+                throw new IllegalStateException(JcrI18n.repositoryCannotBeStartedWithoutTransactionalSupport.text(getName()));
+            }
+
             switch (mode) {
                 case NONE:
                     return new NoClientTransactions(monitorFactory, txnMgr);
@@ -1242,85 +1214,101 @@ public class JcrRepository implements org.modeshape.jcr.api.Repository {
         }
 
         /**
-         * Perform any initialization code that requires the repository to be in a running state.
+         * Performs the steps required after the running state has been created and before a repository is considered "initialized"
+         *
+         * @throws Exception if anything goes wrong in this phase. If it does, the transaction used for startup should be rolled
+         * back
+         */
+        protected final void completeInitialization() throws Exception {
+            try {
+                refreshWorkspaces();
+
+                this.sequencers.initialize();
+
+                // import the preconfigured node types before the initial content, in case the latter use custom types
+                this.nodeTypesImporter.importNodeTypes();
+
+                if (repositoryCache().isInitializingRepository()) {
+                    // import initial content for each of the workspaces (this has to be done after the running state has "started"
+                    this.cache.runSystemOneTimeInitializationOperation(new Callable<Void>() {
+                        @Override
+                        public Void call() throws Exception {
+                            for (String workspaceName : repositoryCache().getWorkspaceNames()) {
+                                initialContentImporter().importInitialContent(workspaceName);
+                            }
+                            return null;
+                        }
+                    });
+                }
+
+                // connectors must be initialized after initial content because that can have an influence on projections
+                this.connectors.initialize();
+
+                // Now record in the content that we're finished initializing the repository. This will commit the startup transaction
+                repositoryCache().completeInitialization();
+            } catch (Throwable t) {
+                this.cache.rollbackRepositoryInfo();
+                resumeExistingUserTransaction();
+                throw t instanceof  Exception ? (Exception) t : new RuntimeException(t);
+            }
+        }
+
+        /**
+         * Perform any initialization code that requires the repository to be in a running state. The repository has been considered
+         * started up.
          * 
          * @throws Exception if there is a problem during this phase.
          */
         protected final void postInitialize() throws Exception {
-            this.sequencers.initialize();
+            try {
+                // check the re-indexing options and do the re-indexing (this must be done after all of the above have finished)
+                if (indexRebuildOptions != null) {
+                    RepositoryConfiguration.QueryRebuild when = indexRebuildOptions.getWhen();
+                    boolean includeSystemContent = indexRebuildOptions.includeSystemContent();
+                    boolean async = indexRebuildOptions.getMode() == RepositoryConfiguration.IndexingMode.ASYNC;
 
-            // import the preconfigured node types before the initial content, in case the latter use custom types
-            this.nodeTypesImporter.importNodeTypes();
-
-            if (repositoryCache().isInitializingRepository()) {
-                // import initial content for each of the workspaces (this has to be done after the running state has "started"
-                this.cache.runSystemOneTimeInitializationOperation(new Callable<Void>() {
-                    @Override
-                    public Void call() throws Exception {
-                        for (String workspaceName : repositoryCache().getWorkspaceNames()) {
-                            initialContentImporter().importInitialContent(workspaceName);
+                    switch (when) {
+                        case ALWAYS: {
+                            this.repositoryQueryManager.reindexContent(false, includeSystemContent, async);
+                            break;
                         }
-                        return null;
-                    }
-                });
-            }
-
-            // connectors must be initialized after initial content because that can have an influence on projections
-            this.connectors.initialize();
-
-            // Now record in the content that we're finished initializing the repository ...
-            repositoryCache().completeInitialization();
-
-            // check the re-indexing options and do the re-indexing (this must be done after all of the above have finished)
-            if (indexRebuildOptions != null) {
-                RepositoryConfiguration.QueryRebuild when = indexRebuildOptions.getWhen();
-                boolean includeSystemContent = indexRebuildOptions.includeSystemContent();
-                boolean async = indexRebuildOptions.getMode() == RepositoryConfiguration.IndexingMode.ASYNC;
-
-                switch (when) {
-                    case ALWAYS: {
-                        this.repositoryQueryManager.reindexContent(false, includeSystemContent, async);
-                        break;
-                    }
-                    case IF_MISSING: {
-                        this.repositoryQueryManager.reindexContent(true, includeSystemContent, async);
-                        break;
-                    }
-                    case NEVER: {
-                        Set<NodeKey> existingIndexes = queryManager().getIndexes().indexedNodes();
-                        if (existingIndexes.isEmpty()) {
-                            logger.info(JcrI18n.noReindex, getName());
-                        } else {
-                            logger.debug("Index rebuild option is 'never' for repository {0} so nothing will be re-indexed. The existing indexed node are: {1}",
-                                         name(),
-                                         existingIndexes);
+                        case IF_MISSING: {
+                            this.repositoryQueryManager.reindexContent(true, includeSystemContent, async);
+                            break;
                         }
-                        break;
+                        case NEVER: {
+                            Set<NodeKey> existingIndexes = queryManager().getIndexes().indexedNodes();
+                            if (existingIndexes.isEmpty()) {
+                                logger.info(JcrI18n.noReindex, getName());
+                            } else {
+                                logger.debug("Index rebuild option is 'never' for repository {0} so nothing will be re-indexed. The existing indexed node are: {1}",
+                                             name(),
+                                             existingIndexes);
+                            }
+                            break;
+                        }
                     }
                 }
+
+                // Register the background processes. Do this last since we want the repository running before these are started ...
+                GarbageCollection gcConfig = config.getGarbageCollection();
+                String threadPoolName = gcConfig.getThreadPoolName();
+                long binaryGcInitialTime = determineInitialDelay(gcConfig.getInitialTimeExpression());
+                long binaryGcInterval = gcConfig.getIntervalInHours();
+                int lockSweepIntervalInMinutes = gcConfig.getLockSweepIntervalInMinutes();
+                assert binaryGcInitialTime >= 0;
+                ScheduledExecutorService garbageCollectionService = this.context.getScheduledThreadPool(threadPoolName);
+                gcProcesses.add(garbageCollectionService.scheduleAtFixedRate(new LockGarbageCollectionTask(JcrRepository.this),
+                                                                             lockSweepIntervalInMinutes,
+                                                                             lockSweepIntervalInMinutes,
+                                                                             TimeUnit.MINUTES));
+                gcProcesses.add(garbageCollectionService.scheduleAtFixedRate(new BinaryValueGarbageCollectionTask(JcrRepository.this),
+                                                                             binaryGcInitialTime,
+                                                                             binaryGcInterval,
+                                                                             TimeUnit.HOURS));
+            } finally {
+                resumeExistingUserTransaction();
             }
-
-            // any potential transaction was suspended during the creation of the running state to make sure intialization is
-            // atomic
-            this.transactions.resume(runningTransaction);
-            this.runningTransaction = null;
-
-            // Register the background processes. Do this last since we want the repository running before these are started ...
-            GarbageCollection gcConfig = config.getGarbageCollection();
-            String threadPoolName = gcConfig.getThreadPoolName();
-            long binaryGcInitialTime = determineInitialDelay(gcConfig.getInitialTimeExpression());
-            long binaryGcInterval = gcConfig.getIntervalInHours();
-            int lockSweepIntervalInMinutes = gcConfig.getLockSweepIntervalInMinutes();
-            assert binaryGcInitialTime >= 0;
-            ScheduledExecutorService garbageCollectionService = this.context.getScheduledThreadPool(threadPoolName);
-            gcProcesses.add(garbageCollectionService.scheduleAtFixedRate(new LockGarbageCollectionTask(JcrRepository.this),
-                                                                         lockSweepIntervalInMinutes,
-                                                                         lockSweepIntervalInMinutes,
-                                                                         TimeUnit.MINUTES));
-            gcProcesses.add(garbageCollectionService.scheduleAtFixedRate(new BinaryValueGarbageCollectionTask(JcrRepository.this),
-                                                                         binaryGcInitialTime,
-                                                                         binaryGcInterval,
-                                                                         TimeUnit.HOURS));
         }
 
         protected final Sequencers sequencers() {
@@ -1742,6 +1730,18 @@ public class JcrRepository implements org.modeshape.jcr.api.Repository {
             RepositoryChangeBus standaloneBus = new RepositoryChangeBus(executor, systemWorkspaceName,
                                                                         separateThreadForSystemWorkspace);
             return clusteringConfiguration.isEnabled() ? new ClusteredRepositoryChangeBus(clusteringConfiguration, standaloneBus) : standaloneBus;
+        }
+
+        void suspendExistingUserTransaction() throws SystemException, NotSupportedException {
+            // suspend any potential existing transaction, so that the initialization is "atomic"
+            this.existingUserTransaction = this.transactions.suspend();
+        }
+
+        void resumeExistingUserTransaction() throws SystemException {
+            if (transactions != null && existingUserTransaction != null) {
+                transactions.resume(existingUserTransaction);
+                existingUserTransaction = null;
+            }
         }
     }
 

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/RepositoryCache.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/RepositoryCache.java
@@ -257,6 +257,24 @@ public class RepositoryCache implements Observable {
         this.documentStore.setLocalSourceKey(this.sourceKey);
     }
 
+    /**
+     * Removes the repository info document, in case the repository has not yet been initialized (as indicated by the presence of
+     * the #REPOSITORY_INITIALIZED_AT_FIELD_NAME field). This should only be used during repository startup, in case an unexpected
+     * error occurs.
+     */
+    public final void rollbackRepositoryInfo() {
+        SchematicEntry repositoryInfoEntry = this.documentStore.localStore().get(REPOSITORY_INFO_KEY);
+        if (repositoryInfoEntry != null) {
+            Document repoInfoDoc = repositoryInfoEntry.getContentAsDocument();
+            //we should only remove the repository info if it wasn't initialized successfully previously
+            //in a cluster, it may happen that another node finished initialization while this node crashed (in which case we
+            //should not remove the entry)
+            if (!repoInfoDoc.containsField(REPOSITORY_INITIALIZED_AT_FIELD_NAME)) {
+                this.documentStore.localStore().remove(REPOSITORY_INFO_KEY);
+            }
+        }
+    }
+
     protected final String processKey() {
         return processKey;
     }

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/document/WritableSessionCache.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/document/WritableSessionCache.java
@@ -1378,7 +1378,7 @@ public class WritableSessionCache extends AbstractSessionCache {
                                                                                  sourceName,
                                                                                  externalPath,
                                                                                  alias,
-                                                                                 err.getMessage()));
+                                                                                 err.getMessage()), err);
         }
     }
 
@@ -1403,7 +1403,7 @@ public class WritableSessionCache extends AbstractSessionCache {
             throw new SystemFailureException(JcrI18n.errorRemovingProjection.text(workspaceName(),
                                                                                   node.getPath(this),
                                                                                   externalNodeKey,
-                                                                                  err.getMessage()));
+                                                                                  err.getMessage()), err);
         }
     }
 }

--- a/modeshape-jcr/src/test/resources/config/invalid-repo-config-persistent-initial-content.json
+++ b/modeshape-jcr/src/test/resources/config/invalid-repo-config-persistent-initial-content.json
@@ -1,0 +1,24 @@
+{
+    "name" : "Persistent Repository With Initial Content",
+    "storage" : {
+        "cacheName" : "persistentRepositoryInitialContent",
+        "cacheConfiguration" : "config/infinispan-persistent-initial-content.xml"
+    },
+    "workspaces" : {
+        "predefined" : ["ws1"],
+        "default" : "default",
+        "allowCreation" : true,
+        "initialContent" : {
+            "ws1" : "xmlImport/docWithInvalidCharacters.xml"
+        }
+    },
+    "security" : {
+        "anonymous" : {
+            "roles" : ["readonly","readwrite","admin"],
+            "useOnFailedLogin" : false
+        }
+    },
+    "query" : {
+        "enabled" : false
+    }
+}

--- a/modeshape-jcr/src/test/resources/xmlImport/docWithInvalidCharacters.xml
+++ b/modeshape-jcr/src/test/resources/xmlImport/docWithInvalidCharacters.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--This is not a valid xml because the chars below are not allowed as tag names-->
+<jcr:root xmlns:jcr="http://www.jcp.org/jcr/1.0">
+    <testRoot>
+        <2_ÜÜÜÜÜ_ÄÄÄÄÄ_2012-02-12/>
+        <ÜÜÜÜÜ/>
+    </testRoot>
+</jcr:root>


### PR DESCRIPTION
The original thought for solving this was to use a start-up transaction which could be easily rolled back in case of an exception. However, this is not feasible since the whole point of the REPOSITORY_INFO_DOC was to notify other members in a potential cluster that one node is doing the initialization.

Therefore, using a long-running start-up transaction would not work, the whole point being that the document gets written to the persistent store ASAP.

The solution was to clean-up/improve exception handling and in the case of an unexpected error, remove the above mentioned document, if the node on which the error occurred was the node which started the initialization process.
