### PR TITLE
MODE-2045: Permission denied exception when access list uses username as principal

### DIFF
--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/AccessControlManagerImpl.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/AccessControlManagerImpl.java
@@ -127,10 +127,10 @@ public class AccessControlManagerImpl implements AccessControlManager {
         JcrAccessControlList acl;
         if (!found(acl = findAccessList(path))) {
             // access list is not assigned, use default
-            return defaultACL.getPrivileges(session.getUserID());
+            return defaultACL.getPrivileges(session.context().getSecurityContext());
         }
         // access list found, ask it to get defined privileges
-        Privilege[] pp = acl.getPrivileges(session.getUserID());
+        Privilege[] pp = acl.getPrivileges(session.context().getSecurityContext());
         return pp;
     }
 

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/security/acl/JcrAccessControlList.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/security/acl/JcrAccessControlList.java
@@ -162,14 +162,14 @@ public class JcrAccessControlList implements AccessControlList {
         } 
         return false;
     }
-    
+
     /**
      * Lists all privileges defined by this access list for the given user.
      * 
      * @param username the name of the user
      * @return list of privilege objects.
      */
-    public Privilege[] getPrivileges(String username) {
+    public Privilege[] getPrivileges(SecurityContext context) {
         ArrayList<Privilege> privs = new ArrayList<Privilege>();
         for (AccessControlEntryImpl ace : principals.values()) {
             //add privileges granted for everyone
@@ -178,7 +178,12 @@ public class JcrAccessControlList implements AccessControlList {
             }
             
             //add privileges granted for given user
-            if (ace.getPrincipal().getName().equals(username)) {
+            if (ace.getPrincipal().getName().equals(username(context.getUserName()))) {
+                privs.addAll(Arrays.asList(ace.getPrivileges()));
+            }
+            
+            //add privileges granted for given role
+            if (context.hasRole(ace.getPrincipal().getName())) {
                 privs.addAll(Arrays.asList(ace.getPrivileges()));
             }
         }
@@ -188,7 +193,7 @@ public class JcrAccessControlList implements AccessControlList {
         
         return res;
     }
-    
+        
     public boolean hasEntry(String name) {
         AccessControlEntry[] entries = this.getAccessControlEntries();
         for (int i = 0; i < entries.length; i++) {

--- a/modeshape-jcr/src/test/java/org/modeshape/jcr/security/AccessControlManagerTest.java
+++ b/modeshape-jcr/src/test/java/org/modeshape/jcr/security/AccessControlManagerTest.java
@@ -367,7 +367,7 @@ public class AccessControlManagerTest extends MultiUseAbstractTest {
         } else {
             acl = (AccessControlList)acm.getPolicies(path)[0];
         }
-        acl.addAccessControlEntry(SimplePrincipal.newInstance(session.getUserID()), permissions);
+        acl.addAccessControlEntry(SimplePrincipal.newInstance("anonymous"), permissions);
 
         acm.setPolicy(path, acl);
         session.save();


### PR DESCRIPTION
This commits fixes user name comparison . Security context returns authenticated user name enclosed in brackets(<username>) what cause name mismatch and false permission denied exception.
