### PR TITLE
MODE-2031 Fixed the updating of modified node types on repository start.

### DIFF
--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrRepository.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrRepository.java
@@ -1782,8 +1782,7 @@ public class JcrRepository implements org.modeshape.jcr.api.Repository {
                                        String systemWorkspaceName,
                                        boolean separateThreadForSystemWorkspace,
                                        String processId ) {
-            RepositoryChangeBus standaloneBus = new RepositoryChangeBus(executor, systemWorkspaceName,
-                                                                        separateThreadForSystemWorkspace);
+            RepositoryChangeBus standaloneBus = new RepositoryChangeBus(executor, systemWorkspaceName, separateThreadForSystemWorkspace);
             return clusteringConfiguration.isEnabled() ? new ClusteredRepositoryChangeBus(clusteringConfiguration, standaloneBus,
                                                                                           processId) : standaloneBus;
         }

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/SystemContent.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/SystemContent.java
@@ -312,6 +312,14 @@ public class SystemContent {
         if (nodeTypeNode != null) {
             // Update the properties ...
             nodeTypeNode.setProperties(system, properties);
+            //make sure each new supertype of the existing node is present *before* the existing node in the parent nodeTypes
+            //this because node type validation is a top-down process, expecting the parents before the children
+            for (NodeType superType : supertypes ) {
+                CachedNode superTypeNode = system.getNode(((JcrNodeType) superType).key());
+                if (superTypeNode instanceof MutableCachedNode && ((MutableCachedNode) superTypeNode).isNew()) {
+                    nodeTypes.reorderChild(system, superTypeNode.getKey(), nodeTypeNode.getKey());
+                }
+            }
         } else {
             // We have to create the node type node ...
             nodeTypeNode = nodeTypes.createChild(system, key, name, properties);

--- a/modeshape-jcr/src/test/resources/cnd/jj_initial.cnd
+++ b/modeshape-jcr/src/test/resources/cnd/jj_initial.cnd
@@ -1,0 +1,6 @@
+<jj='http://jj.com/1.0'>
+
+[jj:nameable] mixin
+ - _name (string) mandatory
+[jj:content] > jj:nameable
+ - _type (string) mandatory

--- a/modeshape-jcr/src/test/resources/cnd/jj_modified.cnd
+++ b/modeshape-jcr/src/test/resources/cnd/jj_modified.cnd
@@ -1,0 +1,6 @@
+<jj='http://jj.com/1.0'>
+
+[jj:name] mixin
+ - _name (string) mandatory
+[jj:content] > jj:name
+ - _type (string) mandatory

--- a/modeshape-jcr/src/test/resources/config/repo-config-jj-initial.json
+++ b/modeshape-jcr/src/test/resources/config/repo-config-jj-initial.json
@@ -1,0 +1,20 @@
+{
+    "name": "JJ initial repository",
+    "storage": {
+        "cacheName": "persistentRepository",
+        "cacheConfiguration": "config/infinispan-persistent.xml",
+        "binaryStorage": {
+            "type": "file",
+            "directory": "target/persistent_repository/binaries",
+            "minimumBinarySizeInBytes": 40
+        }
+    },
+    "workspaces": {
+        "default": "default",
+        "allowCreation": true
+    },
+    "query": {
+        "enabled": false
+    },
+    "node-types": ["cnd/jj_initial.cnd"]
+}

--- a/modeshape-jcr/src/test/resources/config/repo-config-jj-modified.json
+++ b/modeshape-jcr/src/test/resources/config/repo-config-jj-modified.json
@@ -1,0 +1,20 @@
+{
+    "name": "JJ modified repository",
+    "storage": {
+        "cacheName": "persistentRepository",
+        "cacheConfiguration": "config/infinispan-persistent.xml",
+        "binaryStorage": {
+            "type": "file",
+            "directory": "target/persistent_repository/binaries",
+            "minimumBinarySizeInBytes": 40
+        }
+    },
+    "workspaces": {
+        "default": "default",
+        "allowCreation": true
+    },
+    "query": {
+        "enabled": false
+    },
+    "node-types": ["cnd/jj_modified.cnd"]
+}


### PR DESCRIPTION
The problem consisted in the fact that after the update, super-types were placed after regular types in the list of children of the `jcr:system/jcr:nodeTypes` node and therefore couldn't be found during node type validation which requires a top-down order for super-types/sub-types.
