### PR TITLE
MODE-2057 Corrected behavior of UNION with dissimilar queries.

### DIFF
--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/query/QueryResults.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/query/QueryResults.java
@@ -394,6 +394,19 @@ public interface QueryResults extends Serializable {
          * @return the new columns definition; never null
          */
         public Columns joinWith( Columns columns );
+
+        /**
+         * Get the reducer that converts a tuple of the form described by the wrapped columns format to this columns format.
+         * 
+         * @return the reformatter, or null if none is needed (e.g., if this columns is not a subselect of another)
+         */
+        public TupleReformatter getTupleReformatter();
+    }
+
+    public static interface TupleReformatter {
+        public Object[] reformat( Object[] input );
+
+        public Columns getColumns();
     }
 
     @Immutable

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/query/process/ExceptComponent.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/query/process/ExceptComponent.java
@@ -28,8 +28,10 @@ import java.util.Comparator;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.ListIterator;
 import org.modeshape.jcr.query.QueryContext;
 import org.modeshape.jcr.query.QueryResults.Columns;
+import org.modeshape.jcr.query.QueryResults.TupleReformatter;
 
 /**
  */
@@ -54,10 +56,18 @@ public class ExceptComponent extends SetOperationComponent {
         // Execute all of the source components (so we can sort the results from the smallest to the largest) ...
         // TODO: Parallelize this ???
         List<List<Object[]>> allTuples = new LinkedList<List<Object[]>>();
+        Iterator<TupleReformatter> reformatters = sourceReformatters.iterator();
         while (sources.hasNext()) {
             List<Object[]> tuples = sources.next().execute();
             if (tuples == null) continue;
             if (tuples.isEmpty()) return emptyTuples();
+            TupleReformatter reformatter = reformatters.next();
+            if (reformatter != null) {
+                ListIterator<Object[]> iter = tuples.listIterator();
+                while (iter.hasNext()) {
+                    iter.set(reformatter.reformat(iter.next()));
+                }
+            }
             allTuples.add(tuples);
         }
         if (allTuples.isEmpty()) return emptyTuples();

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/query/process/IntersectComponent.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/query/process/IntersectComponent.java
@@ -28,8 +28,10 @@ import java.util.Comparator;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.ListIterator;
 import org.modeshape.jcr.query.QueryContext;
 import org.modeshape.jcr.query.QueryResults.Columns;
+import org.modeshape.jcr.query.QueryResults.TupleReformatter;
 
 /**
  */
@@ -54,11 +56,20 @@ public class IntersectComponent extends SetOperationComponent {
         // Execute all of the source components (so we can sort the results from the smallest to the largest) ...
         // TODO: Parallelize this ???
         List<List<Object[]>> allTuples = new LinkedList<List<Object[]>>();
+        Iterator<TupleReformatter> reformatters = sourceReformatters.iterator();
         while (sources.hasNext()) {
             List<Object[]> tuples = sources.next().execute();
             if (tuples == null) continue;
             if (tuples.isEmpty()) return emptyTuples();
+            TupleReformatter reformatter = reformatters.next();
+            if (reformatter != null) {
+                ListIterator<Object[]> iter = tuples.listIterator();
+                while (iter.hasNext()) {
+                    iter.set(reformatter.reformat(iter.next()));
+                }
+            }
             allTuples.add(tuples);
+
         }
         if (allTuples.isEmpty()) return emptyTuples();
         if (allTuples.size() == 1) return allTuples.get(0); // just one source

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/query/process/UnionComponent.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/query/process/UnionComponent.java
@@ -25,9 +25,11 @@ package org.modeshape.jcr.query.process;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Iterator;
 import java.util.List;
 import org.modeshape.jcr.query.QueryContext;
 import org.modeshape.jcr.query.QueryResults.Columns;
+import org.modeshape.jcr.query.QueryResults.TupleReformatter;
 
 /**
  */
@@ -44,9 +46,17 @@ public class UnionComponent extends SetOperationComponent {
     @Override
     public List<Object[]> execute() {
         List<Object[]> tuples = new ArrayList<Object[]>();
+        Iterator<TupleReformatter> reformatters = sourceReformatters.iterator();
         for (ProcessingComponent source : sources()) {
             List<Object[]> results = source.execute();
-            tuples.addAll(results);
+            TupleReformatter reformatter = reformatters.next();
+            if (reformatter != null) {
+                for (Object[] tuple : results) {
+                    tuples.add(reformatter.reformat(tuple));
+                }
+            } else {
+                tuples.addAll(results);
+            }
         }
         if (removeDuplicatesComparator != null) {
             Collections.sort(tuples, this.removeDuplicatesComparator);


### PR DESCRIPTION
Even though ModeShape should be able to create a UNION of two queries that have the same effective result set, the fact that the internal project operation in the query plan did not reformat the tuples meant that the tuples on each side of the UNION had different structure. Thus, such queries would either fail during execution (if certain columns were used higher in the query plan), an IndexOutOfBoundsException when accessing the result set, or simply result set with values in the wrong columns.

The fix is to for the set operation (including UNION, INTERSECT and EXCEPT) to reformat the incoming tuples if the structure on each side of the operation is different or not compatible. The planning for the restructuring can be done at query planning time, but if needed the actual restructuring of the tuples can only be done at execution time. Thus, in such cases there will be additional work required. 

The new tests to verify the behavior pass with these changes, and all prior query tests also pass.
