### PR TITLE
MODE-2129 Fixed the deployment of the CMIS webapp inside EAP. 

### DIFF
--- a/deploy/jbossas/kit/jboss-eap61/standalone/configuration/standalone-modeshape-ha.xml
+++ b/deploy/jbossas/kit/jboss-eap61/standalone/configuration/standalone-modeshape-ha.xml
@@ -243,7 +243,8 @@
             <!--The list of web applications that is packaged inside the kit and should be deployed when the subsystem starts up-->
             <webapp name="modeshape-rest.war"/>
             <webapp name="modeshape-webdav.war"/>
-	    <webapp name="modeshape-explorer.war"/>
+	        <webapp name="modeshape-explorer.war"/>
+            <webapp name="modeshape-cmis.war"/>
 
             <!-- A sample repository that uses the "sample" cache in the "modeshape" container. All content, binary values,
                  and indexes are stored within the server's data directory. This is the simplest way to configure a repository

--- a/deploy/jbossas/kit/jboss-eap61/standalone/configuration/standalone-modeshape.xml
+++ b/deploy/jbossas/kit/jboss-eap61/standalone/configuration/standalone-modeshape.xml
@@ -208,7 +208,8 @@
             <!--The list of web applications that is packaged inside the kit and should be deployed when the subsystem starts up-->
             <webapp name="modeshape-rest.war"/>
             <webapp name="modeshape-webdav.war"/>
-	    <webapp name="modeshape-explorer.war"/>
+	        <webapp name="modeshape-explorer.war"/>
+	        <webapp name="modeshape-cmis.war"/>
 
             <!-- A sample repository that uses the "sample" cache in the "modeshape" container. All content, binary values,
                  and indexes are stored within the server's data directory. This is the simplest way to configure a repository

--- a/deploy/jbossas/modeshape-jbossas-cmis-war/src/main/webapp/WEB-INF/jboss-deployment-structure.xml
+++ b/deploy/jbossas/modeshape-jbossas-cmis-war/src/main/webapp/WEB-INF/jboss-deployment-structure.xml
@@ -5,5 +5,12 @@
             <module name="org.modeshape.jcr.api" services="import"/>
             <module name="org.modeshape" services="import"/>
         </dependencies>
+        <!--
+            The CMIS endpoints are not compatible with CXF, so we need to disable that when deploying in EAP
+            see https://issues.jboss.org/browse/MODE-2129
+        -->
+        <exclude-subsystems>
+            <subsystem name="webservices"/>
+        </exclude-subsystems>
     </deployment>
 </jboss-deployment-structure>

--- a/integration/modeshape-jbossas-kit-tests/src/test/java/org/modeshape/test/kit/JBossASKitTest.java
+++ b/integration/modeshape-jbossas-kit-tests/src/test/java/org/modeshape/test/kit/JBossASKitTest.java
@@ -127,8 +127,7 @@ public class JBossASKitTest {
         });
         assertURIisAccessible("http://localhost:8080/modeshape-webdav", httpClient);
         assertURIisAccessible("http://localhost:8080/modeshape-rest", httpClient);
-
-//        assertURIisAccessible("http://localhost:8080/modeshape-cmis", httpClient); -- see MODE-1913
+        assertURIisAccessible("http://localhost:8080/modeshape-cmis", httpClient);
     }
 
     private void assertURIisAccessible( String uri,


### PR DESCRIPTION
The solution was to avoid using the default EAP WS stack (which uses CXF) since the CMIS webapp already has pre-packaged the RI jars.
In addition, reverted the changes from https://issues.jboss.org/browse/MODE-1913 since not using the default EAP WS stack fixes the restart issue as well.
