### PR TITLE
MODE-1991 OracleDdlLexicon contains unused type

### DIFF
--- a/sequencers/modeshape-sequencer-ddl/src/main/java/org/modeshape/sequencer/ddl/dialect/derby/DerbyDdlLexicon.java
+++ b/sequencers/modeshape-sequencer-ddl/src/main/java/org/modeshape/sequencer/ddl/dialect/derby/DerbyDdlLexicon.java
@@ -93,7 +93,6 @@ public class DerbyDdlLexicon extends StandardDdlLexicon {
     public static final String ORDER                              = PREFIX + ":order";
     public static final String TABLE_NAME                         = PREFIX + ":tableName";
     public static final String ROLE_NAME                          = PREFIX +  ":roleName";
-    public static final String GENERATED_COLUMN_SPEC_CLAUSE       = PREFIX + ":generatedColumnSpecClause";
     public static final String IS_TABLE_TYPE                      = PREFIX + ":isTableType";
     public static final String PARAMETER_STYLE                    = PREFIX + ":parameterStyle";
 }

--- a/sequencers/modeshape-sequencer-ddl/src/main/java/org/modeshape/sequencer/ddl/dialect/mysql/MySqlDdlLexicon.java
+++ b/sequencers/modeshape-sequencer-ddl/src/main/java/org/modeshape/sequencer/ddl/dialect/mysql/MySqlDdlLexicon.java
@@ -36,12 +36,10 @@ public class MySqlDdlLexicon  extends StandardDdlLexicon {
 
     // MIXINS
     
-    public static final String TYPE_CREATE_DATABASE_STATEMENT 		= Namespace.PREFIX + ":createDatabaseStatement";
     public static final String TYPE_CREATE_DEFINER_STATEMENT 			= Namespace.PREFIX + ":createDefinerStatement";
     public static final String TYPE_CREATE_EVENT_STATEMENT 			= Namespace.PREFIX + ":createEventStatement";
     public static final String TYPE_CREATE_FUNCTION_STATEMENT 		= Namespace.PREFIX + ":createFunctionStatement";
     public static final String TYPE_CREATE_INDEX_STATEMENT 			= Namespace.PREFIX + ":createIndexStatement";
-    public static final String TYPE_CREATE_LOGFILE_GROUP_STATEMENT 	= Namespace.PREFIX + ":createFunctionStatement";
     public static final String TYPE_CREATE_PROCEDURE_STATEMENT 		= Namespace.PREFIX + ":createProcedureStatement";
     public static final String TYPE_CREATE_SERVER_STATEMENT 			= Namespace.PREFIX + ":createFunctionStatement";
     public static final String TYPE_CREATE_TABLESPACE_STATEMENT 		= Namespace.PREFIX + ":createTablespaceStatement";
@@ -62,13 +60,11 @@ public class MySqlDdlLexicon  extends StandardDdlLexicon {
     public static final String TYPE_ALTER_DEFINER_STATEMENT		= Namespace.PREFIX + ":alterDefinerStatement";
     public static final String TYPE_ALTER_EVENT_STATEMENT			= Namespace.PREFIX + ":alterEventStatement";
     public static final String TYPE_ALTER_FUNCTION_STATEMENT 		= Namespace.PREFIX + ":alterFunctionStatement";
-    public static final String TYPE_ALTER_INDEX_STATEMENT 		= Namespace.PREFIX + ":alterIndexStatement";
     public static final String TYPE_ALTER_LOGFILE_GROUP_STATEMENT	= Namespace.PREFIX + ":alterLogfileGroupStatement";
     public static final String TYPE_ALTER_PROCEDURE_STATEMENT 	= Namespace.PREFIX + ":alterProcedureStatement";
     public static final String TYPE_ALTER_SERVER_STATEMENT		= Namespace.PREFIX + ":alterServerStatement";
     public static final String TYPE_ALTER_SCHEMA_STATEMENT		= Namespace.PREFIX + ":alterSchemaStatement";
     public static final String TYPE_ALTER_TABLESPACE_STATEMENT 	= Namespace.PREFIX + ":alterTablespaceStatement";
-    public static final String TYPE_ALTER_TRIGGER_STATEMENT 		= Namespace.PREFIX + ":alterTriggerStatement";
     public static final String TYPE_ALTER_VIEW_STATEMENT 			= Namespace.PREFIX + ":alterViewStatement";
     
     public static final String TYPE_RENAME_DATABASE_STATEMENT 	= Namespace.PREFIX + ":renameDatabaseStatement";

--- a/sequencers/modeshape-sequencer-ddl/src/main/java/org/modeshape/sequencer/ddl/dialect/oracle/OracleDdlLexicon.java
+++ b/sequencers/modeshape-sequencer-ddl/src/main/java/org/modeshape/sequencer/ddl/dialect/oracle/OracleDdlLexicon.java
@@ -47,7 +47,6 @@ public class OracleDdlLexicon extends StandardDdlLexicon {
     public static final String TYPE_CREATE_DISKGROUP_STATEMENT 		= PREFIX + ":createDiskgroupStatement";
     public static final String TYPE_CREATE_FUNCTION_STATEMENT 		= PREFIX + ":createFunctionStatement";
 
-    public static final String TYPE_CREATE_INDEX_STATEMENT          = PREFIX + ":createIndexStatement";
     public static final String TYPE_CREATE_CLUSTER_INDEX_STATEMENT  = PREFIX + ":createClusterIndexStatement";
     public static final String TYPE_CREATE_TABLE_INDEX_STATEMENT    = PREFIX + ":createTableIndexStatement";
     public static final String TYPE_CREATE_BITMAP_JOIN_INDEX_STATEMENT   = PREFIX + ":createBitmapIndexStatement";
@@ -103,13 +102,11 @@ public class OracleDdlLexicon extends StandardDdlLexicon {
     public static final String TYPE_ALTER_CLUSTER_STATEMENT 		= PREFIX + ":alterIndexStatement";
     public static final String TYPE_ALTER_DATABASE_STATEMENT		= PREFIX + ":alterDatabaseStatement";
     public static final String TYPE_ALTER_DIMENSION_STATEMENT 	= PREFIX + ":alterDimensionStatement";
-    public static final String TYPE_ALTER_DIRECTORY_STATEMENT 	= PREFIX + ":alterDirectoryStatement";
     public static final String TYPE_ALTER_DISKGROUP_STATEMENT 	= PREFIX + ":alterDiskgroupStatement";
     public static final String TYPE_ALTER_FUNCTION_STATEMENT 		= PREFIX + ":alterFunctionStatement";
     public static final String TYPE_ALTER_INDEX_STATEMENT 		= PREFIX + ":alterIndexStatement";
     public static final String TYPE_ALTER_INDEXTYPE_STATEMENT 	= PREFIX + ":alterIndextypeStatement";
     public static final String TYPE_ALTER_JAVA_STATEMENT 			= PREFIX + ":alterJavaStatement";
-    public static final String TYPE_ALTER_LIBRARY_STATEMENT 		= PREFIX + ":alterLibraryStatement";
     public static final String TYPE_ALTER_MATERIALIZED_STATEMENT 	= PREFIX + ":alterMaterializedStatement";
     public static final String TYPE_ALTER_OPERATOR_STATEMENT 		= PREFIX + ":alterOperatorStatement";
     public static final String TYPE_ALTER_OUTLINE_STATEMENT 		= PREFIX + ":alterOutlineStatement";
@@ -158,13 +155,10 @@ public class OracleDdlLexicon extends StandardDdlLexicon {
 
     // PROPERTY NAMES
     public static final String TARGET_OBJECT_TYPE = PREFIX + ":targetObjectType";
-    public static final String TARGET_OBJECT_NAME = PREFIX + ":targetObjectName";
     public static final String COMMENT            = PREFIX + ":comment";
     public static final String UNIQUE_INDEX       = PREFIX + ":unique";
     public static final String BITMAP_INDEX       = PREFIX + ":bitmap";
     public static final String TABLE_NAME         = PREFIX + ":tableName";
-    public static final String DEFAULT            = PREFIX + ":default";
-    public static final String DEFAULT_EXPRESSION = PREFIX + ":defaultExpression";
     public static final String IN_OUT_NO_COPY     = PREFIX + ":inOutNoCopy";
     public static final String AUTHID_VALUE       = PREFIX + ":authIdValue";
     public static final String INDEX_TYPE         = PREFIX + ":indexType";

--- a/sequencers/modeshape-sequencer-ddl/src/main/java/org/modeshape/sequencer/ddl/dialect/postgres/PostgresDdlLexicon.java
+++ b/sequencers/modeshape-sequencer-ddl/src/main/java/org/modeshape/sequencer/ddl/dialect/postgres/PostgresDdlLexicon.java
@@ -112,7 +112,6 @@ public class PostgresDdlLexicon  extends StandardDdlLexicon {
     public static final String TYPE_COPY_STATEMENT 					= Namespace.PREFIX + ":copyStatement";
     public static final String TYPE_DEALLOCATE_STATEMENT				= Namespace.PREFIX + ":deallocateStatement";
     public static final String TYPE_DECLARE_STATEMENT 				= Namespace.PREFIX + ":declareStatement";
-    public static final String TYPE_DISCARD_STATEMENT 				= Namespace.PREFIX + ":discardStatement";
     public static final String TYPE_EXPLAIN_STATEMENT 				= Namespace.PREFIX + ":explainStatement";
     public static final String TYPE_FETCH_STATEMENT 					= Namespace.PREFIX + ":fetchStatement";
     public static final String TYPE_LISTEN_STATEMENT 					= Namespace.PREFIX + ":listenStatement";
@@ -140,7 +139,6 @@ public class PostgresDdlLexicon  extends StandardDdlLexicon {
     public static final String TYPE_GRANT_ON_LANGUAGE_STATEMENT       = Namespace.PREFIX + ":grantOnLanguageStatement";
     public static final String TYPE_GRANT_ON_SCHEMA_STATEMENT         = Namespace.PREFIX + ":grantOnSchemaStatement";
     public static final String TYPE_GRANT_ON_TABLESPACE_STATEMENT     = Namespace.PREFIX + ":grantOnTablespaceStatement";
-    public static final String TYPE_GRANT_ON_PROCEDURE_STATEMENT      = Namespace.PREFIX + ":grantOnProcedureStatement";
     public static final String TYPE_GRANT_ROLES_STATEMENT             = Namespace.PREFIX + ":grantRolesStatement";
     
     public static final String TYPE_RENAME_COLUMN 					= Namespace.PREFIX + ":renamedColumn";

--- a/sequencers/modeshape-sequencer-ddl/src/main/resources/org/modeshape/sequencer/ddl/dialect/postgres/PostgresDdl.cnd
+++ b/sequencers/modeshape-sequencer-ddl/src/main/resources/org/modeshape/sequencer/ddl/dialect/postgres/PostgresDdl.cnd
@@ -169,7 +169,6 @@
 [postgresddl:copyStatement]             > ddl:statement mixin
 [postgresddl:deallocateStatement]       > ddl:statement mixin
 [postgresddl:declareStatement]          > ddl:statement mixin
-[postgresddl:discardStatement]          > ddl:statement mixin
 [postgresddl:explainStatement]          > ddl:statement mixin
 [postgresddl:fetchStatement]            > ddl:statement mixin
 [postgresddl:listenStatement]           > ddl:statement mixin


### PR DESCRIPTION
Removed the unused constant. Also removed unused constants in the other DDL lexicon classes.
