### PR TITLE
MODE 1975 Updated the clone operation to support external nodes.

### DIFF
--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/Connectors.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/Connectors.java
@@ -528,12 +528,12 @@ public final class Connectors {
      * Determine there is a projection with the given alias and projected (internal) node key
      *
      * @param alias the alias
-     * @param projectedNodeKey the node key of the projected (internal) node
+     * @param externalNodeKey the node key of the projected (internal) node
      * @return true if there is such a projection, or false otherwise
      */
     public boolean hasExternalProjection( String alias,
-                                          String projectedNodeKey ) {
-        return this.snapshot.get().hasExternalProjection(alias, projectedNodeKey);
+                                          String externalNodeKey ) {
+        return this.snapshot.get().hasExternalProjection(alias, externalNodeKey);
     }
 
     /**

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrI18n.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrI18n.java
@@ -201,6 +201,8 @@ public final class JcrI18n {
     public static I18n unableToMoveProjection;
     public static I18n unableToCopySourceTargetMismatch;
     public static I18n unableToCopySourceNotExternal;
+    public static I18n unableToCloneSameWsContainsExternalNode;
+    public static I18n unableToCloneExternalNodesRequireRoot;
 
     public static I18n typeNotFound;
     public static I18n supertypeNotFound;

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/MutableCachedNode.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/MutableCachedNode.java
@@ -27,6 +27,7 @@ import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
+import org.modeshape.jcr.Connectors;
 import org.modeshape.jcr.value.Name;
 import org.modeshape.jcr.value.Property;
 
@@ -221,6 +222,21 @@ public interface MutableCachedNode extends CachedNode {
     boolean hasChangedPrimaryType();
 
     /**
+     * Adds a new federated segment with the given name and key to this node.
+     *
+     * @param segmentName the name of the segment (i.e. the name of the alias under which an external child is linked); may not be null
+     * @param externalNodeKey the key of the external node which should be linked under this name; may not be null
+     */
+    void addFederatedSegment(String externalNodeKey, String segmentName);
+
+    /**
+     * Removes the federated segment towards an external node.
+     *
+     * @param externalNodeKey the key of the external node which should be linked under this name; may not be null
+     */
+    void removeFederatedSegment(String externalNodeKey);
+
+    /**
      * Create a new node as a child of this node with the supplied name and properties.
      * 
      * @param cache the cache to which this node belongs; may not be null
@@ -351,18 +367,19 @@ public interface MutableCachedNode extends CachedNode {
 
     /**
      * Copies into this node all the properties and children (deep copy) from the given source node.
-     * 
      *
      * @param cache the cache to which this node belongs; may not be null
      * @param sourceNode the node from which to copy the properties and children; may not be null
      * @param sourceCache the cache in which the source node belongs; may not be null
      * @param systemWorkspaceKey the key of the system workspace; may not be null
+     * @param connectors a {@link Connectors} instance which used for processing external nodes.
      * @return a [source key -> target key] which represents the node correspondence after the copy operation.
      */
     public Map<NodeKey, NodeKey> deepCopy( SessionCache cache,
                                            CachedNode sourceNode,
                                            SessionCache sourceCache,
-                                           String systemWorkspaceKey );
+                                           String systemWorkspaceKey,
+                                           Connectors connectors );
 
     /**
      * Clones into this node all the properties and children (deep clone) from the given source node. Each cloned node will have
@@ -372,11 +389,13 @@ public interface MutableCachedNode extends CachedNode {
      * @param sourceNode the node from which to copy the properties and children; may not be null
      * @param sourceCache the cache in which the source node belongs; may not be null
      * @param systemWorkspaceKey the key of the system workspace; may not be null
+     * @param connectors a {@link Connectors} instance which used for processing external nodes.
      */
     public void deepClone( SessionCache cache,
                            CachedNode sourceNode,
                            SessionCache sourceCache,
-                           String systemWorkspaceKey );
+                           String systemWorkspaceKey,
+                           Connectors connectors );
 
     /**
      * Returns a set with the keys of the children which have been removed for this node.

--- a/modeshape-jcr/src/main/resources/org/modeshape/jcr/JcrI18n.properties
+++ b/modeshape-jcr/src/main/resources/org/modeshape/jcr/JcrI18n.properties
@@ -191,6 +191,8 @@ unableToMoveSourceTargetMismatch = Unable to move the nodes because the source n
 unableToMoveProjection = Unable to move the nodes because the path "{0}" represents a projection
 unableToCopySourceTargetMismatch =  Unable to copy the nodes because at least one of the source nodes belong to the "{0}" source while the destination node belongs to the "{1}" source
 unableToCopySourceNotExternal =  Unable to copy the nodes because the source node "{0}" is not an external node itself, but its subgraph contains external nodes.
+unableToCloneSameWsContainsExternalNode =  Unable to perform the clone operation in the same workspace because at least one of the source nodes belongs to the "{0}" source
+unableToCloneExternalNodesRequireRoot = At least one of the source nodes belongs to the "{0}" source. Only entire workspaces can be cloned if the source workspace contains external nodes
 
 SPEC_NAME_DESC = Content Repository for Java Technology API
 


### PR DESCRIPTION
While working on this, I noticed that the way in which federated segments were created/removed was completely "circumventing the `SessionNode`/`WritableSessionCache` design", so that was changed as well.
