### PR TITLE
MODE-1853 - Reverted code introduced by MODE-1729 (commit 2e42871) which shows a similar problem to the class cast exception

### DIFF
--- a/modeshape-schematic/src/main/java/org/infinispan/schematic/internal/schema/DocumentTransformer.java
+++ b/modeshape-schematic/src/main/java/org/infinispan/schematic/internal/schema/DocumentTransformer.java
@@ -335,14 +335,15 @@ public class DocumentTransformer {
             LinkedList<Conversion> nestedConversions = entry.getValue();
             Document nested = original.getDocument(segment);
             Document newDoc = convertValuesWithMismatchedTypes(nested, nextLevel, nestedConversions);
-            if (newDoc instanceof DocumentEditor) {
-                // we need to make sure we don't store the converted documents as editors
-                // because if we do, the asserts from DocumentEditor#editable start failing
-                // This can be seen when running the FederationIntegrationTests, which behind the scenes
-                // (in the SourceService class) calls engine.applyChanges()
-                // to update a configuration containing system variables which need replacing
-                changedFields.put(segment, ((DocumentEditor)newDoc).unwrap());
-            }
+            changedFields.put(segment, newDoc);
+//            if (newDoc instanceof DocumentEditor) {
+//                // we need to make sure we don't store the converted documents as editors
+//                // because if we do, the asserts from DocumentEditor#editable start failing
+//                // This can be seen when running the FederationIntegrationTests, which behind the scenes
+//                // (in the SourceService class) calls engine.applyChanges()
+//                // to update a configuration containing system variables which need replacing
+//                changedFields.put(segment, ((DocumentEditor)newDoc).unwrap());
+//            }
         }
 
         // Now create a copy of the original document but with the changed fields ...


### PR DESCRIPTION
This should not be merged.

However, with the change from this PR, running `FederationIntegrationTest` in AS7 (with an updated schematic jar in the dist) should show a similar problem to the one described in the JIRA issue.

The pull request basically contains a revert of one of my previous commits for MODE-1729. When I first encountered this exception, I thought this commit would fix it. However, it may be very well be that it only fixed a symptom, not the real problem. 

The code behind `DocumentTransformer` and related classes is not trivial, to say the least.
