### PR TITLE
MODE-1995 Fixed the initial content import of nodes defined in namespaces that do not have a http-like URI

### DIFF
--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/InitialContentImporter.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/InitialContentImporter.java
@@ -147,7 +147,8 @@ public final class InitialContentImporter {
 
                 // create the new node
                 AbstractJcrNode newNode = null;
-                String newNodeRelativePath = nodePath.getLastSegment().getName().getString();
+                //make sure the path is not encoded, because that's how the node xml handler generates it
+                String newNodeRelativePath = nodePath.getLastSegment().getName().toString();
                 if (StringUtil.isBlank(element.getType())) {
                     newNode = parentNode.addNode(newNodeRelativePath);
                 } else {

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/xml/NodeImportXmlHandler.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/xml/NodeImportXmlHandler.java
@@ -315,27 +315,29 @@ public class NodeImportXmlHandler extends DefaultHandler2 {
             }
             if (typePropertyValue == null && attributeName.equalsIgnoreCase(typeAttribute)) {
                 typePropertyValue = createName(null, attributes.getValue(i)); // don't use a decoder
+                element.setType(typePropertyValue);
                 continue;
             }
             // Create a property for this attribute ...
             element.addProperty(attributeName, attributes.getValue(i));
         }
 
-        // Create the node name if required ...
+        // Create the default node name if no explicit name has been configured
         if (nodeName == null) {
             // No attribute defines the node name ...
             nodeName = createName(uri, localName);
             element.setName(nodeName);
-        } else if (typePropertyValue == null) {
-            typePropertyValue = createName(uri, localName);
         }
 
-        if (typeAttribute != null) {
-            // A attribute defines the node type. Set the type property, if required
-            if (typePropertyValue == null) {
-                typePropertyValue = typeAttributeValue;
+        //Create the default node type if no explicit type has been configured
+        if (typePropertyValue == null) {
+            if (typeAttributeValue != null) {
+                //there is a preconfigured type to use, so use that
+                element.setType(typeAttributeValue);
+            } else {
+                //there is no default value for the type, so use nt:unstructured
+                element.setType(JcrConstants.NT_UNSTRUCTURED);
             }
-            element.setType(typePropertyValue);
         }
     }
 

--- a/modeshape-jcr/src/test/java/org/modeshape/jcr/xml/NodeImportXmlHandlerTest.java
+++ b/modeshape-jcr/src/test/java/org/modeshape/jcr/xml/NodeImportXmlHandlerTest.java
@@ -231,17 +231,16 @@ public class NodeImportXmlHandlerTest {
         String typeAttributeValue = JcrConstants.NT_UNSTRUCTURED;
         handler = new NodeImportXmlHandler(parseDestination, nameAttribute, typeAttribute, typeAttributeValue, null);
         parse("xmlImport/docWithNamespaces.xml");
-        // Check the generated content; note that the attribute name doesn't match, so the nodes don't get special names
+        // Check the generated content; note that the attribute name DOES match
         String unstructPrimaryType = "jcr:primaryType=nt:unstructured";
-        String carPrimaryType = "jcr:primaryType={http://default.namespace.com}car";
         assertNode("c:Cars", unstructPrimaryType);
         assertNode("c:Cars/c:Hybrid", unstructPrimaryType);
-        assertNode("c:Cars/c:Hybrid/c:Toyota Prius", carPrimaryType, "c:maker=Toyota", "c:model=Prius");
-        assertNode("c:Cars/c:Hybrid/c:Toyota Highlander", carPrimaryType, "c:maker=Toyota", "c:model=Highlander");
-        assertNode("c:Cars/c:Hybrid/c:Nissan Altima", carPrimaryType, "c:maker=Nissan", "c:model=Altima");
+        assertNode("c:Cars/c:Hybrid/c:Toyota Prius", unstructPrimaryType, "c:maker=Toyota", "c:model=Prius");
+        assertNode("c:Cars/c:Hybrid/c:Toyota Highlander", unstructPrimaryType, "c:maker=Toyota", "c:model=Highlander");
+        assertNode("c:Cars/c:Hybrid/c:Nissan Altima", unstructPrimaryType, "c:maker=Nissan", "c:model=Altima");
         assertNode("c:Cars/c:Sports", unstructPrimaryType);
-        assertNode("c:Cars/c:Sports/c:Aston Martin DB9", carPrimaryType, "c:maker=Aston Martin", "c:model=DB9");
-        assertNode("c:Cars/c:Sports/c:Infiniti G37", carPrimaryType, "c:maker=Infiniti", "c:model=G37");
+        assertNode("c:Cars/c:Sports/c:Aston Martin DB9", unstructPrimaryType, "c:maker=Aston Martin", "c:model=DB9");
+        assertNode("c:Cars/c:Sports/c:Infiniti G37", unstructPrimaryType, "c:maker=Infiniti", "c:model=G37");
     }
 
     @Test

--- a/modeshape-jcr/src/test/resources/config/repo-config-initial-content-with-non-HTTP-namespaces.json
+++ b/modeshape-jcr/src/test/resources/config/repo-config-initial-content-with-non-HTTP-namespaces.json
@@ -1,0 +1,12 @@
+{
+    "name" : "Repository with initial content",
+    "workspaces" : {
+        "predefined" : ["ws1", "ws2"],
+        "default" : "default",
+        "allowCreation" : true,
+        "initialContent" : {
+            "default" : "xmlImport/docWithNonHTTPNamespaces.xml",
+            "*" : "xmlImport/docWithNonHTTPNamespaces.xml"
+        }
+    }
+}

--- a/modeshape-jcr/src/test/resources/xmlImport/docWithNonHTTPNamespaces.xml
+++ b/modeshape-jcr/src/test/resources/xmlImport/docWithNonHTTPNamespaces.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns="http://default.namespace.com" xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:test="info:test/ns/">
+    <test:Cars>
+        <test:Hybrid>
+            <test:car jcr:name="Toyota Prius" maker="Toyota" model="Prius"/>
+            <test:car jcr:name="Toyota Highlander" maker="Toyota" model="Highlander"/>
+            <test:car jcr:name="Nissan Altima" maker="Nissan" model="Altima"/>
+        </test:Hybrid>
+        <test:Sports>
+            <test:car jcr:name="Aston Martin DB9" maker="Aston Martin" model="DB9"/>
+            <test:car jcr:name="Infiniti G37" maker="Infiniti" model="G37"/>
+        </test:Sports>
+    </test:Cars>
+</jcr:root>


### PR DESCRIPTION
The problem was caused by the fact that when parsing the XML, new nodes are created & stored in a path-keyed map, but the path itself isn't encoded. However, when attempting to persist the new nodes via a session, the unencoded path was encoded using a default encoder. This meant that parent-child relationships were not recognized correctly. 

In addition, another inconsistency was fixed: when importing nodes which have their name explicitly specified via `jcr:name` instead of using the preconfigured node type (on the importer) or `nt:unstructured`, the actual XML name of the element was being set as the node type. This behavior was completely inconsistent with the other nodes (which didn't have the `jcr:name` attribute) for which either the preconfigured node type property or `nt:unstructured` was used.
