### PR TITLE
MODE-1896 Deprecated the "transactionManagerLookup" field

### DIFF
--- a/modeshape-common/src/main/java/org/modeshape/common/util/StringUtil.java
+++ b/modeshape-common/src/main/java/org/modeshape/common/util/StringUtil.java
@@ -95,6 +95,48 @@ public class StringUtil {
     }
 
     /**
+     * Combine the supplied values into a single string, using the supplied string to delimit values.
+     * 
+     * @param values the values to be combined; may not be null, but may contain null values (which are skipped)
+     * @param delimiter the characters to place between each of the values; may not be null
+     * @return the joined string; never null
+     * @see String#split(String)
+     */
+    public static String join( Object[] values,
+                               String delimiter ) {
+        StringBuilder sb = new StringBuilder();
+        boolean first = true;
+        for (Object segment : values) {
+            if (segment == null) continue;
+            if (first) first = false;
+            else sb.append(delimiter);
+            sb.append(segment);
+        }
+        return sb.toString();
+    }
+
+    /**
+     * Combine the supplied values into a single string, using the supplied string to delimit values.
+     * 
+     * @param values the values to be combined; may not be null, but may contain null values (which are skipped)
+     * @param delimiter the characters to place between each of the values; may not be null
+     * @return the joined string; never null
+     * @see String#split(String)
+     */
+    public static String join( Iterable<?> values,
+                               String delimiter ) {
+        StringBuilder sb = new StringBuilder();
+        boolean first = true;
+        for (Object segment : values) {
+            if (segment == null) continue;
+            if (first) first = false;
+            else sb.append(delimiter);
+            sb.append(segment);
+        }
+        return sb.toString();
+    }
+
+    /**
      * Create a string by substituting the parameters into all key occurrences in the supplied format. The pattern consists of
      * zero or more keys of the form <code>{n}</code>, where <code>n</code> is an integer starting at 0. Therefore, the first
      * parameter replaces all occurrences of "{0}", the second parameter replaces all occurrences of "{1}", etc.

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrI18n.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrI18n.java
@@ -216,6 +216,7 @@ public final class JcrI18n {
     public static I18n unableToSetFieldOnInstance;
     public static I18n missingFieldOnInstance;
     public static I18n missingComponentType;
+    public static I18n repositoryConfigurationContainsDeprecatedField;
 
     public static I18n typeMissingWhenRegisteringEngineInJndi;
     public static I18n repositoryNameNotProvidedWhenRegisteringRepositoryInJndi;

--- a/modeshape-jcr/src/main/resources/org/modeshape/jcr/JcrI18n.properties
+++ b/modeshape-jcr/src/main/resources/org/modeshape/jcr/JcrI18n.properties
@@ -214,6 +214,7 @@ invalidAliasForComponent = The '{0}' value "{1}" is not recognized; allowed valu
 unableToSetFieldOnInstance = Unable to set the '{0}' field on an instance of '{2}' to '{1}' 
 missingFieldOnInstance = The field {0} is not present on {1} or any of its super types
 missingComponentType = The component type is required, and must be either a classname or a valid alias: {0}
+repositoryConfigurationContainsDeprecatedField = The '{0}' field in the repository configuration file is deprecated and is no longer used. {1}
 
 typeMissingWhenRegisteringEngineInJndi = JNDI registration of engine at "{0}": the 'type' parameter should be specified with a value of '{1}'
 repositoryNameNotProvidedWhenRegisteringRepositoryInJndi = JNDI registration failed: unable to register in JNDI a repository at "{0}" because a 'repositoryName' parameter was not provided

--- a/modeshape-jcr/src/main/resources/org/modeshape/jcr/repository-config-schema.json
+++ b/modeshape-jcr/src/main/resources/org/modeshape/jcr/repository-config-schema.json
@@ -82,7 +82,7 @@
                 "transactionManagerLookup" : {
                     "type" : "string",
                     "default" : "org.infinispan.transaction.lookup.GenericTransactionManagerLookup",
-                    "description" : "The name of the Infinispan class that should be used to find the JTA transaction manager instance. It defaults to 'org.infinispan.transaction.lookup.GenericTransactionManagerLookup'"
+                    "description" : "DEPRECATED: This is no longer used. The transaction manager lookup class should be specified in the Infinispan cache configuration (or in a custom Environment subclass for default caches)."
                 },
                 "binaryStorage" : {
                     "type" : [

--- a/modeshape-jcr/src/test/resources/config/JcrQueryManagerTest.json
+++ b/modeshape-jcr/src/test/resources/config/JcrQueryManagerTest.json
@@ -1,8 +1,5 @@
 {
     "name" : "Test Repository",
-    "storage" : {
-        "transactionManagerLookup" : "org.infinispan.transaction.lookup.DummyTransactionManagerLookup"
-    },
     "query" : {
         "indexing": {
             "rebuildOnStartup": {

--- a/modeshape-jcr/src/test/resources/config/JcrQueryManagerTestDisk.json
+++ b/modeshape-jcr/src/test/resources/config/JcrQueryManagerTestDisk.json
@@ -1,8 +1,5 @@
 {
     "name" : "Test Repository",
-    "storage" : {
-        "transactionManagerLookup" : "org.infinispan.transaction.lookup.DummyTransactionManagerLookup"
-    },
     "query" : {
         "indexStorage" : {
             "type" : "filesystem",

--- a/modeshape-jcr/src/test/resources/config/clustered-repo-config-invalid-jgroups-file.json
+++ b/modeshape-jcr/src/test/resources/config/clustered-repo-config-invalid-jgroups-file.json
@@ -5,9 +5,6 @@
         "default" : "default",
         "allowCreation" : true
     },
-    "storage" : {
-        "transactionManagerLookup" : "org.infinispan.transaction.lookup.DummyTransactionManagerLookup"
-    },
     "clustering" : {
         "clusterName" : "modeshape",
         "channelConfiguration" : "config/no-file.xml"

--- a/modeshape-jcr/src/test/resources/config/clustered-repo-config-jgroups-file.json
+++ b/modeshape-jcr/src/test/resources/config/clustered-repo-config-jgroups-file.json
@@ -5,9 +5,6 @@
         "default" : "default",
         "allowCreation" : true
     },
-    "storage" : {
-        "transactionManagerLookup" : "org.infinispan.transaction.lookup.DummyTransactionManagerLookup"
-    },
     "query" : {
         "enabled" : false
     },

--- a/modeshape-jcr/src/test/resources/config/drools-repository.json
+++ b/modeshape-jcr/src/test/resources/config/drools-repository.json
@@ -1,8 +1,5 @@
 {
     "name": "Drools Repository",
-    "storage": {
-        "transactionManagerLookup": "org.infinispan.transaction.lookup.DummyTransactionManagerLookup"
-    },
     "workspaces": {
         "predefined": ["ws1", "ws2"],
         "default": "default",

--- a/modeshape-jcr/src/test/resources/config/index-storage-config-filesystem-master.json
+++ b/modeshape-jcr/src/test/resources/config/index-storage-config-filesystem-master.json
@@ -1,8 +1,5 @@
 {
     "name" : "Test Repository",
-    "storage" : {
-        "transactionManagerLookup" = "org.infinispan.transaction.lookup.DummyTransactionManagerLookup"
-    },
     "query" : {
         "indexStorage" : {
             "type" : "filesystem-master",

--- a/modeshape-jcr/src/test/resources/config/index-storage-config-filesystem-slave.json
+++ b/modeshape-jcr/src/test/resources/config/index-storage-config-filesystem-slave.json
@@ -1,8 +1,5 @@
 {
     "name" : "Test Repository",
-    "storage" : {
-        "transactionManagerLookup" = "org.infinispan.transaction.lookup.DummyTransactionManagerLookup"
-    },
     "query" : {
         "indexStorage" : {
             "type" : "filesystem-slave",

--- a/modeshape-jcr/src/test/resources/config/index-storage-config-filesystem.json
+++ b/modeshape-jcr/src/test/resources/config/index-storage-config-filesystem.json
@@ -1,8 +1,5 @@
 {
     "name" : "Test Repository",
-    "storage" : {
-        "transactionManagerLookup" = "org.infinispan.transaction.lookup.DummyTransactionManagerLookup"
-    },
     "query" : {
         "indexStorage" : {
             "type" : "filesystem",

--- a/modeshape-jcr/src/test/resources/config/index-storage-config-infinispan-classpath.json
+++ b/modeshape-jcr/src/test/resources/config/index-storage-config-infinispan-classpath.json
@@ -1,8 +1,5 @@
 {
     "name" : "ISPNIndexingRepo",
-    "storage" : {
-        "transactionManagerLookup" : "org.infinispan.transaction.lookup.DummyTransactionManagerLookup"
-    },
     "query" : {
         "indexStorage" : {
             "type" : "infinispan",

--- a/modeshape-jcr/src/test/resources/config/index-storage-config-infinispan.json
+++ b/modeshape-jcr/src/test/resources/config/index-storage-config-infinispan.json
@@ -1,8 +1,5 @@
 {
     "name" : "Test Repository",
-    "storage" : {
-        "transactionManagerLookup" = "org.infinispan.transaction.lookup.DummyTransactionManagerLookup"
-    },
     "query" : {
         "indexStorage" : {
             "type" : "infinispan",

--- a/modeshape-jcr/src/test/resources/config/index-storage-config-ram.json
+++ b/modeshape-jcr/src/test/resources/config/index-storage-config-ram.json
@@ -1,8 +1,5 @@
 {
     "name" : "Test Repository",
-    "storage" : {
-        "transactionManagerLookup" = "org.infinispan.transaction.lookup.DummyTransactionManagerLookup"
-    },
     "query" : {
         "indexStorage" : {
             "type" : "ram"

--- a/modeshape-jcr/src/test/resources/config/invalid-index-storage-config-filesystem.json
+++ b/modeshape-jcr/src/test/resources/config/invalid-index-storage-config-filesystem.json
@@ -1,8 +1,5 @@
 {
     "name" : "Test Repository",
-    "storage" : {
-        "transactionManagerLookup" = "org.infinispan.transaction.lookup.DummyTransactionManagerLookup"
-    },
     "query" : {
         "indexStorage" : {
             "type" : "filesystem",

--- a/modeshape-jcr/src/test/resources/config/invalid-old-style-extractors-config.json
+++ b/modeshape-jcr/src/test/resources/config/invalid-old-style-extractors-config.json
@@ -12,7 +12,6 @@
     "storage" : {
         "cacheName" : "Thorough",
         "cacheConfiguration" : "infinispan_configuration.xml",
-        "transactionManagerLookup" = "org.infinispan.transaction.lookup.GenericTransactionManagerLookup",
         "binaryStorage" : {
             "type" : "file",
             "directory" : "Thorough/binaries",

--- a/modeshape-jcr/src/test/resources/config/invalid-old-style-sequencers-config.json
+++ b/modeshape-jcr/src/test/resources/config/invalid-old-style-sequencers-config.json
@@ -12,7 +12,6 @@
     "storage" : {
         "cacheName" : "Thorough",
         "cacheConfiguration" : "infinispan_configuration.xml",
-        "transactionManagerLookup" = "org.infinispan.transaction.lookup.GenericTransactionManagerLookup",
         "binaryStorage" : {
             "type" : "file",
             "directory" : "Thorough/binaries",

--- a/modeshape-jcr/src/test/resources/config/repo-config-initial-content.json
+++ b/modeshape-jcr/src/test/resources/config/repo-config-initial-content.json
@@ -1,8 +1,5 @@
 {
     "name" : "Repository with initial content",
-    "storage" : {
-        "transactionManagerLookup" : "org.infinispan.transaction.lookup.DummyTransactionManagerLookup"
-    },
     "workspaces" : {
         "predefined" : ["ws1", "ws2"],
         "default" : "default",

--- a/modeshape-jcr/src/test/resources/config/repo-config-invalid-node-types.json
+++ b/modeshape-jcr/src/test/resources/config/repo-config-invalid-node-types.json
@@ -1,8 +1,5 @@
 {
     "name" : "Repository with node types",
-    "storage" : {
-        "transactionManagerLookup" : "org.infinispan.transaction.lookup.DummyTransactionManagerLookup"
-    },
     "workspaces" : {
         "predefined" : ["ws1", "ws2"],
         "default" : "default",

--- a/modeshape-jcr/src/test/resources/config/repo-config-node-types.json
+++ b/modeshape-jcr/src/test/resources/config/repo-config-node-types.json
@@ -1,8 +1,5 @@
 {
     "name" : "Repository with node types",
-    "storage" : {
-        "transactionManagerLookup" : "org.infinispan.transaction.lookup.DummyTransactionManagerLookup"
-    },
     "workspaces" : {
         "predefined" : ["ws1", "ws2"],
         "default" : "default",

--- a/modeshape-jcr/src/test/resources/config/sample-repo-config.json
+++ b/modeshape-jcr/src/test/resources/config/sample-repo-config.json
@@ -6,9 +6,6 @@
         "default" : "default",
         "allowCreation" : true
     },
-    "storage" : {
-        "transactionManagerLookup" = "org.infinispan.transaction.lookup.DummyTransactionManagerLookup"
-    },
     "security" : {
         "anonymous" : {
             "roles" : ["readonly","readwrite","admin"],

--- a/modeshape-jcr/src/test/resources/config/simple-repo-config.json
+++ b/modeshape-jcr/src/test/resources/config/simple-repo-config.json
@@ -5,9 +5,6 @@
         "default" : "default",
         "allowCreation" : true
     },
-    "storage" : {
-        "transactionManagerLookup" = "org.infinispan.transaction.lookup.DummyTransactionManagerLookup"
-    },
     "security" : {
         "anonymous" : {
             "roles" : ["readonly","readwrite","admin"],

--- a/modeshape-jcr/src/test/resources/config/thorough-repo-config.json
+++ b/modeshape-jcr/src/test/resources/config/thorough-repo-config.json
@@ -17,7 +17,6 @@
     "storage" : {
         "cacheName" : "Thorough",
         "cacheConfiguration" : "infinispan_configuration.xml",
-        "transactionManagerLookup" = "org.infinispan.transaction.lookup.GenericTransactionManagerLookup",
         "binaryStorage" : {
             "type" : "file",
             "directory" : "Thorough/binaries",

--- a/modeshape-jcr/src/test/resources/config/thorough-with-desc-repo-config.json
+++ b/modeshape-jcr/src/test/resources/config/thorough-with-desc-repo-config.json
@@ -15,7 +15,6 @@
         "description" : "Repository content will be stored in the 'Thorough' cache defined in the specified Infinispan configuration file. If the 'cacheConfiguration' is not specified, the cache will persist content on the file system.",
         "cacheName" : "Thorough",
         "cacheConfiguration" : "infinispan_configuration.xml",
-        "transactionManagerLookup" = "org.infinispan.transaction.lookup.GenericTransactionManagerLookup",
         "binaryStorage" : {
             "description" : "Binary values (>=4096 bytes in size) will be stored on the file system at the relative path 'Thorough/binaries'. Smaller binaries will be stored with the referenced content.",
             "type" : "file",

--- a/modeshape-jcr/src/test/resources/tck/default/repo-config.json
+++ b/modeshape-jcr/src/test/resources/tck/default/repo-config.json
@@ -5,9 +5,6 @@
         "default" : "default",
         "allowCreation" : true
     },
-    "storage" : {
-        "transactionManagerLookup" : "org.infinispan.transaction.lookup.DummyTransactionManagerLookup"
-    },
     "query" : {
         "enabled" : true,
         "enableFullTextSearch" : true,

--- a/modeshape-performance-tests/src/test/resources/config/BerkleyDbCacheStorePerformanceTest.json
+++ b/modeshape-performance-tests/src/test/resources/config/BerkleyDbCacheStorePerformanceTest.json
@@ -1,8 +1,5 @@
 {
     "name" : "Test Repository",
-    "storage" : {
-        "transactionManagerLookup" = "org.infinispan.transaction.lookup.DummyTransactionManagerLookup"
-    },
     "query" : {
         "indexStorage" : {
             "type" : "ram"

--- a/modeshape-performance-tests/src/test/resources/config/InMemoryPerformanceTest.json
+++ b/modeshape-performance-tests/src/test/resources/config/InMemoryPerformanceTest.json
@@ -1,8 +1,5 @@
 {
     "name" : "Test Repository",
-    "storage" : {
-        "transactionManagerLookup" = "org.infinispan.transaction.lookup.DummyTransactionManagerLookup"
-    },
     "query" : {
         "indexStorage" : {
             "type" : "ram"

--- a/modeshape-performance-tests/src/test/resources/config/JdbcBinaryCacheStorePerformanceTest.json
+++ b/modeshape-performance-tests/src/test/resources/config/JdbcBinaryCacheStorePerformanceTest.json
@@ -1,8 +1,5 @@
 {
     "name" : "Test_Repository",
-    "storage" : {
-        "transactionManagerLookup" : "org.infinispan.transaction.lookup.DummyTransactionManagerLookup"
-    },
     "query" : {
         "indexStorage" : {
             "type" : "ram"

--- a/modeshape-performance-tests/src/test/resources/config/JdbcStringCacheStorePerformanceTest.json
+++ b/modeshape-performance-tests/src/test/resources/config/JdbcStringCacheStorePerformanceTest.json
@@ -1,8 +1,5 @@
 {
     "name" : "Test_Repository",
-    "storage" : {
-        "transactionManagerLookup" : "org.infinispan.transaction.lookup.DummyTransactionManagerLookup"
-    },
     "query" : {
         "indexStorage" : {
             "type" : "ram"

--- a/modeshape-performance-tests/src/test/resources/config/JdbmCacheStorePerformanceTest.json
+++ b/modeshape-performance-tests/src/test/resources/config/JdbmCacheStorePerformanceTest.json
@@ -1,8 +1,5 @@
 {
     "name" : "Test Repository",
-    "storage" : {
-        "transactionManagerLookup" = "org.infinispan.transaction.lookup.DummyTransactionManagerLookup"
-    },
     "query" : {
         "indexStorage" : {
             "type" : "ram"

--- a/modeshape-schematic/src/test/resources/json/sample-repo-config.json
+++ b/modeshape-schematic/src/test/resources/json/sample-repo-config.json
@@ -12,7 +12,6 @@
     "storage" : {
         "cacheName" : "Thorough",
         "cacheConfiguration" : "infinispan_configuration.xml",
-        "transactionManagerLookup" = "org.infinispan.transaction.lookup.GenericTransactionManagerLookup",
         "binaryStorage" : {
             "type" : "file",
             "directory" : "Thorough/binaries",

--- a/web/modeshape-web-jcr-rest/src/test/resources/repo-config.json
+++ b/web/modeshape-web-jcr-rest/src/test/resources/repo-config.json
@@ -5,9 +5,6 @@
         "default" : "default",
         "allowCreation" : true
     },
-    "storage" : {
-        "transactionManagerLookup" = "org.infinispan.transaction.lookup.DummyTransactionManagerLookup"
-    },
     "security" : {
         "anonymous" : {
             "roles" : ["readonly","readwrite","admin"],

--- a/web/modeshape-web-jcr-webdav/src/test/resources/repository-config.json
+++ b/web/modeshape-web-jcr-webdav/src/test/resources/repository-config.json
@@ -5,9 +5,6 @@
         "default" : "default",
         "allowCreation" : true
     },
-    "storage" : {
-        "transactionManagerLookup" : "org.infinispan.transaction.lookup.DummyTransactionManagerLookup"
-    },
     "security" : {
         "anonymous" : {
             "roles" : ["readonly","readwrite","admin"],

--- a/web/modeshape-web-jcr/src/test/resources/repo-config.json
+++ b/web/modeshape-web-jcr/src/test/resources/repo-config.json
@@ -5,9 +5,6 @@
         "default" : "default",
         "allowCreation" : true
     },
-    "storage" : {
-        "transactionManagerLookup" : "org.infinispan.transaction.lookup.DummyTransactionManagerLookup"
-    },
     "security" : {
         "anonymous" : {
             "roles" : ["readonly","readwrite","admin"],


### PR DESCRIPTION
This field in repository configuration files has not been used for some time, but at the time it was not properly documented in the schema as being "deprecated". This has been done, and any use of this field in our test configurations have been removed.

Note that the RepositoryConfiguration constructors now log warning messages when this or any other deprecated fields are used.
