### PR TITLE
MODE-1917 Added missing jacc dependency in EAP61 kit

### DIFF
--- a/deploy/jbossas/kit/jboss-eap61/org/modeshape/main/module.xml
+++ b/deploy/jbossas/kit/jboss-eap61/org/modeshape/main/module.xml
@@ -59,6 +59,7 @@
         <!-- For security provider ... -->
         <module name="javax.servlet.api"/>
         <module name="javax.resource.api"/>
+        <module name="javax.security.jacc.api"/>
         <!-- For logging ... -->
         <module name="org.jboss.logging"/>
         <!-- For the subsystem ... -->


### PR DESCRIPTION
While implementing JAAS based authentication integrated with ModeShape, I discovered that the JAASProvider was not finding the JAAS Subject.  The reason is outlined in the following JIRA:

https://issues.jboss.org/browse/MODE-1270

However, the problem was still happening in JBoss AS 7.1.1.Final and EAP6.1 because the jacc APIs were missing from the org.modeshape:main module.  Adding the dependency to the module.xml solved the problem and everything worked as expected.
