### PR TITLE
MODE-1829 - Fixed parsing of leading wildcards

### DIFF
--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/query/lucene/LuceneQueryFactory.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/query/lucene/LuceneQueryFactory.java
@@ -494,14 +494,16 @@ public abstract class LuceneQueryFactory {
             if (simple.containsWildcards()) {
                 // Use the ComplexPhraseQueryParser, but instead of wildcard queries (which don't work with leading
                 // wildcards) we should use our like queries (which often use RegexQuery where applicable) ...
+
+                //as an alternative, for leading wildcards one could call parser.setAllowLeadingWildcard(true);
+                //and use the default Lucene query parser
                 QueryParser parser = new QueryParser(version, fieldName, analyzer) {
                     @Override
                     protected org.apache.lucene.search.Query getWildcardQuery( String field,
                                                                                String termStr ) {
-                        return findNodesLike(selectorName, termStr.toLowerCase(), field, CaseOperations.LOWERCASE);
+                        return findNodesLike(selectorName, field, termStr.toLowerCase(), CaseOperations.LOWERCASE);
                     }
                 };
-                parser.setAllowLeadingWildcard(true);
                 try {
                     String expression = simple.getValue();
                     // The ComplexPhraseQueryParser only understands the '?' and '*' as being wildcards ...

--- a/modeshape-jcr/src/test/java/org/modeshape/jcr/JcrQueryManagerTest.java
+++ b/modeshape-jcr/src/test/java/org/modeshape/jcr/JcrQueryManagerTest.java
@@ -1967,15 +1967,15 @@ public class JcrQueryManagerTest extends MultiUseAbstractTest {
         assertResultsHaveRows(result, "jcr:path", "/Other/NodeA[2]");
     }
 
-    @Ignore
     @FixFor( "MODE-1829" )
     @Test
     public void shouldBeAbleToCreateAndExecuteJcrSql2QueryWithFullTextSearchUsingLeadingWildcard() throws RepositoryException {
         String sql = "select [jcr:path] from [nt:unstructured] as n where contains(n.something, '*earing')";
-        // String sql = "select [jcr:path] from [nt:unstructured] as n where n.[something] LIKE '*earing*'";
         Query query = session.getWorkspace().getQueryManager().createQuery(sql, Query.JCR_SQL2);
         assertThat(query, is(notNullValue()));
         // print = true;
+        sql = "select [jcr:path] from [nt:unstructured] as n where contains(n.something, '*earing*')";
+        query = session.getWorkspace().getQueryManager().createQuery(sql, Query.JCR_SQL2);
         QueryResult result = query.execute();
         assertThat(result, is(notNullValue()));
         assertResults(query, result, 1L);


### PR DESCRIPTION
It turns out, that the existing code (using RegexQuery) does work. The only problem was the incorrect passing of 2 parameters to the method that constructed the Like Query.
