### PR TITLE
MODE-1979 Add second past parsing of Teiid DDL to resolve table referenc...

### DIFF
--- a/sequencers/modeshape-sequencer-ddl/src/main/java/org/modeshape/sequencer/ddl/DdlParser.java
+++ b/sequencers/modeshape-sequencer-ddl/src/main/java/org/modeshape/sequencer/ddl/DdlParser.java
@@ -66,5 +66,14 @@ public interface DdlParser {
      * @return the parser's identifier; never null
      */
     public String getId();
+    
+    /**
+     * Allows parsers to post process the {@link AstNode} tree given the supplied root.
+     * Initial use-case would be to allow a second pass through the tree to resolve any table references (FK's) that were defined out of order
+     * in the DDL
+     * 
+     * @param rootNode the top level {@link AstNode}; may not be null
+     */
+    public void postProcess(AstNode rootNode);
 
 }

--- a/sequencers/modeshape-sequencer-ddl/src/main/java/org/modeshape/sequencer/ddl/StandardDdlParser.java
+++ b/sequencers/modeshape-sequencer-ddl/src/main/java/org/modeshape/sequencer/ddl/StandardDdlParser.java
@@ -215,6 +215,8 @@ public class StandardDdlParser implements DdlParser, DdlConstants, DdlConstants.
             }
             // testPrint("== >> Found Statement" + "(" + (++count) + "):\n" + stmtNode);
         }
+        
+        postProcess(rootNode);
 
         rewrite(tokens, rootNode);
 
@@ -2832,8 +2834,20 @@ public class StandardDdlParser implements DdlParser, DdlConstants, DdlConstants.
 
         testPrint("== >> SOURCE:\n" + source + "\n");
     }
+    
+    
+    /**
+     * {@inheritDoc}
+     * 
+     * @see org.modeshape.sequencer.ddl.DdlParser#postProcess(org.modeshape.sequencer.ddl.node.AstNode)
+     */
+    @Override
+	public void postProcess(AstNode rootNode) {
+		// Default behavior is no post processing
+    	// Subclasses will need to override this method
+	}
 
-    protected void testPrint( String str ) {
+	protected void testPrint( String str ) {
         if (isTestMode()) {
             System.out.println(str);
         }

--- a/sequencers/modeshape-sequencer-ddl/src/main/java/org/modeshape/sequencer/ddl/dialect/teiid/AlterOptionsParser.java
+++ b/sequencers/modeshape-sequencer-ddl/src/main/java/org/modeshape/sequencer/ddl/dialect/teiid/AlterOptionsParser.java
@@ -340,5 +340,10 @@ final class AlterOptionsParser extends StatementParser {
 
         return false; // not an <alter options list> clause
     }
+    
+	@Override
+	protected void postProcess(AstNode rootNode) {
+		
+	}
 
 }

--- a/sequencers/modeshape-sequencer-ddl/src/main/java/org/modeshape/sequencer/ddl/dialect/teiid/CreateProcedureParser.java
+++ b/sequencers/modeshape-sequencer-ddl/src/main/java/org/modeshape/sequencer/ddl/dialect/teiid/CreateProcedureParser.java
@@ -375,5 +375,9 @@ final class CreateProcedureParser extends StatementParser {
 
         return text.toString();
     }
-
+    
+	@Override
+	protected void postProcess(AstNode rootNode) {
+		
+	}
 }

--- a/sequencers/modeshape-sequencer-ddl/src/main/java/org/modeshape/sequencer/ddl/dialect/teiid/CreateTriggerParser.java
+++ b/sequencers/modeshape-sequencer-ddl/src/main/java/org/modeshape/sequencer/ddl/dialect/teiid/CreateTriggerParser.java
@@ -162,5 +162,9 @@ final class CreateTriggerParser extends StatementParser {
 
         throw new TeiidDdlParsingException(tokens, "Unparsable create trigger statement");
     }
-
+    
+	@Override
+	protected void postProcess(AstNode rootNode) {
+		
+	}
 }

--- a/sequencers/modeshape-sequencer-ddl/src/main/java/org/modeshape/sequencer/ddl/dialect/teiid/OptionNamespaceParser.java
+++ b/sequencers/modeshape-sequencer-ddl/src/main/java/org/modeshape/sequencer/ddl/dialect/teiid/OptionNamespaceParser.java
@@ -75,5 +75,9 @@ final class OptionNamespaceParser extends StatementParser {
 
         throw new TeiidDdlParsingException(tokens, "Unparsable option namespace statement");
     }
