### PR TITLE
MODE-2120 Added some checks to prevent duplicate child references from being added/exposed

### DIFF
--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/document/MutableChildReferences.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/document/MutableChildReferences.java
@@ -183,8 +183,15 @@ public class MutableChildReferences extends AbstractChildReferences {
         Lock lock = this.lock.writeLock();
         try {
             lock.lock();
+            ChildReference old = this.childReferencesByKey.put(reference.getKey(), reference);
+            if (old != null && old.getName().equals(name)) {
+                // We already have this key/name pair, so we don't need to add it again ...
+                return;
+            }
+            // We've not seen this node key yet, so it is okay. In fact, we should not see any
+            // node key more than once, since that is clearly an unexpected condition (as a child
+            // may not appear more than once in its parent's list of child nodes). See MODE-2120.
             this.childReferences.put(reference.getName(), reference);
-            this.childReferencesByKey.put(reference.getKey(), reference);
         } finally {
             lock.unlock();
         }
@@ -196,8 +203,15 @@ public class MutableChildReferences extends AbstractChildReferences {
             lock.lock();
             for (ChildReference reference : references) {
                 reference = reference.with(1);
+                ChildReference old = this.childReferencesByKey.put(reference.getKey(), reference);
+                if (old != null && old.getName().equals(reference.getName())) {
+                    // We already have this key/name pair, so we don't need to add it again ...
+                    continue;
+                }
+                // We've not seen this node key yet, so it is okay. In fact, we should not see any
+                // node key more than once, since that is clearly an unexpected condition (as a child
+                // may not appear more than once in its parent's list of child nodes). See MODE-2120.
                 this.childReferences.put(reference.getName(), reference);
-                this.childReferencesByKey.put(reference.getKey(), reference);
             }
         } finally {
             lock.unlock();


### PR DESCRIPTION
We don't yet have confirmation that this will fix/workaround the underlying problem, and that make take a few days of additional testing. So we probably want to hold off merging this into the '3.6.x' branch and 'master' branch.
