### PR TITLE
MODE-1963 Fixed the code that was un-registering node types

### DIFF
--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/RepositoryNodeTypeManager.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/RepositoryNodeTypeManager.java
@@ -274,10 +274,9 @@ class RepositoryNodeTypeManager implements ChangeSetListener {
 
             // Remove the node types from persistent storage ...
             SessionCache system = repository.createSystemSession(context, false);
-            for (JcrNodeType nodeType : removedNodeTypes) {
-                system.destroy(nodeType.key());
-            }
-            system.save();
+            SystemContent systemContent = new SystemContent(system);
+            systemContent.unregisterNodeTypes(removedNodeTypes.toArray(new JcrNodeType[removedNodeTypes.size()]));
+            systemContent.save();
 
             // Now change the cache ...
             this.nodeTypesCache = newNodeTypes;

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/SystemContent.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/SystemContent.java
@@ -765,7 +765,7 @@ public class SystemContent {
         return prefixFor(newNsNode.getSegment(system));
     }
 
-    public boolean unregisterNamespace( String namespaceUri ) {
+    protected boolean unregisterNamespace( String namespaceUri ) {
         MutableCachedNode namespaces = mutableNamespacesNode();
         NodeKey key = keyForNamespaceUri(namespaceUri);
         CachedNode nsNode = system.getNode(key);
@@ -775,6 +775,15 @@ public class SystemContent {
             return true;
         }
         return false;
+    }
+
+    protected void unregisterNodeTypes( JcrNodeType...nodeTypes) {
+        MutableCachedNode nodeTypesNode = mutableNodeTypesNode();
+        for (JcrNodeType nodeType : nodeTypes) {
+            NodeKey nodeTypeKey = nodeType.key();
+            nodeTypesNode.removeChild(system, nodeTypeKey);
+            system.destroy(nodeTypeKey);
+        }
     }
 
     protected final NodeKey keyForNamespaceUri( String namespaceUri ) {

--- a/modeshape-jcr/src/test/java/org/modeshape/jcr/JcrNodeTypeManagerTest.java
+++ b/modeshape-jcr/src/test/java/org/modeshape/jcr/JcrNodeTypeManagerTest.java
@@ -146,7 +146,7 @@ public class JcrNodeTypeManagerTest extends MultiUseAbstractTest {
     @SuppressWarnings( "unchecked" )
     @Test
     @FixFor( "MODE-1954" )
-    public void shouldWork() throws Exception {
+    public void shouldRemovePropertyDefinitionViaTemplate() throws Exception {
         session.getWorkspace().getNamespaceRegistry().registerNamespace("dmsmix", "http://myexample.com/dms");
         NodeTypeTemplate fileContent = nodeTypeMgr.createNodeTypeTemplate();
         fileContent.setName("dmsmix:filecontent");
@@ -169,6 +169,24 @@ public class JcrNodeTypeManagerTest extends MultiUseAbstractTest {
                 pit.remove();
             }
         }
+        nodeTypeMgr.registerNodeType(nodeTypeTemplate, true);
+    }
+
+    @Test
+    @FixFor( "MODE-1963" )
+    public void shouldAllowReRegistrationOfMixinViaTemplate() throws Exception {
+        session.getWorkspace().getNamespaceRegistry().registerNamespace("dmsmix", "http://myexample.com/dms");
+        String mixinName = "dmsmix:test";
+        registerMixin(mixinName);
+        nodeTypeMgr.unregisterNodeType(mixinName);
+        registerMixin(mixinName);
+    }
+
+    private void registerMixin( String name ) throws RepositoryException {
+        NodeTypeTemplate nodeTypeTemplate = nodeTypeMgr.createNodeTypeTemplate();
+        nodeTypeTemplate.setMixin(true);
+        nodeTypeTemplate.setName(name);
+        nodeTypeTemplate.setQueryable(true);
         nodeTypeMgr.registerNodeType(nodeTypeTemplate, true);
     }
 }


### PR DESCRIPTION
The problem was caused by the fact that when a node type was unregistered, it was deleted from the cache but the parent references were not updated.
