### PR TITLE
MODE-1859 - Fixed the CLI errors on repository removal

### DIFF
--- a/deploy/jbossas/modeshape-jbossas-subsystem/src/main/java/org/modeshape/jboss/subsystem/AbstractModeShapeRemoveStepHandler.java
+++ b/deploy/jbossas/modeshape-jbossas-subsystem/src/main/java/org/modeshape/jboss/subsystem/AbstractModeShapeRemoveStepHandler.java
@@ -1,0 +1,92 @@
+/*
+ * ModeShape (http://www.modeshape.org)
+ * See the COPYRIGHT.txt file distributed with this work for information
+ * regarding copyright ownership.  Some portions may be licensed
+ * to Red Hat, Inc. under one or more contributor license agreements.
+ * See the AUTHORS.txt file in the distribution for a full listing of
+ * individual contributors.
+ *
+ * ModeShape is free software. Unless otherwise indicated, all code in ModeShape
+ * is licensed to you under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * ModeShape is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.modeshape.jboss.subsystem;
+
+import java.util.List;
+import org.jboss.as.controller.AbstractRemoveStepHandler;
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.OperationFailedException;
+import org.jboss.as.controller.PathAddress;
+import org.jboss.dmr.ModelNode;
+import org.jboss.logging.Logger;
+import org.jboss.msc.service.ServiceName;
+import org.jboss.msc.service.ServiceRegistry;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
+
+/**
+ * Base {@link AbstractRemoveStepHandler} which should be extended by all ModeShape subsystem services, as removal & recovery
+ * is similar for all.
+ *
+ * @author Horia Chiorean (hchiorea@redhat.com)
+ */
+abstract class AbstractModeShapeRemoveStepHandler extends AbstractRemoveStepHandler {
+
+    protected final Logger log = Logger.getLogger(getClass().getName());
+
+    @Override
+    protected void performRuntime( OperationContext context,
+                                   ModelNode operation,
+                                   ModelNode model ) throws OperationFailedException {
+        String repositoryName = null;
+
+        for (ServiceName serviceName : servicesToRemove(operation, model)) {
+            context.removeService(serviceName);
+            if (log.isDebugEnabled()) {
+                if (repositoryName == null) {
+                    repositoryName = repositoryName(operation);
+                }
+                log.debugf("service '%s' removed for repository '%s'", serviceName, repositoryName);
+            }
+        }
+    }
+
+    @Override
+    protected void recoverServices( OperationContext context,
+                                    ModelNode operation,
+                                    ModelNode model ) throws OperationFailedException {
+        String repositoryName = null;
+
+        ServiceRegistry serviceRegistry = context.getServiceRegistry(false);
+        for (ServiceName serviceName : servicesToRemove(operation, model)) {
+            context.getServiceTarget().addService(serviceName, serviceRegistry.getService(serviceName).getService());
+            if (log.isDebugEnabled()) {
+                if (repositoryName == null) {
+                    repositoryName = repositoryName(operation);
+                }
+                log.debugf("service '%s' recovered for repository '%s'", serviceName, repositoryName);
+            }
+        }
+    }
+
+    abstract List<ServiceName> servicesToRemove( ModelNode operation,
+                                                 ModelNode model );
+
+    String repositoryName(ModelNode operation) {
+        // Get the service addresses ...
+        final PathAddress serviceAddress = PathAddress.pathAddress(operation.get(OP_ADDR));
+        // Get the repository name ...
+        return serviceAddress.getLastElement().getValue();
+    }
+}

