### PR TITLE
MODE-1897 - Updated clustering tests with a new test using JGroups for clustering Hibernate Search.

### DIFF
--- a/deploy/jbossas/modeshape-jbossas-subsystem/src/main/resources/schema/modeshape_1_0.xsd
+++ b/deploy/jbossas/modeshape-jbossas-subsystem/src/main/resources/schema/modeshape_1_0.xsd
@@ -832,15 +832,6 @@
     </xs:attribute>
   </xs:attributeGroup>
 
-  <xs:attributeGroup name="jgroups-backend-attributes">
-    <xs:attribute name="channel-name" type="xs:string" use="required">
-      <xs:annotation>
-        <xs:documentation>The name of the JGroups channel used for indexing updates.</xs:documentation>
-      </xs:annotation>
-    </xs:attribute>
-  </xs:attributeGroup>
-
-
   <!-- Global simple types -->
   <xs:simpleType name="index-format">
     <xs:restriction base="xs:string">

--- a/modeshape-jcr/src/main/resources/org/modeshape/jcr/repository-config-schema.json
+++ b/modeshape-jcr/src/main/resources/org/modeshape/jcr/repository-config-schema.json
@@ -934,8 +934,8 @@
                                         },
                                         "channelConfiguration" : { 
                                             "type" : "string",
-                                            "required" : true,
-                                            "description" : "The JGroups channel configuration. The value should be the path to a resource file on the classpath containing the JGroups configuration."
+                                            "required" : false,
+                                            "description" : "The optional JGroups channel configuration. The value should be the path to a resource file on the classpath containing the JGroups configuration."
                                         },
                                         "description" : {
                                             "type" : "string",
@@ -961,8 +961,8 @@
                                         },
                                         "channelConfiguration" : {
                                             "type" : "string",
-                                            "required" : true,
-                                            "description" : "The JGroups channel configuration. The value should be the path to a resource file on the classpath containing the JGroups configuration."
+                                            "required" : false,
+                                            "description" : "The optional JGroups channel configuration. The value should be the path to a resource file on the classpath containing the JGroups configuration."
                                         },
                                         "description" : {
                                             "type" : "string",

--- a/modeshape-jcr/src/test/resources/config/repo-config-clustered-indexes-1.json
+++ b/modeshape-jcr/src/test/resources/config/repo-config-clustered-indexes-1.json
@@ -1,0 +1,34 @@
+{
+    "name" : "Persistent Repository 1",
+    "workspaces" : {
+        "default" : "default",
+        "allowCreation" : true
+    },
+    "storage" : {
+        "cacheName" : "persistentRepository",
+        "cacheConfiguration" : "config/infinispan-clustered-persistent-1.xml"
+    },
+    "query":{
+        "enabled": true,
+        "indexing" : {
+            "rebuildOnStartup": {
+                "when": "if_missing"
+            },
+            "backend" : {
+                "type" : "jgroups-master",
+                "channelName" : "modeshape-indexing"
+            }
+        },
+        "indexStorage": {
+            "type":"filesystem-master",
+            "sourceLocation":"target/clustered/master_indexes/",
+            "location": "target/clustered/repository_1/indexes/",
+            "refreshInSeconds" : 1,
+            "lockingStrategy":"simple",
+            "fileSystemAccessType":"auto"
+        }
+    },
+    "clustering" : {
+        "clusterName" : "modeshape-cluster"
+    }
+}

--- a/modeshape-jcr/src/test/resources/config/repo-config-clustered-indexes-2.json
+++ b/modeshape-jcr/src/test/resources/config/repo-config-clustered-indexes-2.json
@@ -1,0 +1,35 @@
+{
+    "name" : "Persistent Repository 2",
+    "workspaces" : {
+        "default" : "default",
+        "allowCreation" : true
+    },
+    "storage" : {
+        "cacheName" : "persistentRepository",
+        "cacheConfiguration" : "config/infinispan-clustered-persistent-2.xml"
+    },
+    "query":{
+        "enabled": true,
+        "rebuildUponStartup":"if_missing",
+        "indexing" : {
+            "rebuildOnStartup": {
+                "when": "if_missing"
+            },
+            "backend" : {
+                "type" : "jgroups-slave",
+                "channelName" : "modeshape-indexing"
+            }
+        },
+        "indexStorage": {
+            "type":"filesystem-slave",
+            "sourceLocation":"target/clustered/master_indexes/",
+            "location": "target/clustered/repository_2/indexes/",
+            "refreshInSeconds" : 1,
+            "lockingStrategy":"simple",
+            "fileSystemAccessType":"auto"
+        }
+    },
+    "clustering" : {
+        "clusterName" : "modeshape-cluster"
+    }
+}

--- a/modeshape-jcr/src/test/resources/config/repo-config-clustered-persistent-1.json
+++ b/modeshape-jcr/src/test/resources/config/repo-config-clustered-persistent-1.json
@@ -23,7 +23,11 @@
     },
     "query":{
         "enabled":true,
-        "rebuildUponStartup":"if_missing",
+        "indexing" : {
+            "rebuildOnStartup": {
+                "when": "if_missing"
+            }
+        },
         "indexStorage": {
             "type":"filesystem",
             "location":"target/clustered/repository_1/index",

--- a/modeshape-jcr/src/test/resources/config/repo-config-clustered-persistent-2.json
+++ b/modeshape-jcr/src/test/resources/config/repo-config-clustered-persistent-2.json
@@ -23,7 +23,11 @@
     },
     "query":{
         "enabled":true,
-        "rebuildUponStartup":"if_missing",
+        "indexing" : {
+            "rebuildOnStartup": {
+                "when": "if_missing"
+            }
+        },
         "indexStorage": {
             "type":"filesystem",
             "location":"target/clustered/repository_2/index",

--- a/modeshape-schematic/src/test/resources/json/schema/repository-config-schema.json
+++ b/modeshape-schematic/src/test/resources/json/schema/repository-config-schema.json
@@ -803,8 +803,8 @@
                                         },
                                         "channelConfiguration" : { 
                                             "type" : "string",
-                                            "required" : true,
-                                            "description" : "The JGroups channel configuration. The value should be the path to a resource file on the classpath containing the JGroups configuration."
+                                            "required" : false,
+                                            "description" : "The optional JGroups channel configuration. The value should be the path to a resource file on the classpath containing the JGroups configuration."
                                         },
                                         "description" : {
                                             "type" : "string",
@@ -830,8 +830,8 @@
                                         },
                                         "channelConfiguration" : {
                                             "type" : "string",
-                                            "required" : true,
-                                            "description" : "The JGroups channel configuration. The value should be the path to a resource file on the classpath containing the JGroups configuration."
+                                            "required" : false,
+                                            "description" : "The optional JGroups channel configuration. The value should be the path to a resource file on the classpath containing the JGroups configuration."
                                         },
                                         "description" : {
                                             "type" : "string",


### PR DESCRIPTION
This should hopefully prove that it's possible to cluster indexes using master/slave configurations. Also, updated the JSON schema so that the "channelConfiguration" attribute is optional, because Hibernate Search provides one out-of-the-box.
