### PR TITLE
MODE-1984 Corrected shareable node behavior upon removing a shared node

### DIFF
--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrNode.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrNode.java
@@ -31,6 +31,7 @@ import javax.jcr.lock.LockException;
 import javax.jcr.nodetype.ConstraintViolationException;
 import javax.jcr.version.VersionException;
 import org.modeshape.common.annotation.ThreadSafe;
+import org.modeshape.jcr.JcrSharedNodeCache.SharedSet;
 import org.modeshape.jcr.cache.MutableCachedNode;
 import org.modeshape.jcr.cache.NodeKey;
 import org.modeshape.jcr.cache.SessionCache;
@@ -82,13 +83,47 @@ class JcrNode extends AbstractJcrNode {
     }
 
     @Override
+    boolean isShared() {
+        // Sometimes, a shareable and shared node is represented by a JcrNode rather than a JcrSharedNode. Therefore,
+        // the share-related logic needs to be done here ...
+        try {
+            return isShareable() && sharedSet().getSize() > 1;
+        } catch (RepositoryException e) {
+            // Shouldn't really happen, but just in case ...
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
     protected void doRemove()
         throws VersionException, LockException, ConstraintViolationException, AccessDeniedException, RepositoryException {
+        // Sometimes, a shareable and shared node is represented by a JcrNode rather than a JcrSharedNode. Therefore,
+        // the share-related logic needs to be done here ...
 
         SessionCache cache = sessionCache();
         NodeKey key = key();
         MutableCachedNode parent = mutableParent();
+        if (!isShareable()) {
+            // It's not shareable, so we will always destroy the node immediately ...
+            parent.removeChild(cache, key);
+            cache.destroy(key);
+            return;
+        }
+
+        // It is shareable, so we need to check how many shares there are before we remove this node from its parent ...
+        JcrSharedNodeCache shareableNodeCache = session().shareableNodeCache();
+        SharedSet sharedSet = shareableNodeCache.getSharedSet(this);
+        if (sharedSet.getSize() <= 1) {
+            // There are no shares, so destroy the node and the shared set ...
+            parent.removeChild(cache, key);
+            cache.destroy(key);
+            shareableNodeCache.destroyed(key);
+            return;
+        }
+
+        // The node being removed is shared to at least two places, so we should remove it from the primary parent,
+        // NOT destroy the node, and adjust the SharedSet ...
         parent.removeChild(cache, key);
-        cache.destroy(key);
+        shareableNodeCache.removed(this);
     }
 }

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrSession.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrSession.java
@@ -418,6 +418,10 @@ public class JcrSession implements org.modeshape.jcr.api.Session {
         return stringFactory().create(path);
     }
 
+    protected void releaseCachedNode( AbstractJcrNode node ) {
+        jcrNodes.remove(node.key(), node);
+    }
+
     /**
      * Obtain the {@link Node JCR Node} object for the node with the supplied key.
      * 
@@ -967,7 +971,7 @@ public class JcrSession implements org.modeshape.jcr.api.Session {
             throw new VersionException(JcrI18n.nodeIsCheckedIn.text(destParentNode.getPath()));
         }
 
-        //Check whether external nodes are involved
+        // Check whether external nodes are involved
         validateMoveForExternalNodes(srcPath, destPath);
 
         // check whether the parent definition allows children which match the source
@@ -1030,7 +1034,7 @@ public class JcrSession implements org.modeshape.jcr.api.Session {
         try {
             destNode = node(destPath);
         } catch (PathNotFoundException e) {
-            //the destPath does not point to an existing node, so we'll use the parent
+            // the destPath does not point to an existing node, so we'll use the parent
             destNode = node(destPath.getParent());
         }
         String externalTargetKey = null;
@@ -1048,7 +1052,7 @@ public class JcrSession implements org.modeshape.jcr.api.Session {
             String sourceName = connectors.getSourceNameAtKey(externalTargetKey);
             throw new RepositoryException(JcrI18n.unableToMoveTargetContainExternalNodes.text(srcPath, sourceName));
         } else if (targetIsExternal) {
-            //both source and target are external nodes, but belonging to different sources
+            // both source and target are external nodes, but belonging to different sources
             if (!externalTargetKey.equalsIgnoreCase(srcNode.key().getSourceKey())) {
                 String sourceNodeSourceName = connectors.getSourceNameAtKey(srcNode.key().getSourceKey());
                 String targetNodeSourceName = connectors.getSourceNameAtKey(externalTargetKey);
@@ -1056,7 +1060,7 @@ public class JcrSession implements org.modeshape.jcr.api.Session {
                                                                                             targetNodeSourceName));
             }
 
-            //both source and target belong to the same source, but one of them is a projection root
+            // both source and target belong to the same source, but one of them is a projection root
             if (connectors.hasExternalProjection(srcPath.getLastSegment().getString(), srcNode.key().toString())) {
                 throw new RepositoryException(JcrI18n.unableToMoveProjection.text(srcPath));
             }

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrSharedNode.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrSharedNode.java
@@ -23,18 +23,13 @@
  */
 package org.modeshape.jcr;
 
-import javax.jcr.AccessDeniedException;
 import javax.jcr.InvalidItemStateException;
 import javax.jcr.ItemNotFoundException;
 import javax.jcr.RepositoryException;
-import javax.jcr.lock.LockException;
-import javax.jcr.nodetype.ConstraintViolationException;
-import javax.jcr.version.VersionException;
 import org.modeshape.common.annotation.ThreadSafe;
 import org.modeshape.jcr.JcrSharedNodeCache.SharedSet;
 import org.modeshape.jcr.cache.CachedNode;
 import org.modeshape.jcr.cache.ChildReference;
-import org.modeshape.jcr.cache.MutableCachedNode;
 import org.modeshape.jcr.cache.NodeKey;
 import org.modeshape.jcr.cache.SessionCache;
 import org.modeshape.jcr.value.Name;
@@ -78,19 +73,6 @@ final class JcrSharedNode extends JcrNode {
     @Override
     protected NodeKey parentKey() {
         return parentKey;
-    }
-
-    @Override
-    protected void doRemove()
-        throws VersionException, LockException, ConstraintViolationException, AccessDeniedException, RepositoryException {
-        // Remove this from the shared set ...
-        sharedSet.remove(this);
-
-        // Then remove the child from the parent but do not destroy the node ...
-        SessionCache cache = sessionCache();
-        NodeKey key = key();
-        MutableCachedNode parent = mutableParent();
-        parent.removeChild(cache, key);
     }
 
     @Override

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrVersionManager.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrVersionManager.java
@@ -1350,7 +1350,8 @@ final class JcrVersionManager implements VersionManager {
                 NodeKey targetKey = target.getKey();
                 MutableCachedNode shareable = cache.mutable(desiredKey);
                 Set<NodeKey> allParents = new HashSet<NodeKey>(shareable.getAdditionalParentKeys(cache));
-                allParents.add(shareable.getParentKey(cache));
+                NodeKey primaryParentKey = shareable.getParentKey(cache);
+                if (primaryParentKey != null) allParents.add(primaryParentKey);
                 for (NodeKey parentKey : allParents) {
                     if (parentKey.equals(targetKey)) continue; // skip the new target ...
                     MutableCachedNode parent = cache.mutable(parentKey);
@@ -1706,7 +1707,7 @@ final class JcrVersionManager implements VersionManager {
                 doUpdate(targetNode, sourceNode);
                 return;
             }
-            
+
             if (targetVersion.isSuccessorOf(sourceVersion)) {
                 doLeave(targetNode);
                 return;

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/document/DocumentTranslator.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/document/DocumentTranslator.java
@@ -670,12 +670,16 @@ public class DocumentTranslator {
             if (parent != null && !parent.equals(oldParent)) {
                 parents.addStringIfAbsent(parent.toString());
                 if (oldParent != null) {
-                    parents.remove(oldParent.toString());
+                    parents.remove((Object)oldParent.toString());
                 }
             }
             if (additionalParents != null) {
-                for (NodeKey removed : additionalParents.getRemovals()) {
-                    parents.remove((Object)removed.toString()); // remove by value (not by name)
+                for (NodeKey removedParent : additionalParents.getRemovals()) {
+                    // When the primary parent is removed and changed to one of the additional parents, then the additional
+                    // parent is removed. Therefore, we only want to remove it if it does not equal the new parent ...
+                    if (!removedParent.equals(parent)) {
+                        parents.remove((Object)removedParent.toString()); // remove by value (not by name)
+                    }
                 }
                 for (NodeKey added : additionalParents.getAdditions()) {
                     parents.addStringIfAbsent(added.toString());
@@ -706,7 +710,7 @@ public class DocumentTranslator {
                     parents.add(existingParent);
                 }
                 for (NodeKey removed : additionalParents.getRemovals()) {
-                    parents.remove(removed.toString());
+                    parents.remove((Object)removed.toString());
                 }
                 for (NodeKey added : additionalParents.getAdditions()) {
                     parents.add(added.toString());
@@ -1739,7 +1743,9 @@ public class DocumentTranslator {
         document.set(QUERYABLE_FIELD, queryable);
     }
 
-    protected void addFederatedSegment(EditableDocument document, String externalNodeKey, String name) {
+    protected void addFederatedSegment( EditableDocument document,
+                                        String externalNodeKey,
+                                        String name ) {
         EditableArray federatedSegmentsArray = document.getArray(FEDERATED_SEGMENTS);
         if (federatedSegmentsArray == null) {
             federatedSegmentsArray = Schematic.newArray();

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/document/WritableSessionCache.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/document/WritableSessionCache.java
@@ -1134,7 +1134,7 @@ public class WritableSessionCache extends AbstractSessionCache {
                     changes.nodeChanged(key, newPath);
                 }
 
-                //write the federated segments
+                // write the federated segments
                 for (Map.Entry<String, String> federatedSegment : node.getAddedFederatedSegments().entrySet()) {
                     translator.addFederatedSegment(doc, federatedSegment.getKey(), federatedSegment.getValue());
                 }
@@ -1174,8 +1174,9 @@ public class WritableSessionCache extends AbstractSessionCache {
                                                                                                     .iterator());
                     }
                 } else {
-                    boolean externalNodeChanged = isExternal && (hasPropertyChanges || node.hasNonPropertyChanges()
-                                                                 || node.changedChildren().renameCount() > 0);
+                    boolean externalNodeChanged = isExternal
+                                                  && (hasPropertyChanges || node.hasNonPropertyChanges() || node.changedChildren()
+                                                                                                                .renameCount() > 0);
                     if (externalNodeChanged) {
                         // in the case of external nodes, only if there are changes should the update be called
                         documentStore.updateDocument(keyStr, doc, node);


### PR DESCRIPTION
When a shared node is removed, ModeShape's behavior is that this is the same as calling `node.removeShare()`, which just removes the share and does not affect the other nodes in the shared set. However, when the primary node was removed, ModeShape was incorrectly removing the node from the repository, even though the parents of the other nodes in the shared set still contained references to the shared node.

In particular, the problem appeared to manifest itself only when the shared node was looked up by identifier and then removed. The resulting node was an instance of `JcrNode` rather than `JcrSharedNode`, and thus the remove logic `JcrSharedNode` was never called.

Quite a few small changes were required to fix the problem. First, two unit tests were added to replicate the incorrect behavior. Then, several smaller changes were required in a number of other classes. For example, the logic of removing a shared node was moved out of the `JcrSharedNode` class and into the JcrNode base class. However, this additional logic only kicks in if the node is `mix:shareable`.

While working on this fix, I discovered another subtle bug in how the SessionNode removed a child when that child had additional parents. This was corrected and validated.

The final challenge with this fix was that when `node.save()` was called on the parent (or ancestor) of the parent from which the shared node was removed, the changes to the shared node (which no longer appeared as a descendant of the saved node) were not being saved. The cause turned out to be that when the _primary_ node was removed, ModeShape was not recording that the old parent was removed from the additional nodes, and thus the logic to determine which nodes are affected by the `node.save()` never discovered that the removed node used to exist below the saved node.

All unit and integration tests pass after these changes.
