### PR TITLE
MODE-1910 Update Infinispan buffer size calculation

### DIFF
--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/value/binary/infinispan/InfinispanBinaryStore.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/value/binary/infinispan/InfinispanBinaryStore.java
@@ -216,9 +216,7 @@ public class InfinispanBinaryStore extends AbstractBinaryStore {
                 final String dataKey = dataKeyFrom(binaryKey);
                 final long lastModified = tmpFile.lastModified();
                 final long fileLength = tmpFile.length();
-                int bufferSize = 8192;
-                if (bufferSize > fileLength) bufferSize = 4096;
-                if (bufferSize > fileLength) bufferSize = 2096;
+                int bufferSize = bestBufferSize(fileLength);
                 ChunkOutputStream chunkOutputStream = new ChunkOutputStream(blobCache, dataKey);
                 IoUtil.write(new FileInputStream(tmpFile), chunkOutputStream, bufferSize);
                 // now store metadata


### PR DESCRIPTION
After talking with people in #modeshape, I've swapped out the InfinispanBinaryStore-specific buffer calculation with the AbstractBinaryStore's calculations.