--- a/deploy/jbossas/modeshape-jbossas-subsystem/src/main/java/org/modeshape/jboss/subsystem/AddRepository.java
+++ b/deploy/jbossas/modeshape-jbossas-subsystem/src/main/java/org/modeshape/jboss/subsystem/AddRepository.java
@@ -65,11 +65,10 @@ import org.modeshape.jcr.RepositoryConfiguration.FieldName;
 
 public class AddRepository extends AbstractAddStepHandler {
 
-    private static final org.jboss.logging.Logger LOG = org.jboss.logging.Logger.getLogger(AddRepository.class.getPackage()
-                                                                                                              .getName());
-
     public static final AddRepository INSTANCE = new AddRepository();
 
+    private static final org.jboss.logging.Logger LOG = org.jboss.logging.Logger.getLogger(AddRepository.class.getPackage()
+                                                                                                              .getName());
     private AddRepository() {
     }
 
@@ -223,8 +222,9 @@ public class AddRepository extends AbstractAddStepHandler {
 
         // Set up the JNDI binder service ...
         final ReferenceFactoryService<JcrRepository> referenceFactoryService = new ReferenceFactoryService<JcrRepository>();
-        final ServiceName referenceFactoryServiceName = repositoryServiceName.append("reference-factory");
-        final ServiceBuilder<?> referenceBuilder = target.addService(referenceFactoryServiceName, referenceFactoryService);
+        ServiceName referenceFactoryServiceName = ModeShapeServiceNames.referenceFactoryServiceName(repositoryName);
+        final ServiceBuilder<?> referenceBuilder = target.addService(referenceFactoryServiceName,
+                                                                     referenceFactoryService);
         referenceBuilder.addDependency(repositoryServiceName, JcrRepository.class, referenceFactoryService.getInjector());
         referenceBuilder.setInitialMode(ServiceController.Mode.ACTIVE);
 

--- a/deploy/jbossas/modeshape-jbossas-subsystem/src/main/java/org/modeshape/jboss/subsystem/ModeShapeServiceNames.java
+++ b/deploy/jbossas/modeshape-jbossas-subsystem/src/main/java/org/modeshape/jboss/subsystem/ModeShapeServiceNames.java
@@ -60,27 +60,30 @@ public class ModeShapeServiceNames {
     /**
      * Obtain the name of the service for the {@link IndexStorage} for the given repository name
      * 
-     * @param name the repository name
+     * @param repositoryName the repository name
      * @return the service name
      */
-    public static ServiceName indexStorageServiceName( String name ) {
-        return ServiceName.of(ServiceName.JBOSS, "modeshape", name, "indexes");
+    public static ServiceName indexStorageServiceName( String repositoryName ) {
+        return ServiceName.of(ServiceName.JBOSS, "modeshape", repositoryName, "indexes");
     }
 
-    public static ServiceName indexStorageDirectoryServiceName( String name ) {
-        return ServiceName.of(ServiceName.JBOSS, "modeshape", name, "indexes.dir");
+    public static ServiceName indexStorageDirectoryServiceName( String repositoryName ) {
+        return ServiceName.of(ServiceName.JBOSS, "modeshape", repositoryName, "indexes.dir");
     }
 
-    public static ServiceName indexSourceStorageDirectoryServiceName( String name ) {
-        return ServiceName.of(ServiceName.JBOSS, "modeshape", name, "indexes.source-dir");
+    public static ServiceName indexSourceStorageDirectoryServiceName( String repositoryName ) {
+        return ServiceName.of(ServiceName.JBOSS, "modeshape", repositoryName, "indexes.source-dir");
     }
 
-    public static ServiceName binaryStorageServiceName( String name ) {
-        return ServiceName.of(ServiceName.JBOSS, "modeshape", name, "binaries");
+    public static ServiceName binaryStorageServiceName( String repositoryName ) {
+        return ServiceName.of(ServiceName.JBOSS, "modeshape", repositoryName, "binaries");
     }
 
-    public static ServiceName binaryStorageDirectoryServiceName( String name ) {
-        return ServiceName.of(ServiceName.JBOSS, "modeshape", name, "binaries.dir");
+    public static ServiceName binaryStorageDirectoryServiceName( String repositoryName ) {
+        return ServiceName.of(ServiceName.JBOSS, "modeshape", repositoryName, "binaries.dir");
     }
 
+    public static ServiceName referenceFactoryServiceName( String repositoryName ) {
+        return repositoryServiceName(repositoryName).append("reference-factory");
+    }
 }

--- a/deploy/jbossas/modeshape-jbossas-subsystem/src/main/java/org/modeshape/jboss/subsystem/RemoveAuthenticator.java
+++ b/deploy/jbossas/modeshape-jbossas-subsystem/src/main/java/org/modeshape/jboss/subsystem/RemoveAuthenticator.java
@@ -23,43 +23,29 @@
  */
 package org.modeshape.jboss.subsystem;
 
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
-import org.jboss.as.controller.AbstractRemoveStepHandler;
-import org.jboss.as.controller.OperationContext;
+import java.util.Arrays;
+import java.util.List;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.dmr.ModelNode;
-import org.jboss.logging.Logger;
 import org.jboss.msc.service.ServiceName;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
 
-class RemoveAuthenticator extends AbstractRemoveStepHandler {
+class RemoveAuthenticator extends AbstractModeShapeRemoveStepHandler {
 
-    private static final Logger log = Logger.getLogger(RemoveAuthenticator.class.getPackage().getName());
-
-    public static final RemoveAuthenticator INSTANCE = new RemoveAuthenticator();
+    static final RemoveAuthenticator INSTANCE = new RemoveAuthenticator();
 
     private RemoveAuthenticator() {
     }
 
     @Override
-    protected void performRuntime( OperationContext context,
-                                   ModelNode operation,
-                                   ModelNode model ) {
+    List<ServiceName> servicesToRemove( ModelNode operation,
+                                        ModelNode model ) {
         // Get the service addresses ...
         final PathAddress serviceAddress = PathAddress.pathAddress(operation.get(OP_ADDR));
         // Get the repository name ...
         final String authenticatorName = serviceAddress.getLastElement().getValue();
         final String repositoryName = serviceAddress.getElement(1).getValue();
-        // Remove the service ...
-        final ServiceName serviceName = ModeShapeServiceNames.authenticatorServiceName(repositoryName, authenticatorName);
-        context.removeService(serviceName);
 
-        log.debugf("authenticator '%s' removed for repository '%s'", authenticatorName, repositoryName);
-    }
-
-    @Override
-    protected void recoverServices( OperationContext context,
-                                    ModelNode operation,
-                                    ModelNode model ) {
-        // TODO: RE-ADD SERVICES
+        return Arrays.asList(ModeShapeServiceNames.authenticatorServiceName(repositoryName, authenticatorName));
     }
 }

--- a/deploy/jbossas/modeshape-jbossas-subsystem/src/main/java/org/modeshape/jboss/subsystem/RemoveSequencer.java
+++ b/deploy/jbossas/modeshape-jbossas-subsystem/src/main/java/org/modeshape/jboss/subsystem/RemoveSequencer.java
@@ -23,43 +23,27 @@
  */
 package org.modeshape.jboss.subsystem;
 
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
-import org.jboss.as.controller.AbstractRemoveStepHandler;
-import org.jboss.as.controller.OperationContext;
+import java.util.Arrays;
+import java.util.List;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.dmr.ModelNode;
-import org.jboss.logging.Logger;
 import org.jboss.msc.service.ServiceName;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
 
-class RemoveSequencer extends AbstractRemoveStepHandler {
+class RemoveSequencer extends AbstractModeShapeRemoveStepHandler {
 
-    private static final Logger log = Logger.getLogger(RemoveSequencer.class.getPackage().getName());
-
-    public static final RemoveSequencer INSTANCE = new RemoveSequencer();
+    static final RemoveSequencer INSTANCE = new RemoveSequencer();
 
     private RemoveSequencer() {
     }
 
     @Override
-    protected void performRuntime( OperationContext context,
-                                   ModelNode operation,
-                                   ModelNode model ) {
+    List<ServiceName> servicesToRemove( ModelNode operation,
+                                        ModelNode model ) {
         // Get the service addresses ...
         final PathAddress serviceAddress = PathAddress.pathAddress(operation.get(OP_ADDR));
-        // Get the repository name ...
         final String sequencerName = serviceAddress.getLastElement().getValue();
-        final String repositoryName = serviceAddress.getElement(1).getValue();
-        // Remove the service ...
-        final ServiceName serviceName = ModeShapeServiceNames.sequencerServiceName(repositoryName, sequencerName);
-        context.removeService(serviceName);
 
-        log.debugf("sequencer '%s' removed for repository '%s'", sequencerName, repositoryName);
-    }
-
-    @Override
-    protected void recoverServices( OperationContext context,
-                                    ModelNode operation,
-                                    ModelNode model ) {
-        // TODO: RE-ADD SERVICES
+        return Arrays.asList(ModeShapeServiceNames.sequencerServiceName(repositoryName(operation), sequencerName));
     }
 }

--- a/deploy/jbossas/modeshape-jbossas-subsystem/src/main/java/org/modeshape/jboss/subsystem/RemoveSource.java
+++ b/deploy/jbossas/modeshape-jbossas-subsystem/src/main/java/org/modeshape/jboss/subsystem/RemoveSource.java
@@ -23,11 +23,11 @@
  */
 package org.modeshape.jboss.subsystem;
 
+import java.util.Arrays;
+import java.util.List;
 import org.jboss.as.controller.AbstractRemoveStepHandler;
-import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.dmr.ModelNode;
-import org.jboss.logging.Logger;
 import org.jboss.msc.service.ServiceName;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
 
@@ -36,35 +36,18 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_
  *
  * @author Horia Chiorean
  */
-public class RemoveSource extends AbstractRemoveStepHandler {
+class RemoveSource extends AbstractModeShapeRemoveStepHandler {
 
     static final RemoveSource INSTANCE = new RemoveSource();
-
-    private static final Logger LOGGER = Logger.getLogger(RemoveSource.class.getPackage().getName());
 
     private RemoveSource() {
     }
 
     @Override
-    protected void performRuntime( OperationContext context,
-                                   ModelNode operation,
-                                   ModelNode model ) {
-        // Get the service addresses ...
+    List<ServiceName> servicesToRemove( ModelNode operation,
+                                        ModelNode model ) {
         final PathAddress serviceAddress = PathAddress.pathAddress(operation.get(OP_ADDR));
-        // Get the repository name ...
         final String sourceName = serviceAddress.getLastElement().getValue();
-        final String repositoryName = serviceAddress.getElement(1).getValue();
-        // Remove the service ...
-        final ServiceName serviceName = ModeShapeServiceNames.sourceServiceName(repositoryName, sourceName);
-        context.removeService(serviceName);
-
-        LOGGER.debugf("sequencer '%s' removed for repository '%s'", sourceName, repositoryName);
-    }
-
-    @Override
-    protected void recoverServices( OperationContext context,
-                                    ModelNode operation,
-                                    ModelNode model ) {
-        //TODO author=Horia Chiorean date=12/27/12 description=Re-add service
+        return Arrays.asList(ModeShapeServiceNames.sourceServiceName(repositoryName(operation), sourceName));
     }
 }

--- a/deploy/jbossas/modeshape-jbossas-subsystem/src/main/java/org/modeshape/jboss/subsystem/RemoveTextExtractor.java
+++ b/deploy/jbossas/modeshape-jbossas-subsystem/src/main/java/org/modeshape/jboss/subsystem/RemoveTextExtractor.java
@@ -23,43 +23,27 @@
  */
 package org.modeshape.jboss.subsystem;
 
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
-import org.jboss.as.controller.AbstractRemoveStepHandler;
-import org.jboss.as.controller.OperationContext;
+import java.util.Arrays;
+import java.util.List;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.dmr.ModelNode;
-import org.jboss.logging.Logger;
 import org.jboss.msc.service.ServiceName;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
 
-class RemoveTextExtractor extends AbstractRemoveStepHandler {
+class RemoveTextExtractor extends AbstractModeShapeRemoveStepHandler {
 
-    private static final Logger log = Logger.getLogger(RemoveTextExtractor.class.getPackage().getName());
-
-    public static final RemoveTextExtractor INSTANCE = new RemoveTextExtractor();
+    static final RemoveTextExtractor INSTANCE = new RemoveTextExtractor();
 
     private RemoveTextExtractor() {
     }
 
     @Override
-    protected void performRuntime( OperationContext context,
-                                   ModelNode operation,
-                                   ModelNode model ) {
+    List<ServiceName> servicesToRemove( ModelNode operation,
+                                        ModelNode model ) {
         // Get the service addresses ...
         final PathAddress serviceAddress = PathAddress.pathAddress(operation.get(OP_ADDR));
         // Get the repository name ...
-        final String sequencerName = serviceAddress.getLastElement().getValue();
-        final String repositoryName = serviceAddress.getElement(1).getValue();
-        // Remove the service ...
-        final ServiceName serviceName = ModeShapeServiceNames.textExtractorServiceName(repositoryName, sequencerName);
-        context.removeService(serviceName);
-
-        log.debugf("extractor '%s' removed for repository '%s'", sequencerName, repositoryName);
-    }
-
-    @Override
-    protected void recoverServices( OperationContext context,
-                                    ModelNode operation,
-                                    ModelNode model ) {
-        // TODO: RE-ADD SERVICES
+        final String textExtractorName = serviceAddress.getLastElement().getValue();
+        return Arrays.asList(ModeShapeServiceNames.textExtractorServiceName(repositoryName(operation), textExtractorName));
     }
 }


### PR DESCRIPTION
The errors were caused by the fact that when a repository was removed, not all the services that were started/created when the repository was first added, were stopped/removed.

Also, the entire service remove/recover code for all the services started by the ModeShape subsystem was refactored.

The fix was tested on EAP 6.1.0.Alpha1
