### PR TITLE
MODE-2043 Added some tests for the upgrade mechanism and a small code refactoring.

### DIFF
--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrRepository.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrRepository.java
@@ -1061,7 +1061,7 @@ public class JcrRepository implements org.modeshape.jcr.api.Repository {
                     final SessionEnvironment sessionEnv = new RepositorySessionEnvironment(this.transactions, indexingClustered);
                     CacheContainer workspaceCacheContainer = this.config.getWorkspaceContentCacheContainer();
                     this.cache = new RepositoryCache(context, documentStore, config, systemContentInitializer, sessionEnv,
-                                                     changeBus, workspaceCacheContainer);
+                                                     changeBus, workspaceCacheContainer, Upgrades.STANDARD_UPGRADES);
 
                     // Set up the node type manager ...
                     this.nodeTypes = new RepositoryNodeTypeManager(this, true, true);

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/Upgrades.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/Upgrades.java
@@ -35,6 +35,8 @@ public class Upgrades {
 
     protected static final Logger LOGGER = Logger.getLogger(Upgrades.class);
 
+    protected static final int EMPTY_UPGRADES_ID = 0;
+
     public static interface Context {
         /**
          * Get the repository's running state.
@@ -102,7 +104,7 @@ public class Upgrades {
      * @return the latest identifier; 0 if there are no upgrades in this object, or positive number
      */
     public final int getLatestAvailableUpgradeId() {
-        return operations.isEmpty() ? 0 : operations.get(operations.size() - 1).getId();
+        return operations.isEmpty() ? EMPTY_UPGRADES_ID : operations.get(operations.size() - 1).getId();
     }
 
     protected static abstract class UpgradeOperation {

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/RepositoryCache.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/RepositoryCache.java
@@ -133,6 +133,7 @@ public class RepositoryCache implements Observable {
     private final SessionEnvironment sessionContext;
     private final String processKey;
     private final CacheContainer workspaceCacheManager;
+    private final Upgrades upgrades;
     private volatile boolean initializingRepository = false;
     private volatile boolean upgradingRepository = false;
     private int lastUpgradeId;
@@ -143,7 +144,8 @@ public class RepositoryCache implements Observable {
                             ContentInitializer initializer,
                             SessionEnvironment sessionContext,
                             ChangeBus changeBus,
-                            CacheContainer workspaceCacheContainer ) {
+                            CacheContainer workspaceCacheContainer,
+                            Upgrades upgradeFunctions ) {
         this.context = context;
         this.configuration = configuration;
         this.documentStore = documentStore;
@@ -157,8 +159,8 @@ public class RepositoryCache implements Observable {
         this.name = configuration.getName();
         this.workspaceCachesByName = new ConcurrentHashMap<String, WorkspaceCache>();
         this.workspaceNames = new CopyOnWriteArraySet<String>(configuration.getAllWorkspaceNames());
+        this.upgrades = upgradeFunctions;
 
-        final Upgrades upgrades = Upgrades.STANDARD_UPGRADES;
         SchematicEntry repositoryInfo = this.documentStore.localStore().get(REPOSITORY_INFO_KEY);
         boolean upgradeRequired = false;
         if (repositoryInfo == null) {
@@ -434,7 +436,6 @@ public class RepositoryCache implements Observable {
                     @Override
                     public Void call() throws Exception {
                         LOGGER.debug("Upgrading repository '{0}'", name);
-                        Upgrades upgrades = Upgrades.STANDARD_UPGRADES;
                         lastUpgradeId = upgrades.applyUpgradesSince(lastUpgradeId, resources);
                         LOGGER.debug("Recording upgrade completion in repository '{0}'", name);
 

--- a/modeshape-jcr/src/test/java/org/modeshape/jcr/UpgradesTest.java
+++ b/modeshape-jcr/src/test/java/org/modeshape/jcr/UpgradesTest.java
@@ -1,0 +1,105 @@
+package org.modeshape.jcr;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Unit test for {@link Upgrades}
+ *
+ * @author Horia Chiorean (hchiorea@redhat.com)
+ */
+public class UpgradesTest {
+
+    private TestUpgradeOperation operation1;
+    private TestUpgradeOperation operation2;
+    private TestUpgradeOperation operation3;
+    private Upgrades testUpgrades;
+
+    @Before
+    public void before() {
+        operation1 = new TestUpgradeOperation(2);
+        operation2 = new TestUpgradeOperation(3);
+        operation3 = new TestUpgradeOperation(4);
+        testUpgrades = new Upgrades(operation1, operation2, operation3);
+    }
+
+    @Test
+    public void shouldApplyOnlyLatestUpgrades() throws Exception {
+        testUpgrades.applyUpgradesSince(0, null);
+        operation1.assertCalled();
+        operation2.assertCalled();
+        operation3.assertCalled();
+
+        testUpgrades.applyUpgradesSince(1, null);
+        operation1.assertCalled();
+        operation2.assertCalled();
+        operation3.assertCalled();
+
+        testUpgrades.applyUpgradesSince(2, null);
+        operation1.assertNotCalled();
+        operation2.assertCalled();
+        operation3.assertCalled();
+
+        testUpgrades.applyUpgradesSince(3, null);
+        operation1.assertNotCalled();
+        operation2.assertNotCalled();
+        operation3.assertCalled();
+
+        testUpgrades.applyUpgradesSince(4, null);
+        operation1.assertNotCalled();
+        operation2.assertNotCalled();
+        operation3.assertNotCalled();
+
+        testUpgrades.applyUpgradesSince(5, null);
+        operation1.assertNotCalled();
+        operation2.assertNotCalled();
+        operation3.assertNotCalled();
+    }
+
+    @Test
+    public void shouldReturnLatestAvailableUpgradeId() throws Exception {
+        assertEquals(4, testUpgrades.getLatestAvailableUpgradeId());
+        assertEquals(Upgrades.EMPTY_UPGRADES_ID, new Upgrades().getLatestAvailableUpgradeId());
+    }
+
+    @Test
+    public void shouldCorrectlyDetermineIfUpgradeIsRequired() throws Exception {
+        assertTrue(testUpgrades.isUpgradeRequired(-1));
+        assertTrue(testUpgrades.isUpgradeRequired(0));
+        assertTrue(testUpgrades.isUpgradeRequired(1));
+        assertTrue(testUpgrades.isUpgradeRequired(2));
+        assertTrue(testUpgrades.isUpgradeRequired(3));
+        assertFalse(testUpgrades.isUpgradeRequired(4));
+        assertFalse(testUpgrades.isUpgradeRequired(5));
+    }
+
+    protected static class TestUpgradeOperation extends Upgrades.UpgradeOperation {
+        private boolean called = false;
+
+        protected TestUpgradeOperation( int id ) {
+            super(id);
+        }
+
+        @Override
+        public void apply( Upgrades.Context resources ) {
+            called = true;
+        }
+
+        protected void reset() {
+            called = false;
+        }
+
+        protected void assertCalled() {
+            assertTrue("Upgrade operation not called" , called);
+            reset();
+        }
+
+        protected void assertNotCalled() {
+            assertFalse("Upgrade operation called", called);
+            reset();
+        }
+    }
+}

--- a/modeshape-jcr/src/test/resources/config/repo-config-persistent-no-query.json
+++ b/modeshape-jcr/src/test/resources/config/repo-config-persistent-no-query.json
@@ -1,0 +1,19 @@
+{
+    "name": "Persistent repo no queries",
+    "storage": {
+        "cacheName": "persistentRepository",
+        "cacheConfiguration": "config/infinispan-persistent.xml",
+        "binaryStorage": {
+            "type": "file",
+            "directory": "target/persistent_repository/binaries",
+            "minimumBinarySizeInBytes": 40
+        }
+    },
+    "workspaces": {
+        "default": "default",
+        "allowCreation": true
+    },
+    "query": {
+        "enabled": false
+    }
+}


### PR DESCRIPTION
Due to the fact that the upgrading mechanism is triggered only on the change of some internal repository state, it's not really possible to cleanly test this behavior out-of-context (at least not without exposing internal data).

Therefore, the functional tests will have to be indirect via the testing of other tasks like: https://issues.jboss.org/browse/MODE-2044
