### PR TITLE
MODE-2009 Fixed the workspace.delete() operation 

### DIFF
--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrVersionHistoryNode.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrVersionHistoryNode.java
@@ -107,6 +107,9 @@ final class JcrVersionHistoryNode extends JcrSystemNode implements VersionHistor
     public JcrVersionNode getVersionByLabel( String label ) throws VersionException, RepositoryException {
         try {
             javax.jcr.Property prop = versionLabels().getProperty(nameFrom(label));
+            if (prop == null) {
+                throw new VersionException(JcrI18n.labeledNodeNotFound.text(label, getPath()));
+            }
             return (JcrVersionNode)prop.getNode();
         } catch (PathNotFoundException e) {
             throw new VersionException(JcrI18n.invalidVersionLabel.text(label, getPath()));

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrVersionManager.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrVersionManager.java
@@ -1613,7 +1613,7 @@ final class JcrVersionManager implements VersionManager {
 
             for (int i = versionDates.size() - 1; i >= 0; i--) {
                 DateTime versionDate = versionDates.get(i);
-                if (versionDate.isBefore(checkinTime) || versionDate.isSameAs(checkinTime)) {
+                if (versionDate.isBefore(checkinTime)) {
                     Version version = versions.get(versionDate);
                     return ((JcrVersionNode)version).getFrozenNode();
                 }

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/document/DocumentTranslator.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/document/DocumentTranslator.java
@@ -179,9 +179,7 @@ public class DocumentTranslator implements DocumentConstants {
         return keyFrom(value, primaryWorkspaceKey, secondaryWorkspaceKey);
     }
 
-    public Set<NodeKey> getParentKeys( Document document,
-                                       String primaryWorkspaceKey,
-                                       String secondaryWorkspaceKey ) {
+    public Set<NodeKey> getAdditionalParentKeys( Document document ) {
         Object value = document.get(PARENT);
         if (value instanceof String) {
             // The first key is the primary parent, so there are no more additional parents ...
@@ -203,11 +201,7 @@ public class DocumentTranslator implements DocumentConstants {
                     continue;
                 }
                 String key = (String)v;
-                NodeKey nodeKey = new NodeKey(key);
-                String workspaceKey = nodeKey.getWorkspaceKey();
-                if (workspaceKey.equals(primaryWorkspaceKey) || workspaceKey.equals(secondaryWorkspaceKey)) {
-                    keys.add(nodeKey);
-                }
+                keys.add(new NodeKey(key));
             }
             return keys;
         }

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/document/LazyCachedNode.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/document/LazyCachedNode.java
@@ -125,9 +125,7 @@ public class LazyCachedNode implements CachedNode, Serializable {
     public Set<NodeKey> getAdditionalParentKeys( NodeCache cache ) {
         if (additionalParents == null) {
             WorkspaceCache wsCache = workspaceCache(cache);
-            Set<NodeKey> additionalParents = wsCache.translator().getParentKeys(document(wsCache),
-                                                                                wsCache.getWorkspaceKey(),
-                                                                                key.getWorkspaceKey());
+            Set<NodeKey> additionalParents = wsCache.translator().getAdditionalParentKeys(document(wsCache));
             this.additionalParents = additionalParents.isEmpty() ? additionalParents : Collections.unmodifiableSet(additionalParents);
         }
         return additionalParents;


### PR DESCRIPTION
The fix is made up of
a) checking of WORKSPACE_DELETE permissions 
b) making sure the workspace is actually cleared and all nodes removed. 

This last part was extremely tricky to implement because we need to be sure that everything is done atomically. It also exposed an additional problem regarding the retrieval of all the additional parents of a node.
