### PR TITLE
MODE-1989 - Implemented JMX support for exposing repository statistics information

### DIFF
--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrI18n.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrI18n.java
@@ -505,6 +505,10 @@ public final class JcrI18n {
     public static I18n completeChildrenOptimization;
     public static I18n errorDuringChildrenOptimization;
 
+    public static I18n mBeanAlreadyRegistered;
+    public static I18n cannotRegisterMBean;
+    public static I18n cannotUnRegisterMBean;
+
     static {
         try {
             I18n.initialize(JcrI18n.class);

--- a/modeshape-jcr/src/main/java/org/modeshape/jmx/Details.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jmx/Details.java
@@ -1,0 +1,22 @@
+package org.modeshape.jmx;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import javax.management.DescriptorKey;
+
+/**
+ * Annotation which adds JMX additional information via {@link DescriptorKey} to any MBean, method or parameter. This additional
+ * information may be exposed by JMX clients, allowing better interaction with the MBean(s).
+ *
+ * @author Horia Chiorean (hchiorea@redhat.com)
+ */
+@Documented
+@Target( {ElementType.TYPE, ElementType.PARAMETER, ElementType.METHOD})
+@Retention( RetentionPolicy.RUNTIME)
+public @interface Details {
+    @DescriptorKey("details")
+    String value();
+}

--- a/modeshape-jcr/src/main/java/org/modeshape/jmx/DurationData.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jmx/DurationData.java
@@ -1,0 +1,40 @@
+package org.modeshape.jmx;
+
+import java.beans.ConstructorProperties;
+import java.util.Map;
+
+/**
+ * Values holder which exposes {@link org.modeshape.jcr.api.monitor.DurationActivity} to JMX.
+ *
+ * @author Horia Chiorean (hchiorea@redhat.com)
+ */
+public class DurationData {
+
+    private final long durationSeconds;
+    private final Map<String,String> additionalInformation;
+
+    /**
+     * @param durationSeconds the duration value, in seconds.
+     * @param additionalInformation a custom map of additional information
+     */
+    @ConstructorProperties({"durationSeconds", "payload"})
+    public DurationData( long durationSeconds,
+                         Map<String,String> additionalInformation ) {
+        this.durationSeconds = durationSeconds;
+        this.additionalInformation = additionalInformation;
+    }
+
+    /**
+     * @return the duration; in seconds
+     */
+    public long getDurationSeconds() {
+        return durationSeconds;
+    }
+
+    /**
+     * @return a Map of additional information; may be empty but never null.
+     */
+    public Map<String, String> getAdditionalInformation() {
+        return additionalInformation;
+    }
+}

--- a/modeshape-jcr/src/main/java/org/modeshape/jmx/EnumDescription.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jmx/EnumDescription.java
@@ -1,0 +1,60 @@
+/*
+ * ModeShape (http://www.modeshape.org)
+ * See the COPYRIGHT.txt file distributed with this work for information
+ * regarding copyright ownership.  Some portions may be licensed
+ * to Red Hat, Inc. under one or more contributor license agreements.
+ * See the AUTHORS.txt file in the distribution for a full listing of
+ * individual contributors.
+ *
+ * ModeShape is free software. Unless otherwise indicated, all code in ModeShape
+ * is licensed to you under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * ModeShape is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.modeshape.jmx;
+
+/**
+ * Value holder used by the JMX MBean to expose information about enums.
+ *
+ * @author Horia Chiorean (hchiorea@redhat.com)
+ */
+public class EnumDescription {
+
+    private final String name;
+    private final String description;
+
+    /**
+     * @param name the name of the enum (as result of {@link Enum#name()}
+     * @param description an additional description for the enum.
+     */
+    public EnumDescription( String name,
+                            String description ) {
+        this.name = name;
+        this.description = description;
+    }
+
+    /**
+     * @return the enum name
+     */
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * @return the enum description which better explains the enum
+     */
+    public String getDescription() {
+        return description;
+    }
+}

--- a/modeshape-jcr/src/main/java/org/modeshape/jmx/HistoricalData.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jmx/HistoricalData.java
@@ -1,0 +1,62 @@
+package org.modeshape.jmx;
+
+import java.beans.ConstructorProperties;
+import java.util.List;
+
+/**
+ * Value holder for the JXM-exposed information based on {@link org.modeshape.jcr.api.monitor.History} instances.
+ *
+ * @author Horia Chiorean (hchiorea@redhat.com)
+ */
+public class HistoricalData {
+
+    private final String timeWindow;
+    private final String start;
+    private final String end;
+    private final List<StatisticalData> statisticalData;
+
+    /**
+     * @param timeWindow the name of the time windows for which the data is produced.
+     * @param start the ISO-8601 format of the start time
+     * @param end the ISO-8601 format of the end time
+     * @param statisticalData a list of {@link StatisticalData} for the interval
+     */
+    @ConstructorProperties({"timeWindow", "start", "end", "statisticalData"})
+    public HistoricalData( String timeWindow,
+                           String start,
+                           String end,
+                           List<StatisticalData> statisticalData ) {
+        this.timeWindow = timeWindow;
+        this.start = start;
+        this.end = end;
+        this.statisticalData = statisticalData;
+    }
+
+    /**
+     * @return the name of the time windows for which the data is produced.
+     */
+    public String getTimeWindow() {
+        return timeWindow;
+    }
+
+    /**
+     * @return the ISO-8601 format of the start time
+     */
+    public String getStart() {
+        return start;
+    }
+
+    /**
+     * @return the ISO-8601 format of the end time
+     */
+    public String getEnd() {
+        return end;
+    }
+
+    /**
+     * @return the list of {@link StatisticalData} which make up this data; never null but possibly empty.
+     */
+    public List<StatisticalData> getStatisticalData() {
+        return statisticalData;
+    }
+}

--- a/modeshape-jcr/src/main/java/org/modeshape/jmx/RepositoryStatisticsBean.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jmx/RepositoryStatisticsBean.java
@@ -1,0 +1,161 @@
+package org.modeshape.jmx;
+
+import java.lang.management.ManagementFactory;
+import java.util.ArrayList;
+import java.util.Hashtable;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import javax.jcr.RepositoryException;
+import javax.management.InstanceAlreadyExistsException;
+import javax.management.InstanceNotFoundException;
+import javax.management.MBeanException;
+import javax.management.MBeanServer;
+import javax.management.MalformedObjectNameException;
+import javax.management.ObjectName;
+import org.modeshape.common.logging.Logger;
+import org.modeshape.jcr.JcrI18n;
+import org.modeshape.jcr.api.monitor.DurationActivity;
+import org.modeshape.jcr.api.monitor.DurationMetric;
+import org.modeshape.jcr.api.monitor.History;
+import org.modeshape.jcr.api.monitor.RepositoryMonitor;
+import org.modeshape.jcr.api.monitor.Statistics;
+import org.modeshape.jcr.api.monitor.ValueMetric;
+import org.modeshape.jcr.api.monitor.Window;
+
+/**
+ * MXBean implementation of {@link RepositoryStatisticsMXBean}.
+ *
+ * @author Horia Chiorean (hchiorea@redhat.com)
+ */
+public class RepositoryStatisticsBean implements RepositoryStatisticsMXBean {
+
+    private static final Logger LOGGER = Logger.getLogger(RepositoryStatisticsBean.class);
+
+    private final RepositoryMonitor monitor;
+    private final String repositoryName;
+
+    /**
+     * @param monitor an active {@link RepositoryMonitor} instance which will be used for getting repository statistics
+     * @param repositoryName a non-null String, the name of the repository.
+     */
+    public RepositoryStatisticsBean( RepositoryMonitor monitor,
+                                     String repositoryName ) {
+        this.monitor = monitor;
+        this.repositoryName = repositoryName;
+    }
+
+    /**
+     * Initializes & registers this MBean with the local MBean server.
+     */
+    public void start() {
+        ObjectName beanName = null;
+        try {
+            MBeanServer server = ManagementFactory.getPlatformMBeanServer();
+            beanName = getObjectName();
+            server.registerMBean(this, beanName);
+        } catch (InstanceAlreadyExistsException e) {
+            LOGGER.warn(JcrI18n.mBeanAlreadyRegistered, beanName);
+        } catch (Exception e) {
+           LOGGER.error(e, JcrI18n.cannotRegisterMBean, beanName);
+        }
+    }
+
+    /**
+     * Un-registers the bean from the JMX server.
+     */
+    public void stop() {
+        MBeanServer server = ManagementFactory.getPlatformMBeanServer();
+        ObjectName beanName = null;
+        try {
+            beanName = getObjectName();
+            server.unregisterMBean(beanName);
+        } catch (InstanceNotFoundException e) {
+            LOGGER.warn(JcrI18n.mBeanAlreadyRegistered, beanName);
+        } catch (Exception e) {
+            LOGGER.error(e, JcrI18n.cannotUnRegisterMBean, beanName);
+        }
+    }
+
+    private ObjectName getObjectName() throws MalformedObjectNameException {
+        Hashtable<String, String> props = new Hashtable<String, String>();
+        props.put("name", repositoryName);
+        props.put("type", "RepositoryStatistics");
+        return new ObjectName("org.modeshape", props);
+    }
+
+    @Override
+    public List<EnumDescription> getValueMetrics() {
+        List<EnumDescription> result = new ArrayList<EnumDescription>();
+        for (ValueMetric metric : RepositoryMonitor.ALL_VALUE_METRICS) {
+            result.add(new EnumDescription(metric.name(), metric.getDescription()));
+        }
+        return result;
+    }
+
+    @Override
+    public List<EnumDescription> getDurationMetrics() {
+        List<EnumDescription> result = new ArrayList<EnumDescription>();
+        for (DurationMetric metric : RepositoryMonitor.ALL_DURATION_METRICS) {
+            result.add(new EnumDescription(metric.name(), metric.getDescription()));
+        }
+        return result;
+    }
+
+    @Override
+    public List<EnumDescription> getTimeWindows() {
+        List<EnumDescription> result = new ArrayList<EnumDescription>();
+        for (Window window : RepositoryMonitor.ALL_WINDOWS) {
+            result.add(new EnumDescription(window.name(), window.getLiteral()));
+        }
+        return result;
+    }
+
+    @Override
+    public HistoricalData getValues( ValueMetric metric,
+                                     Window windowInTime ) throws MBeanException {
+        try {
+            History history = monitor.getHistory(metric, windowInTime);
+            return historyToHistoricalData(history);
+        } catch (RepositoryException e) {
+            throw new MBeanException(e);
+        }
+    }
+
+    @Override
+    public HistoricalData getDurations( DurationMetric metric,
+                                        Window windowInTime ) throws MBeanException {
+        try {
+            History history = monitor.getHistory(metric, windowInTime);
+            return historyToHistoricalData(history);
+        } catch (RepositoryException e) {
+            throw new MBeanException(e);
+        }
+    }
+
+    private HistoricalData historyToHistoricalData( History history ) {
+        List<StatisticalData> statisticalData = new ArrayList<StatisticalData>();
+        for (Statistics statistics : history.getStats()) {
+            if (statistics != null) {
+                statisticalData.add(new StatisticalData(statistics.getCount(), statistics.getMaximum(), statistics.getMinimum(),
+                                                        statistics.getMean(), statistics.getVariance()));
+            }
+        }
+        return new HistoricalData(history.getWindow().getLiteral(),
+                                  history.getStartTime().getString(),
+                                  history.getEndTime().getString(),
+                                  statisticalData);
+    }
+
+    @Override
+    public List<DurationData> getLongestRunning( DurationMetric metric ) throws MBeanException {
+        List<DurationData> longestRunning = new ArrayList<DurationData>();
+        try {
+            for (DurationActivity durationActivity : monitor.getLongestRunning(metric)) {
+                longestRunning.add(new DurationData(durationActivity.getDuration(TimeUnit.SECONDS), durationActivity.getPayload()));
+            }
+            return longestRunning;
+        } catch (RepositoryException e) {
+            throw new MBeanException(e);
+        }
+    }
+}

--- a/modeshape-jcr/src/main/java/org/modeshape/jmx/RepositoryStatisticsMXBean.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jmx/RepositoryStatisticsMXBean.java
@@ -1,0 +1,88 @@
+package org.modeshape.jmx;
+
+import java.util.List;
+import javax.management.MBeanException;
+import javax.management.MXBean;
+import org.modeshape.jcr.api.monitor.DurationMetric;
+import org.modeshape.jcr.api.monitor.ValueMetric;
+import org.modeshape.jcr.api.monitor.Window;
+
+/**
+ * JXM MXBean interface which exposes various monitoring information for a running repository. The information exposed by this
+ * interface is obtained via the active {@link org.modeshape.jcr.api.monitor.RepositoryMonitor} instance.
+ *
+ * @author Horia Chiorean (hchiorea@redhat.com)
+ */
+@MXBean
+@Details("JMX MXBean which exposes various repository metrics")
+public interface RepositoryStatisticsMXBean {
+
+    /**
+     * Get the {@link ValueMetric} enumerations that are available for use by the caller with
+     * {@link #getValues(org.modeshape.jcr.api.monitor.ValueMetric, org.modeshape.jcr.api.monitor.Window)}.
+     *
+     * @return a [name, description] map of available value metrics; never null
+     * @see org.modeshape.jcr.api.monitor.RepositoryMonitor#getAvailableValueMetrics()
+     */
+    @Details("A list of enums which represent the available value metrics that should be used as parameters for the getValues operation")
+    List<EnumDescription> getValueMetrics();
+
+    /**
+     * Get the {@link DurationMetric} enumerations that are available for use by the caller with
+     * {@link #getDurations(org.modeshape.jcr.api.monitor.DurationMetric, org.modeshape.jcr.api.monitor.Window)}.
+     *
+     * @return a [name, description] map of available duration metrics; never null
+     * @see org.modeshape.jcr.api.monitor.RepositoryMonitor#getAvailableDurationMetrics()
+     */
+    @Details("A list of enums which represent the available duration metrics that should be used as parameters for the getDurations and getLongestRunning operations")
+    List<EnumDescription> getDurationMetrics();
+
+    /**
+     * Get the {@link Window} enumerations that are available for use by the caller with
+     * {@link #getValues(org.modeshape.jcr.api.monitor.ValueMetric, org.modeshape.jcr.api.monitor.Window)} and
+     * {@link #getDurations(org.modeshape.jcr.api.monitor.DurationMetric, org.modeshape.jcr.api.monitor.Window)}.
+     *
+     * @return a [name, description] map of available time windows; never null
+     * @see org.modeshape.jcr.api.monitor.RepositoryMonitor#getAvailableWindows()
+     */
+    @Details("A list of enums which represent the available time intervals that should be used as operation parameters")
+    List<EnumDescription> getTimeWindows();
+
+    /**
+     * Get the statistics for the specified value metric during the given window in time.
+     *
+     * @param metric the value metric; may not be null
+     * @param windowInTime the window specifying which statistics are to be returned; may not be null
+     * @return the statistical data; never null
+     * @see org.modeshape.jcr.api.monitor.RepositoryMonitor#getHistory(org.modeshape.jcr.api.monitor.ValueMetric, org.modeshape.jcr.api.monitor.Window)
+     * @throws javax.management.MBeanException if anything unexpected fails while performing the operation.
+     */
+    @Details("Returns the values of a certain type in a given period of time")
+    public HistoricalData getValues( @Details("The value metric enum name (see the ValueMetrics)") ValueMetric metric,
+                                     @Details("The time window enum name  (see the TimeWindows)") Window windowInTime ) throws MBeanException;
+
+    /**
+     * Get the statics for the specified duration metric during the given window in time.
+     *
+     * @param metric the duration metric; may not be null
+     * @param windowInTime the window specifying which statistics are to be returned; may not be null
+     * @return the statistical data; never null
+     * @see org.modeshape.jcr.api.monitor.RepositoryMonitor#getHistory(org.modeshape.jcr.api.monitor.DurationMetric, org.modeshape.jcr.api.monitor.Window)
+     * @throws javax.management.MBeanException if anything unexpected fails while performing the operation.
+     */
+    @Details("Returns the values for a duration type in a period of time")
+    public HistoricalData getDurations( @Details("The duration metric enum name (see the DurationMetrics)")DurationMetric metric,
+                                        @Details("The time window enum name (see the TimeWindows)") Window windowInTime ) throws MBeanException;
+
+    /**
+     * Get the longest-running activities recorded for the specified metric. The results contain the duration records in order of
+     * increasing duration, with the activity with the longest duration appearing last in the list.
+     *
+     * @param metric the duration metric; may not be null
+     * @return the longest duration data; never null but possibly empty if no such activities were performed
+     * @see org.modeshape.jcr.api.monitor.RepositoryMonitor#getLongestRunning(org.modeshape.jcr.api.monitor.DurationMetric)
+     * @throws javax.management.MBeanException if anything unexpected fails while performing the operation.
+     */
+    @Details("Returns the longest running time of a duration type (e.g. longest running session)")
+    public List<DurationData> getLongestRunning(@Details("The duration metric enum name  (see the DurationMetrics)") DurationMetric metric ) throws MBeanException;
+}

--- a/modeshape-jcr/src/main/java/org/modeshape/jmx/StatisticalData.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jmx/StatisticalData.java
@@ -1,0 +1,68 @@
+package org.modeshape.jmx;
+
+import java.beans.ConstructorProperties;
+import org.modeshape.jcr.api.monitor.Statistics;
+
+/**
+ * Value holder exposed by JXM which provides statistical information via {@link Statistics}
+ *
+ * @author Horia Chiorean (hchiorea@redhat.com)
+ */
+public class StatisticalData implements Statistics {
+    private final int count;
+    private final long maximum;
+    private final long minimum;
+    private final double mean;
+    private final double variance;
+
+
+    /**
+     * @param count number of elements in the sample
+     * @param maximum max value from the sample
+     * @param minimum min value from the sample
+     * @param mean sample mean
+     * @param variance sample variance
+     */
+    @ConstructorProperties({"count", "maximum", "minimum", "mean", "variance"})
+    public StatisticalData( int count,
+                            long maximum,
+                            long minimum,
+                            double mean,
+                            double variance ) {
+        this.count = count;
+        this.maximum = maximum;
+        this.minimum = minimum;
+        this.mean = mean;
+        this.variance = variance;
+    }
+
+    @Override
+    public int getCount() {
+        return count;
+    }
+
+    @Override
+    public long getMaximum() {
+        return maximum;
+    }
+
+    @Override
+    public long getMinimum() {
+        return minimum;
+    }
+
+    @Override
+    public double getMean() {
+        return mean;
+    }
+
+    @Override
+    public double getVariance() {
+        return variance;
+    }
+
+    @Override
+    public double getStandardDeviation() {
+        return variance <= 0.0d ? 0.0d : Math.sqrt(variance);
+    }
+}

--- a/modeshape-jcr/src/main/resources/org/modeshape/jcr/JcrI18n.properties
+++ b/modeshape-jcr/src/main/resources/org/modeshape/jcr/JcrI18n.properties
@@ -488,3 +488,6 @@ beginChildrenOptimization = Beginning background optimization of children in the
 completeChildrenOptimization = Completed background optimization of children in the '{0}' repository ({1} duration): {2}
 errorDuringChildrenOptimization = Error during background optimization of children in the '{0}' repository ({1} duration before error): {2}
 
+mBeanAlreadyRegistered = JMX bean "{0}" has already been registered
+cannotRegisterMBean = Cannot register MBean "{0}"
+cannotUnRegisterMBean = Cannot un-register MBean "{0}"

--- a/modeshape-jcr/src/test/java/org/modeshape/jmx/RepositoryStatisticsMXBeanTest.java
+++ b/modeshape-jcr/src/test/java/org/modeshape/jmx/RepositoryStatisticsMXBeanTest.java
@@ -1,0 +1,113 @@
+/*
+ * ModeShape (http://www.modeshape.org)
+ * See the COPYRIGHT.txt file distributed with this work for information
+ * regarding copyright ownership.  Some portions may be licensed
+ * to Red Hat, Inc. under one or more contributor license agreements.
+ * See the AUTHORS.txt file in the distribution for a full listing of
+ * individual contributors.
+ *
+ * ModeShape is free software. Unless otherwise indicated, all code in ModeShape
+ * is licensed to you under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * ModeShape is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.modeshape.jmx;
+
+import java.lang.management.ManagementFactory;
+import javax.management.MBeanInfo;
+import javax.management.MBeanServer;
+import javax.management.ObjectName;
+import javax.management.openmbean.CompositeData;
+import org.junit.Test;
+import org.modeshape.jcr.SingleUseAbstractTest;
+import org.modeshape.jcr.api.monitor.DurationMetric;
+import org.modeshape.jcr.api.monitor.RepositoryMonitor;
+import org.modeshape.jcr.api.monitor.ValueMetric;
+import org.modeshape.jcr.api.monitor.Window;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Unit test for {@link RepositoryStatisticsMXBean}
+ *
+ * @author Horia Chiorean (hchiorea@redhat.com)
+ */
+public class RepositoryStatisticsMXBeanTest extends SingleUseAbstractTest {
+
+    private static final MBeanServer SERVER = ManagementFactory.getPlatformMBeanServer();
+
+    private ObjectName mBeanName;
+
+    @Override
+    public void beforeEach() throws Exception {
+        super.beforeEach();
+        mBeanName = new ObjectName("org.modeshape:type=RepositoryStatistics,name=" + REPO_NAME);
+    }
+
+    @Test
+    public void shouldRetrieveMBeanInfo() throws Exception {
+        MBeanInfo mBeanInfo = SERVER.getMBeanInfo(mBeanName);
+
+        assertNotNull(mBeanInfo);
+        assertEquals(3, mBeanInfo.getAttributes().length);
+        assertEquals(3, mBeanInfo.getOperations().length);
+    }
+
+    @Test
+    public void shouldRetrieveAttributes() throws Exception {
+        CompositeData[] valueMetrics =  (CompositeData[])SERVER.getAttribute(mBeanName, "ValueMetrics");
+        assertEquals(valueMetrics.length, RepositoryMonitor.ALL_VALUE_METRICS.size());
+
+        CompositeData[] durationMetrics =  (CompositeData[])SERVER.getAttribute(mBeanName, "DurationMetrics");
+        assertEquals(durationMetrics.length, RepositoryMonitor.ALL_DURATION_METRICS.size());
+
+        CompositeData[] windows =  (CompositeData[])SERVER.getAttribute(mBeanName, "TimeWindows");
+        assertEquals(windows.length, RepositoryMonitor.ALL_WINDOWS.size());
+    }
+
+    @Test
+    public void shouldRetrieveValueMetrics() throws Exception {
+        Object[] arguments = new Object[] { ValueMetric.SESSION_COUNT.name(), Window.PREVIOUS_60_SECONDS.name()};
+        String[] signature = new String[] {String.class.getName(), String.class.getName()};
+        Object result = SERVER.invoke(mBeanName, "getValues", arguments, signature);
+        assertHistoricalData(result);
+    }
+
+    @Test
+    public void shouldRetrieveDurationMetrics() throws Exception {
+        Object[] arguments = new Object[] { DurationMetric.SESSION_LIFETIME.name(), Window.PREVIOUS_60_SECONDS.name()};
+        String[] signature = new String[] {String.class.getName(), String.class.getName()};
+        Object result = SERVER.invoke(mBeanName, "getDurations", arguments, signature);
+        assertHistoricalData(result);
+    }
+
+    @Test
+    public void shouldRetrieveLongestRunningDuration() throws Exception {
+        Object[] arguments = new Object[] { DurationMetric.SESSION_LIFETIME.name()};
+        String[] signature = new String[] {String.class.getName()};
+        Object result = SERVER.invoke(mBeanName, "getLongestRunning", arguments, signature);
+        assertNotNull(result);
+        assertTrue(result instanceof CompositeData[]);
+    }
+
+    private void assertHistoricalData( Object result ) {
+        assertNotNull(result);
+        CompositeData data = (CompositeData) result;
+        assertTrue(data.containsKey("timeWindow"));
+        assertTrue(data.containsKey("start"));
+        assertTrue(data.containsKey("end"));
+        assertTrue(data.containsKey("statisticalData"));
+    }
+}

--- a/modeshape-parent/pom.xml
+++ b/modeshape-parent/pom.xml
@@ -338,15 +338,6 @@
         <jboss-as-arquillian-container-managed.version>7.2.0.Final</jboss-as-arquillian-container-managed.version>
 
         <!--
-            RHQ
-        -->
-        <!--
-        <org.jboss.rhq.as5.version>1.2.0.GA</org.jboss.rhq.as5.version>
-        <org.rhq.version>1.3.0.GA</org.rhq.version>
-        <rhq.jboss.as5.plugin.version>1.4.0.B01</rhq.jboss.as5.plugin.version>
-        -->
-
-        <!--
           Maven plugin versions
           -->
         <cargo.container>jetty7x</cargo.container>


### PR DESCRIPTION
The support was implemented in the form of an MXBean which wraps the existing `RepositoryStatistics` instance and which exposes pretty much the same information in a JMX-friendly fashion.
