### PR TITLE
MODE-2123 Changed the code so that new nodes never try to find themselves in the workspace cache

### DIFF
--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/document/SessionNode.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/document/SessionNode.java
@@ -315,7 +315,7 @@ public class SessionNode implements MutableCachedNode {
      * @return the workspace cache's node, or null if this node is new
      */
     protected CachedNode nodeInWorkspace( AbstractSessionCache session ) {
-        return session.getWorkspace().getNode(key);
+        return isNew() ? null : session.getWorkspace().getNode(key);
     }
 
     @Override


### PR DESCRIPTION
Also fixed some resulting regressions for specific situations. See @hchiorean's [original PR](https://github.com/ModeShape/modeshape/pull/1019) for some discussion about these regressions.

This should be merged into the 'master' branch and cherry-picked into the '3.6.x' branch.
