### PR TITLE
MODE-2070 fixed issues for Teiid DDL file w/ tables defined out of order that contain FK references

### DIFF
--- a/sequencers/modeshape-sequencer-ddl/src/main/java/org/modeshape/sequencer/ddl/dialect/teiid/CreateTableParser.java
+++ b/sequencers/modeshape-sequencer-ddl/src/main/java/org/modeshape/sequencer/ddl/dialect/teiid/CreateTableParser.java
@@ -325,16 +325,23 @@ final class CreateTableParser extends StatementParser {
      * @throws ParsingException if a node of a referenced column cannot be found
      */
     private List<AstNode> parseReferenceList( final DdlTokenStream tokens,
-                                              final AstNode tableNode ) throws ParsingException {
+                                              final AstNode tableNode,
+                                              final UnresolvedTableReferenceNode unresolvedReferencedTableNode) throws ParsingException {
         final List<String> columns = parseIdentifierList(tokens);
         final List<AstNode> references = new ArrayList<AstNode>(columns.size());
 
+        /* If tableNode == null bypass column node setting */
         for (final String columnName : columns) {
+        	if( unresolvedReferencedTableNode != null ) {
+        		unresolvedReferencedTableNode.addColumnReferenceName(columnName);
+        		continue;
+        	}
+        	
             final AstNode referencedColumnNode = getColumnNode(tableNode, columnName);
 
             // can't find referenced column
             if (referencedColumnNode == null) {
-                this.logger.debug("Create table statment node of column reference '{0}' was not found", columnName);
+                this.logger.debug("Create table statement node of column reference '{0}' was not found", columnName);
             } else {
                 references.add(referencedColumnNode);
             }
@@ -423,7 +430,7 @@ final class CreateTableParser extends StatementParser {
                 assert (nodeType != null);
 
                 // process column list and create references to their nodes
-                final List<AstNode> references = parseReferenceList(tokens, tableNode);
+                final List<AstNode> references = parseReferenceList(tokens, tableNode, null);
 
                 // set a constraint ID if needed
                 if (StringUtil.isBlank(constraintId)) {
@@ -442,17 +449,19 @@ final class CreateTableParser extends StatementParser {
                                                                     referencesTableName,
                                                                     TeiidDdlLexicon.CreateTable.TABLE_STATEMENT,
                                                                     TeiidDdlLexicon.CreateTable.VIEW_STATEMENT);
-
+                        
+                        UnresolvedTableReferenceNode unresolvedTableReferenceNode = null;
                         // can't find referenced table
                         if (referencesTableNode == null) {
-                        	unresolvedTableReferences.add(new UnresolvedTableReferenceNode(constraintNode, referencesTableName));
+                        	unresolvedTableReferenceNode = new UnresolvedTableReferenceNode(constraintNode, referencesTableName);
+                        	unresolvedTableReferences.add(unresolvedTableReferenceNode);
                         } else {
                             constraintNode.setProperty(TeiidDdlLexicon.Constraint.TABLE_REFERENCE, referencesTableNode);
                         }
 
                         // may have referenced columns so check for opening paren before parsing refs
                         if (tokens.matches(L_PAREN)) {
-                            final List<AstNode> constraintReferences = parseReferenceList(tokens, referencesTableNode);
+                            final List<AstNode> constraintReferences = parseReferenceList(tokens, referencesTableNode, unresolvedTableReferenceNode);
 
                             if (!constraintReferences.isEmpty()) {
                                 constraintNode.setProperty(TeiidDdlLexicon.Constraint.TABLE_REFERENCE_REFERENCES,
@@ -596,7 +605,7 @@ final class CreateTableParser extends StatementParser {
 		for( UnresolvedTableReferenceNode node : unresolvedTableReferences ) {
 			final AstNode constraintNode = node.getContraintNode();
 	        final String referencesTableName = node.getTableReferenceName();
-	        
+
 	        final AstNode referencesTableNode = getNode(constraintNode.getParent().getParent(),
 	                                                    referencesTableName,
 	                                                    TeiidDdlLexicon.CreateTable.TABLE_STATEMENT,
@@ -607,7 +616,26 @@ final class CreateTableParser extends StatementParser {
 	            this.logger.debug("Create table statment foreign key reference table '{0}' was not found",
 	                              referencesTableName);
 	        } else {
+	        	// Now set the TABLE_REFERENCE property
 	            constraintNode.setProperty(TeiidDdlLexicon.Constraint.TABLE_REFERENCE, referencesTableNode);
+	            final List<AstNode> references = new ArrayList<AstNode>(node.getColumnReferenceNames().size());
+	            
+	            // If any column names references exists, go find the real objects and set the TABLE_REFERENCE_REFERENCES property
+		        for( String columnName : node.getColumnReferenceNames()) {
+		            final AstNode referencedColumnNode = getColumnNode(referencesTableNode, columnName);
+		            
+		            // can't find referenced column
+		            if (referencedColumnNode == null) {
+		                this.logger.debug("Create table statement node of column reference '{0}' was not found", columnName);
+		            } else {
+		                references.add(referencedColumnNode);
+		            }
+	            }
+		        
+		        if (!references.isEmpty()) {
+                    constraintNode.setProperty(TeiidDdlLexicon.Constraint.TABLE_REFERENCE_REFERENCES,
+                    		references);
+                }
 	        }
 		}
 
@@ -618,10 +646,12 @@ final class CreateTableParser extends StatementParser {
 	class UnresolvedTableReferenceNode {
 		AstNode contraintNode;
 		String tableReferenceName;
+		Set<String> columnReferenceNames;
 		
 		public UnresolvedTableReferenceNode(AstNode node, String name) {
 			this.contraintNode = node;
 			this.tableReferenceName = name;
+			this.columnReferenceNames = new HashSet<String>();
 		}
 
 		public AstNode getContraintNode() {
@@ -630,6 +660,14 @@ final class CreateTableParser extends StatementParser {
 
 		public String getTableReferenceName() {
 			return tableReferenceName;
+		}
+		
+		public void addColumnReferenceName(String name) {
+			this.columnReferenceNames.add(name);
+		}
+		
+		public Set<String> getColumnReferenceNames() {
+			return this.columnReferenceNames;
 		}
 	}
     

--- a/sequencers/modeshape-sequencer-ddl/src/main/java/org/modeshape/sequencer/ddl/node/AstNodeFactory.java
+++ b/sequencers/modeshape-sequencer-ddl/src/main/java/org/modeshape/sequencer/ddl/node/AstNodeFactory.java
@@ -63,10 +63,9 @@ public final class AstNodeFactory {
         CheckArg.isNotNull(parent, "parent");
         CheckArg.isNotEmpty(types, "types");
 
-        AstNode node = new AstNode(name);
+        AstNode node = new AstNode(parent, name);
         node.setProperty(JCR_MIXIN_TYPES, types);
         node.setProperty(JCR_PRIMARY_TYPE, NT_UNSTRUCTURED);
-        node.setParent(parent);
         return node;
     }
 
@@ -85,10 +84,9 @@ public final class AstNodeFactory {
         CheckArg.isNotNull(parent, "parent");
         CheckArg.isNotNull(type, "type");
 
-        AstNode node = new AstNode(name);
+        AstNode node = new AstNode(parent, name);
         node.setProperty(JCR_MIXIN_TYPES, type);
         node.setProperty(JCR_PRIMARY_TYPE, NT_UNSTRUCTURED);
-        node.setParent(parent);
         return node;
     }
 

--- a/sequencers/modeshape-sequencer-ddl/src/test/java/org/modeshape/sequencer/ddl/DdlParserTestHelper.java
+++ b/sequencers/modeshape-sequencer-ddl/src/test/java/org/modeshape/sequencer/ddl/DdlParserTestHelper.java
@@ -67,6 +67,14 @@ public class DdlParserTestHelper implements DdlConstants {
     public boolean isPrintToConsole() {
         return printToConsole;
     }
+    
+    public void setRootNode(AstNode rootNode) {
+    	this.rootNode = rootNode;
+    }
+    
+    public AstNode getRootNode() {
+    	return this.rootNode;
+    }
 
     /**
      * @param printToConsole Sets printToConsole to the specified value.
@@ -143,18 +151,18 @@ public class DdlParserTestHelper implements DdlConstants {
                                         int childCount ) {
         // First try with scoring ...
         Object result = parser.score(content, filename, scorer);
-        parser.parse(content, rootNode, result);
+        parser.parse(content, getRootNode(), result);
         assertThat(scorer.getScore() > 0, is(true));
         if (childCount >= 0) {
-            assertThat(rootNode.getChildCount(), is(childCount));
+            assertThat(getRootNode().getChildCount(), is(childCount));
         }
 
         // Do it again, but this time without scoring first ...
-        rootNode = parser.nodeFactory().node("ddlRootNode");
-        parser.setRootNode(rootNode);
-        parser.parse(content, rootNode, null);
+        setRootNode(parser.nodeFactory().node("ddlRootNode"));
+        parser.setRootNode(getRootNode());
+        parser.parse(content, getRootNode(), null);
         if (childCount >= 0) {
-            assertThat(rootNode.getChildCount(), is(childCount));
+            assertThat(getRootNode().getChildCount(), is(childCount));
         }
     }
 

--- a/sequencers/modeshape-sequencer-ddl/src/test/java/org/modeshape/sequencer/ddl/dialect/teiid/TeiidDdlParserTest.java
+++ b/sequencers/modeshape-sequencer-ddl/src/test/java/org/modeshape/sequencer/ddl/dialect/teiid/TeiidDdlParserTest.java
@@ -25,7 +25,10 @@ package org.modeshape.sequencer.ddl.dialect.teiid;
 
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
+
+import java.util.ArrayList;
 import java.util.List;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.modeshape.sequencer.ddl.DdlParserScorer;
@@ -37,10 +40,12 @@ import org.modeshape.sequencer.ddl.node.AstNode;
  */
 public class TeiidDdlParserTest extends DdlParserTestHelper implements TeiidDdlConstants {
 
+    public static final String DDL_FILE_PATH = "ddl/dialect/teiid/";
+	
     @Before
     public void beforeEach() {
         this.parser = new TeiidDdlParser();
-        this.rootNode = this.parser.nodeFactory().node("ddlRootNode");
+        setRootNode(this.parser.nodeFactory().node("DdlRootNode"));
         this.scorer = new DdlParserScorer();
     }
 
@@ -54,7 +59,7 @@ public class TeiidDdlParserTest extends DdlParserTestHelper implements TeiidDdlC
                                + "(param string) RETURNS string";
         assertScoreAndParse(content, null, 2);
 
-        final List<AstNode> kids = this.rootNode.getChildren();
+        final List<AstNode> kids = getRootNode().getChildren();
         assertMixinType(kids.get(0), TeiidDdlLexicon.CreateProcedure.FUNCTION_STATEMENT);
         assertMixinType(kids.get(1), TeiidDdlLexicon.CreateProcedure.FUNCTION_STATEMENT);
     }
@@ -68,13 +73,13 @@ public class TeiidDdlParserTest extends DdlParserTestHelper implements TeiidDdlC
         assertScoreAndParse(content, null, 2);
 
         {
-            final List<AstNode> kids = this.rootNode.childrenWithName("SourceFunc");
+            final List<AstNode> kids = getRootNode().childrenWithName("SourceFunc");
             assertThat(kids.size(), is(1));
             assertMixinType(kids.get(0), TeiidDdlLexicon.CreateProcedure.FUNCTION_STATEMENT);
         }
 
         {
-            final List<AstNode> kids = this.rootNode.childrenWithName("SourceFunc1");
+            final List<AstNode> kids = getRootNode().childrenWithName("SourceFunc1");
             assertThat(kids.size(), is(1));
             assertMixinType(kids.get(0), TeiidDdlLexicon.CreateProcedure.FUNCTION_STATEMENT);
         }
@@ -90,13 +95,13 @@ public class TeiidDdlParserTest extends DdlParserTestHelper implements TeiidDdlC
         assertScoreAndParse(content, null, 2);
 
         {
-            final List<AstNode> kids = this.rootNode.childrenWithName("V1");
+            final List<AstNode> kids = getRootNode().childrenWithName("V1");
             assertThat(kids.size(), is(1));
             assertMixinType(kids.get(0), TeiidDdlLexicon.CreateTable.VIEW_STATEMENT);
         }
 
         {
-            final List<AstNode> kids = this.rootNode.childrenWithName("FOO");
+            final List<AstNode> kids = getRootNode().childrenWithName("FOO");
             assertThat(kids.size(), is(1));
             assertMixinType(kids.get(0), TeiidDdlLexicon.CreateProcedure.PROCEDURE_STATEMENT);
         }
@@ -120,13 +125,13 @@ public class TeiidDdlParserTest extends DdlParserTestHelper implements TeiidDdlC
         assertScoreAndParse(content, null, 2);
 
         {
-            final List<AstNode> kids = this.rootNode.childrenWithName("getTweets");
+            final List<AstNode> kids = getRootNode().childrenWithName("getTweets");
             assertThat(kids.size(), is(1));
             assertMixinType(kids.get(0), TeiidDdlLexicon.CreateProcedure.PROCEDURE_STATEMENT);
         }
 
         {
-            final List<AstNode> kids = this.rootNode.childrenWithName("Tweet");
+            final List<AstNode> kids = getRootNode().childrenWithName("Tweet");
             assertThat(kids.size(), is(1));
             assertMixinType(kids.get(0), TeiidDdlLexicon.CreateTable.VIEW_STATEMENT);
         }
@@ -144,14 +149,14 @@ public class TeiidDdlParserTest extends DdlParserTestHelper implements TeiidDdlC
         assertScoreAndParse(content, null, 3);
 
         {
-            final List<AstNode> kids = this.rootNode.childrenWithName("G1");
+            final List<AstNode> kids = getRootNode().childrenWithName("G1");
             assertThat(kids.size(), is(2)); // view, trigger
             assertMixinType(kids.get(0), TeiidDdlLexicon.CreateTable.VIEW_STATEMENT);
             assertMixinType(kids.get(1), TeiidDdlLexicon.CreateTrigger.STATEMENT);
         }
 
         {
-            final List<AstNode> kids = this.rootNode.childrenWithName("G2");
+            final List<AstNode> kids = getRootNode().childrenWithName("G2");
             assertThat(kids.size(), is(1));
             assertMixinType(kids.get(0), TeiidDdlLexicon.CreateTable.VIEW_STATEMENT);
         }
@@ -167,13 +172,13 @@ public class TeiidDdlParserTest extends DdlParserTestHelper implements TeiidDdlC
         assertScoreAndParse(content, null, 2);
 
         {
-            final List<AstNode> kids = this.rootNode.childrenWithName("G1");
+            final List<AstNode> kids = getRootNode().childrenWithName("G1");
             assertThat(kids.size(), is(1));
             assertMixinType(kids.get(0), TeiidDdlLexicon.CreateTable.TABLE_STATEMENT);
         }
 
         {
-            final List<AstNode> kids = this.rootNode.childrenWithName("G2");
+            final List<AstNode> kids = getRootNode().childrenWithName("G2");
             assertThat(kids.size(), is(1));
             assertMixinType(kids.get(0), TeiidDdlLexicon.CreateTable.TABLE_STATEMENT);
         }
@@ -189,13 +194,13 @@ public class TeiidDdlParserTest extends DdlParserTestHelper implements TeiidDdlC
         assertScoreAndParse(content, null, 2);
 
         {
-            final List<AstNode> kids = this.rootNode.childrenWithName("G1");
+            final List<AstNode> kids = getRootNode().childrenWithName("G1");
             assertThat(kids.size(), is(1));
             assertMixinType(kids.get(0), TeiidDdlLexicon.CreateTable.TABLE_STATEMENT);
         }
 
         {
-            final List<AstNode> kids = this.rootNode.childrenWithName("G2");
+            final List<AstNode> kids = getRootNode().childrenWithName("G2");
             assertThat(kids.size(), is(1));
             assertMixinType(kids.get(0), TeiidDdlLexicon.CreateTable.TABLE_STATEMENT);
         }
@@ -212,7 +217,7 @@ public class TeiidDdlParserTest extends DdlParserTestHelper implements TeiidDdlC
                                + "  DATECLOSED timestamp NOT NULL DEFAULT '0000-00-00 00:00:00' OPTIONS (ANNOTATION '', NAMEINSOURCE '`DATECLOSED`', NATIVE_TYPE 'TIMESTAMP')"
                                + "  )" + " OPTIONS (ANNOTATION '', NAMEINSOURCE '`accounts`.`ACCOUNT`', UPDATABLE TRUE);";
         assertScoreAndParse(content, null, 1);
-        final AstNode tableNode = this.rootNode.getChildren().get(0);
+        final AstNode tableNode = getRootNode().getChildren().get(0);
         assertMixinType(tableNode, TeiidDdlLexicon.CreateTable.TABLE_STATEMENT);
         assertProperty(tableNode, TeiidDdlLexicon.SchemaElement.TYPE, SchemaElementType.FOREIGN.toDdl());
     }
@@ -258,25 +263,25 @@ public class TeiidDdlParserTest extends DdlParserTestHelper implements TeiidDdlC
         assertScoreAndParse(content, null, 4);
 
         {
-            final List<AstNode> kids = this.rootNode.childrenWithName("performRuleOnData");
+            final List<AstNode> kids = getRootNode().childrenWithName("performRuleOnData");
             assertThat(kids.size(), is(1));
             assertMixinType(kids.get(0), TeiidDdlLexicon.CreateProcedure.FUNCTION_STATEMENT);
         }
 
         {
-            final List<AstNode> kids = this.rootNode.childrenWithName("StockPrices");
+            final List<AstNode> kids = getRootNode().childrenWithName("StockPrices");
             assertThat(kids.size(), is(1));
             assertMixinType(kids.get(0), TeiidDdlLexicon.CreateTable.VIEW_STATEMENT);
         }
 
         {
-            final List<AstNode> kids = this.rootNode.childrenWithName("Stock");
+            final List<AstNode> kids = getRootNode().childrenWithName("Stock");
             assertThat(kids.size(), is(1));
             assertMixinType(kids.get(0), TeiidDdlLexicon.CreateTable.VIEW_STATEMENT);
         }
 
         {
-            final List<AstNode> kids = this.rootNode.childrenWithName("StockValidation");
+            final List<AstNode> kids = getRootNode().childrenWithName("StockValidation");
             assertThat(kids.size(), is(1));
             assertMixinType(kids.get(0), TeiidDdlLexicon.CreateProcedure.PROCEDURE_STATEMENT);
         }
@@ -290,18 +295,89 @@ public class TeiidDdlParserTest extends DdlParserTestHelper implements TeiidDdlC
 		assertScoreAndParse(content, null, 2);
 
 		{
-			final List<AstNode> kids = this.rootNode.childrenWithName("G1");
+			final List<AstNode> kids = getRootNode().childrenWithName("G1");
 			assertThat(kids.size(), is(1));
 			assertMixinType(kids.get(0),
 					TeiidDdlLexicon.CreateTable.TABLE_STATEMENT);
 		}
 
 		{
-			final List<AstNode> kids = this.rootNode.childrenWithName("G2");
+			final List<AstNode> kids = getRootNode().childrenWithName("G2");
 			assertThat(kids.size(), is(1));
 			assertMixinType(kids.get(0),
 					TeiidDdlLexicon.CreateTable.TABLE_STATEMENT);
 		}
 	}
+    
+    @Test
+    public void shouldParseTeiidStatements_1() {
+    	// Parses a simplified DDL that contains 3 tables, 2 with Foreign keys.
+    	// The Tables in the DDL are arranged, such that the first table has FK reference to 3rd table
+    	// and results in an Unresolved table reference that should be handled by a postProcess() method
+    	
+        printTest("shouldParseTeiidStatements_1()");
+        String content = getFileContent(DDL_FILE_PATH + "sap_short_test.ddl");
+        assertScoreAndParse(content, "teiid_test_statements_1", 3);
+        final AstNode tableNode = getRootNode().getChildren().get(0);
+        if( tableNode != null) {
+        	final List<AstNode> kids = getRootNode().childrenWithName("BookingCollection");
+            assertThat(kids.size(), is(1));
+            final List<AstNode> tableKids = kids.get(0).getChildren();
+            assertThat(tableKids.size(), is(9));
+            final List<AstNode> fkNodes = kids.get(0).childrenWithName("BookingFlight");
+            assertThat(fkNodes.size(), is(1));
+            
+            final List<AstNode> fc_kids = getRootNode().childrenWithName("FlightCollection");
+            assertThat(fc_kids.size(), is(1));
+            final List<AstNode> fc_columns = fc_kids.get(0).childrenWithName("carrid");
+            assertThat(fc_columns.size(), is(1));
+            AstNode columnNode = fc_columns.get(0);
+            
+            @SuppressWarnings("unchecked")
+			ArrayList<AstNode> props = ((ArrayList<AstNode>)fkNodes.get(0).getProperty(TeiidDdlLexicon.Constraint.TABLE_REFERENCE_REFERENCES));
+            AstNode refColumnNode = props.get(0);
+            assertThat(refColumnNode, is(columnNode));
+        }
+    }
+    
+    @Test
+    public void shouldParseTeiidStatements_2() {
+    	// Parses a full DDL file that contains multiple tables with multiple FK's
+    	// The Tables in the DDL are arranged, such that the at least one table has FK reference to table defined later in the DDL
+    	// and results in an Unresolved table reference that should be handled by a postProcess() method
+    	
+        printTest("shouldParseTeiidStatements_2()");
+        String content = getFileContent(DDL_FILE_PATH + "sap-flight.ddl");
+        assertScoreAndParse(content, "teiid_test_statements_2", 12);
+        final AstNode tableNode = getRootNode().getChildren().get(0);
+        
+        if( tableNode != null) {
+        	final List<AstNode> kids = getRootNode().childrenWithName("BookingCollection");
+            assertThat(kids.size(), is(1));
+            final List<AstNode> tableKids = kids.get(0).getChildren();
+            assertThat(tableKids.size(), is(28));
+            final List<AstNode> fkNodes = kids.get(0).childrenWithName("BookingFlight");
+            assertThat(fkNodes.size(), is(1));
+            
+            final List<AstNode> fc_kids = getRootNode().childrenWithName("FlightCollection");
+            assertThat(fc_kids.size(), is(1));
+            final List<AstNode> fc_columns = fc_kids.get(0).childrenWithName("carrid");
+            assertThat(fc_columns.size(), is(1));
+            AstNode columnNode = fc_columns.get(0);
+            
+            @SuppressWarnings("unchecked")
+			ArrayList<AstNode> props = ((ArrayList<AstNode>)fkNodes.get(0).getProperty(TeiidDdlLexicon.Constraint.TABLE_REFERENCE_REFERENCES));
+            AstNode refColumnNode = null;
+            for( AstNode nextColumnNode : props ) {
+	            
+	        	if( nextColumnNode.getName().equals("carrid")) {
+	        		refColumnNode = nextColumnNode;
+	        		break;
+	        	}
+        	}
+            
+            assertThat(refColumnNode, is(columnNode));
+        }
+    }
 
 }

--- a/sequencers/modeshape-sequencer-ddl/src/test/resources/ddl/dialect/teiid/sap-flight.ddl
+++ b/sequencers/modeshape-sequencer-ddl/src/test/resources/ddl/dialect/teiid/sap-flight.ddl
@@ -1,0 +1,142 @@
+CREATE FOREIGN TABLE BookingCollection (
+	carrid string(3) NOT NULL,
+	connid string(4) NOT NULL,
+	fldate timestamp NOT NULL,
+	bookid string(8) NOT NULL,
+	CUSTOMID string(8) NOT NULL,
+	CUSTTYPE string(1) NOT NULL,
+	SMOKER string(1) NOT NULL,
+	WUNIT string(3) NOT NULL,
+	LUGGWEIGHT bigdecimal NOT NULL,
+	INVOICE string(1) NOT NULL,
+	CLASS string(1) NOT NULL,
+	FORCURAM bigdecimal NOT NULL,
+	FORCURKEY string(5) NOT NULL,
+	LOCCURAM bigdecimal NOT NULL,
+	LOCCURKEY string(5) NOT NULL,
+	ORDER_DATE timestamp NOT NULL,
+	COUNTER string(8) NOT NULL,
+	AGENCYNUM string(8) NOT NULL,
+	CANCELLED string(1) NOT NULL,
+	RESERVED string(1) NOT NULL,
+	PASSNAME string(25) NOT NULL,
+	PASSFORM string(15) NOT NULL,
+	PASSBIRTH timestamp NOT NULL,
+	PRIMARY KEY(carrid, connid, fldate, bookid),
+	CONSTRAINT BookingFlight FOREIGN KEY(fldate, connid, carrid) REFERENCES FlightCollection (fldate, connid, carrid),
+	CONSTRAINT FlightBookings FOREIGN KEY(fldate, connid, carrid) REFERENCES FlightCollection (fldate, connid, carrid)
+) OPTIONS (UPDATABLE TRUE, "teiid_odata:EntityType" 'RMTSAMPLEFLIGHT.Booking');
+
+CREATE FOREIGN TABLE CarrierCollection (
+	carrid string(3) NOT NULL,
+	CARRNAME string(20) NOT NULL,
+	CURRCODE string(5) NOT NULL,
+	URL string(255) NOT NULL,
+	mimeType string(128) NOT NULL,
+	PRIMARY KEY(carrid)
+) OPTIONS (UPDATABLE TRUE, "teiid_odata:EntityType" 'RMTSAMPLEFLIGHT.Carrier');
+
+CREATE FOREIGN TABLE FlightCollection (
+	flightDetails_countryFrom string(3) NOT NULL OPTIONS (NAMEINSOURCE 'countryFrom', "teiid_odata:ColumnGroup" 'flightDetails', "teiid_odata:ComplexType" 'FlightDetails'),
+	flightDetails_cityFrom string(20) NOT NULL OPTIONS (NAMEINSOURCE 'cityFrom', "teiid_odata:ColumnGroup" 'flightDetails', "teiid_odata:ComplexType" 'FlightDetails'),
+	flightDetails_airportFrom string(3) NOT NULL OPTIONS (NAMEINSOURCE 'airportFrom', "teiid_odata:ColumnGroup" 'flightDetails', "teiid_odata:ComplexType" 'FlightDetails'),
+	flightDetails_countryTo string(3) NOT NULL OPTIONS (NAMEINSOURCE 'countryTo', "teiid_odata:ColumnGroup" 'flightDetails', "teiid_odata:ComplexType" 'FlightDetails'),
+	flightDetails_cityTo string(20) NOT NULL OPTIONS (NAMEINSOURCE 'cityTo', "teiid_odata:ColumnGroup" 'flightDetails', "teiid_odata:ComplexType" 'FlightDetails'),
+	flightDetails_airportTo string(3) NOT NULL OPTIONS (NAMEINSOURCE 'airportTo', "teiid_odata:ColumnGroup" 'flightDetails', "teiid_odata:ComplexType" 'FlightDetails'),
+	flightDetails_flightTime integer NOT NULL OPTIONS (NAMEINSOURCE 'flightTime', "teiid_odata:ColumnGroup" 'flightDetails', "teiid_odata:ComplexType" 'FlightDetails'),
+	flightDetails_departureTime time NOT NULL OPTIONS (NAMEINSOURCE 'departureTime', "teiid_odata:ColumnGroup" 'flightDetails', "teiid_odata:ComplexType" 'FlightDetails'),
+	flightDetails_arrivalTime time NOT NULL OPTIONS (NAMEINSOURCE 'arrivalTime', "teiid_odata:ColumnGroup" 'flightDetails', "teiid_odata:ComplexType" 'FlightDetails'),
+	flightDetails_distance bigdecimal NOT NULL OPTIONS (NAMEINSOURCE 'distance', "teiid_odata:ColumnGroup" 'flightDetails', "teiid_odata:ComplexType" 'FlightDetails'),
+	flightDetails_distanceUnit string(3) NOT NULL OPTIONS (NAMEINSOURCE 'distanceUnit', "teiid_odata:ColumnGroup" 'flightDetails', "teiid_odata:ComplexType" 'FlightDetails'),
+	flightDetails_flightType string(1) NOT NULL OPTIONS (NAMEINSOURCE 'flightType', "teiid_odata:ColumnGroup" 'flightDetails', "teiid_odata:ComplexType" 'FlightDetails'),
+	flightDetails_period byte NOT NULL OPTIONS (NAMEINSOURCE 'period', "teiid_odata:ColumnGroup" 'flightDetails', "teiid_odata:ComplexType" 'FlightDetails'),
+	carrid string(3) NOT NULL,
+	connid string(4) NOT NULL,
+	fldate timestamp NOT NULL,
+	PRICE bigdecimal NOT NULL,
+	CURRENCY string(5) NOT NULL,
+	PLANETYPE string(10) NOT NULL,
+	SEATSMAX integer NOT NULL,
+	SEATSOCC integer NOT NULL,
+	PAYMENTSUM bigdecimal NOT NULL,
+	SEATSMAX_B integer NOT NULL,
+	SEATSOCC_B integer NOT NULL,
+	SEATSMAX_F integer NOT NULL,
+	SEATSOCC_F integer NOT NULL,
+	PRIMARY KEY(carrid, connid, fldate),
+	CONSTRAINT CarrierToFlight FOREIGN KEY(carrid) REFERENCES CarrierCollection 
+) OPTIONS (UPDATABLE TRUE, "teiid_odata:EntityType" 'RMTSAMPLEFLIGHT.Flight');
+
+CREATE FOREIGN TABLE NotificationCollection (
+	ID string(32) NOT NULL,
+	collection string(40) NOT NULL,
+	title string NOT NULL,
+	updated timestamp NOT NULL,
+	changeType string(30) NOT NULL,
+	entriesOfInterest integer NOT NULL,
+	recipient string(112) NOT NULL,
+	PRIMARY KEY(ID)
+) OPTIONS (UPDATABLE TRUE, "teiid_odata:EntityType" 'RMTSAMPLEFLIGHT.Notification');
+
+CREATE FOREIGN TABLE SubscriptionCollection (
+	ID string(32) NOT NULL,
+	"user" string(12) NOT NULL,
+	updated timestamp NOT NULL,
+	title string(255) NOT NULL,
+	deliveryAddress string NOT NULL,
+	persistNotifications boolean NOT NULL,
+	collection string(40) NOT NULL,
+	"filter" string NOT NULL,
+	"select" string(255) NOT NULL,
+	changeType string(30) NOT NULL,
+	PRIMARY KEY(ID)
+) OPTIONS (UPDATABLE TRUE, "teiid_odata:EntityType" 'RMTSAMPLEFLIGHT.Subscription');
+
+CREATE FOREIGN TABLE TravelAgencies (
+	agencynum string(8) NOT NULL,
+	NAME string(25) NOT NULL,
+	STREET string(30) NOT NULL,
+	POSTBOX string(10) NOT NULL,
+	POSTCODE string(10) NOT NULL,
+	CITY string(25) NOT NULL,
+	COUNTRY string(3) NOT NULL,
+	REGION string(3) NOT NULL,
+	TELEPHONE string(30) NOT NULL,
+	URL string(255) NOT NULL,
+	LANGU string(2) NOT NULL,
+	CURRENCY string(5) NOT NULL,
+	mimeType string(128) NOT NULL,
+	PRIMARY KEY(agencynum)
+) OPTIONS (UPDATABLE TRUE, "teiid_odata:EntityType" 'RMTSAMPLEFLIGHT.Travelagency');
+
+CREATE FOREIGN TABLE TravelagencyCollection (
+	agencynum string(8) NOT NULL,
+	NAME string(25) NOT NULL,
+	STREET string(30) NOT NULL,
+	POSTBOX string(10) NOT NULL,
+	POSTCODE string(10) NOT NULL,
+	CITY string(25) NOT NULL,
+	COUNTRY string(3) NOT NULL,
+	REGION string(3) NOT NULL,
+	TELEPHONE string(30) NOT NULL,
+	URL string(255) NOT NULL,
+	LANGU string(2) NOT NULL,
+	CURRENCY string(5) NOT NULL,
+	mimeType string(128) NOT NULL,
+	PRIMARY KEY(agencynum)
+) OPTIONS (UPDATABLE TRUE, "teiid_odata:EntityType" 'RMTSAMPLEFLIGHT.Travelagency');
+
+CREATE FOREIGN PROCEDURE CheckFlightAvailability(IN airlineid string, IN connectionid string, IN flightdate timestamp) RETURNS TABLE (ECONOMAX integer, ECONOFREE integer, BUSINMAX integer, BUSINFREE integer, FIRSTMAX integer, FIRSTFREE integer)
+OPTIONS ("teiid_odata:EntityType" 'RMTSAMPLEFLIGHT.FlightAvailability', "teiid_odata:HttpMethod" 'GET')
+
+CREATE FOREIGN PROCEDURE GetAgencyDetails(IN agency_id string) RETURNS TABLE (agencynum string, NAME string, STREET string, POSTBOX string, POSTCODE string, CITY string, COUNTRY string, REGION string, TELEPHONE string, URL string, LANGU string, CURRENCY string, mimeType string)
+OPTIONS ("teiid_odata:EntityType" 'RMTSAMPLEFLIGHT.Travelagency', "teiid_odata:HttpMethod" 'GET')
+
+CREATE FOREIGN PROCEDURE GetAvailableFlights(IN fromdate timestamp, IN todate timestamp, IN cityfrom string, IN cityto string) RETURNS TABLE (flightDetails_countryFrom string, flightDetails_cityFrom string, flightDetails_airportFrom string, flightDetails_countryTo string, flightDetails_cityTo string, flightDetails_airportTo string, flightDetails_flightTime integer, flightDetails_departureTime time, flightDetails_arrivalTime time, flightDetails_distance bigdecimal, flightDetails_distanceUnit string, flightDetails_flightType string, flightDetails_period byte, carrid string, connid string, fldate timestamp, PRICE bigdecimal, CURRENCY string, PLANETYPE string, SEATSMAX integer, SEATSOCC integer, PAYMENTSUM bigdecimal, SEATSMAX_B integer, SEATSOCC_B integer, SEATSMAX_F integer, SEATSOCC_F integer)
+OPTIONS ("teiid_odata:EntityType" 'RMTSAMPLEFLIGHT.Flight', "teiid_odata:HttpMethod" 'GET')
+
+CREATE FOREIGN PROCEDURE GetFlightDetails(IN airlineid string, IN connectionid string) RETURNS TABLE (countryFrom string, cityFrom string, airportFrom string, countryTo string, cityTo string, airportTo string, flightTime integer, departureTime time, arrivalTime time, distance bigdecimal, distanceUnit string, flightType string, period byte)
+OPTIONS ("teiid_odata:EntityType" 'RMTSAMPLEFLIGHT.FlightDetails', "teiid_odata:HttpMethod" 'GET')
+
+CREATE FOREIGN PROCEDURE UpdateAgencyPhoneNo(IN agency_id string, IN telephone string) RETURNS TABLE (agencynum string, NAME string, STREET string, POSTBOX string, POSTCODE string, CITY string, COUNTRY string, REGION string, TELEPHONE string, URL string, LANGU string, CURRENCY string, mimeType string)
+OPTIONS ("teiid_odata:EntityType" 'RMTSAMPLEFLIGHT.Travelagency', "teiid_odata:HttpMethod" 'PUT')

--- a/sequencers/modeshape-sequencer-ddl/src/test/resources/ddl/dialect/teiid/sap_short_test.ddl
+++ b/sequencers/modeshape-sequencer-ddl/src/test/resources/ddl/dialect/teiid/sap_short_test.ddl
@@ -1,0 +1,26 @@
+CREATE FOREIGN TABLE BookingCollection (
+	carrid string(3) NOT NULL,
+	connid string(4) NOT NULL,
+	fldate timestamp NOT NULL,
+	bookid string(8) NOT NULL,
+	PRIMARY KEY(carrid),
+	CONSTRAINT BookingFlight FOREIGN KEY(carrid) REFERENCES FlightCollection (carrid),
+	CONSTRAINT FlightBookings FOREIGN KEY(carrid) REFERENCES FlightCollection (carrid)
+) OPTIONS (UPDATABLE TRUE, "teiid_odata:EntityType" 'RMTSAMPLEFLIGHT.Booking');
+
+CREATE FOREIGN TABLE CarrierCollection (
+	carrid string(3) NOT NULL,
+	CARRNAME string(20) NOT NULL,
+	PRIMARY KEY(carrid)
+) OPTIONS (UPDATABLE TRUE, "teiid_odata:EntityType" 'RMTSAMPLEFLIGHT.Carrier');
+
+CREATE FOREIGN TABLE FlightCollection (
+
+	carrid string(3) NOT NULL,
+	connid string(4) NOT NULL,
+	fldate timestamp NOT NULL,
+	PRICE bigdecimal NOT NULL,
+	CURRENCY string(5) NOT NULL,
+	PRIMARY KEY(carrid),
+	CONSTRAINT CarrierToFlight FOREIGN KEY(carrid) REFERENCES CarrierCollection 
+) OPTIONS (UPDATABLE TRUE, "teiid_odata:EntityType" 'RMTSAMPLEFLIGHT.Flight');

--- a/sequencers/modeshape-sequencer-ddl/src/test/resources/ddl/dialect/teiid/stdcust.ddl
+++ b/sequencers/modeshape-sequencer-ddl/src/test/resources/ddl/dialect/teiid/stdcust.ddl
@@ -1,0 +1,49 @@
+CREATE TABLE customer
+(
+   CustomerId varchar(12) PRIMARY KEY NOT NULL,
+   FirstName varchar(25),
+   LastName varchar(25),
+   MiddleName varchar(15),
+   StreetAddress varchar(50),
+   StreetAddress2 varchar(25),
+   City varchar(25),
+   StateProvince varchar(25),
+   PostalCode varchar(15),
+   Country varchar(15),
+   PhoneNumber varchar(30)
+)
+;
+
+
+CREATE TABLE account
+(
+   AccountID decimal(10,0) PRIMARY KEY NOT NULL,
+   CustomerId varchar(12) NOT NULL,
+   AccountType varchar(10) NOT NULL,
+   AccountStatus varchar(10) NOT NULL,
+   DateOpened timestamp,
+   DateClosed timestamp
+)
+;
+ALTER TABLE account
+ADD CONSTRAINT FK_Account_CustId
+FOREIGN KEY (CustomerId)
+REFERENCES customer(CustomerId)
+;
+
+
+CREATE TABLE accountholdings
+(
+   TransactionID varchar(15) PRIMARY KEY NOT NULL,
+   AccountID decimal(10,0) NOT NULL,
+   ProductID varchar(12) NOT NULL,
+   PurchaseDate timestamp,
+   ProductShares decimal(10,5) NOT NULL
+)
+;
+ALTER TABLE accountholdings
+ADD CONSTRAINT FK_AcctHoldings_AcctID
+FOREIGN KEY (AccountID)
+REFERENCES account(AccountID)
+;
+

--- a/sequencers/modeshape-sequencer-ddl/src/test/resources/ddl/dialect/teiid/teiid_fk_test.ddl
+++ b/sequencers/modeshape-sequencer-ddl/src/test/resources/ddl/dialect/teiid/teiid_fk_test.ddl
@@ -1,0 +1,23 @@
+CREATE FOREIGN TABLE table_1 (
+	column_1 string(3) NOT NULL,
+	column_2 string(4) NOT NULL,
+	column_3 timestamp NOT NULL,
+	column_4 string(8) NOT NULL,
+	PRIMARY KEY(column_1, column_2, column_3, column_4),
+	CONSTRAINT fk_to_table_2 FOREIGN KEY(column_1, column_2, column_3) REFERENCES table_2 (column_1, column_2, column_2),
+) OPTIONS (UPDATABLE TRUE, "teiid_odata:EntityType" 'RMTSAMPLEFLIGHT.Booking');
+
+CREATE FOREIGN TABLE table_3 (
+	column_1 string(3) NOT NULL,
+	CARRNAME string(20) NOT NULL,
+	PRIMARY KEY(column_1)
+) OPTIONS (UPDATABLE TRUE, "teiid_odata:EntityType" 'RMTSAMPLEFLIGHT.Carrier');
+
+CREATE FOREIGN TABLE table_2 {
+	column_1 string(3) NOT NULL,
+	column_2 string(4) NOT NULL,
+	column_3 timestamp NOT NULL,
+	column_5 bigdecimal NOT NULL,
+	PRIMARY KEY(column_1, column_2, column_3),
+	CONSTRAINT fk_to_table_3 FOREIGN KEY(column_1) REFERENCES table_3 
+) OPTIONS (UPDATABLE TRUE, "teiid_odata:EntityType" 'RMTSAMPLEFLIGHT.Flight');


### PR DESCRIPTION
DDL can contain tables defined in any order like, In this use-case, TableA, TableB, TableC where TableA contains a FK reference to TableC. The reference to TableC (AstNode) cannot be resolved until TableC is parsed and the nodes constructed. 

Resolving these references is now handled properly in the Teiid CreateTableParser.postProcess() method.
