### PR TITLE
Node getBaseVersion causes Exception after node removal

### DIFF
--- a/modeshape-jcr/src/test/java/org/modeshape/jcr/GetBaseVersionAfterNodeRemovalTest.java
+++ b/modeshape-jcr/src/test/java/org/modeshape/jcr/GetBaseVersionAfterNodeRemovalTest.java
@@ -1,0 +1,61 @@
+package org.modeshape.jcr;
+
+import java.util.Random;
+import javax.jcr.Node;
+import javax.jcr.RepositoryException;
+import javax.jcr.version.VersionManager;
+
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * @author Alex Panov
+ * @date 9/23/13
+ * @time 4:40 PM
+ */
+
+public class GetBaseVersionAfterNodeRemovalTest extends SingleUseAbstractTest {
+    private VersionManager versionManager;
+
+    @Before
+    public void initializeVersionManager() throws Exception {
+        versionManager = session.getWorkspace().getVersionManager();
+    }
+
+    @Test
+    public void testName() throws Exception {
+        Node node = createVersionedNode();
+
+        createVersion(node);
+
+        String identifier = node.getIdentifier();
+
+        removeNode(node);
+
+        AbstractJcrNode foundNode = session.getNodeByIdentifier(identifier);
+        //exception happens here
+        foundNode.getBaseVersion();
+    }
+
+    private Node createVersionedNode() throws RepositoryException {
+        Node node = session.getRootNode().addNode("outerFolder");
+        node.setProperty("jcr:mimeType", "text/plain");
+        node.setProperty("jcr:data", "Original content");
+        session.save();
+        node.addMixin("mix:versionable");
+        session.save();
+        return node;
+    }
+
+    private void createVersion(Node node) throws RepositoryException {
+        versionManager.checkout(node.getPath());
+        node.setProperty("jcr:data", "Original content " + new Random().nextInt());
+        session.save();
+        versionManager.checkin(node.getPath());
+    }
+
+    private void removeNode(Node node) throws RepositoryException {
+        node.remove();
+        session.save();
+    }
+}


### PR DESCRIPTION
When a versioned node gets removed it still can be found by identifier (should it be?).
More importantly node.getBaseVersion() causes UnsupportedRepositoryOperationException like this:
javax.jcr.UnsupportedRepositoryOperationException: This operation requires that the node be versionable (that is, isNodeType("mix:versionable") == true)
    at org.modeshape.jcr.AbstractJcrNode.getBaseVersion(AbstractJcrNode.java:3264)
    at org.modeshape.jcr.JcrSystemNode.getBaseVersion(JcrSystemNode.java:33)
    at org.modeshape.jcr.GetBaseVersionAfterNodeRemovalTest.testName(GetBaseVersionAfterNodeRemovalTest.java:37)
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:45)
    at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:15)
    at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:42)
    at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:20)
    at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:28)
    at org.junit.internal.runners.statements.RunAfters.evaluate(RunAfters.java:30)
    at org.junit.rules.RunRules.evaluate(RunRules.java:18)
    at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:263)
    at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:68)
    at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:47)
    at org.junit.runners.ParentRunner$3.run(ParentRunner.java:231)
    at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:60)
    at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:229)
    at org.junit.runners.ParentRunner.access$000(ParentRunner.java:50)
    at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:222)
    at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:28)
    at org.junit.internal.runners.statements.RunAfters.evaluate(RunAfters.java:30)
    at org.junit.runners.ParentRunner.run(ParentRunner.java:300)
    at org.junit.runner.JUnitCore.run(JUnitCore.java:157)
    at com.intellij.junit4.JUnit4IdeaTestRunner.startRunnerWithArgs(JUnit4IdeaTestRunner.java:77)
    at com.intellij.rt.execution.junit.JUnitStarter.prepareStreamsAndStart(JUnitStarter.java:195)
    at com.intellij.rt.execution.junit.JUnitStarter.main(JUnitStarter.java:63)
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
    at com.intellij.rt.execution.application.AppMain.main(AppMain.java:120)
