### PR TITLE
MODE-1788 Enhanced initial content import so that the string that separates multi from single value properties can be configured using the jcr:root element.

### DIFF
--- a/modeshape-jcr/src/test/resources/xmlImport/docWithMixinsCustomSeparator.xml
+++ b/modeshape-jcr/src/test/resources/xmlImport/docWithMixinsCustomSeparator.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:jcr="http://www.jcp.org/jcr/1.0" multi-value-separator=";">
+    <cars jcr:mixinTypes="mix:created; mix:lastModified"/>
+</jcr:root>

--- a/modeshape-jcr/src/test/resources/xmlImport/docWithPropertiesCustomSeparator.xml
+++ b/modeshape-jcr/src/test/resources/xmlImport/docWithPropertiesCustomSeparator.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:jcr="http://www.jcp.org/jcr/1.0" multi-value-separator=";">
+    <story title="Story with commas in the text lead and body text" lead="Lead text in attribute, split with a comma.">
+        <body>Body text in sub element, split by the comma.</body>
+        <multiBody>Body text in sub element; split by semicolon</multiBody>
+    </story>
+</jcr:root>


### PR DESCRIPTION
To specify another separator, one can add an additional attribute like so:

```
 <jcr:root xmlns:jcr="http://www.jcp.org/jcr/1.0" multi-value-separator=";">
```
