### PR TITLE
MODE-1915 - Updated ModeShape's EAP kit to 6.1.0.Beta

### DIFF
--- a/bin/install-eap.bat
+++ b/bin/install-eap.bat
@@ -12,5 +12,5 @@ REM ----------------------------------------------------------------------------
 if "%1" == "" (
     echo "Usage: install-eap.bat <eap_zip_file>"
 ) else (
-    mvn install:install-file -Dfile="%1" -DgroupId=org.jboss.as -DartifactId=jboss-eap -Dversion=6.1.0.Alpha1 -Dpackaging=zip
+    mvn install:install-file -Dfile="%1" -DgroupId=org.jboss.as -DartifactId=jboss-eap -Dversion=6.1.0.Beta -Dpackaging=zip
 )

--- a/bin/install-eap.sh
+++ b/bin/install-eap.sh
@@ -13,5 +13,5 @@ if [ "$#" -ne 1 ] ; then
 	echo "Usage: install-eap.sh <eap_zip_file>"
 	exit 1
 else
-	 mvn install:install-file -Dfile="$1" -DgroupId=org.jboss.as -DartifactId=jboss-eap -Dversion=6.1.0.Alpha1 -Dpackaging=zip
+	 mvn install:install-file -Dfile="$1" -DgroupId=org.jboss.as -DartifactId=jboss-eap -Dversion=6.1.0.Beta -Dpackaging=zip
 fi

--- a/deploy/jbossas/kit/jboss-eap61/org/apache/solr/3.6.2/module.xml
+++ b/deploy/jbossas/kit/jboss-eap61/org/apache/solr/3.6.2/module.xml
@@ -35,7 +35,7 @@
         <resource-root path="commons-lang-2.6.jar" />
     </resources>
     <dependencies>
-        <module name="org.apache.lucene" />
+        <module name="org.apache.lucene" slot="3.6.2"/>
         <module name="org.jboss.logging" />
     </dependencies>
 </module>

--- a/modeshape-distribution/pom.xml
+++ b/modeshape-distribution/pom.xml
@@ -426,7 +426,7 @@
                 <dependency>
                     <groupId>org.jboss.as</groupId>
                     <artifactId>jboss-as-controller</artifactId>
-                    <version>${jbossas-version}</version>
+                    <version>${jbossas.version}</version>
                     <scope>compile</scope>
                 </dependency>
             </dependencies>

--- a/modeshape-parent/pom.xml
+++ b/modeshape-parent/pom.xml
@@ -257,7 +257,6 @@
         <jbossjta.version>4.16.2.Final</jbossjta.version>
         <atomikos.version>3.8.0</atomikos.version>
         <picketbox.version>4.0.7.Final</picketbox.version>
-        <byteman.version>1.5.1</byteman.version>
         <lucene.version>3.6.2</lucene.version>
         <lucene.regex.version>3.0.3</lucene.regex.version>
 
@@ -289,7 +288,6 @@
         <jdbc.mssql2008.version>2.0.1008.2</jdbc.mssql2008.version>
         <javax.servlet.version>2.5</javax.servlet.version>
         <javax.jacc.version>1.0.0.Final</javax.jacc.version>
-        <jboss.seam.version>2.2.2.Final</jboss.seam.version>
         <resteasy.version>2.3.5.Final</resteasy.version>
         <jettison.version>1.3.1</jettison.version>
         <httpclient.version>4.1.2</httpclient.version>
@@ -336,11 +334,12 @@
         -->
 
         <!--Version of the artifacts (API) needed by the AS7 subsystem and provided as part of EAP-->
-        <jbossas-version>7.2.0.Alpha1-redhat-4</jbossas-version>
+        <jbossas.version>7.2.0.Final-redhat-4</jbossas.version>
+        <jbossas.model-test.version>7.2.0.Final</jbossas.model-test.version>
         <!--Properties which must be used when installing locally an EAP ZIP distribution -->
         <jboss.eap.groupId>org.jboss.as</jboss.eap.groupId>
         <jboss.eap.artifactId>jboss-eap</jboss.eap.artifactId>
-        <jboss.eap.version>6.1.0.Alpha1</jboss.eap.version>
+        <jboss.eap.version>6.1.0.Beta</jboss.eap.version>
         <jboss.eap.root.folder>jboss-eap-6.1</jboss.eap.root.folder>
 
         <!--The root folder under EAP/AS where the ModeShape & related modules should be placed-->
@@ -353,7 +352,7 @@
         <javax.jta.version>1.1</javax.jta.version>
 
         <!--Versions used by the integration/kit tests an -->
-        <jboss-javaee-6.0-with-tools.version>1.0.4.Final-redhat-1</jboss-javaee-6.0-with-tools.version>
+        <jboss-javaee-6.0-with-tools.version>1.0.4.Final-redhat-3</jboss-javaee-6.0-with-tools.version>
         <jboss-as-arquillian-container-managed.version>7.2.0.Final</jboss-as-arquillian-container-managed.version>
 
         <!--
@@ -371,7 +370,7 @@
         <cargo.container>jetty7x</cargo.container>
         <maven.codehaus.cargo.plugin.version>1.3.3</maven.codehaus.cargo.plugin.version>
         <version.jar.plugin>2.4</version.jar.plugin>
