### PR TITLE
MODE-1878 Corrected determination of correct SNS child node definitions

### DIFF
--- a/modeshape-jcr/src/test/java/org/modeshape/jcr/JcrNodeTypesTest.java
+++ b/modeshape-jcr/src/test/java/org/modeshape/jcr/JcrNodeTypesTest.java
@@ -28,6 +28,7 @@ import static junit.framework.Assert.assertEquals;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
 import javax.jcr.NamespaceRegistry;
+import javax.jcr.Node;
 import javax.jcr.PropertyType;
 import javax.jcr.RepositoryException;
 import javax.jcr.nodetype.NodeType;
@@ -79,6 +80,98 @@ public class JcrNodeTypesTest extends SingleUseAbstractTest {
         PropertyDefinition uriPropDefn = nt.getDeclaredPropertyDefinitions()[0];
         assertThat(uriPropDefn.getName(), is("ex:path"));
         assertThat(uriPropDefn.getRequiredType(), is(PropertyType.URI));
+    }
+
+    @Test
+    @FixFor( "MODE-1878" )
+    public void shouldRegisterNodeTypesWithSnsAndCreateChildren() throws Exception {
+        startRepository();
+        registerNodeTypes("cnd/nodetypes-with-sns.cnd");
+        NodeTypeManager ntmgr = session.getWorkspace().getNodeTypeManager();
+        NodeType nt = ntmgr.getNodeType("inf:patient");
+        PropertyDefinition uriPropDefn = nt.getDeclaredPropertyDefinitions()[0];
+        assertThat(uriPropDefn.getName(), is("inf:masterId"));
+        assertThat(uriPropDefn.getRequiredType(), is(PropertyType.STRING));
+
+        Node top = session.getRootNode().addNode("top");
+        Node patient = top.addNode("patient", "inf:patient");
+        patient.setProperty("inf:masterId", "id1");
+        patient.setProperty("inf:masterNs", "ns1");
+        Node section1 = patient.addNode("section", "inf:section");
+        section1.setProperty("inf:name", "sectionA");
+        assertThat(section1.getIndex(), is(1));
+        assertThat(section1.getPath(), is("/top/patient/section"));
+        Node section2 = patient.addNode("section", "inf:section");
+        section2.setProperty("inf:name", "sectionA");
+        assertThat(section2.getIndex(), is(2));
+        assertThat(section2.getPath(), is("/top/patient/section[2]"));
+        assertThat(section2.getDefinition().allowsSameNameSiblings(), is(true));
+        assertThat(section2.getDefinition().getName(), is("*"));
+        session.save();
+
+        Node section3 = patient.addNode("section", "inf:section");
+        section3.setProperty("inf:name", "sectionA");
+        assertThat(section3.getIndex(), is(3));
+        assertThat(section3.getPath(), is("/top/patient/section[3]"));
+        session.save();
+
+        Node section4 = patient.addNode("section", "inf:section");
+        section4.setProperty("inf:name", "sectionA");
+        assertThat(section4.getIndex(), is(4));
+        assertThat(section4.getPath(), is("/top/patient/section[4]"));
+        Node section5 = patient.addNode("section", "inf:section");
+        section5.setProperty("inf:name", "sectionA");
+        assertThat(section5.getIndex(), is(5));
+        assertThat(section5.getPath(), is("/top/patient/section[5]"));
+        section2.remove();
+        session.save();
+    }
+
+    @Test
+    @FixFor( "MODE-1878" )
+    public void shouldRegisterNodeTypesWithSnsAndCreateChildrenAlternative2() throws Exception {
+        startRepository();
+        registerNodeTypes("cnd/nodetypes-with-sns.cnd");
+        NodeTypeManager ntmgr = session.getWorkspace().getNodeTypeManager();
+        NodeType nt = ntmgr.getNodeType("inf:patient");
+        PropertyDefinition uriPropDefn = nt.getDeclaredPropertyDefinitions()[0];
+        assertThat(uriPropDefn.getName(), is("inf:masterId"));
+        assertThat(uriPropDefn.getRequiredType(), is(PropertyType.STRING));
+
+        Node top = session.getRootNode().addNode("top");
+        Node patient = top.addNode("patient", "inf:patient");
+        patient.setProperty("inf:masterId", "id1");
+        patient.setProperty("inf:masterNs", "ns1");
+        Node section1 = patient.addNode("section", "inf:section");
+        section1.setProperty("inf:name", "sectionA");
+        assertThat(section1.getIndex(), is(1));
+        assertThat(section1.getPath(), is("/top/patient/section"));
+        session.save();
+
+        Node section2 = patient.addNode("section", "inf:section");
+        section2.setProperty("inf:name", "sectionA");
+        assertThat(section2.getIndex(), is(2));
+        assertThat(section2.getPath(), is("/top/patient/section[2]"));
+        assertThat(section2.getDefinition().allowsSameNameSiblings(), is(true));
+        assertThat(section2.getDefinition().getName(), is("*"));
+        session.save();
+
+        Node section3 = patient.addNode("section", "inf:section");
+        section3.setProperty("inf:name", "sectionA");
+        assertThat(section3.getIndex(), is(3));
+        assertThat(section3.getPath(), is("/top/patient/section[3]"));
+        session.save();
+
+        Node section4 = patient.addNode("section", "inf:section");
+        section4.setProperty("inf:name", "sectionA");
+        assertThat(section4.getIndex(), is(4));
+        assertThat(section4.getPath(), is("/top/patient/section[4]"));
+        Node section5 = patient.addNode("section", "inf:section");
+        section5.setProperty("inf:name", "sectionA");
+        assertThat(section5.getIndex(), is(5));
+        assertThat(section5.getPath(), is("/top/patient/section[5]"));
+        section2.remove();
+        session.save();
     }
 
     @Override

--- a/modeshape-jcr/src/test/resources/cnd/nodetypes-with-sns.cnd
+++ b/modeshape-jcr/src/test/resources/cnd/nodetypes-with-sns.cnd
@@ -1,0 +1,20 @@
+<jcr='http://www.jcp.org/jcr/1.0'>
+<nt='http://www.jcp.org/jcr/nt/1.0'>
+<inf='http://www.example.com/test'>
+
+[inf:patient] > mix:versionable, nt:hierarchyNode
++ * (inf:patientId) COPY
++ * (inf:section) SNS COPY 
+- inf:masterId (STRING) mandatory COPY
+- inf:masterNs (STRING) mandatory COPY
+
+
+/**
+ * A section node is a named container of either episodes or documents.
+ */
+[inf:section] > nt:hierarchyNode orderable 
+- inf:name (STRING) mandatory COPY
++ * (nt:hierarchyNode) SNS VERSION 
+
+[inf:patientId]
+- inf:name (STRING) mandatory COPY


### PR DESCRIPTION
When a node with a child is persisted, and then a new child node with the same name as the existing child is added to the parent, and when the parent node type contains more than one applicable residual child node definition, ModeShape incorrected determined that no child node definition could be found for the new SNS child.

Two new test cases were added to replicate this scenario, and the validation logic was corrected.
