### PR TITLE
MODE-1945 Fixed the code which validated mandatory children of a node type, before saving a session.

### DIFF
--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrContentHandler.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrContentHandler.java
@@ -343,11 +343,6 @@ class JcrContentHandler extends DefaultHandler {
         }
     }
 
-    /**
-     * {@inheritDoc}
-     * 
-     * @see org.xml.sax.ContentHandler#characters(char[], int, int)
-     */
     @Override
     public void characters( char[] ch,
                             int start,
@@ -356,11 +351,6 @@ class JcrContentHandler extends DefaultHandler {
         delegate.characters(ch, start, length);
     }
 
-    /**
-     * {@inheritDoc}
-     * 
-     * @see org.xml.sax.helpers.DefaultHandler#endDocument()
-     */
     @Override
     public void endDocument() throws SAXException {
         postProcessNodes();
@@ -375,11 +365,6 @@ class JcrContentHandler extends DefaultHandler {
         super.endDocument();
     }
 
-    /**
-     * {@inheritDoc}
-     * 
-     * @see org.xml.sax.ContentHandler#endElement(java.lang.String, java.lang.String, java.lang.String)
-     */
     @Override
     public void endElement( String uri,
                             String localName,
@@ -388,11 +373,6 @@ class JcrContentHandler extends DefaultHandler {
         delegate.endElement(uri, localName, name);
     }
 
-    /**
-     * {@inheritDoc}
-     * 
-     * @see org.xml.sax.ContentHandler#startElement(java.lang.String, java.lang.String, java.lang.String, org.xml.sax.Attributes)
-     */
     @Override
     public void startElement( String uri,
                               String localName,
@@ -428,11 +408,6 @@ class JcrContentHandler extends DefaultHandler {
         return new String(decoded, "UTF-8");
     }
 
-    /**
-     * {@inheritDoc}
-     * 
-     * @see org.xml.sax.ContentHandler#startPrefixMapping(java.lang.String, java.lang.String)
-     */
     @Override
     public void startPrefixMapping( String prefix,
                                     String uri ) throws SAXException {
@@ -463,13 +438,8 @@ class JcrContentHandler extends DefaultHandler {
 
     class EnclosingSAXException extends SAXException {
 
-        /**
-         */
         private static final long serialVersionUID = -1044992767566435542L;
 
-        /**
-         * @param e
-         */
         EnclosingSAXException( Exception e ) {
             super(e);
 
@@ -514,11 +484,6 @@ class JcrContentHandler extends DefaultHandler {
             }
         }
 
-        /**
-         * {@inheritDoc}
-         * 
-         * @see java.lang.Object#toString()
-         */
         @Override
         public String toString() {
             NodeHandler parent = parentHandler();
@@ -610,11 +575,6 @@ class JcrContentHandler extends DefaultHandler {
             return ignoreAllChildren;
         }
 
-        /**
-         * {@inheritDoc}
-         * 
-         * @see org.modeshape.jcr.JcrContentHandler.NodeHandler#name()
-         */
         @Override
         protected String name() {
             return stringFor(nodeName);
@@ -873,31 +833,16 @@ class JcrContentHandler extends DefaultHandler {
             this.parentHandler = parentHandler;
         }
 
-        /**
-         * {@inheritDoc}
-         * 
-         * @see org.modeshape.jcr.JcrContentHandler.NodeHandler#node()
-         */
         @Override
         public AbstractJcrNode node() {
             return node;
         }
 
-        /**
-         * {@inheritDoc}
-         * 
-         * @see org.modeshape.jcr.JcrContentHandler.NodeHandler#parentHandler()
-         */
         @Override
         public NodeHandler parentHandler() {
             return parentHandler;
         }
 
-        /**
-         * {@inheritDoc}
-         * 
-         * @see org.modeshape.jcr.JcrContentHandler.NodeHandler#addPropertyValue(Name, String, boolean, int, TextDecoder)
-         */
         @Override
         public void addPropertyValue( Name propertyName,
                                       String value,
@@ -913,11 +858,6 @@ class JcrContentHandler extends DefaultHandler {
             super(root, null);
         }
 
-        /**
-         * {@inheritDoc}
-         * 
-         * @see org.modeshape.jcr.JcrContentHandler.NodeHandler#addPropertyValue(Name, String, boolean, int, TextDecoder)
-         */
         @Override
         public void addPropertyValue( Name propertyName,
                                       String value,
@@ -935,11 +875,6 @@ class JcrContentHandler extends DefaultHandler {
             this.parentHandler = parentHandler;
         }
 
-        /**
-         * {@inheritDoc}
-         * 
-         * @see org.modeshape.jcr.JcrContentHandler.NodeHandler#parentHandler()
-         */
         @Override
         public NodeHandler parentHandler() {
             return parentHandler;
@@ -1005,12 +940,6 @@ class JcrContentHandler extends DefaultHandler {
             this.currentPropertyValue = new StringBuilder();
         }
 
-        /**
-         * {@inheritDoc}
-         * 
-         * @see org.xml.sax.ContentHandler#startElement(java.lang.String, java.lang.String, java.lang.String,
-         *      org.xml.sax.Attributes)
-         */
         @Override
         public void startElement( String uri,
                                   String localName,
@@ -1051,11 +980,6 @@ class JcrContentHandler extends DefaultHandler {
             }
         }
 
-        /**
-         * {@inheritDoc}
-         * 
-         * @see org.xml.sax.ContentHandler#characters(char[], int, int)
-         */
         @Override
         public void characters( char[] ch,
                                 int start,
@@ -1097,21 +1021,12 @@ class JcrContentHandler extends DefaultHandler {
         private NodeHandler current;
         private final NodeHandlerFactory nodeHandlerFactory;
 
-        /**
-         * @param currentNode
-         */
         DocumentViewContentHandler( AbstractJcrNode currentNode ) {
             super();
             this.current = new ExistingNodeHandler(currentNode, null);
             this.nodeHandlerFactory = new StandardNodeHandlerFactory();
         }
 
-        /**
-         * {@inheritDoc}
-         * 
-         * @see org.xml.sax.ContentHandler#startElement(java.lang.String, java.lang.String, java.lang.String,
-         *      org.xml.sax.Attributes)
-         */
         @Override
         public void startElement( String uri,
                                   String localName,
@@ -1155,11 +1070,6 @@ class JcrContentHandler extends DefaultHandler {
             current = current.parentHandler();
         }
 
-        /**
-         * {@inheritDoc}
-         * 
-         * @see org.xml.sax.ContentHandler#characters(char[], int, int)
-         */
         @Override
         public void characters( char[] ch,
                                 int start,

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrSession.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrSession.java
@@ -1916,18 +1916,9 @@ public class JcrSession implements org.modeshape.jcr.api.Session {
             Collection<JcrNodeDefinition> mandatoryChildDefns = null;
             mandatoryChildDefns = nodeTypeCapabilities.getMandatoryChildNodeDefinitions(primaryType, mixinTypes);
             if (!mandatoryChildDefns.isEmpty()) {
-                // There is at least one auto-created child node definition on this node, so figure out if they are all
-                // covered by existing children ...
-                Set<NodeKey> allChildren = cache().getNodeKeysAtAndBelow(node.getKey());
-                allChildren.addAll(cache().getChangedNodeKeysAtOrBelow(node));
-                // remove the current node
-                allChildren.remove(node.getKey());
-                // remove all the keys of the nodes which are removed
-                allChildren.removeAll(node.getNodeChanges().removedChildren());
                 Set<Name> childrenNames = new HashSet<Name>();
-
-                for (NodeKey childKey : allChildren) {
-                    childrenNames.add(cache().getNode(childKey).getName(cache()));
+                for (ChildReference childRef : node.getChildReferences(cache())) {
+                    childrenNames.add(childRef.getName());
                 }
 
                 for (JcrNodeDefinition defn : mandatoryChildDefns) {

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/document/WritableSessionCache.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/document/WritableSessionCache.java
@@ -1106,8 +1106,9 @@ public class WritableSessionCache extends AbstractSessionCache {
                     // when linking/un-linking nodes (e.g. shareable node or jcr:system) this condition will be false.
                     // the downside of this is that there may be cases (e.g. back references when working with versions) in which
                     // we might loose information from the indexes
-                    Path oldPath = workspacePaths.getPath(workspaceCache.getNode(node.getKey()));
-                    boolean pathChanged = !oldPath.equals(newPath);
+                    Path oldNodePath = workspacePaths.getPath(workspaceCache.getNode(node.getKey()));
+                    Path newNodePath = sessionPaths.getPath(node);
+                    boolean pathChanged = !oldNodePath.equals(newNodePath);
                     boolean shouldUpdateIndexes = (isSameWorkspace && (hasPropertyChanges || node.hasIndexRelatedChanges() || pathChanged))
                                                   || externalNodeChanged;
                     if (monitor != null && queryable && shouldUpdateIndexes) {
@@ -1115,14 +1116,14 @@ public class WritableSessionCache extends AbstractSessionCache {
                         // should be there and shouldn't require a looking in the cache...
                         Name primaryType = node.getPrimaryType(this);
                         Set<Name> mixinTypes = node.getMixinTypes(this);
-                        monitor.recordUpdate(workspaceName, key, newPath, primaryType, mixinTypes, node.getProperties(this));
+                        monitor.recordUpdate(workspaceName, key, newNodePath, primaryType, mixinTypes, node.getProperties(this));
 
                         if (pathChanged) {
                             //we're dealing with a path change, so in case there is a persisted node at "new path" we need to remove
                             //it from the indexes, because the current node will take its place
                             CachedNode persistedParent = workspaceCache.getNode(node.getParentKey(this));
                             ChildReference persistedNodeAtNewPath = persistedParent.getChildReferences(workspaceCache).getChild(
-                                    newPath.getLastSegment().getName(), newPath.getLastSegment().getIndex());
+                                    newNodePath.getLastSegment().getName(), newNodePath.getLastSegment().getIndex());
                             if (persistedNodeAtNewPath != null) {
                                 monitor.recordRemove(workspaceName, Arrays.asList(persistedNodeAtNewPath.getKey()));
                             }

--- a/modeshape-jcr/src/test/java/org/modeshape/jcr/ImportExportTest.java
+++ b/modeshape-jcr/src/test/java/org/modeshape/jcr/ImportExportTest.java
@@ -351,15 +351,7 @@ public class ImportExportTest extends SingleUseAbstractTest {
 
         assertImport("io/cars-system-view.xml", "/a/b", ImportBehavior.CREATE_NEW);
         assertThat(session, is(notNullValue()));
-        assertNode("/a/b/Cars");
-        assertNode("/a/b/Cars/Hybrid");
-        assertNode("/a/b/Cars/Hybrid/Toyota Prius");
-        assertNode("/a/b/Cars/Sports/Infiniti G37");
-        assertNode("/a/b/Cars/Utility/Land Rover LR3");
-        assertNoNode("/a/b/Cars[2]");
-        assertNoNode("/a/b/Cars/Hybrid[2]");
-        assertNoNode("/a/b/Cars/Hybrid/Toyota Prius[2]");
-        assertNoNode("/a/b/Cars/Sports[2]");
+        assertCarsImported();
     }
 
     @Test
@@ -369,15 +361,7 @@ public class ImportExportTest extends SingleUseAbstractTest {
 
         assertImport("io/cars-system-view.xml", "/a/b", ImportBehavior.REMOVE_EXISTING);
         assertThat(session, is(notNullValue()));
-        assertNode("/a/b/Cars");
-        assertNode("/a/b/Cars/Hybrid");
-        assertNode("/a/b/Cars/Hybrid/Toyota Prius");
-        assertNode("/a/b/Cars/Sports/Infiniti G37");
-        assertNode("/a/b/Cars/Utility/Land Rover LR3");
-        assertNoNode("/a/b/Cars[2]");
-        assertNoNode("/a/b/Cars/Hybrid[2]");
-        assertNoNode("/a/b/Cars/Hybrid/Toyota Prius[2]");
-        assertNoNode("/a/b/Cars/Sports[2]");
+        assertCarsImported();
     }
 
     @Test
@@ -387,15 +371,7 @@ public class ImportExportTest extends SingleUseAbstractTest {
 
         assertImport("io/cars-system-view.xml", "/a/b", ImportBehavior.REPLACE_EXISTING);
         assertThat(session, is(notNullValue()));
-        assertNode("/a/b/Cars");
-        assertNode("/a/b/Cars/Hybrid");
-        assertNode("/a/b/Cars/Hybrid/Toyota Prius");
-        assertNode("/a/b/Cars/Sports/Infiniti G37");
-        assertNode("/a/b/Cars/Utility/Land Rover LR3");
-        assertNoNode("/a/b/Cars[2]");
-        assertNoNode("/a/b/Cars/Hybrid[2]");
-        assertNoNode("/a/b/Cars/Hybrid/Toyota Prius[2]");
-        assertNoNode("/a/b/Cars/Sports[2]");
+        assertCarsImported();
     }
 
     @Test
@@ -406,15 +382,7 @@ public class ImportExportTest extends SingleUseAbstractTest {
 
         // Set up the repository with existing content ...
         assertImport("io/cars-system-view.xml", "/a/b", ImportBehavior.CREATE_NEW);
-        assertNode("/a/b/Cars");
-        assertNode("/a/b/Cars/Hybrid");
-        assertNode("/a/b/Cars/Hybrid/Toyota Prius");
-        assertNode("/a/b/Cars/Sports/Infiniti G37");
-        assertNode("/a/b/Cars/Utility/Land Rover LR3");
-        assertNoNode("/a/b/Cars[2]");
-        assertNoNode("/a/b/Cars/Hybrid[2]");
-        assertNoNode("/a/b/Cars/Hybrid/Toyota Prius[2]");
-        assertNoNode("/a/b/Cars/Sports[2]");
+        assertCarsImported();
 
         // Now import again to create a second copy ...
         assertImport("io/cars-system-view.xml", "/a/b", ImportBehavior.REMOVE_EXISTING);
@@ -443,15 +411,7 @@ public class ImportExportTest extends SingleUseAbstractTest {
 
         // Set up the repository with existing content ...
         assertImport("io/cars-system-view.xml", "/a/b", ImportBehavior.CREATE_NEW);
-        assertNode("/a/b/Cars");
-        assertNode("/a/b/Cars/Hybrid");
-        assertNode("/a/b/Cars/Hybrid/Toyota Prius");
-        assertNode("/a/b/Cars/Sports/Infiniti G37");
-        assertNode("/a/b/Cars/Utility/Land Rover LR3");
-        assertNoNode("/a/b/Cars[2]");
-        assertNoNode("/a/b/Cars/Hybrid[2]");
-        assertNoNode("/a/b/Cars/Hybrid/Toyota Prius[2]");
-        assertNoNode("/a/b/Cars/Sports[2]");
+        assertCarsImported();
 
         // And attempt to reimport the same content (with UUIDs) into the repository that already has that content ...
         // print = true;
@@ -479,15 +439,7 @@ public class ImportExportTest extends SingleUseAbstractTest {
 
         // Set up the repository with existing content ...
         assertImport("io/cars-system-view-with-uuids.xml", "/a/b", ImportBehavior.CREATE_NEW);
-        assertNode("/a/b/Cars");
-        assertNode("/a/b/Cars/Hybrid");
-        assertNode("/a/b/Cars/Hybrid/Toyota Prius");
-        assertNode("/a/b/Cars/Sports/Infiniti G37");
-        assertNode("/a/b/Cars/Utility/Land Rover LR3");
-        assertNoNode("/a/b/Cars[2]");
-        assertNoNode("/a/b/Cars/Hybrid[2]");
-        assertNoNode("/a/b/Cars/Hybrid/Toyota Prius[2]");
-        assertNoNode("/a/b/Cars/Sports[2]");
+        assertCarsImported();
 
         // And attempt to reimport the same content (with UUIDs) into the repository that already has that content ...
         // print = true;
@@ -515,15 +467,7 @@ public class ImportExportTest extends SingleUseAbstractTest {
 
         // Set up the repository with existing content ...
         assertImport("io/cars-system-view-with-uuids.xml", "/a/b", ImportBehavior.CREATE_NEW);
-        assertNode("/a/b/Cars");
-        assertNode("/a/b/Cars/Hybrid");
-        assertNode("/a/b/Cars/Hybrid/Toyota Prius");
-        assertNode("/a/b/Cars/Sports/Infiniti G37");
-        assertNode("/a/b/Cars/Utility/Land Rover LR3");
-        assertNoNode("/a/b/Cars[2]");
-        assertNoNode("/a/b/Cars/Hybrid[2]");
-        assertNoNode("/a/b/Cars/Hybrid/Toyota Prius[2]");
-        assertNoNode("/a/b/Cars/Sports[2]");
+        assertCarsImported();
 
         // And attempt to reimport the same content (with UUIDs) into the repository that already has that content ...
         // print = true;
@@ -532,15 +476,7 @@ public class ImportExportTest extends SingleUseAbstractTest {
 
         // Verify that the original content has been replaced (since the SystemView contained UUIDs) and there is no copy ...
         assertThat(session, is(notNullValue()));
-        assertNode("/a/b/Cars");
-        assertNode("/a/b/Cars/Hybrid");
-        assertNode("/a/b/Cars/Hybrid/Toyota Prius");
-        assertNode("/a/b/Cars/Sports/Infiniti G37");
-        assertNode("/a/b/Cars/Utility/Land Rover LR3");
-        assertNoNode("/a/b/Cars[2]");
-        assertNoNode("/a/b/Cars/Hybrid[2]");
-        assertNoNode("/a/b/Cars/Hybrid/Toyota Prius[2]");
-        assertNoNode("/a/b/Cars/Sports[2]");
+        assertCarsImported();
 
         // And attempt to reimport the same content (with UUIDs) into the repository that already has that content ...
         // print = true;
@@ -549,15 +485,7 @@ public class ImportExportTest extends SingleUseAbstractTest {
 
         // Verify that the original content has been replaced (since the SystemView contained UUIDs) and there is no copy ...
         assertThat(session, is(notNullValue()));
-        assertNode("/a/b/Cars");
-        assertNode("/a/b/Cars/Hybrid");
-        assertNode("/a/b/Cars/Hybrid/Toyota Prius");
-        assertNode("/a/b/Cars/Sports/Infiniti G37");
-        assertNode("/a/b/Cars/Utility/Land Rover LR3");
-        assertNoNode("/a/b/Cars[2]");
-        assertNoNode("/a/b/Cars/Hybrid[2]");
-        assertNoNode("/a/b/Cars/Hybrid/Toyota Prius[2]");
-        assertNoNode("/a/b/Cars/Sports[2]");
+        assertCarsImported();
     }
 
     @Test
@@ -568,15 +496,7 @@ public class ImportExportTest extends SingleUseAbstractTest {
 
         // Set up the repository with existing content ...
         assertImport("io/cars-system-view-with-uuids.xml", "/a/b", ImportBehavior.CREATE_NEW);
-        assertNode("/a/b/Cars");
-        assertNode("/a/b/Cars/Hybrid");
-        assertNode("/a/b/Cars/Hybrid/Toyota Prius");
-        assertNode("/a/b/Cars/Sports/Infiniti G37");
-        assertNode("/a/b/Cars/Utility/Land Rover LR3");
-        assertNoNode("/a/b/Cars[2]");
-        assertNoNode("/a/b/Cars/Hybrid[2]");
-        assertNoNode("/a/b/Cars/Hybrid/Toyota Prius[2]");
-        assertNoNode("/a/b/Cars/Sports[2]");
+        assertCarsImported();
 
         // And attempt to reimport the same content (with UUIDs) into the repository that already has that content ...
         // print = true;
@@ -587,15 +507,7 @@ public class ImportExportTest extends SingleUseAbstractTest {
         assertThat(session, is(notNullValue()));
         assertNode("/a/b");
         assertNode("/a/c");
-        assertNode("/a/b/Cars");
-        assertNode("/a/b/Cars/Hybrid");
-        assertNode("/a/b/Cars/Hybrid/Toyota Prius");
-        assertNode("/a/b/Cars/Sports/Infiniti G37");
-        assertNode("/a/b/Cars/Utility/Land Rover LR3");
-        assertNoNode("/a/b/Cars[2]");
-        assertNoNode("/a/b/Cars/Hybrid[2]");
-        assertNoNode("/a/b/Cars/Hybrid/Toyota Prius[2]");
-        assertNoNode("/a/b/Cars/Sports[2]");
+        assertCarsImported();
 
         // And attempt to reimport the same content (with UUIDs) into the repository that already has that content ...
         // print = true;
@@ -625,15 +537,7 @@ public class ImportExportTest extends SingleUseAbstractTest {
 
         // Set up the repository with existing content ...
         assertImport("io/cars-system-view-with-uuids.xml", "/a/b", ImportBehavior.CREATE_NEW);
-        assertNode("/a/b/Cars");
-        assertNode("/a/b/Cars/Hybrid");
-        assertNode("/a/b/Cars/Hybrid/Toyota Prius");
-        assertNode("/a/b/Cars/Sports/Infiniti G37");
-        assertNode("/a/b/Cars/Utility/Land Rover LR3");
-        assertNoNode("/a/b/Cars[2]");
-        assertNoNode("/a/b/Cars/Hybrid[2]");
-        assertNoNode("/a/b/Cars/Hybrid/Toyota Prius[2]");
-        assertNoNode("/a/b/Cars/Sports[2]");
+        assertCarsImported();
 
         // And attempt to reimport the same content (with UUIDs) into the repository that already has that content ...
         // print = true;
@@ -651,15 +555,7 @@ public class ImportExportTest extends SingleUseAbstractTest {
 
         // Set up the repository ...
         assertImport("io/full-workspace-system-view-with-uuids.xml", "/", ImportBehavior.THROW); // no matching UUIDs expected
-        assertNode("/a/b/Cars");
-        assertNode("/a/b/Cars/Hybrid");
-        assertNode("/a/b/Cars/Hybrid/Toyota Prius");
-        assertNode("/a/b/Cars/Sports/Infiniti G37");
-        assertNode("/a/b/Cars/Utility/Land Rover LR3");
-        assertNoNode("/a/b/Cars[2]");
-        assertNoNode("/a/b/Cars/Hybrid[2]");
-        assertNoNode("/a/b/Cars/Hybrid/Toyota Prius[2]");
-        assertNoNode("/a/b/Cars/Sports[2]");
+        assertCarsImported();
     }
 
     @Test
@@ -784,15 +680,7 @@ public class ImportExportTest extends SingleUseAbstractTest {
 
         // Set up the repository ...
         assertImport("io/full-workspace-document-view-with-uuids.xml", "/", ImportBehavior.THROW); // no matching UUIDs expected
-        assertNode("/a/b/Cars");
-        assertNode("/a/b/Cars/Hybrid");
-        assertNode("/a/b/Cars/Hybrid/Toyota Prius");
-        assertNode("/a/b/Cars/Sports/Infiniti G37");
-        assertNode("/a/b/Cars/Utility/Land Rover LR3");
-        assertNoNode("/a/b/Cars[2]");
-        assertNoNode("/a/b/Cars/Hybrid[2]");
-        assertNoNode("/a/b/Cars/Hybrid/Toyota Prius[2]");
-        assertNoNode("/a/b/Cars/Sports[2]");
+        assertCarsImported();
     }
 
     // ----------------------------------------------------------------------------------------------------------------
@@ -806,15 +694,7 @@ public class ImportExportTest extends SingleUseAbstractTest {
 
         // Set up the repository ...
         assertImport("io/full-workspace-document-view-with-uuids.xml", "/", ImportBehavior.THROW); // no matching UUIDs expected
-        assertNode("/a/b/Cars");
-        assertNode("/a/b/Cars/Hybrid");
-        assertNode("/a/b/Cars/Hybrid/Toyota Prius");
-        assertNode("/a/b/Cars/Sports/Infiniti G37");
-        assertNode("/a/b/Cars/Utility/Land Rover LR3");
-        assertNoNode("/a/b/Cars[2]");
-        assertNoNode("/a/b/Cars/Hybrid[2]");
-        assertNoNode("/a/b/Cars/Hybrid/Toyota Prius[2]");
-        assertNoNode("/a/b/Cars/Sports[2]");
+        assertCarsImported();
     }
 
     @FixFor( "MODE-1171" )
@@ -1018,6 +898,42 @@ public class ImportExportTest extends SingleUseAbstractTest {
         // Get the prefix for the namespace used in the imported file ...
         String prefix = session.getWorkspace().getNamespaceRegistry().getPrefix("http://www.ns.com");
         assertNode("/" + prefix + ":childNode", "nt:unstructured");
+    }
+
+    @FixFor( "MODE-1945" )
+    @Test
+    public void shouldBeAbleToImportDocumentViewTwiceWithRemoveExistingCollisionMode() throws Exception {
+        // Register the node types ...
+        tools.registerNodeTypes(session, "cars.cnd");
+
+        // Set up the repository ...
+        assertImport("io/full-workspace-document-view-with-uuids.xml", "/", ImportBehavior.REMOVE_EXISTING);
+        assertCarsImported();
+
+        assertImport("io/full-workspace-document-view-with-uuids.xml", "/", ImportBehavior.REMOVE_EXISTING);
+        assertCarsImported();
+    }
+
+    @FixFor( "MODE-1945" )
+    @Test
+    public void shouldBeAbleToImportSystemViewWithBinaryTwiceWithRemoveExistingCollisionMode2() throws Exception {
+        // Register the node types ...
+        tools.registerNodeTypes(session, "cnd/magnolia.cnd");
+        // Now import the file ...
+        assertImport("io/system-export-with-binary-data-and-uuids.xml", "/", ImportBehavior.REMOVE_EXISTING); // no matching UUIDs expected
+        assertImport("io/system-export-with-binary-data-and-uuids.xml", "/", ImportBehavior.REMOVE_EXISTING); // no matching UUIDs expected
+    }
+
+    private void assertCarsImported() throws RepositoryException {
+        assertNode("/a/b/Cars");
+        assertNode("/a/b/Cars/Hybrid");
+        assertNode("/a/b/Cars/Hybrid/Toyota Prius");
+        assertNode("/a/b/Cars/Sports/Infiniti G37");
+        assertNode("/a/b/Cars/Utility/Land Rover LR3");
+        assertNoNode("/a/b/Cars[2]");
+        assertNoNode("/a/b/Cars/Hybrid[2]");
+        assertNoNode("/a/b/Cars/Hybrid/Toyota Prius[2]");
+        assertNoNode("/a/b/Cars/Sports[2]");
     }
 
     // ----------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
The previous version of the code added all the children below a node (at any given level) which a) are not needed (only 1st level children are of interest) and b) could expose keys of removed children, which would not be found in the cache (this is what caused the actual bug).
