### PR TITLE
MODE-1946 Corrected WebDAV behavior when putting file with OS X

### DIFF
--- a/web/modeshape-web-jcr-webdav-war/src/main/resources/log4j.properties
+++ b/web/modeshape-web-jcr-webdav-war/src/main/resources/log4j.properties
@@ -1,12 +1,20 @@
-log4j.rootLogger = INFO, stdout
+# Direct log messages to stdout
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.Target=System.out
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+log4j.appender.stdout.layout.ConversionPattern=%d{ABSOLUTE} %5p %c %m%n
+
+# Root logger option
+log4j.rootLogger=INFO, stdout
 
 log4j.category.org.apache=INFO
 log4j.category.org.mortbay.jetty.security=ERROR
 log4j.category.org.slf4j.impl.JCLLoggerAdapter=INFO
 log4j.category.org.springframework=INFO
 
-log4j.appender.stdout = org.apache.log4j.ConsoleAppender
-log4j.appender.stdout.Threshold = INFO
-log4j.appender.stdout.Target   = System.out
-log4j.appender.stdout.layout = org.apache.log4j.PatternLayout
-log4j.appender.stdout.layout.ConversionPattern = %d{ABSOLUTE} %5p %c %m%n
+# Set up the default logging to be INFO level, then override specific units
+log4j.logger.org.modeshape=INFO
+log4j.logger.org.infinispan=INFO
+
+# Uncomment the following line to enable tracing on the ModeShape WebDAV code
+#log4j.logger.org.modeshape.webdav=TRACE

--- a/web/modeshape-webdav/src/test/java/org/modeshape/webdav/methods/DoPutTest.java
+++ b/web/modeshape-webdav/src/test/java/org/modeshape/webdav/methods/DoPutTest.java
@@ -143,6 +143,9 @@ public class DoPutTest extends AbstractWebDAVTest {
                 one(mockReq).getHeader("User-Agent");
                 will(returnValue("WebDAVFS/1.5.0 (01500000) ....."));
 
+                one(mockReq).getContentLength();
+                will(returnValue(2));
+
                 StoredObject parentSo = null;
 
                 one(mockStore).getStoredObject(mockTransaction, PARENT_PATH);
@@ -193,6 +196,9 @@ public class DoPutTest extends AbstractWebDAVTest {
 
                 one(mockReq).getHeader("User-Agent");
                 will(returnValue("WebDAVFS/1.5.0 (01500000) ....."));
+
+                one(mockReq).getContentLength();
+                will(returnValue(2));
 
                 StoredObject parentSo = initFileStoredObject(RESOURCE_CONTENT);
 


### PR DESCRIPTION
The OS X Finder application is used on OS X to mount a WebDAV service (e.g., a repository) as a networked drive. However, the behavior of Finder is verbose in that it sends multiple PUT operations when copying a single file into the WebDAV area. The first PUT has no content, and is followed by a LOCK, a second PUT (with the content), and and UNLOCK. ModeShape's WebDAV service was not expecting this pattern and was not writing the second content.

The fix was relatively gross, since it entails OS-specific checks. But it does work, and all tests do pass.