-        <version.javadoc.plugin>2.8.1</version.javadoc.plugin>
+        <version.javadoc.plugin>2.9</version.javadoc.plugin>
         <version.bundle.plugin>2.3.7</version.bundle.plugin>
         <version.failsafe.plugin>2.13</version.failsafe.plugin> 
 
@@ -653,7 +652,7 @@
                             <value>${skipLongRunningTests}</value>
                         </property>
                     </systemProperties>
-                    <argLine>-Xmx1324M ${debug.argline} -XX:MaxPermSize=256M</argLine>
+                    <argLine>-Xmx1524M ${debug.argline} -XX:MaxPermSize=256M</argLine>
                     <runOrder>alphabetical</runOrder>
                 </configuration>
             </plugin>
@@ -886,13 +885,6 @@
                 <version>${javax.jacc.version}</version>
                 <scope>provided</scope>
             </dependency>
-            <dependency>
-                <groupId>org.jboss.seam</groupId>
-                <artifactId>jboss-seam</artifactId>
-                <version>${jboss.seam.version}</version>
-                <scope>provided</scope>
-            </dependency>
-
             <!--
                 Infinispan
             -->
@@ -1028,27 +1020,6 @@
                 <groupId>org.mockito</groupId>
                 <artifactId>mockito-all</artifactId>
                 <version>${mockito.all.version}</version>
-                <scope>test</scope>
-            </dependency>
-            <!--
-            Byteman Dependencies, used for the bytecode injection during performance tests
-            -->
-            <dependency>
-                <groupId>org.jboss.byteman</groupId>
-                <artifactId>byteman-bmunit</artifactId>
-                <version>${byteman.version}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.jboss.byteman</groupId>
-                <artifactId>byteman-install</artifactId>
-                <version>${byteman.version}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.jboss.byteman</groupId>
-                <artifactId>byteman</artifactId>
-                <version>${byteman.version}</version>
                 <scope>test</scope>
             </dependency>
             <!-- Logging (all of the libraries should be optional, as the logging implementation falls back to JUL if nothig is found -->
@@ -1703,33 +1674,44 @@
             <dependency>
                 <groupId>org.jboss.as</groupId>
                 <artifactId>jboss-as-controller</artifactId>
-                <version>${jbossas-version}</version>
+                <version>${jbossas.version}</version>
                 <scope>provided</scope>
             </dependency>
             <dependency>
                 <groupId>org.jboss.as</groupId>
                 <artifactId>jboss-as-naming</artifactId>
-                <version>${jbossas-version}</version>
+                <version>${jbossas.version}</version>
                 <scope>provided</scope>
             </dependency>
             <dependency>
                 <groupId>org.jboss.as</groupId>
                 <artifactId>jboss-as-clustering-jgroups</artifactId>
-                <version>${jbossas-version}</version>
+                <version>${jbossas.version}</version>
                 <scope>provided</scope>
             </dependency>
             <dependency>
                 <groupId>org.jboss.as</groupId>
                 <artifactId>jboss-as-subsystem-test</artifactId>
-                <version>${jbossas-version}</version>
+                <version>${jbossas.version}</version>
                 <scope>test</scope>
             </dependency>
+            
+            <!--
+                //TODO author=Horia Chiorean date=4/30/13 description=For the time being, the EAP Beta repository is *incomplete* and this artifact is missing,
+                so we need another version. Note that isn't a direct dependency of ours, but a transitive one of the above.
+            -->
+            <dependency>
+                <groupId>org.jboss.as</groupId>
+                <artifactId>jboss-as-model-test</artifactId>
+                <version>${jbossas.model-test.version}</version>
+                <scope>test</scope>
+            </dependency>
+
             <dependency>
                 <groupId>org.jboss.ironjacamar</groupId>
                 <artifactId>ironjacamar-depchain</artifactId>
                 <version>${version.org.jboss.ironjacamar}</version>
                 <type>pom</type>
-                <!-- scope>import</scope -->
             </dependency>
         <dependency>
             <groupId>org.jboss.ironjacamar</groupId>

--- a/settings.xml
+++ b/settings.xml
@@ -47,7 +47,7 @@
                 <repository>
                     <id>jboss-eap-techpreview</id>
                     <name>JBoss.org Public EAP Repository</name>
-                    <url>http://maven.repository.redhat.com/techpreview/eap6/6.1.0.Alpha1/maven-repository</url>
+                    <url>http://maven.repository.redhat.com/techpreview/eap6/6.1.0.Beta1/maven-repository</url>
                     <layout>default</layout>
                     <releases>
                         <enabled>true</enabled>


### PR DESCRIPTION
To validate this PR, please make sure JBoss EAP Beta is installed locally in your Maven repo, via the `bin/install-eap.sh` script.

Also, if the `settings.xml` file provided with the project is not used, make sure the Maven repository is updated in your local `settings.xml`

Even though the published Maven repository is incomplete, the only artifact(s) that seem to be missing are transitive test artifacts (which we use to validate/test our subsystem). Therefore, a workaround was added in which we depend upon another version of the missing test artifact.
