### PR TITLE
MODE-1944 Migrated ModeShape EAP kit to EAP 6.1.0.GA. 

### DIFF
--- a/bin/install-eap.bat
+++ b/bin/install-eap.bat
@@ -12,5 +12,5 @@ REM ----------------------------------------------------------------------------
 if "%1" == "" (
     echo "Usage: install-eap.bat <eap_zip_file>"
 ) else (
-    mvn install:install-file -Dfile="%1" -DgroupId=org.jboss.as -DartifactId=jboss-eap -Dversion=6.1.0.Beta -Dpackaging=zip
+    mvn install:install-file -Dfile="%1" -DgroupId=org.jboss.as -DartifactId=jboss-eap -Dversion=6.1.0.GA -Dpackaging=zip
 )

--- a/bin/install-eap.sh
+++ b/bin/install-eap.sh
@@ -13,5 +13,5 @@ if [ "$#" -ne 1 ] ; then
 	echo "Usage: install-eap.sh <eap_zip_file>"
 	exit 1
 else
-	 mvn install:install-file -Dfile="$1" -DgroupId=org.jboss.as -DartifactId=jboss-eap -Dversion=6.1.0.Beta -Dpackaging=zip
+	 mvn install:install-file -Dfile="$1" -DgroupId=org.jboss.as -DartifactId=jboss-eap -Dversion=6.1.0.GA -Dpackaging=zip
 fi

--- a/boms/modeshape-bom-parent/pom.xml
+++ b/boms/modeshape-bom-parent/pom.xml
@@ -52,7 +52,7 @@
         <!-- Versions of non-ModeShape dependencies -->
         <jcr.version>2.0</jcr.version>
         <joda.time.version>1.6.2</joda.time.version>
-        <infinispan.version>5.2.5.Final</infinispan.version>
+        <infinispan.version>5.2.6.Final</infinispan.version>
         <c3p0.version>0.9.1.2</c3p0.version>  <!-- same as the one used by Infinispan's JDBC cache store -->
         <jgroups.version>3.2.7.Final</jgroups.version> <!-- same as the one used by Infinispan -->
         <hibernate.search.version>4.2.0.Final</hibernate.search.version>
@@ -63,7 +63,7 @@
 
         <jbossjta.version>4.16.2.Final</jbossjta.version>
         <picketbox.version>4.0.7.Final</picketbox.version>
-        <resteasy.version>2.3.5.Final</resteasy.version>
+        <resteasy.version>2.3.6.Final</resteasy.version>
         <jettison.version>1.3.1</jettison.version>
         <httpclient.version>4.1.2</httpclient.version>
         <mongo.driver.version>2.7.3</mongo.driver.version>

--- a/deploy/jbossas/modeshape-jbossas-cmis-war/src/main/webapp/META-INF/MANIFEST.MF
+++ b/deploy/jbossas/modeshape-jbossas-cmis-war/src/main/webapp/META-INF/MANIFEST.MF
@@ -1,3 +1,0 @@
-Manifest-Version: 1.0
-Class-Path: 
-Dependencies: javax.jcr, org.modeshape.jcr.api services, org.modeshape services

--- a/deploy/jbossas/modeshape-jbossas-cmis-war/src/main/webapp/WEB-INF/jboss-deployment-structure.xml
+++ b/deploy/jbossas/modeshape-jbossas-cmis-war/src/main/webapp/WEB-INF/jboss-deployment-structure.xml
@@ -1,0 +1,9 @@
+<jboss-deployment-structure>
+    <deployment>
+        <dependencies>
+            <module name="javax.jcr"/>
+            <module name="org.modeshape.jcr.api" services="import"/>
+            <module name="org.modeshape" services="import"/>
+        </dependencies>
+    </deployment>
+</jboss-deployment-structure>

--- a/deploy/jbossas/modeshape-jbossas-subsystem/src/main/java/org/modeshape/jboss/subsystem/ModeShapeSubsystemXMLReader_1_0.java
+++ b/deploy/jbossas/modeshape-jbossas-subsystem/src/main/java/org/modeshape/jboss/subsystem/ModeShapeSubsystemXMLReader_1_0.java
@@ -113,10 +113,6 @@ public class ModeShapeSubsystemXMLReader_1_0 implements XMLStreamConstants, XMLE
                     ModelAttributes.EXPLODED.parseAndSetParameter(attrValue, webapp, reader);
                     break;
                 }
