### PR TITLE
MODE-2125 Implemented additional methods in DatabaseMetaData implementation

### DIFF
--- a/modeshape-jdbc-local/src/main/java/org/modeshape/jdbc/JcrMetaData.java
+++ b/modeshape-jdbc-local/src/main/java/org/modeshape/jdbc/JcrMetaData.java
@@ -29,6 +29,7 @@ import java.sql.ResultSet;
 import java.sql.RowIdLifetime;
 import java.sql.SQLException;
 import java.sql.SQLFeatureNotSupportedException;
+import java.sql.Types;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -51,6 +52,7 @@ import org.modeshape.jdbc.metadata.MetaDataQueryResult;
 import org.modeshape.jdbc.metadata.MetadataProvider;
 import org.modeshape.jdbc.metadata.ResultSetMetaDataImpl;
 import org.modeshape.jdbc.metadata.ResultsMetadataConstants;
+import org.modeshape.jdbc.metadata.ResultsMetadataConstants.NULL_TYPES;
 
 /**
  * This driver's implementation of JDBC {@link DatabaseMetaData}.
@@ -740,7 +742,7 @@ public class JcrMetaData implements DatabaseMetaData {
     public ResultSet getExportedKeys( String catalog,
                                       String schema,
                                       String table ) throws SQLException {
-        throw new SQLFeatureNotSupportedException();
+        return getImportedKeys(catalog, schema, table); // empty, but same resultsetmetadata
     }
 
     /**
@@ -805,7 +807,98 @@ public class JcrMetaData implements DatabaseMetaData {
     public ResultSet getImportedKeys( String catalog,
                                       String schema,
                                       String table ) throws SQLException {
-        throw new SQLFeatureNotSupportedException();
+        @SuppressWarnings( "unchecked" )
+        Map<?, Object>[] metadataList = new Map[JDBCColumnPositions.REFERENCE_KEYS.MAX_COLUMNS];
+        metadataList[0] = MetadataProvider.getColumnMetadata(catalogName,
+                                                             null,
+                                                             JDBCColumnNames.REFERENCE_KEYS_INFO.PK_TABLE_CAT,
+                                                             JcrType.DefaultDataTypes.STRING,
+                                                             ResultsMetadataConstants.NULL_TYPES.NULLABLE,
+                                                             this.connection);
+        metadataList[1] = MetadataProvider.getColumnMetadata(catalogName,
+                                                             null,
+                                                             JDBCColumnNames.REFERENCE_KEYS_INFO.PK_TABLE_SCHEM,
+                                                             JcrType.DefaultDataTypes.STRING,
+                                                             ResultsMetadataConstants.NULL_TYPES.NULLABLE,
+                                                             this.connection);
+        metadataList[2] = MetadataProvider.getColumnMetadata(catalogName,
+                                                             null,
+                                                             JDBCColumnNames.REFERENCE_KEYS_INFO.PK_TABLE_NAME,
+                                                             JcrType.DefaultDataTypes.STRING,
+                                                             ResultsMetadataConstants.NULL_TYPES.NOT_NULL,
+                                                             this.connection);
+        metadataList[3] = MetadataProvider.getColumnMetadata(catalogName,
+                                                             null,
+                                                             JDBCColumnNames.REFERENCE_KEYS_INFO.PK_COLUMN_NAME,
+                                                             JcrType.DefaultDataTypes.STRING,
+                                                             ResultsMetadataConstants.NULL_TYPES.NOT_NULL,
+                                                             this.connection);
+        metadataList[4] = MetadataProvider.getColumnMetadata(catalogName,
+                                                             null,
+                                                             JDBCColumnNames.REFERENCE_KEYS_INFO.FK_TABLE_CAT,
+                                                             JcrType.DefaultDataTypes.STRING,
+                                                             ResultsMetadataConstants.NULL_TYPES.NULLABLE,
+                                                             this.connection);
+        metadataList[5] = MetadataProvider.getColumnMetadata(catalogName,
+                                                             null,
+                                                             JDBCColumnNames.REFERENCE_KEYS_INFO.FK_TABLE_SCHEM,
+                                                             JcrType.DefaultDataTypes.STRING,
+                                                             ResultsMetadataConstants.NULL_TYPES.NULLABLE,
+                                                             this.connection);
+        metadataList[6] = MetadataProvider.getColumnMetadata(catalogName,
+                                                             null,
+                                                             JDBCColumnNames.REFERENCE_KEYS_INFO.FK_TABLE_NAME,
+                                                             JcrType.DefaultDataTypes.STRING,
+                                                             ResultsMetadataConstants.NULL_TYPES.NOT_NULL,
+                                                             this.connection);
+        metadataList[7] = MetadataProvider.getColumnMetadata(catalogName,
+                                                             null,
+                                                             JDBCColumnNames.REFERENCE_KEYS_INFO.FK_COLUMN_NAME,
+                                                             JcrType.DefaultDataTypes.STRING,
+                                                             ResultsMetadataConstants.NULL_TYPES.NOT_NULL,
+                                                             this.connection);
+        metadataList[8] = MetadataProvider.getColumnMetadata(catalogName,
+                                                             null,
+                                                             JDBCColumnNames.REFERENCE_KEYS_INFO.KEY_SEQ,
+                                                             JcrType.DefaultDataTypes.LONG,
+                                                             ResultsMetadataConstants.NULL_TYPES.NOT_NULL,
+                                                             this.connection);
+        metadataList[9] = MetadataProvider.getColumnMetadata(catalogName,
+                                                             null,
+                                                             JDBCColumnNames.REFERENCE_KEYS_INFO.UPDATE_RULE,
+                                                             JcrType.DefaultDataTypes.LONG,
+                                                             ResultsMetadataConstants.NULL_TYPES.NOT_NULL,
+                                                             this.connection);
+        metadataList[10] = MetadataProvider.getColumnMetadata(catalogName,
+                                                              null,
+                                                              JDBCColumnNames.REFERENCE_KEYS_INFO.DELETE_RULE,
+                                                              JcrType.DefaultDataTypes.LONG,
+                                                              ResultsMetadataConstants.NULL_TYPES.NOT_NULL,
+                                                              this.connection);
+        metadataList[11] = MetadataProvider.getColumnMetadata(catalogName,
+                                                              null,
+                                                              JDBCColumnNames.REFERENCE_KEYS_INFO.FK_NAME,
+                                                              JcrType.DefaultDataTypes.STRING,
+                                                              ResultsMetadataConstants.NULL_TYPES.NULLABLE,
+                                                              this.connection);
+        metadataList[12] = MetadataProvider.getColumnMetadata(catalogName,
+                                                              null,
+                                                              JDBCColumnNames.REFERENCE_KEYS_INFO.PK_NAME,
+                                                              JcrType.DefaultDataTypes.STRING,
+                                                              ResultsMetadataConstants.NULL_TYPES.NULLABLE,
+                                                              this.connection);
+        metadataList[13] = MetadataProvider.getColumnMetadata(catalogName,
+                                                              null,
+                                                              JDBCColumnNames.REFERENCE_KEYS_INFO.DEFERRABILITY,
+                                                              JcrType.DefaultDataTypes.LONG,
+                                                              ResultsMetadataConstants.NULL_TYPES.NOT_NULL,
+                                                              this.connection);
+        JcrStatement jcrstmt = new JcrStatement(this.connection);
+        MetadataProvider provider = new MetadataProvider(metadataList);
+        ResultSetMetaDataImpl resultSetMetaData = new ResultSetMetaDataImpl(provider);
+        List<List<?>> records = Collections.emptyList();
+        QueryResult queryresult = MetaDataQueryResult.createResultSet(records, resultSetMetaData);
+        return new JcrResultSet(jcrstmt, queryresult, resultSetMetaData);
     }
 
     /**
@@ -1309,7 +1402,69 @@ public class JcrMetaData implements DatabaseMetaData {
     public ResultSet getProcedures( String catalog,
                                     String schemaPattern,
                                     String procedureNamePattern ) throws SQLException {
-        throw new SQLFeatureNotSupportedException();
+        @SuppressWarnings( "unchecked" )
+        Map<?, Object>[] metadataList = new Map[JDBCColumnPositions.PROCEDURES.MAX_COLUMNS];
+        metadataList[0] = MetadataProvider.getColumnMetadata(catalogName,
+                                                             null,
+                                                             JDBCColumnNames.PROCEDURES.PROCEDURE_CAT,
+                                                             JcrType.DefaultDataTypes.STRING,
+                                                             ResultsMetadataConstants.NULL_TYPES.NULLABLE,
+                                                             this.connection);
+        metadataList[1] = MetadataProvider.getColumnMetadata(catalogName,
+                                                             null,
+                                                             JDBCColumnNames.PROCEDURES.PROCEDURE_SCHEM,
+                                                             JcrType.DefaultDataTypes.STRING,
+                                                             ResultsMetadataConstants.NULL_TYPES.NULLABLE,
+                                                             this.connection);
+        metadataList[2] = MetadataProvider.getColumnMetadata(catalogName,
+                                                             null,
+                                                             JDBCColumnNames.PROCEDURES.PROCEDURE_NAME,
+                                                             JcrType.DefaultDataTypes.STRING,
+                                                             ResultsMetadataConstants.NULL_TYPES.NOT_NULL,
+                                                             this.connection);
+        metadataList[3] = MetadataProvider.getColumnMetadata(catalogName,
+                                                             null,
+                                                             JDBCColumnNames.PROCEDURES.RESERVED1,
+                                                             JcrType.DefaultDataTypes.STRING,
+                                                             ResultsMetadataConstants.NULL_TYPES.NULLABLE,
+                                                             this.connection);
+        metadataList[4] = MetadataProvider.getColumnMetadata(catalogName,
+                                                             null,
+                                                             JDBCColumnNames.PROCEDURES.RESERVED2,
+                                                             JcrType.DefaultDataTypes.STRING,
+                                                             ResultsMetadataConstants.NULL_TYPES.NULLABLE,
+                                                             this.connection);
+        metadataList[5] = MetadataProvider.getColumnMetadata(catalogName,
+                                                             null,
+                                                             JDBCColumnNames.PROCEDURES.RESERVED3,
+                                                             JcrType.DefaultDataTypes.STRING,
+                                                             ResultsMetadataConstants.NULL_TYPES.NULLABLE,
+                                                             this.connection);
+        metadataList[6] = MetadataProvider.getColumnMetadata(catalogName,
+                                                             null,
+                                                             JDBCColumnNames.PROCEDURES.REMARKS,
+                                                             JcrType.DefaultDataTypes.STRING,
+                                                             ResultsMetadataConstants.NULL_TYPES.NOT_NULL,
+                                                             this.connection);
+        metadataList[7] = MetadataProvider.getColumnMetadata(catalogName,
+                                                             null,
+                                                             JDBCColumnNames.PROCEDURES.PROCEDURE_TYPE,
+                                                             JcrType.DefaultDataTypes.LONG,
+                                                             ResultsMetadataConstants.NULL_TYPES.NULLABLE,
+                                                             this.connection);
+        metadataList[8] = MetadataProvider.getColumnMetadata(catalogName,
+                                                             null,
+                                                             JDBCColumnNames.PROCEDURES.SPECIFIC_NAME,
+                                                             JcrType.DefaultDataTypes.STRING,
+                                                             ResultsMetadataConstants.NULL_TYPES.NOT_NULL,
+                                                             this.connection);
+
+        JcrStatement jcrstmt = new JcrStatement(this.connection);
+        MetadataProvider provider = new MetadataProvider(metadataList);
+        ResultSetMetaDataImpl resultSetMetaData = new ResultSetMetaDataImpl(provider);
+        List<List<?>> records = Collections.emptyList();
+        QueryResult queryresult = MetaDataQueryResult.createResultSet(records, resultSetMetaData);
+        return new JcrResultSet(jcrstmt, queryresult, resultSetMetaData);
     }
 
     /**
@@ -1646,6 +1801,163 @@ public class JcrMetaData implements DatabaseMetaData {
         return null;
     }
 
+    private static List<List<?>> typeInfoRows() {
+        List<List<?>> rows = new ArrayList<List<?>>();
+        rows.add(typeInfoRow(JcrType.DefaultDataTypes.STRING,
+                             Types.VARCHAR,
+                             Integer.MAX_VALUE,
+                             NULL_TYPES.NULLABLE,
+                             true,
+                             ResultsMetadataConstants.SEARCH_TYPES.SEARCHABLE,
+                             false,
+                             false,
+                             0,
+                             0));
+        rows.add(typeInfoRow(JcrType.DefaultDataTypes.BINARY,
+                             Types.BLOB,
+                             Integer.MAX_VALUE,
+                             NULL_TYPES.NULLABLE,
+                             true,
+                             ResultsMetadataConstants.SEARCH_TYPES.SEARCHABLE,
+                             false,
+                             false,
+                             0,
+                             0));
+        rows.add(typeInfoRow(JcrType.DefaultDataTypes.BOOLEAN,
+                             Types.BOOLEAN,
+                             1,
+                             NULL_TYPES.NULLABLE,
+                             true,
+                             ResultsMetadataConstants.SEARCH_TYPES.SEARCHABLE,
+                             false,
+                             false,
+                             0,
+                             0));
+        rows.add(typeInfoRow(JcrType.DefaultDataTypes.DATE,
+                             Types.TIMESTAMP,
+                             Integer.MAX_VALUE,
+                             NULL_TYPES.NULLABLE,
+                             true,
+                             ResultsMetadataConstants.SEARCH_TYPES.SEARCHABLE,
+                             false,
+                             false,
+                             0,
+                             0));
+        rows.add(typeInfoRow(JcrType.DefaultDataTypes.DECIMAL,
+                             Types.DECIMAL,
+                             Integer.MAX_VALUE,
+                             NULL_TYPES.NULLABLE,
+                             true,
+                             ResultsMetadataConstants.SEARCH_TYPES.SEARCHABLE,
+                             false,
+                             false,
+                             0,
+                             0));
+        rows.add(typeInfoRow(JcrType.DefaultDataTypes.DOUBLE,
+                             Types.DOUBLE,
+                             18,
+                             NULL_TYPES.NULLABLE,
+                             true,
+                             ResultsMetadataConstants.SEARCH_TYPES.SEARCHABLE,
+                             false,
+                             false,
+                             0,
+                             0));
+        rows.add(typeInfoRow(JcrType.DefaultDataTypes.LONG,
+                             Types.BIGINT,
+                             18,
+                             NULL_TYPES.NULLABLE,
+                             true,
+                             ResultsMetadataConstants.SEARCH_TYPES.SEARCHABLE,
+                             false,
+                             false,
+                             0,
+                             0));
+        rows.add(typeInfoRow(JcrType.DefaultDataTypes.NAME,
+                             Types.VARCHAR,
+                             Integer.MAX_VALUE,
+                             NULL_TYPES.NULLABLE,
+                             true,
+                             ResultsMetadataConstants.SEARCH_TYPES.SEARCHABLE,
+                             false,
+                             false,
+                             0,
+                             0));
+        rows.add(typeInfoRow(JcrType.DefaultDataTypes.PATH,
+                             Types.VARCHAR,
+                             Integer.MAX_VALUE,
+                             NULL_TYPES.NULLABLE,
+                             true,
+                             ResultsMetadataConstants.SEARCH_TYPES.SEARCHABLE,
+                             false,
+                             false,
+                             0,
+                             0));
+        rows.add(typeInfoRow(JcrType.DefaultDataTypes.REFERENCE,
+                             Types.VARCHAR,
+                             Integer.MAX_VALUE,
+                             NULL_TYPES.NULLABLE,
+                             true,
+                             ResultsMetadataConstants.SEARCH_TYPES.SEARCHABLE,
+                             false,
+                             false,
+                             0,
+                             0));
+        rows.add(typeInfoRow(JcrType.DefaultDataTypes.WEAK_REF,
+                             Types.VARCHAR,
+                             Integer.MAX_VALUE,
+                             NULL_TYPES.NULLABLE,
+                             true,
+                             ResultsMetadataConstants.SEARCH_TYPES.SEARCHABLE,
+                             false,
+                             false,
+                             0,
+                             0));
+        rows.add(typeInfoRow(JcrType.DefaultDataTypes.URI,
+                             Types.VARCHAR,
+                             Integer.MAX_VALUE,
+                             NULL_TYPES.NULLABLE,
+                             true,
+                             ResultsMetadataConstants.SEARCH_TYPES.SEARCHABLE,
+                             false,
+                             false,
+                             0,
+                             0));
+        return rows;
+    }
+
+    private static List<?> typeInfoRow( String typeName,
+                                        int sqlType,
+                                        int precision,
+                                        Integer nullability,
+                                        boolean caseSensitive,
+                                        Integer searchable,
+                                        boolean isUnsigned,
+                                        boolean canBeAutoIncremented,
+                                        int minimumScale,
+                                        int maximumScale ) {
+        List<Object> row = new ArrayList<Object>(JDBCColumnPositions.TYPE_INFO.MAX_COLUMNS);
+        row.add(typeName);
+        row.add(sqlType);
+        row.add(precision);
+        row.add(null); // literal prefix
+        row.add(null); // literal suffix
+        row.add(null); // create params
+        row.add(nullability);
+        row.add(caseSensitive);
+        row.add(searchable);
+        row.add(isUnsigned);
+        row.add(false); // is money
+        row.add(canBeAutoIncremented);
+        row.add(null); // localized type name
+        row.add(minimumScale);
+        row.add(maximumScale);
+        row.add(0); // unused
+        row.add(0); // unused
+        row.add(10); // radix
+        return row;
+    }
+
     /**
      * {@inheritDoc}
      * 
@@ -1653,7 +1965,127 @@ public class JcrMetaData implements DatabaseMetaData {
      */
     @Override
     public ResultSet getTypeInfo() throws SQLException {
-        throw new SQLFeatureNotSupportedException();
+        @SuppressWarnings( "unchecked" )
+        Map<?, Object>[] metadataList = new Map[JDBCColumnPositions.TYPE_INFO.MAX_COLUMNS];
+
+        metadataList[0] = MetadataProvider.getColumnMetadata(catalogName,
+                                                             null,
+                                                             JDBCColumnNames.TYPE_INFO.TYPE_NAME,
+                                                             JcrType.DefaultDataTypes.STRING,
+                                                             ResultsMetadataConstants.NULL_TYPES.NOT_NULL,
+                                                             this.connection);
+        metadataList[1] = MetadataProvider.getColumnMetadata(catalogName,
+                                                             null,
+                                                             JDBCColumnNames.TYPE_INFO.DATA_TYPE,
+                                                             JcrType.DefaultDataTypes.LONG,
+                                                             ResultsMetadataConstants.NULL_TYPES.NOT_NULL,
+                                                             this.connection);
+        metadataList[2] = MetadataProvider.getColumnMetadata(catalogName,
+                                                             null,
+                                                             JDBCColumnNames.TYPE_INFO.PRECISION,
+                                                             JcrType.DefaultDataTypes.LONG,
+                                                             ResultsMetadataConstants.NULL_TYPES.NOT_NULL,
+                                                             this.connection);
+        metadataList[3] = MetadataProvider.getColumnMetadata(catalogName,
+                                                             null,
+                                                             JDBCColumnNames.TYPE_INFO.LITERAL_PREFIX,
+                                                             JcrType.DefaultDataTypes.STRING,
+                                                             ResultsMetadataConstants.NULL_TYPES.NULLABLE,
+                                                             this.connection);
+        metadataList[4] = MetadataProvider.getColumnMetadata(catalogName,
+                                                             null,
+                                                             JDBCColumnNames.TYPE_INFO.LITERAL_SUFFIX,
+                                                             JcrType.DefaultDataTypes.STRING,
+                                                             ResultsMetadataConstants.NULL_TYPES.NULLABLE,
+                                                             this.connection);
+        metadataList[5] = MetadataProvider.getColumnMetadata(catalogName,
+                                                             null,
+                                                             JDBCColumnNames.TYPE_INFO.CREATE_PARAMS,
+                                                             JcrType.DefaultDataTypes.STRING,
+                                                             ResultsMetadataConstants.NULL_TYPES.NULLABLE,
+                                                             this.connection);
+        metadataList[6] = MetadataProvider.getColumnMetadata(catalogName,
+                                                             null,
+                                                             JDBCColumnNames.TYPE_INFO.NULLABLE,
+                                                             JcrType.DefaultDataTypes.LONG,
+                                                             ResultsMetadataConstants.NULL_TYPES.NOT_NULL,
+                                                             this.connection);
+        metadataList[7] = MetadataProvider.getColumnMetadata(catalogName,
+                                                             null,
+                                                             JDBCColumnNames.TYPE_INFO.CASE_SENSITIVE,
+                                                             JcrType.DefaultDataTypes.BOOLEAN,
+                                                             ResultsMetadataConstants.NULL_TYPES.NOT_NULL,
+                                                             this.connection);
+        metadataList[8] = MetadataProvider.getColumnMetadata(catalogName,
+                                                             null,
+                                                             JDBCColumnNames.TYPE_INFO.SEARCHABLE,
+                                                             JcrType.DefaultDataTypes.LONG,
+                                                             ResultsMetadataConstants.NULL_TYPES.NOT_NULL,
+                                                             this.connection);
+        metadataList[9] = MetadataProvider.getColumnMetadata(catalogName,
+                                                             null,
+                                                             JDBCColumnNames.TYPE_INFO.UNSIGNED_ATTRIBUTE,
+                                                             JcrType.DefaultDataTypes.BOOLEAN,
+                                                             ResultsMetadataConstants.NULL_TYPES.NOT_NULL,
+                                                             this.connection);
+        metadataList[10] = MetadataProvider.getColumnMetadata(catalogName,
+                                                              null,
+                                                              JDBCColumnNames.TYPE_INFO.FIXED_PREC_SCALE,
+                                                              JcrType.DefaultDataTypes.BOOLEAN,
+                                                              ResultsMetadataConstants.NULL_TYPES.NOT_NULL,
+                                                              this.connection);
+        metadataList[11] = MetadataProvider.getColumnMetadata(catalogName,
+                                                              null,
+                                                              JDBCColumnNames.TYPE_INFO.AUTOINCREMENT,
+                                                              JcrType.DefaultDataTypes.BOOLEAN,
+                                                              ResultsMetadataConstants.NULL_TYPES.NOT_NULL,
+                                                              this.connection);
+        metadataList[12] = MetadataProvider.getColumnMetadata(catalogName,
+                                                              null,
+                                                              JDBCColumnNames.TYPE_INFO.LOCAL_TYPE_NAME,
+                                                              JcrType.DefaultDataTypes.STRING,
+                                                              ResultsMetadataConstants.NULL_TYPES.NULLABLE,
+                                                              this.connection);
+        metadataList[13] = MetadataProvider.getColumnMetadata(catalogName,
+                                                              null,
+                                                              JDBCColumnNames.TYPE_INFO.MINIMUM_SCALE,
+                                                              JcrType.DefaultDataTypes.LONG,
+                                                              ResultsMetadataConstants.NULL_TYPES.NOT_NULL,
+                                                              this.connection);
+        metadataList[14] = MetadataProvider.getColumnMetadata(catalogName,
+                                                              null,
+                                                              JDBCColumnNames.TYPE_INFO.MAXIMUM_SCALE,
+                                                              JcrType.DefaultDataTypes.LONG,
+                                                              ResultsMetadataConstants.NULL_TYPES.NOT_NULL,
+                                                              this.connection);
+        metadataList[15] = MetadataProvider.getColumnMetadata(catalogName,
+                                                              null,
+                                                              JDBCColumnNames.TYPE_INFO.SQL_DATA_TYPE,
+                                                              JcrType.DefaultDataTypes.LONG,
+                                                              ResultsMetadataConstants.NULL_TYPES.NOT_NULL,
+                                                              this.connection);
+        metadataList[16] = MetadataProvider.getColumnMetadata(catalogName,
+                                                              null,
+                                                              JDBCColumnNames.TYPE_INFO.SQL_DATETIME_SUB,
+                                                              JcrType.DefaultDataTypes.LONG,
+                                                              ResultsMetadataConstants.NULL_TYPES.NOT_NULL,
+                                                              this.connection);
+        metadataList[17] = MetadataProvider.getColumnMetadata(catalogName,
+                                                              null,
+                                                              JDBCColumnNames.TYPE_INFO.NUM_PREC_RADIX,
+                                                              JcrType.DefaultDataTypes.LONG,
+                                                              ResultsMetadataConstants.NULL_TYPES.NOT_NULL,
+                                                              this.connection);
+
+        // Build the result set metadata ...
+        MetadataProvider provider = new MetadataProvider(metadataList);
+        ResultSetMetaDataImpl resultSetMetaData = new ResultSetMetaDataImpl(provider);
+        // The rows ...
+        List<List<?>> records = typeInfoRows();
+        // And the result set ...
+        JcrStatement jcrstmt = new JcrStatement(this.connection);
+        QueryResult queryresult = MetaDataQueryResult.createResultSet(records, resultSetMetaData);
+        return new JcrResultSet(jcrstmt, queryresult, resultSetMetaData);
     }
 
     /**
@@ -2734,7 +3166,7 @@ public class JcrMetaData implements DatabaseMetaData {
 
         List<PropertyDefinition> resultDefns = null;
 
-        if (columnNamePattern.trim().equals(WILDCARD)) {
+        if (columnNamePattern == null || columnNamePattern.trim().equals(WILDCARD)) {
             resultDefns = allDefns;
         } else if (columnNamePattern.contains(WILDCARD)) {
             resultDefns = new ArrayList<PropertyDefinition>();

--- a/modeshape-jdbc-local/src/main/java/org/modeshape/jdbc/metadata/JDBCColumnNames.java
+++ b/modeshape-jdbc-local/src/main/java/org/modeshape/jdbc/metadata/JDBCColumnNames.java
@@ -32,32 +32,30 @@ package org.modeshape.jdbc.metadata;
 public interface JDBCColumnNames {
 
     /**
-     * This class contains constants representing column names on ResultSet
-     * returned by getCatalogs method on DatabaseMetaData. These constant values
-     * are be used for the column names used in constructing the ResultSet obj.
+     * This class contains constants representing column names on ResultSet returned by getCatalogs method on DatabaseMetaData.
+     * These constant values are be used for the column names used in constructing the ResultSet obj.
      */
     interface CATALOGS {
-        //  name of the column containing catalog or Virtual database name.
+        // name of the column containing catalog or Virtual database name.
         static final String TABLE_CAT = "TABLE_CAT"; //$NON-NLS-1$
     }
 
     /**
-     * This class contains constants representing column names on ResultSet
-     * returned by getColumns method on DatabaseMetaData. These constant values
-     * are be used to hardcode the column names used in constructin the ResultSet obj.
+     * This class contains constants representing column names on ResultSet returned by getColumns method on DatabaseMetaData.
+     * These constant values are be used to hardcode the column names used in constructin the ResultSet obj.
      */
     interface COLUMNS {
 
-        //  name of the column containing catalog or Virtual database name.
+        // name of the column containing catalog or Virtual database name.
         static final String TABLE_CAT = "TABLE_CAT"; //$NON-NLS-1$
 
-        //  name of the column containing schema or Virtual database version.
+        // name of the column containing schema or Virtual database version.
         static final String TABLE_SCHEM = "TABLE_SCHEM"; //$NON-NLS-1$
 
-        //  name of the column containing table or group name.
+        // name of the column containing table or group name.
         static final String TABLE_NAME = "TABLE_NAME"; //$NON-NLS-1$
 
-        //  name of the column containing column or element name.
+        // name of the column containing column or element name.
         static final String COLUMN_NAME = "COLUMN_NAME"; //$NON-NLS-1$
 
         /** name of column that contains SQL type from java.sql.Types for column's data type. */
@@ -66,16 +64,16 @@ public interface JDBCColumnNames {
         /** name of column that contains local type name used by the data source. */
         static final String TYPE_NAME = "TYPE_NAME"; //$NON-NLS-1$
 
-        //  name of the column containing column size.
+        // name of the column containing column size.
         static final String COLUMN_SIZE = "COLUMN_SIZE"; //$NON-NLS-1$
 
         /** name of column that is not used will contain nulls */
         static final String BUFFER_LENGTH = "BUFFER_LENGTH"; //$NON-NLS-1$
 
-        //  name of the column containing number of digits to right of decimal
+        // name of the column containing number of digits to right of decimal
         static final String DECIMAL_DIGITS = "DECIMAL_DIGITS"; //$NON-NLS-1$
 
-        //  name of the column containing column's Radix.
+        // name of the column containing column's Radix.
         static final String NUM_PREC_RADIX = "NUM_PREC_RADIX"; //$NON-NLS-1$
 
         /** name of column that has an String value indicating nullablity */
@@ -102,21 +100,21 @@ public interface JDBCColumnNames {
         /** name of column that has an String value indicating nullablity */
         static final String IS_NULLABLE = "IS_NULLABLE"; //$NON-NLS-1$
 
-        /** name of column that is the scope of a reference attribute (null if DATA_TYPE isn't REF)*/ 
+        /** name of column that is the scope of a reference attribute (null if DATA_TYPE isn't REF) */
         static final String SCOPE_CATLOG = "SCOPE_CATLOG"; //$NON-NLS-1$
-        
-        /** name of column that is the scope of a reference attribute (null if the DATA_TYPE isn't REF) */ 
+
+        /** name of column that is the scope of a reference attribute (null if the DATA_TYPE isn't REF) */
         static final String SCOPE_SCHEMA = "SCOPE_SCHEMA"; //$NON-NLS-1$
-        
+
         /** name of column that is the scope of a reference attribure (null if the DATA_TYPE isn't REF) */
         static final String SCOPE_TABLE = "SCOPE_TABLE"; //$NON-NLS-1$
-        
-        /** 
-         * name of column that is source type of a distinct type or user-generated Ref type, SQL type
-         * from java.sql.Types (null if DATA_TYPE isn't DISTINCT or user-generated REF)
-         */ 
+
+        /**
+         * name of column that is source type of a distinct type or user-generated Ref type, SQL type from java.sql.Types (null if
+         * DATA_TYPE isn't DISTINCT or user-generated REF)
+         */
         static final String SOURCE_DATA_TYPE = "SOURCE_DATA_TYPE"; //$NON-NLS-1$
-        
+
         /** name of column that has an String value indicating format */
         static final String FORMAT = "FORMAT"; //$NON-NLS-1$
 
@@ -125,13 +123,11 @@ public interface JDBCColumnNames {
 
         /** name of column that has an String value indicating maximum range */
         static final String MAX_RANGE = "MAX_RANGE"; //$NON-NLS-1$
-     }
-
+    }
 
     /**
-     * This class contains constants representing column names on ResultSet
-     * returned by getSchemas method on DatabaseMetaData. These constant values
-     * are be used to hardcode the column names used in constructin the ResultSet obj.
+     * This class contains constants representing column names on ResultSet returned by getSchemas method on DatabaseMetaData.
+     * These constant values are be used to hardcode the column names used in constructin the ResultSet obj.
      */
     interface SCHEMAS {
 
@@ -144,10 +140,8 @@ public interface JDBCColumnNames {
     }
 
     /**
-     * This class contains constants representing column names on ResultSet
-     * returned by getTables and getTableTypes methods on DatabaseMetaData. These
-     * constant values are be used to hardcode the column names used in construction
-     * the ResultSet obj.
+     * This class contains constants representing column names on ResultSet returned by getTables and getTableTypes methods on
+     * DatabaseMetaData. These constant values are be used to hardcode the column names used in construction the ResultSet obj.
      */
     interface TABLES {
 
@@ -171,14 +165,12 @@ public interface JDBCColumnNames {
         static final String SELF_REFERENCING_COL_NAME = "SELF_REFERENCING_COL_NAME"; //$NON-NLS-1$
         static final String REF_GENERATION = "REF_GENERATION"; //$NON-NLS-1$
         static final String ISPHYSICAL = "ISPHYSICAL"; //$NON-NLS-1$
-    
+
     }
 
     /**
-     * This class contains constants representing column names on ResultSet
-     * returned by getTables and getTableTypes methods on DatabaseMetaData. These
-     * constant values are be used to hardcode the column names used in construction
-     * the ResultSet obj.
+     * This class contains constants representing column names on ResultSet returned by getTables and getTableTypes methods on
+     * DatabaseMetaData. These constant values are be used to hardcode the column names used in construction the ResultSet obj.
      */
     interface TABLE_TYPES {
 
@@ -187,9 +179,8 @@ public interface JDBCColumnNames {
     }
 
     /**
-     * This class contains constants representing column names on ResultSet
-     * returned by getTypeInfo method on DatabaseMetaData. These constant values
-     * are be used to hard code the column names used in construction of the ResultSet obj.
+     * This class contains constants representing column names on ResultSet returned by getTypeInfo method on DatabaseMetaData.
+     * These constant values are be used to hard code the column names used in construction of the ResultSet obj.
      */
     interface TYPE_INFO {
 
@@ -247,22 +238,21 @@ public interface JDBCColumnNames {
         // constant indiacting column's Radix.
         static final String NUM_PREC_RADIX = "NUM_PREC_RADIX"; //$NON-NLS-1$
     }
-    
+
     /**
-     * This class contains constants representing column names on ResultSet
-     * returned by getCrossReference, getExportedKeys, and getImportedKeys methods
-     * on DatabaseMetaData. These constant values are be used to hard code the
-     * column names used in construction the ResultSet obj.
+     * This class contains constants representing column names on ResultSet returned by getCrossReference, getExportedKeys, and
+     * getImportedKeys methods on DatabaseMetaData. These constant values are be used to hard code the column names used in
+     * construction the ResultSet obj.
      */
     interface REFERENCE_KEYS {
 
-        //  name of the column containing catalog or Virtual database name for primary key's table.
+        // name of the column containing catalog or Virtual database name for primary key's table.
         static final String PKTABLE_CAT = "PKTABLE_CAT"; //$NON-NLS-1$
 
-        //  name of the column containing schema or Virtual database version for primary key's table.
+        // name of the column containing schema or Virtual database version for primary key's table.
         static final String PKTABLE_SCHEM = "PKTABLE_SCHEM"; //$NON-NLS-1$
 
-        //  name of the column containing table or group name for primary key's table.
+        // name of the column containing table or group name for primary key's table.
         static final String PKTABLE_NAME = "PKTABLE_NAME"; //$NON-NLS-1$
 
         // name of the column containing column or element name of the primary key.
@@ -300,11 +290,9 @@ public interface JDBCColumnNames {
         static final String FKPOSITION = "FKPOSITION"; //$NON-NLS-1$
     }
 
-
     /**
-     * This class contains constants representing column names on ResultSet
-     * returned by getPrimaryKeys method on DatabaseMetaData. These constant values
-     * are be used to hard code the column names used in construction the ResultSet obj.
+     * This class contains constants representing column names on ResultSet returned by getPrimaryKeys method on DatabaseMetaData.
+     * These constant values are be used to hard code the column names used in construction the ResultSet obj.
      */
     interface PRIMARY_KEYS {
 
@@ -329,9 +317,8 @@ public interface JDBCColumnNames {
     }
 
     /**
-     * This class contains constants representing column names on ResultSet
-     * returned by getIndexInfo method on DatabaseMetaData. These constant values
-     * are be used to hard code the column names used in construction the ResultSet obj.
+     * This class contains constants representing column names on ResultSet returned by getIndexInfo method on DatabaseMetaData.
+     * These constant values are be used to hard code the column names used in construction the ResultSet obj.
      */
     interface INDEX_INFO {
 
@@ -375,6 +362,77 @@ public interface JDBCColumnNames {
         static final String FILTER_CONDITION = "FILTER_CONDITION"; //$NON-NLS-1$
     }
 
-    
+    /**
+     * This class contains constants representing column names on ResultSet returned by getImportedKeys method on
+     * DatabaseMetaData. These constant values are be used to hard code the column names used in construction the ResultSet obj.
+     */
+    interface REFERENCE_KEYS_INFO {
+
+        // name of the column containing tables catalog name on which the primary key is present
+        static final String PK_TABLE_CAT = "PKTABLE_CAT"; //$NON-NLS-1$
+
+        // name of the column containing tables schema name on which the primary key is present
+        static final String PK_TABLE_SCHEM = "PKTABLE_SCHEM"; //$NON-NLS-1$
+
+        // name of the column containing primary key's table or group name.
+        static final String PK_TABLE_NAME = "PKTABLE_NAME"; //$NON-NLS-1$
+
+        // name of the column containing primary key's column name.
+        static final String PK_COLUMN_NAME = "PKCOLUMN_NAME"; //$NON-NLS-1$
+
+        // name of the column containing tables catalog name on which the foreign key is present
+        static final String FK_TABLE_CAT = "FKTABLE_CAT"; //$NON-NLS-1$
+
+        // name of the column containing tables schema name on which the foreign key is present
+        static final String FK_TABLE_SCHEM = "FKTABLE_SCHEM"; //$NON-NLS-1$
+
+        // name of the column containing foreign key's table or group name.
+        static final String FK_TABLE_NAME = "FKTABLE_NAME"; //$NON-NLS-1$
+
+        // name of the column containing foreign key's column name.
+        static final String FK_COLUMN_NAME = "PKCOLUMN_NAME"; //$NON-NLS-1$
+
+        // name of the column containing sequence number within the primary key
+        static final String KEY_SEQ = "KEY_SEQ"; //$NON-NLS-1$
+
+        // name of the column containing the delete rule
+        static final String UPDATE_RULE = "UPDATE_RULE"; //$NON-NLS-1$
+
+        // name of the column containing the delete rule
+        static final String DELETE_RULE = "DELETE_RULE"; //$NON-NLS-1$
+
+        // name of the column containing name of the foreign key.
+        static final String FK_NAME = "FK_NAME"; //$NON-NLS-1$
+
+        // name of the column containing name of the primary key.
+        static final String PK_NAME = "PK_NAME"; //$NON-NLS-1$
+
+        static final String DEFERRABILITY = "DEFERRABILITY"; //$NON-NLS-1$
+    }
+
+    /**
+     * This class contains constants representing column names on ResultSet returned by getProcedures on DatabaseMetaData. These
+     * constant values are be used to hardcode the column names used in construction the ResultSet obj.
+     */
+    interface PROCEDURES {
+
+        // name of the column containing catalog name.
+        static final String PROCEDURE_CAT = "PROCEDURE_CAT"; //$NON-NLS-1$
+
+        // name of the column containing schema name.
+        static final String PROCEDURE_SCHEM = "PROCEDURE_SCHEM"; //$NON-NLS-1$
+
+        // name of the column containing table or group name.
+        static final String PROCEDURE_NAME = "PROCEDURE_NAME"; //$NON-NLS-1$
+
+        static final String RESERVED1 = ""; //$NON-NLS-1$
+        static final String RESERVED2 = ""; //$NON-NLS-1$
+        static final String RESERVED3 = ""; //$NON-NLS-1$
+
+        // name of column containing explanatory notes.
+        static final String REMARKS = "REMARKS"; //$NON-NLS-1$
+        static final String PROCEDURE_TYPE = "PROCEDURE_TYPE"; //$NON-NLS-1$
+        static final String SPECIFIC_NAME = "SPECIFIC_NAME"; //$NON-NLS-1$
+    }
 
 }

--- a/modeshape-jdbc-local/src/test/java/org/modeshape/jdbc/JcrMetaDataTest.java
+++ b/modeshape-jdbc-local/src/test/java/org/modeshape/jdbc/JcrMetaDataTest.java
@@ -30,6 +30,7 @@ import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.when;
 import java.lang.reflect.Method;
 import java.sql.Connection;
+import java.sql.ResultSet;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -108,6 +109,48 @@ public class JcrMetaDataTest extends MultiUseAbstractTest {
     @Test
     public void shouldHaveMetaData() {
         assertThat(metadata, is(notNullValue()));
+    }
+
+    @Test
+    public void shouldImplementGetTables() throws Exception {
+        ResultSet result = metadata.getTables(null, null, null, null);
+        assertThat(result, is(notNullValue()));
+    }
+
+    @Test
+    public void shouldImplementGetColumns() throws Exception {
+        ResultSet result = metadata.getColumns(null, null, null, null);
+        assertThat(result, is(notNullValue()));
+    }
+
+    @Test
+    public void shouldImplementGetProcedures() throws Exception {
+        ResultSet result = metadata.getProcedures(null, null, null);
+        assertThat(result, is(notNullValue()));
+    }
+
+    @Test
+    public void shouldImplementGetImportedKeys() throws Exception {
+        ResultSet result = metadata.getImportedKeys(null, null, null);
+        assertThat(result, is(notNullValue()));
+    }
+
+    @Test
+    public void shouldImplementGetExportedKeys() throws Exception {
+        ResultSet result = metadata.getExportedKeys(null, null, null);
+        assertThat(result, is(notNullValue()));
+    }
+
+    @Test
+    public void shouldImplementGetUniqueIndexes() throws Exception {
+        ResultSet result = metadata.getIndexInfo(null, null, null, true, false);
+        assertThat(result, is(notNullValue()));
+    }
+
+    @Test
+    public void shouldImplementGetNonUniqueIndexes() throws Exception {
+        ResultSet result = metadata.getIndexInfo(null, null, null, false, false);
+        assertThat(result, is(notNullValue()));
     }
 
     /**


### PR DESCRIPTION
Teiid requires us to implement several more methods in our DatabaseMetaData implementation, so that was done. Also fixed a bug in the getColumns(...) method that expected the column name pattern parameter to be null, when null should be allowed.