-
+    
+	@Override
+	protected void postProcess(AstNode rootNode) {
+		
+	}
 }

--- a/sequencers/modeshape-sequencer-ddl/src/main/java/org/modeshape/sequencer/ddl/dialect/teiid/StatementParser.java
+++ b/sequencers/modeshape-sequencer-ddl/src/main/java/org/modeshape/sequencer/ddl/dialect/teiid/StatementParser.java
@@ -295,5 +295,11 @@ abstract class StatementParser implements DdlConstants {
 
         return id;
     }
+    
+    /**
+     * 
+     * @param rootNode the top level {@link AstNode}; may not be null
+     */
+	abstract void postProcess(AstNode rootNode);
 
 }

--- a/sequencers/modeshape-sequencer-ddl/src/main/java/org/modeshape/sequencer/ddl/dialect/teiid/TeiidDdlParser.java
+++ b/sequencers/modeshape-sequencer-ddl/src/main/java/org/modeshape/sequencer/ddl/dialect/teiid/TeiidDdlParser.java
@@ -157,4 +157,19 @@ public final class TeiidDdlParser extends StandardDdlParser implements TeiidDdlC
         throw new TeiidDdlParsingException(tokens, "Unparsable DDL statement");
     }
 
+    /**
+     * {@inheritDoc}
+     * 
+     * @see org.modeshape.sequencer.ddl.DdlParser#postProcess(org.modeshape.sequencer.ddl.node.AstNode)
+     */
+	@Override
+	public void postProcess(AstNode rootNode) {
+		super.postProcess(rootNode);
+		
+        for (final StatementParser parser : this.parsers) {
+        	parser.postProcess(rootNode);
+        }
+	}
+
+    
 }

--- a/sequencers/modeshape-sequencer-ddl/src/test/java/org/modeshape/sequencer/ddl/dialect/teiid/StatementParserTest.java
+++ b/sequencers/modeshape-sequencer-ddl/src/test/java/org/modeshape/sequencer/ddl/dialect/teiid/StatementParserTest.java
@@ -252,6 +252,11 @@ public class StatementParserTest extends TeiidDdlTest {
                        AstNode parentNode ) throws ParsingException {
             return null;
         }
+        
+    	@Override
+    	protected void postProcess(AstNode rootNode) {
+    		
+    	}
 
     }
 }

--- a/sequencers/modeshape-sequencer-ddl/src/test/java/org/modeshape/sequencer/ddl/dialect/teiid/TeiidDdlParserTest.java
+++ b/sequencers/modeshape-sequencer-ddl/src/test/java/org/modeshape/sequencer/ddl/dialect/teiid/TeiidDdlParserTest.java
@@ -281,5 +281,27 @@ public class TeiidDdlParserTest extends DdlParserTestHelper implements TeiidDdlC
             assertMixinType(kids.get(0), TeiidDdlLexicon.CreateProcedure.PROCEDURE_STATEMENT);
         }
     }
+    
+    @Test
+	public void shouldParseAndResolveTableReference() {
+		final String content = "CREATE FOREIGN TABLE G2(g2e1 integer, g2e2 varchar, PRIMARY KEY(g2e1, g2e2), FOREIGN KEY (g2e1, g2e2) REFERENCES G1)"
+				+ "CREATE FOREIGN TABLE G1(g1e1 integer, g1e2 varchar, PRIMARY KEY(g1e1, g1e2));";
+
+		assertScoreAndParse(content, null, 2);
+
+		{
+			final List<AstNode> kids = this.rootNode.childrenWithName("G1");
+			assertThat(kids.size(), is(1));
+			assertMixinType(kids.get(0),
+					TeiidDdlLexicon.CreateTable.TABLE_STATEMENT);
+		}
+
+		{
+			final List<AstNode> kids = this.rootNode.childrenWithName("G2");
+			assertThat(kids.size(), is(1));
+			assertMixinType(kids.get(0),
+					TeiidDdlLexicon.CreateTable.TABLE_STATEMENT);
+		}
+	}
 
 }


### PR DESCRIPTION
...es for in-line FK constraints when referenced table has not been parsed yet
- added postProcess() method in DdlParser and subclasses
  - added postProcess() method in StatementParser and subclasses
