### PR TITLE
MODE-2061 Changed UrlBinaryKey to be return hashes that are more consistent with JavaDoc contract.

### DIFF
--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/ExecutionContext.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/ExecutionContext.java
@@ -25,7 +25,6 @@ package org.modeshape.jcr;
 
 import java.math.BigDecimal;
 import java.security.AccessController;
-import java.security.NoSuchAlgorithmException;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -34,18 +33,17 @@ import java.util.UUID;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
-import org.modeshape.common.SystemFailureException;
 import org.modeshape.common.annotation.Immutable;
 import org.modeshape.common.logging.Logger;
 import org.modeshape.common.text.TextDecoder;
 import org.modeshape.common.text.TextEncoder;
 import org.modeshape.common.util.CheckArg;
-import org.modeshape.common.util.SecureHash;
 import org.modeshape.common.util.ThreadPoolFactory;
 import org.modeshape.common.util.ThreadPools;
 import org.modeshape.jcr.query.model.TypeSystem;
 import org.modeshape.jcr.security.SecurityContext;
 import org.modeshape.jcr.value.BinaryFactory;
+import org.modeshape.jcr.value.BinaryKey;
 import org.modeshape.jcr.value.DateTimeFactory;
 import org.modeshape.jcr.value.NameFactory;
 import org.modeshape.jcr.value.NamespaceRegistry;
@@ -96,15 +94,6 @@ public final class ExecutionContext implements ThreadPoolFactory, Cloneable, Nam
 
     public static final ExecutionContext DEFAULT_CONTEXT = new ExecutionContext();
 
-    private static String sha1( String name ) {
-        try {
-            byte[] sha1 = SecureHash.getHash(SecureHash.Algorithm.SHA_1, name.getBytes());
-            return SecureHash.asHexString(sha1);
-        } catch (NoSuchAlgorithmException e) {
-            throw new SystemFailureException(e);
-        }
-    }
-
     private final ThreadPoolFactory threadPools;
     private final PropertyFactory propertyFactory;
     private final ValueFactories valueFactories;
@@ -112,7 +101,7 @@ public final class ExecutionContext implements ThreadPoolFactory, Cloneable, Nam
     private final SecurityContext securityContext;
     private final BinaryStore binaryStore;
     /** The unique ID string, which is always generated so that it can be final and not volatile. */
-    private final String id = sha1(UUID.randomUUID().toString()).substring(0, 9);
+    private final String id = BinaryKey.hexHashFor(UUID.randomUUID().toString()).substring(0, 9);
     private final String processId;
     private final Map<String, String> data;
 
@@ -154,7 +143,8 @@ public final class ExecutionContext implements ThreadPoolFactory, Cloneable, Nam
              context.binaryStore, context.data, context.processId, context.decoder, context.encoder, context.stringFactory,
              context.binaryFactory, context.booleanFactory, context.dateFactory, context.decimalFactory, context.doubleFactory,
              context.longFactory, context.nameFactory, context.pathFactory, context.referenceFactory,
