### PR TITLE
Mode 1972 Updated the copy & clone operations so that it's possible to copy & clone an entire workspace into another workspace

### DIFF
--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrI18n.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrI18n.java
@@ -68,6 +68,7 @@ public final class JcrI18n {
     public static I18n pathNotFoundRelativeTo;
     public static I18n pathCannotHaveSameNameSiblingIndex;
     public static I18n cannotCopySubgraphIntoRoot;
+    public static I18n cannotCloneSubgraphIntoRoot;
     public static I18n permissionDenied;
     public static I18n repositoryMustBeConfigured;
     public static I18n sourceInUse;

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrWorkspace.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrWorkspace.java
@@ -160,6 +160,7 @@ class JcrWorkspace implements org.modeshape.jcr.api.Workspace {
             throw new RepositoryException(JcrI18n.pathCannotHaveSameNameSiblingIndex.text(destAbsPath));
         }
 
+        //Do not allow to copy a subgraph into root
         if (destPath.isRoot() && !srcPath.isRoot()) {
             throw new RepositoryException(JcrI18n.cannotCopySubgraphIntoRoot.text(srcAbsPath, srcWorkspace, getName()));
         }
@@ -208,7 +209,8 @@ class JcrWorkspace implements org.modeshape.jcr.api.Workspace {
                                                                                               null, false);
             Map<NodeKey, NodeKey> nodeKeyCorrespondence = copy.mutable().deepCopy(copySession.cache(),
                                                                                   sourceNode.node(),
-                                                                                  sourceSession.cache());
+                                                                                  sourceSession.cache(),
+                                                                                  repository().systemWorkspaceKey());
             /**
              * Do some extra processing for each copied node
              */
@@ -294,6 +296,11 @@ class JcrWorkspace implements org.modeshape.jcr.api.Workspace {
             throw new RepositoryException(JcrI18n.pathCannotHaveSameNameSiblingIndex.text(destAbsPath));
         }
 
