### PR TITLE
MODE-1840 CONTAINS clause should allow use of bind variables

### DIFF
--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/GraphI18n.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/GraphI18n.java
@@ -211,6 +211,7 @@ public final class GraphI18n {
     public static I18n expectingComparisonOperator;
     public static I18n expectingConstraintCondition;
     public static I18n functionIsAmbiguous;
+    public static I18n functionHasInvalidBindVariable;
     public static I18n bindVariableMustConformToNcName;
     public static I18n invalidPropertyType;
     public static I18n valueCannotBeCastToSpecifiedType;

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/query/model/FullTextSearch.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/query/model/FullTextSearch.java
@@ -35,7 +35,6 @@ import javax.jcr.PropertyType;
 import javax.jcr.RepositoryException;
 import javax.jcr.Value;
 import javax.jcr.ValueFormatException;
-import javax.jcr.query.qom.StaticOperand;
 import org.modeshape.common.annotation.Immutable;
 import org.modeshape.common.text.ParsingException;
 import org.modeshape.common.util.CheckArg;
@@ -266,6 +265,10 @@ public class FullTextSearch implements Constraint, javax.jcr.query.qom.FullTextS
             return true;
         }
         return false;
+    }
+
+    public FullTextSearch withFullTextExpression( String expression ) {
+        return new FullTextSearch(selectorName, propertyName, expression);
     }
 
     @Override

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/query/model/Visitors.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/query/model/Visitors.java
@@ -662,6 +662,7 @@ public class Visitors {
         @Override
         public void visit( FullTextSearch fullTextSearch ) {
             strategy.visit(fullTextSearch);
+            enqueue(fullTextSearch.getFullTextSearchExpression());
             visitNext();
         }
 

--- a/modeshape-jcr/src/main/resources/org/modeshape/jcr/GraphI18n.properties
+++ b/modeshape-jcr/src/main/resources/org/modeshape/jcr/GraphI18n.properties
@@ -200,6 +200,7 @@ secondValueInLimitRangeCannotBeLessThanFirst = Second value {0} in LIMIT range c
 expectingComparisonOperator = Expecting '=', '<>', '!=', '<', '<=', '>', '>=', or 'LIKE' but found '{0}' at line {1}, column {2}
 expectingConstraintCondition = Expecting a constraint, but found '{0}' at line {1}, column {2}
 functionIsAmbiguous = The {0} function at line {1}, column {2} is ambiguous since there is more than one selector
+functionHasInvalidBindVariable = The {0} function at line {1}, column {2} contains a bind variable '{3}' that is not valid
 bindVariableMustConformToNcName = The name of a variable must conform to a valid NCName, but found '{0}' at line {1}, column {2}
 invalidPropertyType = Expecting 'STRING', 'BINARY', 'DATE', 'LONG', 'DOUBLE', 'DECIMAL', 'BOOLEAN', 'NAME', 'PATH', 'REFERENCE', 'WEAKREFERENCE', or 'URI', but found '{0}' at line {1}, column {2}
 valueCannotBeCastToSpecifiedType = The literal value '{0}' at line {1}, column {2} cannot be cast to a {3} type: {4}


### PR DESCRIPTION
Per the JCR 2.0 specification, the 'CONTAINS' clause in JCR-SQL2 queries allows using a bind variable in place of the full text search expression. This commit adds this support, including two new test cases that verify the functionality.
