### PR TITLE
MODE-2006 reworked "doUpdate" part of Merge operation

### DIFF
--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/AbstractJcrNode.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/AbstractJcrNode.java
@@ -3121,6 +3121,10 @@ abstract class AbstractJcrNode extends AbstractJcrItem implements Node {
 
     @Override
     public void removeShare() throws VersionException, LockException, ConstraintViolationException, RepositoryException {
+        internalRemove(false);
+    }
+
+    void internalRemove(boolean skipVersioningValidation) throws VersionException, LockException, ConstraintViolationException, RepositoryException {
         checkSession();
 
         // A node that is locked by one session can be removed by another session as long as there is no lock
@@ -3148,7 +3152,7 @@ abstract class AbstractJcrNode extends AbstractJcrItem implements Node {
             throw new InvalidItemStateException(e);
         }
 
-        if (!parent.isCheckedOut()) {
+        if (!skipVersioningValidation && !parent.isCheckedOut()) {
             // The parent node is checked in, so we can only remove this node if this node has an OPV of 'ignore'.
             // This is probably rarely the case, so the extra work is acceptable
             // See Section 15.2.2 of JSR-283 spec for details ...

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrWorkspace.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrWorkspace.java
@@ -300,6 +300,16 @@ class JcrWorkspace implements org.modeshape.jcr.api.Workspace {
                        boolean removeExisting )
         throws NoSuchWorkspaceException, ConstraintViolationException, VersionException, AccessDeniedException,
         PathNotFoundException, ItemExistsException, LockException, RepositoryException {
+        internalClone(srcWorkspace, srcAbsPath, destAbsPath, removeExisting, false);
+    }
+
+    void internalClone( String srcWorkspace,
+                        String srcAbsPath,
+                        String destAbsPath,
+                        boolean removeExisting,
+                        boolean skipVersioningValidation)
+        throws NoSuchWorkspaceException, ConstraintViolationException, VersionException, AccessDeniedException,
+        PathNotFoundException, ItemExistsException, LockException, RepositoryException {
         CheckArg.isNotEmpty(srcAbsPath, "srcAbsPath");
         CheckArg.isNotEmpty(destAbsPath, "destAbsPath");
 
@@ -461,7 +471,7 @@ class JcrWorkspace implements org.modeshape.jcr.api.Workspace {
                 if (!destPath.isRoot()) {
                     // Use the JCR add child here to perform the parent validations
                     cloneKey = parentNode.key().withId(sourceNode.key().getIdentifier());
-                    parentNode.addChildNode(newNodeName, sourceNode.getPrimaryTypeName(), cloneKey, false, false);
+                    parentNode.addChildNode(newNodeName, sourceNode.getPrimaryTypeName(), cloneKey, skipVersioningValidation, false);
                 } else {
                     cloneKey = parentNode.key();
                 }


### PR DESCRIPTION
- doUpdate now finds correcsponding nodes by correspondingNodeForPath() which
  is based on UUIDs, instead of by name
- nodes to be removed are now removed by a new package-private internalRemove()
  that skips versioning check
- nodes to be added are now cloned instead of copied; cloning is done by a new
  package-private internalClone() that skips versioning check

Also, added a corresponding test case.
