### PR TITLE
MODE-1954 Corrected code that removes property definition during registration

### DIFF
--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/SystemContent.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/SystemContent.java
@@ -333,7 +333,9 @@ public class SystemContent {
         // Remove any children that weren't represented by a property definition or child node definition ...
         if (existingChildKeys != null && !existingChildKeys.isEmpty()) {
             for (NodeKey childKey : existingChildKeys) {
+                // Remove the child from the parent, then destrot it ...
                 nodeTypeNode.removeChild(system, childKey);
+                system.destroy(childKey);
             }
         }
     }


### PR DESCRIPTION
The code that removes existing property definitions when storing a node type template did not properly remove the node under '/jcr:system/jcr:nodeTypes' that represented the property definition. Instead, it merely removed it from its parent, but left the node (which could not be found in its parent when later processed). There was a bold node in the JavaDoc for the method stating this behavior, so it was merely a method call that was not corrected a while
back.

The test case failed with the same exception, and now succeeds with the aforementioned fix.
