### PR TITLE
MODE-2034 Fixed the restore operation of a parent with 2 unversioned children.

### DIFF
--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/document/AbstractChildReferences.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/document/AbstractChildReferences.java
@@ -132,8 +132,8 @@ public abstract class AbstractChildReferences implements ChildReferences {
                         continue;
                     }
 
-                    // See if this child has been removed ...
-                    if (changes.isRemoved(next)) continue;
+                    // See if this child has been removed but not inserted ...
+                    if (changes.isRemoved(next) && changes.inserted(next.getKey()) == null) continue;
 
                     // See if this child has been renamed ...
                     Name newName = changes.renamed(next.getKey());

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/document/ImmutableChildReferences.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/document/ImmutableChildReferences.java
@@ -296,10 +296,6 @@ public class ImmutableChildReferences {
                 if (context != null) {
                     Changes changes = context.changes();
                     if (changes != null) {
-                        if (changes.isRemoved(ref)) {
-                            // The node was removed ...
-                            return null;
-                        }
                         boolean renamed = false;
                         if (changes.isRenamed(ref)) {
                             // The node was renamed, so get the new name ...
@@ -317,7 +313,12 @@ public class ImmutableChildReferences {
                                 ChildReference child = iter.next();
                                 if (child.getKey().equals(key)) return child;
                             }
-                            // Shouldn't really happen ...
+                        }
+
+                        //check if the node was removed only at the end to that insertions before can be processed first
+                        if (changes.isRemoved(ref)) {
+                            // The node was removed ...
+                            return null;
                         }
                     } else {
                         // It's in our list but there are no changes ...

--- a/modeshape-jcr/src/test/java/org/modeshape/jcr/ClusteredRepositoryTest.java
+++ b/modeshape-jcr/src/test/java/org/modeshape/jcr/ClusteredRepositoryTest.java
@@ -247,7 +247,7 @@ public class ClusteredRepositoryTest extends AbstractTransactionalTest {
         queryAndExpectResults(process1Session, pathQuery, 1);
 
         // wait a bit for state transfer to complete
-        Thread.sleep(1000);
+        Thread.sleep(1500);
 
         // check that the custom jcr node created on the other process, was sent to this one
         assertNotNull(process2Session.getNode("/testNode"));
@@ -261,7 +261,7 @@ public class ClusteredRepositoryTest extends AbstractTransactionalTest {
         queryAndExpectResults(process1Session, propertyQuery, 1);
 
         // wait a bit for state transfer to complete
-        Thread.sleep(1000);
+        Thread.sleep(1500);
         // check the property change was made in the indexes on the second node
         queryAndExpectResults(process2Session, propertyQuery, 1);
 
@@ -271,7 +271,7 @@ public class ClusteredRepositoryTest extends AbstractTransactionalTest {
         process1Session.save();
         queryAndExpectResults(process1Session, pathQuery, 0);
         // wait a bit for state transfer to complete
-        Thread.sleep(1000);
+        Thread.sleep(1500);
         // check the node was removed from the indexes in the second cluster node
         queryAndExpectResults(process2Session, pathQuery, 0);
     }

--- a/modeshape-jcr/src/test/java/org/modeshape/jcr/JcrNodeTest.java
+++ b/modeshape-jcr/src/test/java/org/modeshape/jcr/JcrNodeTest.java
@@ -196,6 +196,28 @@ public class JcrNodeTest extends MultiUseAbstractTest {
     }
 
     @Test
+    @FixFor( "MODE-2034" )
+    public void shouldReorderChildrenWithChanges() throws Exception {
+        Node parent = session.getRootNode().addNode("parent", "nt:unstructured");
+        Node child1 = parent.addNode("child1");
+        Node child2 = parent.addNode("child2");
+        session.save();
+
+        parent.orderBefore("child2", "child1");
+        child1.setProperty("prop", "value");
+        child2.setProperty("prop", "value");
+        session.save();
+
+        NodeIterator nodeIterator = parent.getNodes();
+        long childIdx = nodeIterator.getSize();
+        while (nodeIterator.hasNext()) {
+            Node child = nodeIterator.nextNode();
+            assertEquals("child" + childIdx, child.getName());
+            childIdx--;
+        }
+    }
+
+    @Test
     @FixFor( "MODE-1663" )
     public void shouldMakeReferenceableNodesUsingCustomTypes() throws Exception {
         Node cars = session.getNode("/Cars");

--- a/modeshape-jcr/src/test/resources/cnd/jj.cnd
+++ b/modeshape-jcr/src/test/resources/cnd/jj.cnd
@@ -1,0 +1,10 @@
+<jj='http://jj.com/1.0'>
+
+[jj:content] > mix:referenceable orderable
+  - * (undefined) multiple
+  - * (undefined)
+  + * (jj:content) = jj:contentType sns
+
+[jj:page] > mix:versionable orderable
+  + * (jj:page) ignore
+  + * (jj:content)


### PR DESCRIPTION
The underlying problem was caused by the fact that when performing `orderBefore` operations, children appear both as _removed_ and _insertedBefore_. However, the existing child reference iterators were always seeing the nodes as removed first, never returning them.
