### PR TITLE
MODE-1876 Corrected the logic that determines if indexes are empty

### DIFF
--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/RepositoryDisabledQueryManager.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/RepositoryDisabledQueryManager.java
@@ -72,8 +72,8 @@ class RepositoryDisabledQueryManager extends RepositoryQueryManager {
         }
 
         @Override
-        public boolean isEmpty() {
-            // Even though there is no content, this system is disabled so pretend we're not empty
+        public boolean initializedIndexes() {
+            // Even though there is no content, this system is disabled so pretend we didn't initialize the indexes
             return false;
         }
 

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/RepositoryQueryManager.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/RepositoryQueryManager.java
@@ -195,8 +195,8 @@ class RepositoryQueryManager {
     protected void reindexContent( final boolean includeSystemContent,
                                    boolean async,
                                    boolean onlyIfEmpty ) {
-        if (onlyIfEmpty && !getIndexes().isEmpty()) {
-            // Only need to reindex if no content, but there is content, so we're done
+        if (onlyIfEmpty && !getIndexes().initializedIndexes()) {
+            // There already was some indexed content, so there's nothing to do ...
             return;
         }
 

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/query/QueryIndexing.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/query/QueryIndexing.java
@@ -82,11 +82,12 @@ public interface QueryIndexing {
                       TransactionContext txnCtx );
 
     /**
-     * Retrieve whether at least one node is currently stored in the index.
+     * Retrieve whether the indexes were initialized and empty upon startup.
      * 
-     * @return true if the index(es) have no content, or false if there is at least some content in the indexes
+     * @return true if the index(es) initially had no content, or false if there was already at least some content in the indexes
+     *         upon startup
      */
-    boolean isEmpty();
+    boolean initializedIndexes();
 
     void removeFromIndex( String workspace,
                           Iterable<NodeKey> keys,


### PR DESCRIPTION
Because the JcrRepository is trying to determine if the indexes are empty after the system nodes have already been created, the query components have to determine when the indexes are first set up whether there is already content in the persisted indexes (e.g., the files on the directory).
