### PR TITLE
MODE-2124 Changed the code so that child node re-indexing (on update of the parent) is only performed when the path of the parent has changed. 

### DIFF
--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/document/WritableSessionCache.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/document/WritableSessionCache.java
@@ -1257,10 +1257,10 @@ public class WritableSessionCache extends AbstractSessionCache {
                                     monitor.recordRemove(workspaceName, Arrays.asList(persistedNodeAtNewPath.getKey()));
                                 }
                             } // otherwise the parent was not PERSISTED and there's nothing to do
+                            //for each of the children of the node which has the changed path, we need to update the path
+                            //in the indexes
+                            updateIndexesForAllChildren(node, sessionPaths, workspaceName, monitor);
                         }
-                        //for each of the children of the node which has the changed path, we need to update the path
-                        //in the indexes
-                       updateIndexesForAllChildren(node, sessionPaths, workspaceName, monitor);
                     }
 
                     //writable connectors *may* change their data in-place, so the update operation needs to be called only

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/value/basic/BasicName.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/value/basic/BasicName.java
@@ -71,7 +71,7 @@ public class BasicName implements Name {
     public BasicName( String namespaceUri,
                       String localName ) {
         CheckArg.isNotNull(localName, "localName");
-        this.namespaceUri = namespaceUri != null ? namespaceUri.trim().intern() : "";
+        this.namespaceUri = namespaceUri != null ? namespaceUri.trim() : "";
         this.localName = trimNonEmptyStrings(localName);
         this.hc = HashCode.compute(this.namespaceUri, this.localName);
     }


### PR DESCRIPTION
Also, based on additional CPU usage profiling, removed a `String.intern` call.

@rhauch: after fixing the indexing issue, additional profiling showed a significant hot-spot in an `intern` call

![profiling_hotspot](https://f.cloud.github.com/assets/995683/1806139/c90ab39c-6ca3-11e3-9ac5-4e8c0b6461c0.png)

Some additional links regarding the benefits/drawbacks of intern: http://hype-free.blogspot.ro/2010/03/stringintern-there-are-better-ways.html & http://www.codeinstructions.com/2009/01/busting-javalangstringintern-myths.html
