### PR TITLE
MODE-2123 Changed the code so that new nodes never try to find themselves in the workspace cache.

### DIFF
--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/document/SessionNode.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/document/SessionNode.java
@@ -315,7 +315,7 @@ public class SessionNode implements MutableCachedNode {
      * @return the workspace cache's node, or null if this node is new
      */
     protected CachedNode nodeInWorkspace( AbstractSessionCache session ) {
-        return session.getWorkspace().getNode(key);
+        return isNew() ? null : session.getWorkspace().getNode(key);
     }
 
     @Override


### PR DESCRIPTION
Building the current `master` with this causes the following failures:

```
Tests in error:
  shouldBeAbleToImportSystemViewWithBinaryTwiceWithRemoveExistingCollisionMode2(org.modeshape.jcr.ImportExportTest): javax.jcr.InvalidItemStateException: This session tried to save changes to node with key 'Cannot locate child node: ee0a8387505d649e088bdc-8416-4dec-83b2-63047ae14fc2 within parent: ee0a8387505d64aa5ed17b-f39b-4234-9196-e908ca849a5b', but it was removed by another session.
  shouldBeAbleToImportTwiceWithoutLoosingMixins(org.modeshape.jcr.ImportExportTest): This session tried to save changes to node with key 'Cannot locate child node: ee0a8387505d6491b0ee75-567e-4ce2-bbba-783596ce4ce5 within parent: ee0a8387505d6440ec235e-cad2-4188-ba63-6d2c0fa0b139', but it was removed by another session.
```
