### PR TITLE
fix filesystem connector jcr:content fix, add options for increased bina...

### DIFF
--- a/modeshape-jcr/src/main/java/org/modeshape/connector/filesystem/JsonSidecarExtraPropertyStore.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/connector/filesystem/JsonSidecarExtraPropertyStore.java
@@ -140,7 +140,7 @@ class JsonSidecarExtraPropertyStore implements ExtraPropertiesStore {
     }
 
     protected String resourceExtension() {
-        return DEFAULT_EXTENSION;
+        return DEFAULT_RESOURCE_EXTENSION;
     }
 
     @Override

--- a/modeshape-jcr/src/test/resources/cnd/flex.cnd
+++ b/modeshape-jcr/src/test/resources/cnd/flex.cnd
@@ -13,3 +13,10 @@
 [flex:anyProperties] mixin
 - * (undefined) multiple 
 - * (undefined) 
+
+/*
+ * Some content that can have a checksum
+ */
+[jcr:binary] mixin
+  - jcr:size (LONG) COPY
+  - jcr:digest (URI) COPY

--- a/modeshape-jcr/src/test/resources/config/repo-config-filesystem-federation.json
+++ b/modeshape-jcr/src/test/resources/config/repo-config-filesystem-federation.json
@@ -48,6 +48,13 @@
             "extraPropertiesStorage" : "none",
             "pageSize" : 2
         } ,
+        "large-files" : {
+            "classname" : "org.modeshape.connector.filesystem.FileSystemConnector",
+            "directoryPath" : "F:/ff/large-files",
+            "extraPropertiesStorage" : "none",
+            "opensslDeployment" : "F:/openssl-0.9.8h-1-bin/bin",            
+            "hashMode" : "cached"         
+        } ,
         "targetDirectory" : {
             "classname" : "filesystem",
             "directoryPath" : "target/classes",


### PR DESCRIPTION
1) FileSystemConnector was using a id of parent (nt:file) rather than content (jcr:content) putting jcr:content properties in nt:file properties. JsonSidecarExtraPropertiesStorage wasn't distinguishing between file or content.  Fixes to this MODE-2060

2) 2 new options within extraSources when using FileSystemConnector as classname:
  a) opensslDeployment - path to openssl binaries installation
  b) hashMode - 
      i) missing or "default" - check binary key as is
      ii) "cached" - binarykey only computed once, stored in HashMap, uses opensslDeployment if configured
      iii) "mocked" - binary key created from filepath rather than file content
Features MODE-2061

stats for retrieving jcr:content node of 1.3GB and 64GB file:
default modeshape secureHash - 12 sec/16.6 minutes
cached openssl - 3.5 sec/8.1 minutes
cached modeshape secureHash - 6.2 sec/8.1 minutes
mocked - .002 sec