-             context.weakReferenceFactory, context.simpleReferenceFactory, context.uriFactory, context.uuidFactory, context.objectFactory);
+             context.weakReferenceFactory, context.simpleReferenceFactory, context.uriFactory, context.uuidFactory,
+             context.objectFactory);
     }
 
     /**
@@ -183,7 +173,8 @@ public final class ExecutionContext implements ThreadPoolFactory, Cloneable, Nam
      * @param pathFactory the path factory that should be used; if null, a default implementation will be used
      * @param referenceFactory the strong reference factory that should be used; if null, a default implementation will be used
      * @param weakReferenceFactory the weak reference factory that should be used; if null, a default implementation will be used
-     * @param simpleReferenceFactory the simple reference factory that should be used; if null, a default implementation will be used
+     * @param simpleReferenceFactory the simple reference factory that should be used; if null, a default implementation will be
+     *        used
      * @param uriFactory the URI factory that should be used; if null, a default implementation will be used
      * @param uuidFactory the UUID factory that should be used; if null, a default implementation will be used
      * @param objectFactory the object factory that should be used; if null, a default implementation will be used
@@ -670,7 +661,7 @@ public final class ExecutionContext implements ThreadPoolFactory, Cloneable, Nam
      * Default security context that confers no roles.
      */
     private static class NullSecurityContext implements SecurityContext {
-        
+
         @Override
         public boolean isAnonymous() {
             return true;

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/NodeKey.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/NodeKey.java
@@ -24,14 +24,12 @@
 package org.modeshape.jcr.cache;
 
 import java.io.Serializable;
-import java.security.NoSuchAlgorithmException;
 import java.util.UUID;
 import org.infinispan.schematic.SchematicDb;
-import org.modeshape.common.SystemFailureException;
 import org.modeshape.common.annotation.Immutable;
-import org.modeshape.common.util.SecureHash;
 import org.modeshape.common.util.StringUtil;
 import org.modeshape.jcr.JcrRepository;
+import org.modeshape.jcr.value.BinaryKey;
 
 /**
  * An immutable unique key for a node within the {@link JcrRepository repository}'s {@link SchematicDb database}.
@@ -173,7 +171,7 @@ public final class NodeKey implements Serializable, Comparable<NodeKey> {
      * @return the hexadecimal representation of the identifier's SHA-1 hash; never null
      */
     public String getIdentifierHash() {
-        return sha1(getIdentifier());
+        return BinaryKey.hexHashFor(getIdentifier());
     }
 
     @Override
@@ -229,24 +227,14 @@ public final class NodeKey implements Serializable, Comparable<NodeKey> {
     }
 
     public static String keyForSourceName( String name ) {
-        return sha1(name).substring(0, NodeKey.SOURCE_LENGTH);
+        return BinaryKey.hexHashFor(name).substring(0, NodeKey.SOURCE_LENGTH);
     }
 
     public static String keyForWorkspaceName( String name ) {
-        return sha1(name).substring(0, NodeKey.WORKSPACE_LENGTH);
+        return BinaryKey.hexHashFor(name).substring(0, NodeKey.WORKSPACE_LENGTH);
     }
 
     public static String sourceKey( String key ) {
         return isValidFormat(key) ? key.substring(SOURCE_START_INDEX, SOURCE_END_INDEX) : null;
     }
-
-    private static String sha1( String name ) {
-        try {
-            byte[] sha1 = SecureHash.getHash(SecureHash.Algorithm.SHA_1, name.getBytes());
-            return SecureHash.asHexString(sha1);
-        } catch (NoSuchAlgorithmException e) {
-            throw new SystemFailureException(e);
-        }
-    }
-
 }

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/value/BinaryKey.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/value/BinaryKey.java
@@ -39,6 +39,15 @@ public class BinaryKey implements Serializable, Comparable<BinaryKey> {
 
     private static final SecureHash.Algorithm ALGORITHM = SecureHash.Algorithm.SHA_1;
 
+    public static String hexHashFor( String value ) {
+        try {
+            byte[] sha1 = SecureHash.getHash(SecureHash.Algorithm.SHA_1, value.getBytes());
+            return SecureHash.asHexString(sha1);
+        } catch (NoSuchAlgorithmException e) {
+            throw new SystemFailureException(e);
+        }
+    }
+
     public static int maxHexadecimalLength() {
         return ALGORITHM.getHexadecimalStringLength();
     }

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/value/binary/UrlBinaryValue.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/value/binary/UrlBinaryValue.java
@@ -16,14 +16,15 @@ import org.modeshape.jcr.value.BinaryValue;
 public class UrlBinaryValue extends ExternalBinaryValue {
     private static final long serialVersionUID = 1L;
 
-    private URL url;
+    private final URL url;
 
     public UrlBinaryValue( String sourceName,
                            URL content,
                            long size,
                            String nameHint,
                            MimeTypeDetector mimeTypeDetector ) {
-        super(new BinaryKey(content.toString()), sourceName, content.toExternalForm(), size, nameHint, mimeTypeDetector);
+        super(new BinaryKey(BinaryKey.hexHashFor(content.toString())), sourceName, content.toExternalForm(), size, nameHint,
+              mimeTypeDetector);
         this.url = content;
     }
 


### PR DESCRIPTION
The `UrlBinaryKey`'s `getHash()` and `getHexHash()` methods were returning values that were the not same size and non characteristic of SHA-1 values. This modification changes these methods to return the SHA-1 of the string form of the URL. This is consistent with the requirements of the methods signatures, and with the equals/compare behavior of how these methods are used within ModeShape: if the hash is the same then it is expected that the binary value is the same.
