### PR TITLE
MODE-1909: Fix typo in BLOB type declaration.

### DIFF
--- a/modeshape-jcr/src/main/resources/org/modeshape/jcr/database/binary_store_mysql_database.properties
+++ b/modeshape-jcr/src/main/resources/org/modeshape/jcr/database/binary_store_mysql_database.properties
@@ -7,7 +7,7 @@ create_table = CREATE TABLE {0} ( \
                  ext_text VARCHAR(1000), \
                  usage_flag INTEGER, \
                  usage_time TIMESTAMP, \
-                 payload LARGEBLOB, \
+                 payload LONGBLOB, \
                  primary key(cid) \
                )
 


### PR DESCRIPTION
Following to MySQL manual: "The four BLOB types are TINYBLOB, BLOB, MEDIUMBLOB, and LONGBLOB". 
