### PR TITLE
MODE-1467 Added ability to explicitly invoke sequencer within session

### DIFF
--- a/modeshape-jcr-api/src/main/java/org/modeshape/jcr/api/Session.java
+++ b/modeshape-jcr-api/src/main/java/org/modeshape/jcr/api/Session.java
@@ -23,9 +23,13 @@
  */
 package org.modeshape.jcr.api;
 
+import javax.jcr.Node;
+import javax.jcr.Property;
+import javax.jcr.RepositoryException;
+
 /**
  * A specialization of the standard JCR {@link javax.jcr.Session} interface that returns the ModeShape-specific extension
- * interfaces from {@link #getWorkspace()} and {@link #getRepository()}.
+ * interfaces from {@link #getWorkspace()}, {@link #getRepository()}, and {@link #getValueFactory()}.
  */
 public interface Session extends javax.jcr.Session {
 
@@ -34,6 +38,32 @@ public interface Session extends javax.jcr.Session {
 
     @Override
     public Repository getRepository();
+
+    @Override
+    public ValueFactory getValueFactory() throws RepositoryException;
+
+    /**
+     * Sequence the specified property using the named sequencer, and place the generated output at the specified location using
+     * this session. The output nodes will be transient within the current session, so this session will need to be saved to
+     * persist the output.
+     * <p>
+     * It is suggested that this method be used on inputs that the sequencer is not configured to process automatically, otherwise
+     * ModeShape will also sequence the same property. If your application is to only manually sequence, simply configure each
+     * sequencer without a path expression or with a path expression that will never apply to the manually-sequenced nodes.
+     * </p>
+     * 
+     * @param sequencerName the name of the configured sequencer that should be executed
+     * @param inputProperty the property that was changed and that should be used as the input; never null
+     * @param outputNode the node that represents the output for the derived information; never null, and will either be
+     *        {@link Node#isNew() new} if the output is being placed outside of the selected node, or will not be new when the
+     *        output is to be placed on the selected input node
+     * @return true if the sequencer did generate output; false if the sequencer could not process the specified content or if
+     *         {@code sequencerName} is null or does not match a configured sequencer
+     * @throws RepositoryException if there was a problem with the sequencer
+     */
+    boolean sequence( String sequencerName,
+                      Property inputProperty,
+                      Node outputNode ) throws RepositoryException;
 
     /**
      * Evaluate a local name and replace any characters that are not allowed within the local names of nodes and properties. Such

--- a/modeshape-jcr-api/src/main/java/org/modeshape/jcr/api/sequencer/Sequencer.java
+++ b/modeshape-jcr-api/src/main/java/org/modeshape/jcr/api/sequencer/Sequencer.java
@@ -128,7 +128,11 @@ public abstract class Sequencer {
     public final String[] getPathExpressions() {
         String pathExpression = this.pathExpression;
         Object[] pathExpressions = this.pathExpressions;
-        if (pathExpression != null && pathExpressions == null || pathExpressions.length == 0) {
+        if (pathExpression == null && (pathExpressions == null || pathExpressions.length == 0)) {
+            // there's none ...
+            return new String[] {};
+        }
+        if (pathExpression != null && (pathExpressions == null || pathExpressions.length == 0)) {
             // There's just one ...
             return new String[] {pathExpression};
         }

--- a/modeshape-jcr/src/test/java/org/modeshape/jcr/RepositoryConfigurationTest.java
+++ b/modeshape-jcr/src/test/java/org/modeshape/jcr/RepositoryConfigurationTest.java
@@ -94,6 +94,12 @@ public class RepositoryConfigurationTest {
     }
 
     @Test
+    public void shouldAcceptSequencerWithNoPathExpression() throws Exception {
+        RepositoryConfiguration config = RepositoryConfiguration.read("{ 'name' : 'Repo', \"sequencing\" : { 'sequencers' : { 'foo' : { 'classname' : 'xsdsequencer' } } } }");
+        assertValid(config);
+    }
+
+    @Test
     public void shouldNotReplaceBlankValuesWithNull() throws Exception {
         RepositoryConfiguration config = RepositoryConfiguration.read("{ 'name' : 'Repo', 'jndiName' : '' }");
         assertThat(config.getJndiName(), is(""));

--- a/modeshape-jcr/src/test/java/org/modeshape/jcr/sequencer/ManualSequencingTest.java
+++ b/modeshape-jcr/src/test/java/org/modeshape/jcr/sequencer/ManualSequencingTest.java
@@ -1,0 +1,73 @@
+/*
+ * ModeShape (http://www.modeshape.org)
+ * See the COPYRIGHT.txt file distributed with this work for information
+ * regarding copyright ownership.  Some portions may be licensed
+ * to Red Hat, Inc. under one or more contributor license agreements.
+ * See the AUTHORS.txt file in the distribution for a full listing of 
+ * individual contributors.
+ *
+ * ModeShape is free software. Unless otherwise indicated, all code in ModeShape
+ * is licensed to you under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ * 
+ * ModeShape is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.modeshape.jcr.sequencer;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import java.net.URL;
+import javax.jcr.Node;
+import javax.jcr.Property;
+import org.junit.Test;
+import org.modeshape.jcr.Environment;
+import org.modeshape.jcr.RepositoryConfiguration;
+import org.modeshape.jcr.SingleUseAbstractTest;
+import org.modeshape.jcr.TestSequencersHolder;
+import org.modeshape.jcr.api.JcrTools;
+import org.modeshape.jcr.api.Session;
+
+public class ManualSequencingTest extends SingleUseAbstractTest {
+
+    @Override
+    protected RepositoryConfiguration createRepositoryConfiguration( String repositoryName,
+                                                                     Environment environment ) throws Exception {
+        return RepositoryConfiguration.read("config/repo-config-manual-sequencing.json");
+    }
+
+    private JcrTools tools = new JcrTools();
+
+    @Test
+    public void shouldManuallySequence() throws Exception {
+        URL url = getClass().getClassLoader().getResource("log4j.properties");
+        assertNotNull(url);
+        Session session = session();
+        tools.uploadFile(session, "/files/log4j.properties", url);
+
+        Node propFile = session.getNode("/files/log4j.properties");
+        Property content = propFile.getProperty("jcr:content/jcr:data");
+        assertNotNull(content);
+
+        Node output = session.getRootNode().addNode("output");
+        assertFalse(output.hasNode(TestSequencersHolder.DERIVED_NODE_NAME));
+
+        session.sequence("Counting sequencer", content, output);
+        assertTrue(output.hasNode(TestSequencersHolder.DERIVED_NODE_NAME));
+
+        session.refresh(false);
+
+        assertFalse(session.getRootNode().hasNode("files"));
+        assertFalse(session.getRootNode().hasNode("output"));
+    }
+
+}

--- a/modeshape-jcr/src/test/resources/config/repo-config-manual-sequencing.json
+++ b/modeshape-jcr/src/test/resources/config/repo-config-manual-sequencing.json
@@ -1,0 +1,10 @@
+{
+    "name":"Test Config with various property types",
+    "sequencing":{
+        "sequencers": {
+            "Counting sequencer" : {
+                "classname":"org.modeshape.jcr.TestSequencersHolder$DefaultSequencer"
+            }
+        }
+    }
+}


### PR DESCRIPTION
ModeShape now supports applications explicitly invoking sequencing from within the scope of a session. There are several differences with using sequencers in this style:
- A specific sequencer must be named, and only that sequencer will be invoked.
- The path expressions of that configured sequencer are not used in any way. All other configured properties are still used.
- The sequencer's accepted MIME types are still respected. If the input content's MIME type is known and is not in the sequencer's set of supported MIME types, the sequencing operation will return immediately.
- The caller must supply the property containing the value to be sequenced.
- The caller must supply a new node into which the sequencer output will be placed.
- The session used to sequence contains all sequencing output as transient state; the caller is expected to call 'session.save()' if the output is to be persisted.
