### PR TITLE
MODE-1960 Updated the POI dependency to 3.10-beta1 and added back the MSOffice Sequencer and Tika Extractor, which were disabled as a result of https://issues.jboss.org/browse/MODE-1934.

### DIFF
--- a/boms/modeshape-bom-embedded/pom.xml
+++ b/boms/modeshape-bom-embedded/pom.xml
@@ -79,14 +79,11 @@
                 <artifactId>modeshape-sequencer-mp3</artifactId>
                 <version>${project.version}</version>
             </dependency>
-            <!--
-                See MODE-1934
-                <dependency>
-                    <groupId>org.modeshape</groupId>
-                    <artifactId>modeshape-sequencer-msoffice</artifactId>
-                    <version>${project.version}</version>
-                </dependency>
-            -->
+            <dependency>
+                <groupId>org.modeshape</groupId>
+                <artifactId>modeshape-sequencer-msoffice</artifactId>
+                <version>${project.version}</version>
+            </dependency>
             <dependency>
                 <groupId>org.modeshape</groupId>
                 <artifactId>modeshape-sequencer-sramp</artifactId>
@@ -351,7 +348,7 @@
                 <artifactId>jaudiotagger</artifactId>
                 <version>${jaudiotagger.version}</version>
             </dependency>
-            <!--MsOffice sequencer See MODE-1934
+            <!--MsOffice sequencer -->
             <dependency>
                 <groupId>org.apache.poi</groupId>
                 <artifactId>poi</artifactId>
@@ -362,7 +359,20 @@
                 <artifactId>poi-scratchpad</artifactId>
                 <version>${poi.version}</version>
             </dependency>