+        //Do not allow to clone a subgraph into root
+        if (destPath.isRoot() && !srcPath.isRoot()) {
+            throw new RepositoryException(JcrI18n.cannotCloneSubgraphIntoRoot.text(srcAbsPath, srcWorkspace, getName()));
+        }
+
         try {
             // create an inner session for cloning
             JcrSession cloneSession = session.spawnSession(false);
@@ -304,11 +311,19 @@ class JcrWorkspace implements org.modeshape.jcr.api.Workspace {
             Name newNodeName = null;
             if (destPath.isIdentifier()) {
                 AbstractJcrNode existingDestNode = cloneSession.node(destPath);
-                parentNode = existingDestNode.getParent();
-                newNodeName = existingDestNode.segment().getName();
+                if (!existingDestNode.isRoot()) {
+                    parentNode = existingDestNode.getParent();
+                    newNodeName = existingDestNode.segment().getName();
+                } else {
+                    parentNode = existingDestNode;
+                }
             } else {
-                parentNode = cloneSession.node(destPath.getParent());
-                newNodeName = destPath.getLastSegment().getName();
+                if (!destPath.isRoot()) {
+                    parentNode = cloneSession.node(destPath.getParent());
+                    newNodeName = destPath.getLastSegment().getName();
+                } else {
+                    parentNode = cloneSession.getRootNode();
+                }
             }
 
             /*
@@ -354,6 +369,7 @@ class JcrWorkspace implements org.modeshape.jcr.api.Workspace {
                 // use the source session to load all the keys from the source subgraph
                 SessionCache sourceCache = sourceSession.cache();
                 Set<NodeKey> sourceKeys = sourceCache.getNodeKeysAtAndBelow(sourceNode.key());
+                sourceKeys = filterNodeKeysForClone(sourceKeys, sourceCache);
 
                 for (NodeKey srcKey : sourceKeys) {
                     try {
@@ -396,10 +412,14 @@ class JcrWorkspace implements org.modeshape.jcr.api.Workspace {
                     }
                 }
 
-                // Use the JCR add child here to perform the parent validations
-                NodeKey cloneKey = parentNode.key().withId(sourceNode.key().getIdentifier());
-                parentNode.addChildNode(newNodeName, sourceNode.getPrimaryTypeName(), cloneKey, false);
-
+                NodeKey cloneKey = null;
+                if (!parentNode.isRoot()) {
+                    // Use the JCR add child here to perform the parent validations
+                    cloneKey = parentNode.key().withId(sourceNode.key().getIdentifier());
+                    parentNode.addChildNode(newNodeName, sourceNode.getPrimaryTypeName(), cloneKey, false);
+                } else {
+                    cloneKey = parentNode.key();
+                }
                 deepClone(sourceSession, sourceNode.key(), cloneSession, cloneKey);
             }
         } catch (ItemNotFoundException e) {
@@ -410,6 +430,18 @@ class JcrWorkspace implements org.modeshape.jcr.api.Workspace {
         } catch (InvalidPathException e) {
             throw new RepositoryException(e.getLocalizedMessage(), e);
         }
+    }
+
+    private Set<NodeKey> filterNodeKeysForClone(Set<NodeKey> sourceKeys, SessionCache sourceCache ) {
+        Set<NodeKey> filteredSet = new HashSet<NodeKey>();
+        for (NodeKey sourceKey : sourceKeys) {
+            if (sourceKey.equals(sourceCache.getRootKey()) ||
+                sourceKey.getWorkspaceKey().equalsIgnoreCase(repository().systemWorkspaceKey())) {
+                continue;
+            }
+            filteredSet.add(sourceKey);
+        }
+        return filteredSet;
     }
 
     protected void validateCrossWorkspaceAction( String srcWorkspace ) throws RepositoryException {
@@ -714,7 +746,7 @@ class JcrWorkspace implements org.modeshape.jcr.api.Workspace {
         /**
          * Perform the clone at the cache level - clone all properties & children
          */
-        mutableCloneNode.deepClone(cloneCache, sourceNode, sourceCache);
+        mutableCloneNode.deepClone(cloneCache, sourceNode, sourceCache, repository().systemWorkspaceKey());
 
         /**
          * Make sure the version history is preserved

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/MutableCachedNode.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/MutableCachedNode.java
@@ -352,26 +352,31 @@ public interface MutableCachedNode extends CachedNode {
     /**
      * Copies into this node all the properties and children (deep copy) from the given source node.
      * 
+     *
      * @param cache the cache to which this node belongs; may not be null
      * @param sourceNode the node from which to copy the properties and children; may not be null
      * @param sourceCache the cache in which the source node belongs; may not be null
+     * @param systemWorkspaceKey the key of the system workspace; may not be null
      * @return a [source key -> target key] which represents the node correspondence after the copy operation.
      */
     public Map<NodeKey, NodeKey> deepCopy( SessionCache cache,
                                            CachedNode sourceNode,
-                                           SessionCache sourceCache );
+                                           SessionCache sourceCache,
+                                           String systemWorkspaceKey );
 
     /**
      * Clones into this node all the properties and children (deep clone) from the given source node. Each cloned node will have
      * the same identifier as the source node.
-     * 
+     *
      * @param cache the cache to which this node belongs; may not be null
      * @param sourceNode the node from which to copy the properties and children; may not be null
      * @param sourceCache the cache in which the source node belongs; may not be null
+     * @param systemWorkspaceKey the key of the system workspace; may not be null
      */
     public void deepClone( SessionCache cache,
                            CachedNode sourceNode,
-                           SessionCache sourceCache );
+                           SessionCache sourceCache,
+                           String systemWorkspaceKey );
 
     /**
      * Returns a set with the keys of the children which have been removed for this node.

--- a/modeshape-jcr/src/main/resources/org/modeshape/jcr/JcrI18n.properties
+++ b/modeshape-jcr/src/main/resources/org/modeshape/jcr/JcrI18n.properties
@@ -58,6 +58,7 @@ pathNotFound = No item exists at path '{0}' in workspace "{1}"
 pathNotFoundRelativeTo = No item exists at path {0} relative to {1} in workspace "{2}"
 pathCannotHaveSameNameSiblingIndex = The path specified by the argument "{0}" cannot have a same-name-sibling index
 cannotCopySubgraphIntoRoot = Cannot copy the subgraph of nodes starting at "{0}" from the workspace "{1}", into the root of the "{2}" workspace
+cannotCloneSubgraphIntoRoot = Cannot clone the subgraph of nodes starting at "{0}" from the workspace "{1}", into the root of the "{2}" workspace
 permissionDenied = Permission denied to perform actions "{1}" on path {0}
 repositoryMustBeConfigured = ModeShape repositories must be configured with either a repository source factory or a repository source
 sourceInUse = All sessions must end before a new repository source can be set

--- a/modeshape-jcr/src/test/java/org/modeshape/jcr/JcrWorkspaceTest.java
+++ b/modeshape-jcr/src/test/java/org/modeshape/jcr/JcrWorkspaceTest.java
@@ -25,6 +25,7 @@ package org.modeshape.jcr;
 
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsNull.notNullValue;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
@@ -81,6 +82,23 @@ public class JcrWorkspaceTest extends SingleUseAbstractTest {
         workspace.clone(null, "/src", "/dest", false);
     }
 
+    @Test
+    @FixFor( "MODE-1972" )
+    public void shouldCloneEntireWorkspaces() throws Exception {
+        otherWorkspace.clone(workspaceName, "/", "/", true);
+
+        assertEquals(session.getNode("/a").getIdentifier(), otherSession.getNode("/a").getIdentifier());
+        assertEquals(session.getNode("/a/b").getIdentifier(), otherSession.getNode("/a/b").getIdentifier());
+        assertEquals(session.getNode("/a/b/c").getIdentifier(), otherSession.getNode("/a/b/c").getIdentifier());
+        assertEquals(session.getNode("/b").getIdentifier(), otherSession.getNode("/b").getIdentifier());
+    }
+
+    @Test(expected = RepositoryException.class)
+    @FixFor( "MODE-1972" )
+    public void shouldNotClonePartialWorkspaceIntoWorkspaceRoot() throws Exception {
+        otherWorkspace.clone(workspaceName, "/a/b", "/", false);
+    }
+
     @Test( expected = IllegalArgumentException.class )
     public void shouldNotAllowCopyFromNullPathToNullPath() throws Exception {
         workspace.copy(null, null);
@@ -100,7 +118,6 @@ public class JcrWorkspaceTest extends SingleUseAbstractTest {
         assertNotNull(otherSession.getNode("/a/b"));
         assertNotNull(otherSession.getNode("/a/b/c"));
         assertNotNull(otherSession.getNode("/b"));
-        assertNotNull(otherSession.getNode("/jcr:system"));
     }
 
     @Test(expected = RepositoryException.class)


### PR DESCRIPTION
Also, copying or cloning a subgraph from a workspace into the root of another workspace is not allowed, because that would mean that the root node would have "behave" as a standard node, at the end of the operation.

When copying/cloning and entire workspace into another workspace, the root node(s) and the `jcr:system` nodes have to be explicitly excluded from the operation.