-                case AUTO_DEPLOY: {
-                    ModelAttributes.AUTO_DEPLOY.parseAndSetParameter(attrValue, webapp, reader);
-                    break;
-                }
                 default:
                     throw ParseUtils.unexpectedAttribute(reader, i);
             }

--- a/deploy/jbossas/modeshape-jbossas-subsystem/src/main/java/org/modeshape/jboss/subsystem/ModeShapeSubsystemXMLWriter.java
+++ b/deploy/jbossas/modeshape-jbossas-subsystem/src/main/java/org/modeshape/jboss/subsystem/ModeShapeSubsystemXMLWriter.java
@@ -73,7 +73,6 @@ public class ModeShapeSubsystemXMLWriter implements XMLStreamConstants, XMLEleme
         writer.writeStartElement(Element.WEBAPP.getLocalName());
         writer.writeAttribute(Attribute.NAME.getLocalName(), repositoryName);
         ModelAttributes.EXPLODED.marshallAsAttribute(webapp, false, writer);
-        ModelAttributes.AUTO_DEPLOY.marshallAsAttribute(webapp, false, writer);
         writer.writeEndElement();
     }
 

--- a/deploy/jbossas/modeshape-jbossas-subsystem/src/main/java/org/modeshape/jboss/subsystem/ModelAttributes.java
+++ b/deploy/jbossas/modeshape-jbossas-subsystem/src/main/java/org/modeshape/jboss/subsystem/ModelAttributes.java
@@ -796,18 +796,12 @@ public class ModelAttributes {
                                                                                                   .setXmlName(Attribute.EXPLODED.getLocalName())
                                                                                                   .setAllowExpression(false)
                                                                                                   .setAllowNull(true)
-                                                                                                  .setDefaultValue(new ModelNode().set(true))
+                                                                                                  .setDefaultValue(new ModelNode().set(false))
                                                                                                   .build();
 
-    public static final SimpleAttributeDefinition AUTO_DEPLOY = new MappedAttributeDefinitionBuilder(ModelKeys.AUTO_DEPLOY, ModelType.BOOLEAN)
-                                                                                                  .setXmlName(Attribute.AUTO_DEPLOY.getLocalName())
-                                                                                                  .setAllowExpression(false)
-                                                                                                  .setAllowNull(true)
-                                                                                                  .setDefaultValue(new ModelNode().set(true))
-                                                                                                  .build();
     public static final AttributeDefinition[] SUBSYSTEM_ATTRIBUTES = {};
 
-    public static final AttributeDefinition[] WEBAPP_ATTRIBUTES = {EXPLODED, AUTO_DEPLOY};
+    public static final AttributeDefinition[] WEBAPP_ATTRIBUTES = {EXPLODED};
 
     public static final AttributeDefinition[] REPOSITORY_ATTRIBUTES = {CACHE_NAME, CACHE_CONTAINER, JNDI_NAME, ENABLE_MONITORING,
         ENABLE_QUERIES, SECURITY_DOMAIN, ANONYMOUS_ROLES, ANONYMOUS_USERNAME, USE_ANONYMOUS_IF_AUTH_FAILED, NODE_TYPES,

--- a/deploy/jbossas/modeshape-jbossas-subsystem/src/test/resources/org/modeshape/jboss/subsystem/modeshape-webapp-config.xml
+++ b/deploy/jbossas/modeshape-jbossas-subsystem/src/test/resources/org/modeshape/jboss/subsystem/modeshape-webapp-config.xml
@@ -1,7 +1,7 @@
 <subsystem xmlns="urn:jboss:domain:modeshape:1.0">
   <webapp name="app1"/>
-  <webapp name="app2" exploded="true" auto-deploy="true"/>
-  <webapp name="app3" exploded="false" auto-deploy="false"/>
+  <webapp name="app2" exploded="true" />
+  <webapp name="app3" exploded="false"/>
   <repository name="sample" />
 </subsystem>
 

--- a/deploy/jbossas/modeshape-jbossas-web-rest-war/pom.xml
+++ b/deploy/jbossas/modeshape-jbossas-web-rest-war/pom.xml
@@ -53,11 +53,10 @@
                     <groupId>org.jboss.resteasy</groupId>
                     <artifactId>resteasy-multipart-provider</artifactId>
                 </exclusion>
-                <!-- ModeShape REST service code uses this directly ...
-                  <exclusion>
-                    <groupId>org.codehaus.jettison</groupId>
-                    <artifactId>jettison</artifactId>
-                  </exclusion-->
+                <exclusion>
+                    <groupId>commons-logging</groupId>
+                    <artifactId>commons-logging</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
     </dependencies>

--- a/deploy/jbossas/modeshape-jbossas-web-rest-war/src/main/webapp/META-INF/MANIFEST.MF
+++ b/deploy/jbossas/modeshape-jbossas-web-rest-war/src/main/webapp/META-INF/MANIFEST.MF
@@ -1,3 +1,0 @@
-Manifest-Version: 1.0
-Class-Path: 
-Dependencies: javax.jcr, org.modeshape.jcr.api services, org.modeshape services

--- a/deploy/jbossas/modeshape-jbossas-web-rest-war/src/main/webapp/WEB-INF/jboss-deployment-structure.xml
+++ b/deploy/jbossas/modeshape-jbossas-web-rest-war/src/main/webapp/WEB-INF/jboss-deployment-structure.xml
@@ -1,0 +1,9 @@
+<jboss-deployment-structure>
+    <deployment>
+        <dependencies>
+            <module name="javax.jcr"/>
+            <module name="org.modeshape.jcr.api" services="import"/>
+            <module name="org.modeshape" services="import"/>
+        </dependencies>
+    </deployment>
+</jboss-deployment-structure>

--- a/deploy/jbossas/modeshape-jbossas-web-webdav-war/src/main/webapp/META-INF/MANIFEST.MF
+++ b/deploy/jbossas/modeshape-jbossas-web-webdav-war/src/main/webapp/META-INF/MANIFEST.MF
@@ -1,3 +1,0 @@
-Manifest-Version: 1.0
-Class-Path: 
-Dependencies: javax.jcr, org.modeshape.jcr.api services, org.modeshape services

--- a/deploy/jbossas/modeshape-jbossas-web-webdav-war/src/main/webapp/WEB-INF/jboss-deployment-structure.xml
+++ b/deploy/jbossas/modeshape-jbossas-web-webdav-war/src/main/webapp/WEB-INF/jboss-deployment-structure.xml
@@ -1,0 +1,9 @@
+<jboss-deployment-structure>
+    <deployment>
+        <dependencies>
+            <module name="javax.jcr"/>
+            <module name="org.modeshape.jcr.api" services="import"/>
+            <module name="org.modeshape" services="import"/>
+        </dependencies>
+    </deployment>
+</jboss-deployment-structure>

--- a/integration/modeshape-jbossas-integration-tests/pom.xml
+++ b/integration/modeshape-jbossas-integration-tests/pom.xml
@@ -127,8 +127,7 @@
         </dependency>
 
         <!--
-            //TODO author=Horia Chiorean date=3/12/13 description=This is not defined in any of the above mentioned BOMs, but is
-            critical for working with managed EAP containers
+            This is not defined in any of the above mentioned BOMs, but is critical for working with managed EAP containers
           -->
         <dependency>
             <groupId>org.jboss.as</groupId>

--- a/integration/modeshape-jbossas-kit-tests/pom.xml
+++ b/integration/modeshape-jbossas-kit-tests/pom.xml
@@ -90,8 +90,7 @@
         </dependency>
 
         <!--
-             //TODO author=Horia Chiorean date=3/12/13 description=This is not defined in any of the above mentioned BOMs, but is
-             critical for working with managed EAP/AS containers.
+             This is not defined in any of the above mentioned BOMs, but is critical for working with managed EAP/AS containers.
            -->
         <dependency>
             <groupId>org.jboss.as</groupId>

--- a/modeshape-assembly-descriptors/src/main/resources/assemblies/jbosseap-61-dist.xml
+++ b/modeshape-assembly-descriptors/src/main/resources/assemblies/jbosseap-61-dist.xml
@@ -52,28 +52,37 @@
 			</includes>
 			<outputDirectory>docs/schema</outputDirectory>
 		</fileSet>
-
-	  <!-- Deployment for the ModeShape RESTful service WAR (as an exploded directory) -->
-		<fileSet>
-			<directory>../deploy/jbossas/modeshape-jbossas-web-rest-war/target/modeshape-jbossas-web-rest-war-${project.version}</directory>
-		    <outputDirectory>${jboss.eap.modules.location}/org/modeshape/main/deployments/modeshape-rest.war</outputDirectory>
-		</fileSet>
-
-        <!-- Deployment for the ModeShape WebDAV service WAR (as an exploded directory) -->
-        <fileSet>
-            <directory>../deploy/jbossas/modeshape-jbossas-web-webdav-war/target/modeshape-jbossas-web-webdav-war-${project.version}</directory>
-            <outputDirectory>${jboss.eap.modules.location}/org/modeshape/main/deployments/modeshape-webdav.war</outputDirectory>
-        </fileSet>
-
-        <!-- Deployment for the ModeShape CMIS service WAR (as an exploded directory) -->
-        <fileSet>
-            <directory>../deploy/jbossas/modeshape-jbossas-cmis-war/target/modeshape-jbossas-cmis-war-${project.version}</directory>
-            <outputDirectory>${jboss.eap.modules.location}/org/modeshape/main/deployments/modeshape-cmis.war</outputDirectory>
-        </fileSet>
     </fileSets>
-	
-	<dependencySets>
 
+    <files>
+        <!-- Deployment for the ModeShape RESTful service WAR -->
+        <file>
+            <source>
+                ../deploy/jbossas/modeshape-jbossas-web-rest-war/target/modeshape-jbossas-web-rest-war-${project.version}.war
+            </source>
+            <outputDirectory>${jboss.eap.modules.location}/org/modeshape/main/deployments</outputDirectory>
+            <destName>modeshape-rest.war</destName>
+        </file>
+
+        <!-- Deployment for the ModeShape WebDAV service WAR -->
+        <file>
+            <source>
+                ../deploy/jbossas/modeshape-jbossas-web-webdav-war/target/modeshape-jbossas-web-webdav-war-${project.version}.war
+            </source>
+            <outputDirectory>${jboss.eap.modules.location}/org/modeshape/main/deployments</outputDirectory>
+            <destName>modeshape-webdav.war</destName>
+        </file>
+
+        <!-- Deployment for the ModeShape CMIS service WAR -->
+        <file>
+            <source>../deploy/jbossas/modeshape-jbossas-cmis-war/target/modeshape-jbossas-cmis-war-${project.version}.war
+            </source>
+            <outputDirectory>${jboss.eap.modules.location}/org/modeshape/main/deployments</outputDirectory>
+            <destName>modeshape-cmis.war</destName>
+        </file>
+    </files>
+
+    <dependencySets>
 		<!-- Module for the standard JCR API -->
 		<dependencySet>
             <useProjectArtifact>false</useProjectArtifact>

--- a/modeshape-parent/pom.xml
+++ b/modeshape-parent/pom.xml
@@ -267,7 +267,7 @@
         <hibernate.search.jackson-mapper-asl.version>1.9.2</hibernate.search.jackson-mapper-asl.version>
         <hibernate.search.jackson-core-asl.version>1.9.2</hibernate.search.jackson-core-asl.version>
 
-        <infinispan.version>5.2.5.Final</infinispan.version>
+        <infinispan.version>5.2.6.Final</infinispan.version>
         <!--Make sure the jgroups version is the same as the one used by ISPN -->
         <jgroups.version>3.2.7.Final</jgroups.version>
         <c3p0.version>0.9.1.2</c3p0.version>
@@ -289,7 +289,8 @@
         <javax.servlet.version>2.5</javax.servlet.version>
         <javax.jms.version>1.1-rev-1</javax.jms.version>
         <javax.jacc.version>1.0.0.Final</javax.jacc.version>
-        <resteasy.version>2.3.5.Final</resteasy.version>
+        <resteasy.version>2.3.6.Final</resteasy.version>
+        <commons.logging.version>1.1.1</commons.logging.version>
         <jettison.version>1.3.1</jettison.version>
         <httpclient.version>4.1.2</httpclient.version>
         <sardine.version>146</sardine.version>
@@ -335,12 +336,11 @@
         -->
 
         <!--Version of the artifacts (API) needed by the AS7 subsystem and provided as part of EAP-->
-        <jbossas.version>7.2.0.Final-redhat-4</jbossas.version>
-        <jbossas.model-test.version>7.2.0.Final</jbossas.model-test.version>
+        <jbossas.version>7.2.0.Final-redhat-8</jbossas.version>
         <!--Properties which must be used when installing locally an EAP ZIP distribution -->
         <jboss.eap.groupId>org.jboss.as</jboss.eap.groupId>
         <jboss.eap.artifactId>jboss-eap</jboss.eap.artifactId>
-        <jboss.eap.version>6.1.0.Beta</jboss.eap.version>
+        <jboss.eap.version>6.1.0.GA</jboss.eap.version>
         <jboss.eap.root.folder>jboss-eap-6.1</jboss.eap.root.folder>
 
         <!--The root folder under EAP/AS where the ModeShape & related modules should be placed-->
@@ -353,7 +353,7 @@
         <javax.jta.version>1.1</javax.jta.version>
 
         <!--Versions used by the integration/kit tests an -->
-        <jboss-javaee-6.0-with-tools.version>1.0.4.Final-redhat-3</jboss-javaee-6.0-with-tools.version>
+        <jboss-javaee-6.0-with-tools.version>1.0.4.Final-redhat-4</jboss-javaee-6.0-with-tools.version>
         <jboss-as-arquillian-container-managed.version>7.2.0.Final</jboss-as-arquillian-container-managed.version>
 
         <!--
@@ -1257,6 +1257,17 @@
                     </exclusion>
                 </exclusions>
             </dependency>
+            <!--
+                Since 2.3.6, RestEASY excludes the following dependency because of https://issues.jboss.org/browse/RESTEASY-848
+                This is most likely a bug in RestEASY, because commons-logging is needed by resteasy-multipart-provider via
+                its org.apache.james dependency
+            -->
+            <dependency>
+                <groupId>commons-logging</groupId>
+                <artifactId>commons-logging</artifactId>
+                <version>${commons.logging.version}</version>
+                <scope>runtime</scope>
+            </dependency>
             <dependency>
                 <groupId>org.codehaus.jettison</groupId>
                 <artifactId>jettison</artifactId>
@@ -1726,15 +1737,11 @@
                 <version>${jbossas.version}</version>
                 <scope>test</scope>
             </dependency>
-            
-            <!--
-                //TODO author=Horia Chiorean date=4/30/13 description=For the time being, the EAP Beta repository is *incomplete* and this artifact is missing,
-                so we need another version. Note that isn't a direct dependency of ours, but a transitive one of the above.
-            -->
+
             <dependency>
                 <groupId>org.jboss.as</groupId>
                 <artifactId>jboss-as-model-test</artifactId>
-                <version>${jbossas.model-test.version}</version>
+                <version>${jbossas.version}</version>
                 <scope>test</scope>
             </dependency>
 

--- a/settings.xml
+++ b/settings.xml
@@ -47,7 +47,7 @@
                 <repository>
                     <id>jboss-eap-techpreview</id>
                     <name>JBoss.org Public EAP Repository</name>
-                    <url>http://maven.repository.redhat.com/techpreview/eap6/6.1.0.Beta1/maven-repository</url>
+                    <url>http://maven.repository.redhat.com/techpreview/eap6/6.1.0/maven-repository</url>
                     <layout>default</layout>
                     <releases>
                         <enabled>true</enabled>

--- a/web/modeshape-web-jcr-rest/pom.xml
+++ b/web/modeshape-web-jcr-rest/pom.xml
@@ -35,6 +35,11 @@
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-multipart-provider</artifactId>
         </dependency>
+        <!--See modeshape-parent for an explanation of this dependency-->
+        <dependency>
+            <groupId>commons-logging</groupId>
+            <artifactId>commons-logging</artifactId>
+        </dependency>
         <dependency>
             <groupId>org.codehaus.jettison</groupId>
             <artifactId>jettison</artifactId>


### PR DESCRIPTION
This presented a number of challenges:
- RestEASY 2.3.6 excludes explicitly a dependency required by `resteasy-multipart-provider/apache.james`. For this to work, it had to be re-added with the scope "runtime"
- Deploying exploded webapps does not work anymore (for whatever reason...). This means that our EAP kit had to be changed to provide packaged .war files for the web application. This brought forth several issues around the subsystem and the content of the wars which were fixed.

Before testing this, make sure you run the `install-eap` script on the downloaded EAP 6.1.0.GA zip.
