### PR TITLE
MODE-2074 Fixed the usage of CharSet decoders/encoders by the BsonDataInput/Output classes

### DIFF
--- a/modeshape-schematic/src/main/java/org/infinispan/schematic/internal/io/BsonDataOutput.java
+++ b/modeshape-schematic/src/main/java/org/infinispan/schematic/internal/io/BsonDataOutput.java
@@ -382,7 +382,7 @@ public class BsonDataOutput implements DataOutput {
     public int writeUTF( int position,
                          String str ) {
         CharBuffer chars = CharBuffer.wrap(str);
-        CharsetEncoder encoder = Utf8Util.getUtf8Encoder();
+        CharsetEncoder encoder = Utf8Util.CHARSET.newEncoder();
         ByteBuffer output = getBufferFor(position);
         int index = position % bufferSize;
         int newPosition = position;

--- a/modeshape-schematic/src/main/java/org/infinispan/schematic/internal/io/Utf8Util.java
+++ b/modeshape-schematic/src/main/java/org/infinispan/schematic/internal/io/Utf8Util.java
@@ -22,38 +22,7 @@
 package org.infinispan.schematic.internal.io;
 
 import java.nio.charset.Charset;
-import java.nio.charset.CharsetDecoder;
-import java.nio.charset.CharsetEncoder;
 
 public final class Utf8Util {
-
-   private static transient Charset utf8;
-   private static transient CharsetDecoder utf8Decoder;
-   private static transient CharsetEncoder utf8Encoder;
-
-   private Utf8Util() {
-      // prevent instantiation
-   }
-
-   protected static Charset getUtf8() {
-      if (utf8 == null) {
-         utf8 = Charset.forName("UTF-8");
-      }
-      return utf8;
-   }
-
-   protected static CharsetDecoder getUtf8Decoder() {
-      if (utf8Decoder == null) {
-         utf8Decoder = getUtf8().newDecoder();
-      }
-      return utf8Decoder;
-   }
-
-   protected static CharsetEncoder getUtf8Encoder() {
-      if (utf8Encoder == null) {
-         utf8Encoder = getUtf8().newEncoder();
-      }
-      return utf8Encoder;
-   }
-
+    public static final Charset CHARSET = Charset.forName("UTF-8");
 }

--- a/modeshape-schematic/src/test/resources/json/sample-large-modeshape-doc3.json
+++ b/modeshape-schematic/src/test/resources/json/sample-large-modeshape-doc3.json
@@ -1,0 +1,301 @@
+{
+    "metadata": {
+        "id": "7505d647505d64427bec55-4083-4407-8519-fe1347a87421"
+    },
+    "content": {
+        "key": "7505d647505d64427bec55-4083-4407-8519-fe1347a87421",
+        "parent": "7505d647505d64/",
+        "properties": {
+            "http://www.jcp.org/jcr/1.0": {
+                "primaryType": {
+                    "$name": "nt:unstructured"
+                }
+            }
+        },
+        "children": [
+            {
+                "key": "7505d647505d64ca3b40b8-755f-441f-b815-f5c3262bf115",
+                "name": "childNode0"
+            },
+            {
+                "key": "7505d647505d64c95c30d7-4ccc-428a-8c2a-1ec975b2ab40",
+                "name": "childNode1"
+            },
+            {
+                "key": "7505d647505d6449e9662b-ee3a-4cd1-8935-da77374d9e06",
+                "name": "childNode2"
+            },
+            {
+                "key": "7505d647505d6408a473ec-5364-433e-bca5-073890b429da",
+                "name": "childNode3"
+            },
+            {
+                "key": "7505d647505d64537ac76f-48bf-4cd6-8520-fed7750f6886",
+                "name": "childNode4"
+            },
+            {
+                "key": "7505d647505d64e383a058-de20-4c4e-9e34-5c76ba3511ca",
+                "name": "childNode5"
+            },
+            {
+                "key": "7505d647505d64642a5c6b-e58c-4658-96b8-2eb4cd90c129",
+                "name": "childNode6"
+            },
+            {
+                "key": "7505d647505d64d4cd6659-709d-4ace-8e4e-77e31edf3328",
+                "name": "childNode7"
+            },
+            {
+                "key": "7505d647505d6414187df6-22c1-4926-a16f-8bcd49684aa1",
+                "name": "childNode8"
+            },
+            {
+                "key": "7505d647505d6489ead848-41ec-4770-8501-767e6e170120",
+                "name": "childNode9"
+            },
+            {
+                "key": "7505d647505d645cd7d564-0dd1-4b64-979f-205be9d0ca19",
+                "name": "childNode10"
+            },
+            {
+                "key": "7505d647505d6472d85990-742b-4992-bbe3-91be72e1715f",
+                "name": "childNode11"
+            },
+            {
+                "key": "7505d647505d640a26da55-5284-454b-b7c7-037735d275cf",
+                "name": "childNode12"
+            },
+            {
+                "key": "7505d647505d640aff84a8-e7ad-4257-9a49-ff3c6bf46e5e",
+                "name": "childNode13"
+            },
+            {
+                "key": "7505d647505d6483e49b50-59bc-46a9-8c4a-cd03b1aee100",
+                "name": "childNode14"
+            },
+            {
+                "key": "7505d647505d6434bda86e-718b-4983-bd16-02ad6f45f2e8",
+                "name": "childNode15"
+            },
+            {
+                "key": "7505d647505d64c3bc90e5-737e-4d1e-bcb1-b83326e7faa6",
+                "name": "childNode16"
+            },
+            {
+                "key": "7505d647505d6404d87208-3c35-4e4f-9448-caf4fa0a2a32",
+                "name": "childNode17"
+            },
+            {
+                "key": "7505d647505d64b5c5cf34-7427-4786-a682-54bd1ddb909e",
+                "name": "childNode18"
+            },
+            {
+                "key": "7505d647505d646305fe69-2c13-40c3-bbc1-98051409dd1e",
+                "name": "childNode19"
+            },
+            {
+                "key": "7505d647505d6434a607db-7ac0-4736-a264-4c00da555b7f",
+                "name": "childNode20"
+            },
+            {
+                "key": "7505d647505d64fc323a1b-0b59-4dfe-84e6-966b3c4166b5",
+                "name": "childNode21"
+            },
+            {
+                "key": "7505d647505d64f3e68197-39db-4fd7-a2f4-b43b8d318e44",
+                "name": "childNode22"
+            },
+            {
+                "key": "7505d647505d641b17e3e6-5621-4c12-8e1f-c7e57a077d36",
+                "name": "childNode23"
+            },
+            {
+                "key": "7505d647505d64884140a8-bc80-4d39-b5e3-43db47897861",
+                "name": "childNode24"
+            },
+            {
+                "key": "7505d647505d644142bf68-d949-432c-866d-9932e9b5e7df",
+                "name": "childNode25"
+            },
+            {
+                "key": "7505d647505d64e2eb0b2f-c80e-42e9-b530-6921b0c45af4",
+                "name": "childNode26"
+            },
+            {
+                "key": "7505d647505d64289c7f6c-e663-4946-a608-755dfffb5eeb",
+                "name": "childNode27"
+            },
+            {
+                "key": "7505d647505d6447fd542c-d943-4ac2-9f0b-18eedb0815d9",
+                "name": "childNode28"
+            },
+            {
+                "key": "7505d647505d647a1b26c0-0e31-4a67-b0fe-58a341d741fc",
+                "name": "childNode29"
+            },
+            {
+                "key": "7505d647505d64bf5fcd32-a654-4bf8-a2e9-7d1e59ccf6d0",
+                "name": "childNode30"
+            },
+            {
+                "key": "7505d647505d6441842cda-e5ef-4e86-b2fc-1abd6bdc36dd",
+                "name": "childNode31"
+            },
+            {
+                "key": "7505d647505d6438273c6a-bfe8-4916-a204-4d3a8093ab7e",
+                "name": "childNode32"
+            },
+            {
+                "key": "7505d647505d640073ea59-a6ae-4398-9d4c-d0c5ed51ae06",
+                "name": "childNode33"
+            },
+            {
+                "key": "7505d647505d64f21cdf89-fbab-4c2a-9857-67b64113188d",
+                "name": "childNode34"
+            },
+            {
+                "key": "7505d647505d64a3c3b386-509f-4aa3-ac89-8317f4da58b6",
+                "name": "childNode35"
+            },
+            {
+                "key": "7505d647505d64b51bc71a-9c2e-453d-8bc8-187fb2aedc78",
+                "name": "childNode36"
+            },
+            {
+                "key": "7505d647505d64ec1aa03f-d91a-431e-ae85-e5630bf46ec9",
+                "name": "childNode37"
+            },
+            {
+                "key": "7505d647505d64e999b079-9341-4da4-bd6f-780e5250f13d",
+                "name": "childNode38"
+            },
+            {
+                "key": "7505d647505d647639ae7d-fabc-4eb8-bc16-b62bcb868ba9",
+                "name": "childNode39"
+            },
+            {
+                "key": "7505d647505d6436f8cb90-4f61-4519-b94b-d809a1c728c3",
+                "name": "childNode40"
+            },
+            {
+                "key": "7505d647505d64f03d6823-a683-4478-a7d4-fa6ee772abf4",
+                "name": "childNode41"
+            },
+            {
+                "key": "7505d647505d647064eb1c-d477-47b9-b70a-9ca32a0be274",
+                "name": "childNode42"
+            },
+            {
+                "key": "7505d647505d64549befc1-f46f-49d9-8c3e-f3a289ee01e5",
+                "name": "childNode43"
+            },
+            {
+                "key": "7505d647505d64a22200cf-5fa3-4d19-a489-7e001d34f94c",
+                "name": "childNode44"
+            },
+            {
+                "key": "7505d647505d64e5e81e3f-e49d-43a3-926a-9e872314689b",
+                "name": "childNode45"
+            },
+            {
+                "key": "7505d647505d6460871da6-3110-4cce-8ed5-a4f4c381115a",
+                "name": "childNode46"
+            },
+            {
+                "key": "7505d647505d64374c755d-feae-417e-a667-66d43763c417",
+                "name": "childNode47"
+            },
+            {
+                "key": "7505d647505d644bbd38f6-577a-44f1-a1d1-f05b6b0256f9",
+                "name": "childNode48"
+            },
+            {
+                "key": "7505d647505d64d8ae9ad9-cd88-499a-9fc2-229aebcf518c",
+                "name": "childNode49"
+            },
+            {
+                "key": "7505d647505d647556261d-ce17-412b-8bb6-994caffb04a3",
+                "name": "childNode50"
+            },
+            {
+                "key": "7505d647505d64bbd6e7aa-08ce-41de-8656-35bf275be167",
+                "name": "childNode51"
+            },
+            {
+                "key": "7505d647505d6452074474-2c33-40a7-b835-3727a58e1244",
+                "name": "childNode52"
+            },
+            {
+                "key": "7505d647505d64c2320e39-3b9f-41ce-aede-76a6b46cacf6",
+                "name": "childNode53"
+            },
+            {
+                "key": "7505d647505d6429a7830a-998c-4669-9d8c-3ad706908962",
+                "name": "childNode54"
+            },
+            {
+                "key": "7505d647505d64152343c5-b90e-4d21-9eb9-f2e6c0a4b6ae",
+                "name": "childNode55"
+            },
+            {
+                "key": "7505d647505d6487b8e9f3-d856-4a35-94db-47d895ed866e",
+                "name": "childNode56"
+            },
+            {
+                "key": "7505d647505d64fa7fbb65-7ded-4728-a6e3-c30f4dddfe45",
+                "name": "childNode57"
+            },
+            {
+                "key": "7505d647505d641dfd9f12-0537-42ea-b275-10185842d46e",
+                "name": "childNode58"
+            },
+            {
+                "key": "7505d647505d643fff7db5-4ce2-4680-aa82-a7947b008d44",
+                "name": "childNode59"
+            },
+            {
+                "key": "7505d647505d643f0a5953-8053-44cb-8ec4-5d8ea1ce0b5d",
+                "name": "childNode60"
+            },
+            {
+                "key": "7505d647505d649243e51c-7dc9-47e8-a399-1a1ed848f677",
+                "name": "childNode61"
+            },
+            {
+                "key": "7505d647505d6404d1cc4c-770c-43b4-aa0f-872379a1c7c0",
+                "name": "childNode62"
+            },
+            {
+                "key": "7505d647505d64b87ff826-2562-490a-9a4f-04f8bad979ba",
+                "name": "childNode63"
+            },
+            {
+                "key": "7505d647505d641b3657e0-384d-4404-a500-9d78d9faa941",
+                "name": "childNode64"
+            },
+            {
+                "key": "7505d647505d643fd06a57-e857-4e52-afbc-2ade9c66f5a7",
+                "name": "childNode65"
+            },
+            {
+                "key": "7505d647505d646c135f73-f168-45aa-81d0-b1cf4cce2d5f",
+                "name": "childNode66"
+            },
+            {
+                "key": "7505d647505d6454703e4d-8134-44bd-8e37-d7b262e93a15",
+                "name": "childNode67"
+            },
+            {
+                "key": "7505d647505d64581b3b28-de25-4d0a-950c-4c82adb3de88",
+                "name": "childNode68"
+            },
+            {
+                "key": "7505d647505d64c3cb937d-2383-4cb4-8230-225a2a36ed42",
+                "name": "childNode69"
+            }
+        ],
+        "childrenInfo": {
+            "count": 69
+        }
+    }
+}


### PR DESCRIPTION
It's worth mentioning that CharSet encoders/decoders a) hold state and b) are _not thread safe_. The way ModeShape was/is using them, is as local variables, so there are no reasons IMO to try and make them "global".

Fixing the above exposed another bug inside `BsonDataInput` around reading strings when the string size is larger than the default buffer. This PR attempts to fix that as well.
