### PR TITLE
Schematic improvement to add ability to merge documents

### DIFF
--- a/modeshape-schematic/src/main/java/org/infinispan/schematic/document/EditableDocument.java
+++ b/modeshape-schematic/src/main/java/org/infinispan/schematic/document/EditableDocument.java
@@ -66,6 +66,60 @@ public interface EditableDocument extends Document {
     void putAll( Map<? extends String, ? extends Object> map );
 
     /**
+     * Merges the supplied document onto this document. This will set on this document each of the fields in the supplied
+     * document; nested documents in the supplied document will be merged recursively.
+     * <p>
+     * Consider the following example. If this document contains:
+     * 
+     * <pre>
+     * {
+     *   "firstName" : "Jane",
+     *   "lastName" : "Smith",
+     *   "address" : {
+     *     "street" : "Main Street",
+     *     "city" : "Springfield"
+     *   },
+     *   "phone" : "(800)555-1212"
+     * }
+     * </pre>
+     * 
+     * and another document 'other' contains:
+     * 
+     * <pre>
+     * {
+     *   "lastName" : "Doe",
+     *   "address" : {
+     *     "city" : "Memphis",
+     *     "zip" : 12345
+     *   },
+     *   "phone" : {
+     *     "home" : "(800)555-1212"
+     *   }
+     * }
+     * </pre>
+     * 
+     * then merging 'other' onto the first will result in the first being modified to contain:
+     * 
+     * <pre>
+     * {
+     *   "firstName" : "Jane",
+     *   "lastName" : "Doe",
+     *   "address" : {
+     *     "street" : "Main Street",
+     *     "city" : "Memphis",
+     *     "zip" : 12345
+     *   },
+     *   "phone" : {
+     *     "home" : "(800)555-1212"
+     *   }
+     * }
+     * </pre>
+     * 
+     * @param other the other document whose values should be merged
+     */
+    void merge( Document other );
+
+    /**
      * Set the value for the field with the given name to the supplied value.
      * 
      * @param name The name of the field

--- a/modeshape-schematic/src/main/java/org/infinispan/schematic/internal/document/ArrayEditor.java
+++ b/modeshape-schematic/src/main/java/org/infinispan/schematic/internal/document/ArrayEditor.java
@@ -136,6 +136,11 @@ public class ArrayEditor implements EditableArray {
     }
 
     @Override
+    public void merge( Document other ) {
+        array.putAll(other);
+    }
+
+    @Override
     public Object remove( String name ) {
         return array.remove(name);
     }

--- a/modeshape-schematic/src/main/java/org/infinispan/schematic/internal/document/DocumentEditor.java
+++ b/modeshape-schematic/src/main/java/org/infinispan/schematic/internal/document/DocumentEditor.java
@@ -146,6 +146,28 @@ public class DocumentEditor implements EditableDocument {
     }
 
     @Override
+    public void merge( Document other ) {
+        if (other == this) return;
+        for (Field field : other.fields()) {
+            Document otherDoc = field.getValueAsDocument();
+            if (!Null.matches(otherDoc)) {
+                // Get the corresponding value in this document ...
+                EditableDocument thisField = getDocument(field.getName());
+                if (!Null.matches(thisField)) {
+                    // There are docs in both sides, so merge them ...
+                    thisField.merge(otherDoc);
+                } else {
+                    // There is not a document on this side (perhaps another value), so replace with that other doc ...
+                    doSetValue(field.getName(), otherDoc);
+                }
+            } else {
+                // The field is something other than a document, so just set it on this document ...
+                doSetValue(field.getName(), field.getValue());
+            }
+        }
+    }
+
+    @Override
     public Object remove( String name ) {
         return document.remove(name);
     }

--- a/modeshape-schematic/src/test/java/org/infinispan/schematic/internal/document/DocumentEditorTest.java
+++ b/modeshape-schematic/src/test/java/org/infinispan/schematic/internal/document/DocumentEditorTest.java
@@ -1,0 +1,50 @@
+/*
+ * ModeShape (http://www.modeshape.org)
+ * See the COPYRIGHT.txt file distributed with this work for information
+ * regarding copyright ownership.  Some portions may be licensed
+ * to Red Hat, Inc. under one or more contributor license agreements.
+ * See the AUTHORS.txt file in the distribution for a full listing of 
+ * individual contributors.
+ *
+ * ModeShape is free software. Unless otherwise indicated, all code in ModeShape
+ * is licensed to you under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ * 
+ * ModeShape is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.infinispan.schematic.internal.document;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+import java.io.InputStream;
+import org.infinispan.schematic.document.Document;
+import org.infinispan.schematic.document.EditableDocument;
+import org.infinispan.schematic.document.Json;
+import org.junit.Test;
+
+public class DocumentEditorTest {
+
+    protected InputStream stream( String path ) {
+        return this.getClass().getClassLoader().getResourceAsStream(path);
+    }
+
+    @Test
+    public void shouldMergeTwoDocuments() throws Exception {
+        Document doc1 = Json.read(stream("json/merge-1.json"));
+        Document doc2 = Json.read(stream("json/merge-2.json"));
+        Document doc3 = Json.read(stream("json/merge-3.json"));
+        EditableDocument editor = new DocumentEditor((MutableDocument)doc1);
+        assertThat(Json.writePretty(editor).equals(Json.writePretty(doc3)), is(false));
+        editor.merge(doc2);
+        assertThat(Json.writePretty(editor).equals(Json.writePretty(doc3)), is(true));
+    }
+}

--- a/modeshape-schematic/src/test/resources/json/merge-1.json
+++ b/modeshape-schematic/src/test/resources/json/merge-1.json
@@ -1,0 +1,9 @@
+{
+  "firstName": "Jane",
+  "lastName": "Smith",
+  "address": {
+    "street": "Main Street",
+    "city": "Springfield"
+  },
+  "phone": "(800)555-1212"
+}

--- a/modeshape-schematic/src/test/resources/json/merge-2.json
+++ b/modeshape-schematic/src/test/resources/json/merge-2.json
@@ -1,0 +1,10 @@
+{
+  "lastName": "Doe",
+  "address": {
+    "city": "Memphis",
+    "zip": 12345
+  },
+  "phone": {
+    "home": "(800)555-1212"
+  }
+}

--- a/modeshape-schematic/src/test/resources/json/merge-3.json
+++ b/modeshape-schematic/src/test/resources/json/merge-3.json
@@ -1,0 +1,12 @@
+{
+  "firstName": "Jane",
+  "lastName": "Doe",
+  "address": {
+    "street": "Main Street",
+    "city": "Memphis",
+    "zip": 12345
+  },
+  "phone": {
+    "home": "(800)555-1212"
+  }
+}


### PR DESCRIPTION
Added the ability to merge one document onto another, where nested documents are merged properly. (This differs from `putAll(Document)`, which just operates on the top-level fields.)
