### PR TITLE
MODE-2076: Exception handling

### DIFF
--- a/web/modeshape-web-explorer/src/main/java/org/modeshape/web/client/Console.java
+++ b/web/modeshape-web-explorer/src/main/java/org/modeshape/web/client/Console.java
@@ -222,6 +222,7 @@ public class Console implements EntryPoint {
     }
     
     private String parent(String path) {
-        return path.substring(0, path.lastIndexOf('/'));
+        String parent = path.substring(0, path.lastIndexOf('/'));
+        return parent.length() > 0 ? parent : "/";
     }
 }

--- a/web/modeshape-web-explorer/src/main/java/org/modeshape/web/client/JcrService.java
+++ b/web/modeshape-web-explorer/src/main/java/org/modeshape/web/client/JcrService.java
@@ -78,7 +78,7 @@ public interface JcrService extends RemoteService {
      * 
      * @return description of the repository capabilities.
      */
-    public JcrRepositoryDescriptor repositoryInfo();
+    public JcrRepositoryDescriptor repositoryInfo() throws RemoteException;
     
     /**
      * Gets all registered node types.
@@ -93,7 +93,7 @@ public interface JcrService extends RemoteService {
      * 
      * @return language names
      */
-    public String[] supportedQueryLanguages();
+    public String[] supportedQueryLanguages() throws RemoteException;
     
     /**
      * Executes query.
@@ -102,7 +102,7 @@ public interface JcrService extends RemoteService {
      * @param lang query language name
      * @return Query result
      */
-    public ResultSet query(String text, String lang);
+    public ResultSet query(String text, String lang) throws RemoteException;
     
     /**
      * Adds new node.

--- a/web/modeshape-web-explorer/src/main/java/org/modeshape/web/client/Navigator.java
+++ b/web/modeshape-web-explorer/src/main/java/org/modeshape/web/client/Navigator.java
@@ -57,10 +57,6 @@ public class Navigator extends Label {
     private TreeNode ROOT = new TreeNode();
     private Console console;
 
-//    static {
-//        ROOT.setTitle("root");
-//        ROOT.setAttribute("path", "/");
-//    }
     public Navigator(Console console) {
         super();
         this.console = console;
@@ -178,7 +174,19 @@ public class Navigator extends Label {
         if (node == null) {
             node = (JcrTreeNode) ROOT;
         }
-        console.jcrService.childNodes(node.getAttribute("path"), new ChildrenHandler());
+        
+        String path = node.getAttribute("path");
+        if (path == null) {
+            path = "/";
+        }
+        
+        path = path.trim();
+        
+        if (path.length() == 0) {
+            path = "/";
+        }
+                
+        console.jcrService.childNodes(path, new ChildrenHandler());
         console.nodePanel.display(node);
     }
 
@@ -225,7 +233,7 @@ public class Navigator extends Label {
         public void onSuccess(JcrNode node) {
             //one more conversation of the value object into tree node object
             JcrTreeNode root = convert(node);
-            ROOT = new JcrTreeNode("", "", root);
+            ROOT = new JcrTreeNode("root", "/", root);
 
             jcrTree.setModelType(TreeModelType.PARENT);
             jcrTree.setNameProperty("name");

--- a/web/modeshape-web-explorer/src/main/java/org/modeshape/web/server/JcrServiceImpl.java
+++ b/web/modeshape-web-explorer/src/main/java/org/modeshape/web/server/JcrServiceImpl.java
@@ -87,7 +87,6 @@ public class JcrServiceImpl extends RemoteServiceServlet implements JcrService {
         try {
             repository = RepositoryManager.getRepository(jndiName);
         } catch (Exception e) {
-            e.printStackTrace();
             try {
                 InitialContext context = new InitialContext();
                 repository = (Repository) context.lookup(jndiName);
@@ -148,12 +147,10 @@ public class JcrServiceImpl extends RemoteServiceServlet implements JcrService {
         ArrayList<JcrNode> children = new ArrayList();
         try {
             Node node = (Node) session().getItem(path);
-            System.out.println("----- path: " + path);
             NodeIterator it = node.getNodes();
 
             while (it.hasNext()) {
                 Node n = it.nextNode();
-                System.out.println("+++++ child: " + n.getName());
                 JcrNode childNode = new JcrNode(n.getName(), n.getPath(), n.getPrimaryNodeType().getName());
                 childNode.setProperties(getProperties(n));
                 childNode.setAcessControlList(getAccessList(session().getAccessControlManager(), node));
@@ -163,7 +160,6 @@ public class JcrServiceImpl extends RemoteServiceServlet implements JcrService {
             }
 
         } catch (RepositoryException e) {
-            log.log(Level.SEVERE, "Unexpected error", e);
             throw new RemoteException(e.getMessage());
         }
 
@@ -306,6 +302,10 @@ public class JcrServiceImpl extends RemoteServiceServlet implements JcrService {
             return "";
         }
         
+        if (values.length == 0) {
+            return "";
+        }
+        
         if (values.length == 1) {
             return values[0].getString();
         }
@@ -319,7 +319,7 @@ public class JcrServiceImpl extends RemoteServiceServlet implements JcrService {
     }
     
     @Override
-    public JcrRepositoryDescriptor repositoryInfo() {
+    public JcrRepositoryDescriptor repositoryInfo() throws RemoteException {
         Session session = (Session) this.getThreadLocalRequest().getSession().getAttribute("session");
         JcrRepositoryDescriptor desc = new JcrRepositoryDescriptor();
         
@@ -331,14 +331,14 @@ public class JcrServiceImpl extends RemoteServiceServlet implements JcrService {
                 desc.add(keys[i], value != null ? value.getString() : "N/A");
             }
         } catch (RepositoryException e) {
-            e.printStackTrace();
+            throw new RemoteException(e.getMessage());
         }
         return desc;
     }
     
 
     @Override
-    public ResultSet query(String text, String lang) {
+    public ResultSet query(String text, String lang) throws RemoteException {
         Session session = (Session) this.getThreadLocalRequest().getSession().getAttribute("session");
         ResultSet rs = new ResultSet();
         try {
@@ -364,22 +364,20 @@ public class JcrServiceImpl extends RemoteServiceServlet implements JcrService {
             
             rs.setRows(rows);
         } catch (RepositoryException e) {
-            e.printStackTrace();
+            throw new RemoteException(e.getMessage());
         }
         return rs;
     }
 
     @Override
-    public String[] supportedQueryLanguages() {
+    public String[] supportedQueryLanguages() throws RemoteException {
         Session session = (Session) this.getThreadLocalRequest().getSession().getAttribute("session");
-        ResultSet rs = new ResultSet();
         try {
             QueryManager qm = session.getWorkspace().getQueryManager();
             return qm.getSupportedQueryLanguages();
         } catch (RepositoryException e) {
-            e.printStackTrace();
+            throw new RemoteException(e.getMessage());
         }
-        return null;
     }
 
     @Override
@@ -407,7 +405,6 @@ public class JcrServiceImpl extends RemoteServiceServlet implements JcrService {
         try {
             Node node = (Node) session().getItem(path);
             node.addMixin(mixin);
-            System.out.println("Added mixing to the node: " + path);
         } catch (RepositoryException e) {
             throw new RemoteException(e.getMessage());
         }


### PR DESCRIPTION
This PR fixes the following problems:
- prevent selection node with 'empty' path. it happens when selection method is triggered before root node initialization.
- handle multiple values of the property (array out of band exception during browsing)
- improve exception logging. display error messages to the users on console instead of printing to the server log.
