### PR TITLE
MODE-1978 Corrected the WritableSessionCache to fix NPE from recently-added code 

### DIFF
--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/document/SessionNode.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/document/SessionNode.java
@@ -748,7 +748,7 @@ public class SessionNode implements MutableCachedNode {
     public void setReference( SessionCache cache,
                               Property property,
                               SessionCache systemCache ) {
-        assert property.isReference();
+        assert property.isEmpty() || property.isReference();
 
         writableSession(cache).assertInSession(this);
         Name name = property.getName();
@@ -2154,7 +2154,7 @@ public class SessionNode implements MutableCachedNode {
             this.startingPathInSource = sourceNode.getPath(sourceCache);
             this.propertyFactory = this.targetCache.getContext().getPropertyFactory();
             this.targetWorkspaceKey = targetNode.getKey().getWorkspaceKey();
-            this.documentStore = ((WorkspaceCache) sourceCache.getWorkspace()).documentStore();
+            this.documentStore = ((WorkspaceCache)sourceCache.getWorkspace()).documentStore();
             this.systemWorkspaceKey = systemWorkspaceKey;
         }
 
@@ -2202,8 +2202,9 @@ public class SessionNode implements MutableCachedNode {
                 NodeKey parentSourceKey = sourceChild.getParentKeyInAnyWorkspace(sourceCache);
                 if (sourceKey.equals(parentSourceKey)) {
                     // The child is a normal child of this node ...
-                    String childCopyPreferredKey = documentStore.newDocumentKey(targetKey.toString(), childReference.getName(),
-                                                                       sourceChild.getPrimaryType(sourceCache));
+                    String childCopyPreferredKey = documentStore.newDocumentKey(targetKey.toString(),
+                                                                                childReference.getName(),
+                                                                                sourceChild.getPrimaryType(sourceCache));
                     NodeKey newKey = createTargetKeyFor(childKey, targetKey, childCopyPreferredKey);
                     MutableCachedNode childCopy = targetNode.createChild(targetCache, newKey, childReference.getName(), null);
                     doPhase1(childCopy, sourceChild);
@@ -2227,8 +2228,7 @@ public class SessionNode implements MutableCachedNode {
                                 NodeKey placeholderKey = createTargetKeyFor(childKey, targetKey, null);
                                 String childCopyPreferredKey = documentStore.newDocumentKey(targetKey.toString(),
                                                                                             childReference.getName(),
-                                                                                            sourceChild.getPrimaryType(
-                                                                                                    sourceCache));
+                                                                                            sourceChild.getPrimaryType(sourceCache));
                                 newKey = createTargetKeyFor(childKey, targetKey, childCopyPreferredKey);
                                 sourceToTargetKeys.put(childKey, newKey);
                                 targetNode.createChild(targetCache, placeholderKey, childReference.getName(), null);
@@ -2315,9 +2315,9 @@ public class SessionNode implements MutableCachedNode {
             return "Copy";
         }
 
-        protected boolean shouldProcessSourceKey(NodeKey sourceKey) {
-            return !sourceKey.equals(sourceCache.getRootKey()) &&
-                   !sourceKey.getWorkspaceKey().equalsIgnoreCase(systemWorkspaceKey);
+        protected boolean shouldProcessSourceKey( NodeKey sourceKey ) {
+            return !sourceKey.equals(sourceCache.getRootKey())
+                   && !sourceKey.getWorkspaceKey().equalsIgnoreCase(systemWorkspaceKey);
         }
     }
 
@@ -2346,8 +2346,7 @@ public class SessionNode implements MutableCachedNode {
                                               NodeKey parentKeyInTarget,
                                               String preferredKey ) {
             // Reuse the same source and identifier, but a different workspace ...
-            return !StringUtil.isBlank(preferredKey) ? new NodeKey(preferredKey) : parentKeyInTarget.withId(
-                    sourceKey.getIdentifier());
+            return !StringUtil.isBlank(preferredKey) ? new NodeKey(preferredKey) : parentKeyInTarget.withId(sourceKey.getIdentifier());
         }
 
         @Override

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/document/WritableSessionCache.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/document/WritableSessionCache.java
@@ -937,7 +937,7 @@ public class WritableSessionCache extends AbstractSessionCache {
                     SchematicEntry nodeEntry = documentStore.get(keyStr);
                     if (nodeEntry == null) {
                         if (isExternal && renamedExternalNodes.contains(key)) {
-                            //this is a renamed external node which has been processed in the parent, so we can skip it
+                            // this is a renamed external node which has been processed in the parent, so we can skip it
                             continue;
                         }
                         // Could not find the entry in the documentStore, which means it was deleted by someone else
@@ -1163,7 +1163,9 @@ public class WritableSessionCache extends AbstractSessionCache {
                         // should be there and shouldn't require a looking in the cache...
                         Name primaryType = node.getPrimaryType(this);
                         Set<Name> mixinTypes = node.getMixinTypes(this);
-                        monitor.recordAdd(workspaceName, key, newPath, primaryType, mixinTypes, node.changedProperties().values().iterator());
+                        monitor.recordAdd(workspaceName, key, newPath, primaryType, mixinTypes, node.changedProperties()
+                                                                                                    .values()
+                                                                                                    .iterator());
                     }
                 } else {
                     boolean externalNodeChanged = isExternal && (hasPropertyChanges || node.hasNonPropertyChanges());
@@ -1194,17 +1196,20 @@ public class WritableSessionCache extends AbstractSessionCache {
                         monitor.recordUpdate(workspaceName, key, newNodePath, primaryType, mixinTypes, node.getProperties(this));
 
                         if (pathChanged) {
-                            //we're dealing with a path change, so in case there is a persisted node at "new path" we need to remove
-                            //it from the indexes, because the current node will take its place
+                            // we're dealing with a path change, so in case there is a PERSISTED node at "new path" we need to
+                            // remove it from the indexes, because the current node will take its place
                             CachedNode persistedParent = workspaceCache.getNode(node.getParentKey(this));
-                            ChildReference persistedNodeAtNewPath = persistedParent.getChildReferences(workspaceCache)
-                                                                                   .getChild(newNodePath.getLastSegment()
-                                                                                                        .getName(),
-                                                                                             newNodePath.getLastSegment()
-                                                                                                        .getIndex());
-                            if (persistedNodeAtNewPath != null) {
-                                monitor.recordRemove(workspaceName, Arrays.asList(persistedNodeAtNewPath.getKey()));
-                            }
+                            if (persistedParent != null) {
+                                // The parent is found in the workspace cache ...
+                                ChildReference persistedNodeAtNewPath = persistedParent.getChildReferences(workspaceCache)
+                                                                                       .getChild(newNodePath.getLastSegment()
+                                                                                                            .getName(),
+                                                                                                 newNodePath.getLastSegment()
+                                                                                                            .getIndex());
+                                if (persistedNodeAtNewPath != null) {
+                                    monitor.recordRemove(workspaceName, Arrays.asList(persistedNodeAtNewPath.getKey()));
+                                }
+                            } // otherwise the parent was not PERSISTED and there's nothing to do
                         }
                     }
                 }

--- a/modeshape-jcr/src/test/resources/cnd/sramp-notional.cnd
+++ b/modeshape-jcr/src/test/resources/cnd/sramp-notional.cnd
@@ -43,3 +43,8 @@
 - * (string) multiple
 + * (sramp:relationship)
 
+// Not really representative of the actual S-RAMP types ...
+[sramp:testArtifactType] > mix:created, mix:lastModified, mix:referenceable, mix:versionable mixin
+
+// Not really representative of the actual S-RAMP types ...
+[sramp:removedArtifactType] > mix:created, mix:lastModified, mix:referenceable, mix:versionable mixin

--- a/modeshape-jcr/src/test/resources/cnd/sramp.cnd
+++ b/modeshape-jcr/src/test/resources/cnd/sramp.cnd
@@ -1,0 +1,238 @@
+/*
+ * Copyright 2012 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//------------------------------------------------------------------------------
+// N A M E S P A C E S
+//------------------------------------------------------------------------------
+<jcr='http://www.jcp.org/jcr/1.0'>
+<nt='http://www.jcp.org/jcr/nt/1.0'>
+<mix='http://www.jcp.org/jcr/mix/1.0'>
+<sramp='http://docs.oasis-open.org/s-ramp/ns/s-ramp-v1.0'>
+<audit='http://downloads.jboss.org/overlord/sramp/2013/auditing.xsd'>
+
+//------------------------------------------------------------------------------
+// N O D E T Y P E S
+//------------------------------------------------------------------------------
+
+// -------------------------------------------------------
+// S-RAMP Ontologies
+// -------------------------------------------------------
+
+[sramp:class]
+- sramp:uri (string) mandatory
+- sramp:id (string) mandatory
+- sramp:label (string)
+- sramp:comment (string)
++ * (sramp:class)
+
+[sramp:ontology] > nt:hierarchyNode, mix:created, mix:lastModified
+- sramp:uuid (string) mandatory
+- sramp:label (string)
+- sramp:comment (string)
+- sramp:base (string)
+- sramp:id (string)
++ * (sramp:class)
+
+
+// -------------------------------------------------------
+// Auditing
+// -------------------------------------------------------
+
+[audit:auditItem]
+- audit:type (string)
+- * (string)
+- * (string) multiple
+
+[audit:auditEntry] > nt:hierarchyNode
+- audit:uuid (string) mandatory
+- audit:sortId (long)
+- audit:type (string)
+- audit:who (string)
+- audit:when (date)
++ * (audit:auditItem)
+
+
+// -------------------------------------------------------
+// S-RAMP Core Model Artifacts
+// -------------------------------------------------------
+
+[sramp:nonDocumentArtifactType] > nt:hierarchyNode
+
+[sramp:derivedArtifactPrimaryType] > nt:hierarchyNode
+
+[sramp:relationship]
+- sramp:relationshipType (string)
+- sramp:generic (boolean)
+- sramp:maxCardinality (long)
+- sramp:targetType (string)
+- sramp:relationshipTarget (reference) multiple < 'sramp:baseArtifactType'
+
+[sramp:baseArtifactType] > mix:created, mix:lastModified, mix:referenceable, mix:versionable abstract mixin
+- sramp:uuid (string) mandatory
+- sramp:name (string)
+- sramp:artifactModel (string)
+- sramp:artifactType (string)
+- sramp:classifiedBy (string) multiple
+- sramp:normalizedClassifiedBy (string) multiple
+- sramp:description (string)
+- sramp:derived (boolean)
+- * (string)
+- * (string) multiple
++ * (sramp:relationship)
++ * (audit:auditEntry)
+
+[sramp:documentArtifactType] > sramp:baseArtifactType abstract mixin
+- sramp:contentType (string)
+- sramp:contentSize (long)
+- sramp:contentHash (string)
++ * (sramp:derivedArtifactPrimaryType)
+
+[sramp:document] > sramp:documentArtifactType mixin
+
+[sramp:xmlDocument] > sramp:documentArtifactType mixin
+- sramp:contentEncoding (string)
+
+[sramp:derivedArtifactType] > sramp:baseArtifactType abstract mixin
+
+// Special case of a extended type that is derived.
+[sramp:extendedDerivedArtifactType] > sramp:baseArtifactType mixin
+- sramp:extendedType (string)
+
+[sramp:extendedArtifactType] > sramp:baseArtifactType mixin
+- sramp:extendedType (string) mandatory
+
+[sramp:extendedDocument] > sramp:documentArtifactType mixin
+- sramp:extendedType (string) mandatory
++ * (sramp:extendedDerivedArtifactType)
+
+[sramp:storedQuery] > nt:query
+- sramp:propertyList (string) multiple
+
+
+// -------------------------------------------------------
+// S-RAMP XSD Model Artifacts
+// -------------------------------------------------------
+[sramp:xsdDerivedArtifactType] > sramp:derivedArtifactType abstract mixin
+- sramp:ncName (string)
+- sramp:namespace (string)
+
+[sramp:elementDeclaration] > sramp:xsdDerivedArtifactType mixin
+
+[sramp:attributeDeclaration] > sramp:xsdDerivedArtifactType mixin
+
+[sramp:simpleTypeDeclaration] > sramp:xsdDerivedArtifactType mixin
+
+[sramp:complexTypeDeclaration] > sramp:xsdDerivedArtifactType mixin
+
+[sramp:xsdDocument] > sramp:xmlDocument mixin
++ * (sramp:elementDeclaration)
++ * (sramp:attributeDeclaration)
++ * (sramp:simpleTypeDeclaration)
++ * (sramp:complexTypeDeclaration)
+
+
+// -------------------------------------------------------
+// S-RAMP WSDL Model Artifacts
+// -------------------------------------------------------
+[sramp:wsdlDerivedArtifactType] > sramp:derivedArtifactType abstract mixin
+- sramp:namespace (string)
+
+[sramp:namedWsdlDerivedArtifactType] > sramp:wsdlDerivedArtifactType abstract mixin
+- sramp:ncName (string)
+
+[sramp:wsdlService] > sramp:namedWsdlDerivedArtifactType mixin
+
+[sramp:port] > sramp:namedWsdlDerivedArtifactType mixin
+
+[sramp:part] > sramp:namedWsdlDerivedArtifactType mixin
+
+[sramp:message] > sramp:namedWsdlDerivedArtifactType mixin
+
+[sramp:fault] > sramp:namedWsdlDerivedArtifactType mixin
+
+[sramp:portType] > sramp:namedWsdlDerivedArtifactType mixin
+
+[sramp:operation] > sramp:namedWsdlDerivedArtifactType mixin
+
+[sramp:operationInput] > sramp:namedWsdlDerivedArtifactType mixin
+
+[sramp:operationOutput] > sramp:namedWsdlDerivedArtifactType mixin
+
+[sramp:binding] > sramp:namedWsdlDerivedArtifactType mixin
+
+[sramp:bindingOperation] > sramp:namedWsdlDerivedArtifactType mixin
+
+[sramp:bindingOperationInput] > sramp:namedWsdlDerivedArtifactType mixin
+
+[sramp:bindingOperationOutput] > sramp:namedWsdlDerivedArtifactType mixin
+
+[sramp:bindingOperationFault] > sramp:namedWsdlDerivedArtifactType mixin
+
+[sramp:wsdlExtension] > sramp:derivedArtifactType abstract mixin
+- sramp:namespace (string)
+- sramp:ncName (string)
+
+[sramp:wsdlDocument] > sramp:xmlDocument mixin
+- sramp:targetNamespace (string)
++ * (sramp:elementDeclaration)
++ * (sramp:attributeDeclaration)
++ * (sramp:simpleTypeDeclaration)
++ * (sramp:complexTypeDeclaration)
++ * (sramp:wsdlService)
++ * (sramp:port)
++ * (sramp:part)
++ * (sramp:message)
++ * (sramp:fault)
++ * (sramp:portType)
++ * (sramp:operation)
++ * (sramp:operationInput)
++ * (sramp:operationOutput)
++ * (sramp:binding)
++ * (sramp:bindingOperation)
++ * (sramp:bindingOperationInput)
++ * (sramp:bindingOperationOutput)
++ * (sramp:bindingOperationFault)
++ * (sramp:wsdlExtension)
+
+
+// -------------------------------------------------------
+// S-RAMP SOAP WSDL Model Artifacts
+// -------------------------------------------------------
+[sramp:soapBinding] > sramp:wsdlExtension mixin
+- sramp:style (string)
+- sramp:transport (string)
+
+[sramp:soapAddress] > sramp:wsdlExtension mixin
+- sramp:soapLocation (string)
+
+// -------------------------------------------------------
+// S-RAMP Policy Model Artifacts
+// -------------------------------------------------------
+[sramp:policyDocument] > sramp:xmlDocument mixin
+
+
+// -------------------------------------------------------
+// Type used for deleted artifacts
+// -------------------------------------------------------
+[sramp:deletedArtifact] > mix:created, mix:lastModified, mix:referenceable, mix:versionable mixin
+- sramp:uuid (string)
+- * (string)
+- * (boolean)
+- * (long)
+- * (string) multiple
++ * (sramp:relationship)
++ * (audit:auditEntry)
++ * (sramp:derivedArtifactPrimaryType)


### PR DESCRIPTION
A recent fix for MODE-1940 added code that updated the indexes if the new parent was persisted (previously) and the child was moved. In some cases when the new parent was not persisted in a previous save but instead was created as part of this save, the code resulted in an NPE. The fix was a simple change.

A test case was added to first replicate the problem. After the change, the test now succeeds (and the S-RAMP build works completely).

Ready for review and merging into 'master' and '3.3.x'.
