### PR TITLE
MODE-2114 Removed redundant code of reference resolving on copy. 

### DIFF
--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/AbstractJcrNode.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/AbstractJcrNode.java
@@ -2205,20 +2205,6 @@ abstract class AbstractJcrNode extends AbstractJcrItem implements Node {
         return propertiesOnOtherNodesReferencingThis(propertyName, PropertyType.WEAKREFERENCE);
     }
 
-    protected PropertyIterator getAllReferences() throws RepositoryException {
-        List<javax.jcr.Property> allReferences = new ArrayList<javax.jcr.Property>();
-
-        for (PropertyIterator strongRefIterator = getReferences(); strongRefIterator.hasNext();) {
-            allReferences.add(strongRefIterator.nextProperty());
-        }
-
-        for (PropertyIterator weakRefIterator = getReferences(); weakRefIterator.hasNext();) {
-            allReferences.add(weakRefIterator.nextProperty());
-        }
-
-        return new JcrPropertyIterator(allReferences);
-    }
-
     /**
      * Find the properties on other nodes that are REFERENCE or WEAKREFERENCE properties (as dictated by the
      * <code>referenceType</code> parameter) to this node.

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrWorkspace.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrWorkspace.java
@@ -227,28 +227,11 @@ class JcrWorkspace implements org.modeshape.jcr.api.Workspace {
             Set<NodeKey> srcNodeKeys = nodeKeyCorrespondence.keySet();
             for (NodeKey sourceKey : srcNodeKeys) {
                 AbstractJcrNode srcNode = sourceSession.node(sourceKey, null);
-                NodeKey dstNodeKey = nodeKeyCorrespondence.get(sourceKey);
-                AbstractJcrNode dstNode = copySession.node(dstNodeKey, null);
-
                 if (srcNode.isNodeType(JcrMixLexicon.VERSIONABLE)) {
+                    NodeKey dstNodeKey = nodeKeyCorrespondence.get(sourceKey);
+
                     // For the nodes which were versionable, set the mappings for the original version
                     copySession.setOriginalVersionKey(dstNodeKey, srcNode.getBaseVersion().key());
-                }
-
-                if (dstNode.isNodeType(JcrMixLexicon.REFERENCEABLE) && dstNode.hasProperty(JcrLexicon.UUID)) {
-                    // for referenceable nodes, update the UUID to be be same as the new identifier
-                    JcrValue identifierValue = dstNode.valueFactory().createValue(dstNode.getIdentifier());
-                    dstNode.setProperty(JcrLexicon.UUID, identifierValue, true, true, false, false);
-
-                    // if there are any incoming references within the copied subgraph, they need to point to the new nodes
-                    for (PropertyIterator incomingReferencesIterator = dstNode.getAllReferences(); incomingReferencesIterator.hasNext();) {
-                        Property incomingRef = incomingReferencesIterator.nextProperty();
-                        NodeKey referringNodeKey = ((AbstractJcrNode)incomingRef.getParent()).key();
-                        boolean isReferrerWithinSubgraph = srcNodeKeys.contains(referringNodeKey);
-                        if (isReferrerWithinSubgraph) {
-                            incomingRef.setValue(copySession.node(dstNodeKey, null));
-                        }
-                    }
                 }
             }
 


### PR DESCRIPTION
The code which has been removed wasn't being used because reference resolving occurs earlier in the copy logic.

The commit which replaced the logic that was removed is: https://github.com/ModeShape/modeshape/commit/68883876423d06910f55aacc882c69b474e464f7#diff-c05ab135c609ddfb3a5ff6b439a262f9R2401 and was part of MODE-2012.
