### PR TITLE
MODE-1858 Building query results should work when nodes are concurrently removed

### DIFF
--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/document/WorkspaceCache.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/document/WorkspaceCache.java
@@ -165,7 +165,13 @@ public class WorkspaceCache implements DocumentCache, ChangeSetListener {
             // There is no such node ...
             return null;
         }
-        return entry.getContentAsDocument();
+        try {
+            return entry.getContentAsDocument();
+        } catch (IllegalStateException e) {
+            LOGGER.debug("The document '{0}' was concurrently removed; returning null.", key);
+            // The document was already removed
+            return null;
+        }
     }
 
     final Document blockFor( String key ) {

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/query/lucene/basic/BasicTupleCollector.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/query/lucene/basic/BasicTupleCollector.java
@@ -190,6 +190,7 @@ public class BasicTupleCollector extends TupleCollector {
 
         // Every tuple has the location ...
         if (node != null) {
+            // The node was found in the cache/store ...
             try {
                 Path path = lastWorkspacePathCache.getPath(node);
                 Location location = new Location(path, key);
@@ -223,6 +224,7 @@ public class BasicTupleCollector extends TupleCollector {
                 tuples.add(tuple);
                 return score;
             } catch (NodeNotFoundException e) {
+                // The node was removed while we're trying to read it, so just ignore this error and return 0.0f
             }
         }
         return 0.0f;

--- a/modeshape-schematic/src/main/java/org/infinispan/schematic/internal/SchematicEntryProxy.java
+++ b/modeshape-schematic/src/main/java/org/infinispan/schematic/internal/SchematicEntryProxy.java
@@ -133,6 +133,7 @@ public class SchematicEntryProxy extends AutoBatchSupport implements SchematicEn
      * returns the persisted and available entry.
      * 
      * @return the literal entry
+     * @throws IllegalStateException if the entry no longer exists ...
      */
     private SchematicEntryLiteral getDeltaValueForRead() {
         SchematicEntryLiteral value = toValue(context.getCache().get(key));


### PR DESCRIPTION
When the query results are being processed/produced, any node that is not found is simply ignored (treated as non-existant from the perspective of the query). However, in certain cases, the timing of a removal could occur within the method that obtains the document from the cache, causing an exception. This was rectified to return null in such cases. Thus, the existing code in the BasicTupleCollector that handles null nodes will continue to work in all cases.

I was not able to come up with a test case able to replicate this scenario, however. That's because the failure occurs within a single WorkspaceCache method, after the SchematicEntry is obtained but before the SchematicEntry's content document can be obtained. A test case cannot reliably ensure this condition occurs (without adding junk code within the WorkspaceCache).
