### PR TITLE
MODE-1856 Attempt to index changes only when there are real changes

### DIFF
--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/document/SessionNode.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/document/SessionNode.java
@@ -892,17 +892,34 @@ public class SessionNode implements MutableCachedNode {
                                 Name name ) {
         writableSession(cache).assertInSession(this);
         changedProperties.remove(name);
-        if (!isNew) removedProperties.put(name, name);
+        if (!isNew) {
+            // Determine if the existing node already contained this property ...
+            AbstractSessionCache session = session(cache);
+            CachedNode raw = nodeInWorkspace(session);
+            if (raw.hasProperty(name, cache)) {
+                removedProperties.put(name, name);
+            }
+        }
         updateReferences(cache, name, null);
     }
 
     @Override
     public void removeAllProperties( SessionCache cache ) {
         writableSession(cache).assertInSession(this);
+        CachedNode raw = null;
         for (Iterator<Property> propertyIterator = getProperties(cache); propertyIterator.hasNext();) {
             Name name = propertyIterator.next().getName();
             changedProperties.remove(name);
-            if (!isNew) removedProperties.put(name, name);
+            if (!isNew) {
+                // Determine if the existing node already contained this property ...
+                if (raw == null) {
+                    AbstractSessionCache session = session(cache);
+                    raw = nodeInWorkspace(session);
+                }
+                if (raw.hasProperty(name, cache)) {
+                    removedProperties.put(name, name);
+                }
+            }
             updateReferences(cache, name, null);
         }
     }

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/document/WritableSessionCache.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/document/WritableSessionCache.java
@@ -1073,7 +1073,8 @@ public class WritableSessionCache extends AbstractSessionCache {
                     boolean isExternal = !workspaceCache().getRootKey()
                                                           .getSourceKey()
                                                           .equalsIgnoreCase(node.getKey().getSourceKey());
-                    boolean externalNodeChanged = isExternal && node.hasChanges();
+                    boolean hasChanges = node.hasChanges();
+                    boolean externalNodeChanged = isExternal && hasChanges;
                     if (externalNodeChanged) {
                         // in the case of external nodes, only if there are changes should the update be called
                         documentStore.updateDocument(keyStr, doc, node);
@@ -1086,7 +1087,7 @@ public class WritableSessionCache extends AbstractSessionCache {
                     // when linking/un-linking nodes (e.g. shareable node or jcr:system) this condition will be false.
                     // the downside of this is that there may be cases (e.g. back references when working with versions) in which
                     // we might loose information from the indexes
-                    if (monitor != null && queryable && (isSameWorkspace || externalNodeChanged)) {
+                    if (monitor != null && queryable && ((isSameWorkspace && hasChanges) || externalNodeChanged)) {
                         // Get the primary and mixin type names; even though we're passing in the session, the two properties
                         // should be there and shouldn't require a looking in the cache...
                         Name primaryType = node.getPrimaryType(this);


### PR DESCRIPTION
The internal session nodes that track transient changes were not correctly recording how a property was removed. If a property were added and immediately removed (all before saving), the add was cleared from the transient state but the remove was still kept. (This was due to the fact that it's more difficult to track removes, since we're using a single structure to track adds and sets, so it's not really easy to tell when a property was added and then removed.) This change works around that constraint by using the persisted state of the node to determine if any added/set property already exists in the persisted state. If not, then the remove is considered to undo the prior add/set.

A single test was added to perform the add/remove prior to a save. However, due to the eventing mechanism, it's not possible for the test to verify that the node was not re-indexed. (Simple debugging and trace logging was used to verify that such changes no longer cause an update to the node's indexes. If there are better ideas for how the test can verify, please say so.)
