### PR TITLE
MODE-1880 FileSystemConnector uses incorrect ID when adding content to nt:file nodes

### DIFF
--- a/modeshape-jcr/src/main/java/org/modeshape/connector/filesystem/FileSystemConnector.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/connector/filesystem/FileSystemConnector.java
@@ -540,7 +540,8 @@ public class FileSystemConnector extends WritableConnector {
             //the FS connector does not support namespaces in names
             getLogger().warn(JcrI18n.fileConnectorNamespaceIgnored, getSourceName(), newDocumentName.getNamespaceUri());
         }
-        documentIdBuilder.append(newDocumentName.getLocalName());
+        //treat jcr:content nodes as 'special' so isContentNode(id) and fileFor(id) see the ID they expect
+        documentIdBuilder.append(JCR_CONTENT.equals(newDocumentName.getString()) ? newDocumentName.getString() : newDocumentName.getLocalName());
         return documentIdBuilder.toString();
     }
 


### PR DESCRIPTION
The local name was being used to prevent generation of filenames containing the : character, but this is unnecessary for jcr:content nodes since the content should end up on disk in the file associated with the nt:file ancestor node.