-            -->
+            <!--
+                The following 2 POI dependencies are not used directly, but defined so that we use the same "beta" version
+                across the board (see https://issues.jboss.org/browse/MODE-1934).Tika-parsers brings these 2 transitively in
+             -->
+            <dependency>
+                <groupId>org.apache.poi</groupId>
+                <artifactId>poi-ooxml</artifactId>
+                <version>${poi.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.poi</groupId>
+                <artifactId>poi-ooxml-schemas</artifactId>
+                <version>${poi.version}</version>
+            </dependency>
             <!--Teiid sequencer-->
             <dependency>
                 <groupId>com.beust</groupId>
@@ -419,23 +429,6 @@
                 <artifactId>tika-parsers</artifactId>
                 <version>${tika.version}</version>
                 <exclusions>
-                    <!--See MODE-1934-->
-                    <exclusion>
-                        <groupId>org.apache.poi</groupId>
-                        <artifactId>poi</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>org.apache.poi</groupId>
-                        <artifactId>poi-scratchpad</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>org.apache.poi</groupId>
-                        <artifactId>poi-ooxml</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>org.apache.poi</groupId>
-                        <artifactId>poi-ooxml-schemas</artifactId>
-                    </exclusion>
                     <!--
                     The NetCDF and HDF files are often used in the scientific community, so we exclude this
                     library (and the Commons HTTP Client library) by default.

--- a/boms/modeshape-bom-parent/pom.xml
+++ b/boms/modeshape-bom-parent/pom.xml
@@ -71,7 +71,7 @@
         <tika.version>1.3</tika.version>
         <javaassist.version>3.11.0.GA</javaassist.version>
         <jaudiotagger.version>2.0.3</jaudiotagger.version>
-        <poi.version>3.8</poi.version>
+        <poi.version>3.10-beta1</poi.version>
         <jcommander.version>1.5</jcommander.version>
         <wsdl4j.version>1.6.2</wsdl4j.version>
         <eclipse.equinox.common.version>3.3.0-v20070426</eclipse.equinox.common.version>

--- a/demos/sequencers/pom.xml
+++ b/demos/sequencers/pom.xml
@@ -40,10 +40,6 @@
             <groupId>org.modeshape</groupId>
             <artifactId>modeshape-sequencer-text</artifactId>
         </dependency>
-        <!--dependency>
-          <groupId>org.modeshape</groupId>
-          <artifactId>modeshape-sequencer-zip</artifactId>
-        </dependency-->
         <!--
         Logging (require SLF4J API for compiling, but use Logback binding for running)
         -->

--- a/deploy/jbossas/kit/jboss-eap61/org/apache/tika/1.3/module.xml
+++ b/deploy/jbossas/kit/jboss-eap61/org/apache/tika/1.3/module.xml
@@ -38,15 +38,12 @@
         <resource-root path="jempbox-1.7.1.jar" />
         <resource-root path="juniversalchardet-1.0.3.jar" />
         <resource-root path="pdfbox-1.7.1.jar" />
-        <!--
-          See MODE-1934
-        <resource-root path="poi-3.8.jar" />
-        <resource-root path="poi-ooxml-3.8.jar" />
-        <resource-root path="poi-ooxml-schemas-3.8.jar" />
-        <resource-root path="poi-scratchpad-3.8.jar" />
+        <resource-root path="poi-${poi.version}.jar" />
+        <resource-root path="poi-ooxml-${poi.version}.jar" />
+        <resource-root path="poi-ooxml-schemas-${poi.version}.jar" />
+        <resource-root path="poi-scratchpad-${poi.version}.jar" />
         <resource-root path="dom4j-1.6.1.jar" />
         <resource-root path="xmlbeans-2.3.0.jar" />
-        -->
         <resource-root path="tagsoup-1.2.1.jar" />
         <resource-root path="vorbis-java-core-0.1.jar" />
         <resource-root path="vorbis-java-core-0.1-tests.jar" />

--- a/deploy/jbossas/kit/jboss-eap61/standalone/configuration/standalone-modeshape.xml
+++ b/deploy/jbossas/kit/jboss-eap61/standalone/configuration/standalone-modeshape.xml
@@ -259,7 +259,9 @@
                     <sequencer name="cnd-sequencer" classname="cnd" module="org.modeshape">
                         <path-expression>default:/files(//*.cnd[*])/jcr:content[@jcr:data] => /derived/cnd/$1</path-expression>
                     </sequencer>
-                    <!--Ms Office sequencer has been removed since MODE-1934-->
+                    <sequencer name="msoffice-sequencer" classname="msoffice" module="org.modeshape.sequencer.msoffice">
+                        <path-expression>/files(//*.(xls|ppt|doc)[*])/jcr:content[@jcr:data] => /derived/msoffice/$1</path-expression>
+                    </sequencer>
                     <sequencer name="teiid-model-sequencer" classname="model" module="org.modeshape.sequencer.teiid">
                       <path-expression>/files(//*.xmi[*])/jcr:content[@jcr:data] => /derived/teiid/models/$1</path-expression>
                     </sequencer>

--- a/extractors/modeshape-extractor-tika/src/test/java/org/modeshape/extractor/tika/TikaTextExtractorRepositoryTest.java
+++ b/extractors/modeshape-extractor-tika/src/test/java/org/modeshape/extractor/tika/TikaTextExtractorRepositoryTest.java
@@ -57,7 +57,6 @@ public class TikaTextExtractorRepositoryTest extends SingleUseAbstractTest {
     }
 
     @Test
-    @Ignore ("MODE-1934")
     public void shouldExtractAndIndexContentFromDocFile() throws Exception {
         startRepositoryWithConfiguration(getResource("repo-config.json"));
         uploadFile("modeshape.doc");

--- a/extractors/modeshape-extractor-tika/src/test/java/org/modeshape/extractor/tika/TikaTextExtractorTest.java
+++ b/extractors/modeshape-extractor-tika/src/test/java/org/modeshape/extractor/tika/TikaTextExtractorTest.java
@@ -97,7 +97,6 @@ public class TikaTextExtractorTest {
     }
 
     @Test
-    @Ignore("MODE-1934")
     public void shouldSupportExtractingFromDocWordFiles() throws Exception {
         assertThat(extractor.supportsMimeType("application/msword"), is(true));
     }
@@ -123,7 +122,6 @@ public class TikaTextExtractorTest {
     }
 
     @Test
-    @Ignore("MODE-1934")
     public void shouldExtractTextFromDocFile() throws Exception {
         extractTermsFrom("modeshape.doc");
         loadExpectedFrom("modeshape.txt");
@@ -131,7 +129,6 @@ public class TikaTextExtractorTest {
     }
 
     @Test
-    @Ignore("MODE-1934")
     public void shouldExtractTextFromDocxFile() throws Exception {
         extractTermsFrom("modeshape.docx");
         loadExpectedFrom("modeshape.txt");
@@ -172,7 +169,6 @@ public class TikaTextExtractorTest {
 
     @Test
     @FixFor( "MODE-1810" )
-    @Ignore("MODE-1934")
     public void shouldExtractTextFromXlsxFile() throws Exception {
         extractTermsFrom("sample-file.xlsx");
         assertTrue(!extracted.isEmpty());

--- a/integration/modeshape-jbossas-integration-tests/src/main/resources/kit/jboss-eap61/standalone/configuration/standalone-modeshape.xml
+++ b/integration/modeshape-jbossas-integration-tests/src/main/resources/kit/jboss-eap61/standalone/configuration/standalone-modeshape.xml
@@ -507,7 +507,10 @@
                     <sequencer name="cnd-sequencer" classname="cnd" module="org.modeshape">
                         <path-expression>default:/files(//*.cnd[*])/jcr:content[@jcr:data] => /derived/cnd/$1</path-expression>
                     </sequencer>
-                    <!--Ms Office sequencer has been removed since MODE-1934-->
+                    <sequencer name="msoffice-sequencer" classname="msoffice" module="org.modeshape.sequencer.msoffice">
+                        <path-expression>/files(//*.(xls|ppt|doc)[*])/jcr:content[@jcr:data] => /derived/msoffice/$1
+                        </path-expression>
+                    </sequencer>
                     <sequencer name="teiid-model-sequencer" classname="model" module="org.modeshape.sequencer.teiid">
                         <path-expression>/files(//*.xmi[*])/jcr:content[@jcr:data] => /derived/teiid/models/$1</path-expression>
                     </sequencer>

--- a/integration/modeshape-jbossas-integration-tests/src/test/java/org/modeshape/test/integration/SequencersIntegrationTest.java
+++ b/integration/modeshape-jbossas-integration-tests/src/test/java/org/modeshape/test/integration/SequencersIntegrationTest.java
@@ -132,7 +132,6 @@ public class SequencersIntegrationTest {
     }
 
     @Test
-    @Ignore( "MODE-1934" )
     public void shouldSequenceMsOfficeFile() throws Exception {
         uploadFileAndAssertSequenced("/msoffice_file.xls",
                                      "/derived/msoffice",

--- a/integration/modeshape-jbossas-integration-tests/src/test/java/org/modeshape/test/integration/TikaTextExtractorIntegrationTest.java
+++ b/integration/modeshape-jbossas-integration-tests/src/test/java/org/modeshape/test/integration/TikaTextExtractorIntegrationTest.java
@@ -86,7 +86,6 @@ public class TikaTextExtractorIntegrationTest {
     }
 
     @Test
-    @Ignore("MODE-1934")
     public void shouldExtractAndIndexContentFromDocFile() throws Exception {
         String queryString = "select [jcr:path] from [nt:resource] as res where contains(res.*, 'ModeShape supports')";
         uploadFileAndCheckExtraction("text-extractor/modeshape.doc", queryString);
@@ -94,7 +93,6 @@ public class TikaTextExtractorIntegrationTest {
 
     @Test
     @FixFor( "MODE-1810" )
-    @Ignore("MODE-1934")
     public void shouldExtractAndIndexContentFromXlsxFile() throws Exception {
         String queryString = "select [jcr:path] from [nt:resource] as res where contains(res.*, 'Operations')";
         uploadFileAndCheckExtraction("text-extractor/sample-file.xlsx", queryString);

--- a/modeshape-assembly-descriptors/src/main/resources/assemblies/jbosseap-61-dist.xml
+++ b/modeshape-assembly-descriptors/src/main/resources/assemblies/jbosseap-61-dist.xml
@@ -28,8 +28,6 @@
 			<outputDirectory>${jboss.eap.modules.location}</outputDirectory>
             <excludes>
                 <exclude>standalone/**</exclude>
-                <!-- See MODE-1934-->
-                <exclude>**/msoffice/**</exclude>
             </excludes>
             <filtered>true</filtered>
 		</fileSet>
@@ -136,7 +134,7 @@
                 <include>org.apache.james:apache-mime4j-core:jar</include>
                 <include>org.apache.james:apache-mime4j-dom:jar</include>
                 <include>org.apache.pdfbox:*:jar</include>
-                <!--<include>org.apache.poi:*:jar</include> See MODE-1934 -->
+                <include>org.apache.poi:*:jar</include>
                 <include>org.apache.xmlbeans:*:jar</include>
                 <include>org.apache.geronimo.specs:*:jar</include>
                 <include>dom4j:dom4j:jar</include>
@@ -212,18 +210,15 @@
             </includes>
         </dependencySet>
 
-        <!--
-            See MODE-1934
-            <dependencySet>
-                <useProjectArtifact>false</useProjectArtifact>
-                <outputDirectory>${jboss.eap.modules.location}/org/modeshape/sequencer/msoffice/main</outputDirectory>
-                <includes>
-                    <include>org.modeshape:modeshape-sequencer-msoffice:jar</include>
-                    <include>org.apache*:poi:jar</include>
-                    <include>org.apache*:poi-scratchpad:jar</include>
-                </includes>
-            </dependencySet>
-         -->
+        <dependencySet>
+            <useProjectArtifact>false</useProjectArtifact>
+            <outputDirectory>${jboss.eap.modules.location}/org/modeshape/sequencer/msoffice/main</outputDirectory>
+            <includes>
+                <include>org.modeshape:modeshape-sequencer-msoffice:jar</include>
+                <include>org.apache*:poi:jar</include>
+                <include>org.apache*:poi-scratchpad:jar</include>
+            </includes>
+        </dependencySet>
 
         <dependencySet>
             <useProjectArtifact>false</useProjectArtifact>

--- a/modeshape-distribution/pom.xml
+++ b/modeshape-distribution/pom.xml
@@ -65,14 +65,10 @@
             <artifactId>modeshape-sequencer-java</artifactId>
         </dependency>
 
-        <!--
-            See MODE-1934
-
-            <dependency>
-                <groupId>org.modeshape</groupId>
-                <artifactId>modeshape-sequencer-msoffice</artifactId>
-            </dependency>
-       -->
+        <dependency>
+            <groupId>org.modeshape</groupId>
+            <artifactId>modeshape-sequencer-msoffice</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>org.modeshape</groupId>
@@ -236,9 +232,6 @@
                     <type>zip</type>
                 </dependency>
 
-                <!--
-                See MODE-1934
-
                 <dependency>
                     <groupId>org.modeshape</groupId>
                     <artifactId>modeshape-sequencer-msoffice</artifactId>
@@ -246,7 +239,7 @@
                     <version>${project.version}</version>
                     <type>zip</type>
                 </dependency>
-                -->
+
                 <dependency>
                     <groupId>org.modeshape</groupId>
                     <artifactId>modeshape-sequencer-teiid</artifactId>

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/RepositoryConfiguration.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/RepositoryConfiguration.java
@@ -681,7 +681,7 @@ public class RepositoryConfiguration {
         String javaSequencer = "org.modeshape.sequencer.javafile.JavaFileSequencer";
         String modelSequencer = "org.modeshape.sequencer.teiid.model.ModelSequencer";
         String vdbSequencer = "org.modeshape.sequencer.teiid.VdbSequencer";
-        // String msofficeSequencer = "org.modeshape.sequencer.msoffice.MSOfficeMetadataSequencer";
+        String msofficeSequencer = "org.modeshape.sequencer.msoffice.MSOfficeMetadataSequencer";
         String wsdlSequencer = "org.modeshape.sequencer.wsdl.WsdlSequencer";
         String xsdSequencer = "org.modeshape.sequencer.xsd.XsdSequencer";
         String xmlSequencer = "org.modeshape.sequencer.xml.XmlSequencer";
@@ -709,9 +709,8 @@ public class RepositoryConfiguration {
         aliases.put("modelsequencer", modelSequencer);
         aliases.put("vdb", vdbSequencer);
         aliases.put("vdbsequencer", vdbSequencer);
-        /**
-         * See MODE-1934 aliases.put("msoffice", msofficeSequencer); aliases.put("msofficesequencer", msofficeSequencer);
-         **/
+        aliases.put("msoffice", msofficeSequencer);
+        aliases.put("msofficesequencer", msofficeSequencer);
         aliases.put("wsdl", wsdlSequencer);
         aliases.put("wsdlsequencer", wsdlSequencer);
         aliases.put("xsd", xsdSequencer);

--- a/modeshape-jcr/src/test/java/org/modeshape/jcr/mimetype/TikaMimeTypeDetectorTest.java
+++ b/modeshape-jcr/src/test/java/org/modeshape/jcr/mimetype/TikaMimeTypeDetectorTest.java
@@ -82,7 +82,6 @@ public class TikaMimeTypeDetectorTest {
     }
 
     @Test
-    @Ignore("MODE-1934")
     public void shouldDetectMsWordWithoutName() throws Exception {
         assertEquals(MimeTypeConstants.MICROSOFT_APPLICATION_MS_WORD, detector.mimeTypeOf(null, binaryFromFile(WORD_FILE)));
     }
@@ -93,26 +92,22 @@ public class TikaMimeTypeDetectorTest {
     }
 
     @Test
-    @Ignore("MODE-1934")
     public void shouldDetectMsWordOpenXMLWithoutName() throws Exception {
         assertEquals(MimeTypeConstants.MICROSOFT_WORD_OPEN_XML, detector.mimeTypeOf(null, binaryFromFile(WORD_OPEN_XML_FILE)));
     }
 
     @Test
-    @Ignore("MODE-1934")
     public void shouldDetectMsWordOpenXMLWithName() throws Exception {
         assertEquals(MimeTypeConstants.MICROSOFT_WORD_OPEN_XML,
                      detector.mimeTypeOf(WORD_OPEN_XML_FILE, binaryFromFile(WORD_OPEN_XML_FILE)));
     }
 
     @Test
-    @Ignore("MODE-1934")
     public void shouldDetectExcelDocumentWithoutName() throws Exception {
         assertEquals(MimeTypeConstants.MICROSOFT_EXCEL, detector.mimeTypeOf(null, binaryFromFile(EXCEL_FILE)));
     }
 
     @Test
-    @Ignore("MODE-1934")
     public void shouldDetectExcelDocumentWithName() throws Exception {
         assertEquals(MimeTypeConstants.MICROSOFT_EXCEL, detector.mimeTypeOf(EXCEL_FILE, binaryFromFile(EXCEL_FILE)));
     }

--- a/modeshape-parent/pom.xml
+++ b/modeshape-parent/pom.xml
@@ -296,7 +296,7 @@
         <sardine.version>146</sardine.version>
         <javaassist.version>3.11.0.GA</javaassist.version>
         <jaudiotagger.version>2.0.3</jaudiotagger.version>
-        <poi.version>3.8</poi.version>
+        <poi.version>3.10-beta1</poi.version>
         <jcommander.version>1.5</jcommander.version>
         <wsdl4j.version>1.6.2</wsdl4j.version>
         <bson4jackson.version>1.1.2</bson4jackson.version>
@@ -764,15 +764,11 @@
                 <artifactId>modeshape-sequencer-mp3</artifactId>
                 <version>${project.version}</version>
             </dependency>
-            <!--
-            See MODE-1934
-
             <dependency>
                 <groupId>org.modeshape</groupId>
                 <artifactId>modeshape-sequencer-msoffice</artifactId>
                 <version>${project.version}</version>
             </dependency>
-            -->
             <dependency>
                 <groupId>org.modeshape</groupId>
                 <artifactId>modeshape-sequencer-sramp</artifactId>
@@ -1372,9 +1368,7 @@
                 <artifactId>jaudiotagger</artifactId>
                 <version>${jaudiotagger.version}</version>
             </dependency>
-            <!--MsOffice sequencer
-            See MODE-1934
-
+            <!--MsOffice sequencer-->
             <dependency>
                 <groupId>org.apache.poi</groupId>
                 <artifactId>poi</artifactId>
@@ -1385,7 +1379,20 @@
                 <artifactId>poi-scratchpad</artifactId>
                 <version>${poi.version}</version>
             </dependency>
-            -->
+            <!--
+                The following 2 POI dependencies are not used directly, but defined so that we use the same "beta" version
+                across the board (see https://issues.jboss.org/browse/MODE-1934).Tika-parsers brings these 2 transitively in
+             -->
+            <dependency>
+                <groupId>org.apache.poi</groupId>
+                <artifactId>poi-ooxml</artifactId>
+                <version>${poi.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.poi</groupId>
+                <artifactId>poi-ooxml-schemas</artifactId>
+                <version>${poi.version}</version>
+            </dependency>
             <!--Teiid sequencer-->
             <dependency>
                 <groupId>com.beust</groupId>
@@ -1440,23 +1447,6 @@
                 <artifactId>tika-parsers</artifactId>
                 <version>${tika.version}</version>
                 <exclusions>
-                    <!--See MODE-1934-->
-                    <exclusion>
-                        <groupId>org.apache.poi</groupId>
-                        <artifactId>poi</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>org.apache.poi</groupId>
-                        <artifactId>poi-scratchpad</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>org.apache.poi</groupId>
-                        <artifactId>poi-ooxml</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>org.apache.poi</groupId>
-                        <artifactId>poi-ooxml-schemas</artifactId>
-                    </exclusion>
                     <!--
                     The NetCDF and HDF files are often used in the scientific community, so we exclude this
                     library (and the Commons HTTP Client library) by default.

--- a/sequencers/pom.xml
+++ b/sequencers/pom.xml
@@ -82,10 +82,7 @@
     </dependencies>
 
     <modules>
-        <!--
-            See MODE-1934
-            <module>modeshape-sequencer-msoffice</module>
-        -->
+        <module>modeshape-sequencer-msoffice</module>
         <module>modeshape-sequencer-images</module>
         <module>modeshape-sequencer-java</module>
         <module>modeshape-sequencer-zip</module>


### PR DESCRIPTION
This presented an additional problem in that `poi-ooxml` and `poi-ooxml-schemas`, both transitive dependencies of `tika-parsers` remained at `3.8`. Therefore, they were explicitly added in the `<dependencyManagement>` section so that all POI artifacts have their version aligned.
