### PR TITLE
MODE-2047 Fixed locking of transient nodes

### DIFF
--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrLockManager.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrLockManager.java
@@ -248,7 +248,7 @@ class JcrLockManager implements LockManager {
             throw new LockException(JcrI18n.nodeNotLockable.text(node.location()));
         }
 
-        if (node.isModified()) {
+        if (node.isNew()|| node.isModified()) {
             throw new InvalidItemStateException(JcrI18n.changedNodeCannotBeLocked.text(node.location()));
         }
 

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/document/SessionNode.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/document/SessionNode.java
@@ -785,7 +785,7 @@ public class SessionNode implements MutableCachedNode {
         // first try to determine if there's old reference property with the same name so that old references can be removed
         boolean oldPropertyWasReference = false;
         List<Reference> referencesToRemove = new ArrayList<Reference>();
-        if (!isNew()) {
+        if (isPropertyModified(cache, propertyName) || isPropertyRemoved(propertyName)) {
             // remove potential existing references
             CachedNode persistedNode = nodeInWorkspace(session(cache));
             Property oldProperty = persistedNode.getProperty(propertyName, cache);

--- a/modeshape-jcr/src/test/java/org/modeshape/jcr/JcrLockManagerTest.java
+++ b/modeshape-jcr/src/test/java/org/modeshape/jcr/JcrLockManagerTest.java
@@ -1,0 +1,28 @@
+package org.modeshape.jcr;
+
+import static org.junit.Assert.fail;
+import javax.jcr.InvalidItemStateException;
+import org.junit.Test;
+import org.modeshape.common.FixFor;
+
+/**
+ * Unit test for {@link JcrLockManager}
+ *
+ * @author Horia Chiorean (hchiorea@redhat.com)
+ */
+public class JcrLockManagerTest extends SingleUseAbstractTest {
+
+    @Test
+    @FixFor( "MODE-2047" )
+    public void shouldNotAllowLockOnTransientNode() throws Exception {
+        AbstractJcrNode testNode = session.getRootNode().addNode("test");
+        testNode.addMixin("mix:lockable");
+        JcrLockManager lockManager = session.lockManager();
+        try {
+            lockManager.lock(testNode, true, false, Long.MAX_VALUE, null);
+            fail("Transient nodes should not be locked");
+        } catch (InvalidItemStateException e) {
+            //expected
+        }
+    }
+}


### PR DESCRIPTION
According to the Javadoc from the spec methods any kind of locking on a node which contains modifications should throw an `InvalidItemStateException`.
