### PR TITLE
MODE-2092 Added community information to BOMs, which is required by the JBoss Maven repository manager.

### DIFF
--- a/boms/modeshape-bom-embedded/pom.xml
+++ b/boms/modeshape-bom-embedded/pom.xml
@@ -11,6 +11,42 @@
     <url>http://www.modeshape.org</url>
     <packaging>pom</packaging>
     <description>Bill of Material (BOM) for embedding ModeShape within JavaSE apps, libraries, and (non-EAP) web apps</description>
+    <inceptionYear>2008</inceptionYear>
+
+    <organization>
+        <name>JBoss, by Red Hat</name>
+        <url>http://www.jboss.org</url>
+    </organization>
+
+    <licenses>
+        <license>
+            <name>GNU Lesser General Public License</name>
+            <url>http://repository.jboss.org/licenses/lgpl-2.1.txt</url>
+            <!--url>http://www.gnu.org/licenses/lgpl.html</url-->
+            <distribution>repo</distribution>
+            <comments>A business-friendly OSS license</comments>
+        </license>
+    </licenses>
+
+    <scm>
+        <connection>scm:git:git://github.com/ModeShape/modeshape.git</connection>
+        <developerConnection>scm:git:git@github.com:ModeShape/modeshape.git</developerConnection>
+        <url>http://github.com/ModeShape/modeshape</url>
+    </scm>
+
+    <issueManagement>
+        <system>jira</system>
+        <url>http://issues.jboss.org/browse/MODE</url>
+    </issueManagement>
+
+    <developers>
+        <developer>
+            <id>modeshape.org</id>
+            <name>ModeShape Community</name>
+            <organization>modeshape.org</organization>
+            <organizationUrl>http://modeshape.org</organizationUrl>
+        </developer>
+    </developers>
 
     <properties>
         <infinispan.version>5.2.7.Final</infinispan.version>
@@ -25,6 +61,12 @@
         <cassandra.all.version>1.2.0</cassandra.all.version>
         <apache.avro.version>1.4.0</apache.avro.version>
         <tika.version>1.3</tika.version>
+
+        <!-- ***************** -->
+        <!-- Repository Deployment URLs -->
+        <!-- ***************** -->
+        <jboss.releases.repo.url>https://repository.jboss.org/nexus/service/local/staging/deploy/maven2/</jboss.releases.repo.url>
+        <jboss.snapshots.repo.url>https://repository.jboss.org/nexus/content/repositories/snapshots/</jboss.snapshots.repo.url>
     </properties>
 
     <!--
@@ -505,4 +547,17 @@
             </dependency>
         </dependencies>
     </dependencyManagement>
+
+    <distributionManagement>
+      <repository>
+        <id>jboss-releases-repository</id>
+        <name>JBoss Releases Repository</name>
+        <url>${jboss.releases.repo.url}</url>
+      </repository>
+      <snapshotRepository>
+        <id>jboss-snapshots-repository</id>
+        <name>JBoss Snapshots Repository</name>
+        <url>${jboss.snapshots.repo.url}</url>
+      </snapshotRepository>
+    </distributionManagement>
 </project>

--- a/boms/modeshape-bom-jbosseap/pom.xml
+++ b/boms/modeshape-bom-jbosseap/pom.xml
@@ -11,6 +11,50 @@
     <url>http://www.modeshape.org</url>
     <packaging>pom</packaging>
     <description>ModeShape and EAP6 usage Bill of Material (BOM)</description>
+    <inceptionYear>2008</inceptionYear>
+
+    <organization>
+        <name>JBoss, by Red Hat</name>
+        <url>http://www.jboss.org</url>
+    </organization>
+
+    <licenses>
+        <license>
+            <name>GNU Lesser General Public License</name>
+            <url>http://repository.jboss.org/licenses/lgpl-2.1.txt</url>
+            <!--url>http://www.gnu.org/licenses/lgpl.html</url-->
+            <distribution>repo</distribution>
+            <comments>A business-friendly OSS license</comments>
+        </license>
+    </licenses>
+
+    <scm>
+        <connection>scm:git:git://github.com/ModeShape/modeshape.git</connection>
+        <developerConnection>scm:git:git@github.com:ModeShape/modeshape.git</developerConnection>
+        <url>http://github.com/ModeShape/modeshape</url>
+    </scm>
+
+    <issueManagement>
+        <system>jira</system>
+        <url>http://issues.jboss.org/browse/MODE</url>
+    </issueManagement>
+
+    <developers>
+        <developer>
+            <id>modeshape.org</id>
+            <name>ModeShape Community</name>
+            <organization>modeshape.org</organization>
+            <organizationUrl>http://modeshape.org</organizationUrl>
+        </developer>
+    </developers>
+
+    <properties>
+        <!-- ***************** -->
+        <!-- Repository Deployment URLs -->
+        <!-- ***************** -->
+        <jboss.releases.repo.url>https://repository.jboss.org/nexus/service/local/staging/deploy/maven2/</jboss.releases.repo.url>
+        <jboss.snapshots.repo.url>https://repository.jboss.org/nexus/content/repositories/snapshots/</jboss.snapshots.repo.url>
+    </properties>
 
     <!--
          This section defines the default dependency settings inherited by
@@ -30,4 +74,17 @@
             </dependency>
         </dependencies>
     </dependencyManagement>
+
+    <distributionManagement>
+      <repository>
+        <id>jboss-releases-repository</id>
+        <name>JBoss Releases Repository</name>
+        <url>${jboss.releases.repo.url}</url>
+      </repository>
+      <snapshotRepository>
+        <id>jboss-snapshots-repository</id>
+        <name>JBoss Snapshots Repository</name>
+        <url>${jboss.snapshots.repo.url}</url>
+      </snapshotRepository>
+    </distributionManagement>
 </project>

--- a/boms/modeshape-bom-remote-client/pom.xml
+++ b/boms/modeshape-bom-remote-client/pom.xml
@@ -11,6 +11,50 @@
     <url>http://www.modeshape.org</url>
     <packaging>pom</packaging>
     <description>Bill of Material (BOM) for applications using ModeShape's REST client or remote JDBC driver.</description>
+    <inceptionYear>2008</inceptionYear>
+
+    <organization>
+        <name>JBoss, by Red Hat</name>
+        <url>http://www.jboss.org</url>
+    </organization>
+
+    <licenses>
+        <license>
+            <name>GNU Lesser General Public License</name>
+            <url>http://repository.jboss.org/licenses/lgpl-2.1.txt</url>
+            <!--url>http://www.gnu.org/licenses/lgpl.html</url-->
+            <distribution>repo</distribution>
+            <comments>A business-friendly OSS license</comments>
+        </license>
+    </licenses>
+
+    <scm>
+        <connection>scm:git:git://github.com/ModeShape/modeshape.git</connection>
+        <developerConnection>scm:git:git@github.com:ModeShape/modeshape.git</developerConnection>
+        <url>http://github.com/ModeShape/modeshape</url>
+    </scm>
+
+    <issueManagement>
+        <system>jira</system>
+        <url>http://issues.jboss.org/browse/MODE</url>
+    </issueManagement>
+
+    <developers>
+        <developer>
+            <id>modeshape.org</id>
+            <name>ModeShape Community</name>
+            <organization>modeshape.org</organization>
+            <organizationUrl>http://modeshape.org</organizationUrl>
+        </developer>
+    </developers>
+
+    <properties>
+        <!-- ***************** -->
+        <!-- Repository Deployment URLs -->
+        <!-- ***************** -->
+        <jboss.releases.repo.url>https://repository.jboss.org/nexus/service/local/staging/deploy/maven2/</jboss.releases.repo.url>
+        <jboss.snapshots.repo.url>https://repository.jboss.org/nexus/content/repositories/snapshots/</jboss.snapshots.repo.url>
+    </properties>
 
     <!--
          This section defines the default dependency settings inherited by
@@ -31,4 +75,17 @@
             </dependency>
         </dependencies>
     </dependencyManagement>
+
+    <distributionManagement>
+      <repository>
+        <id>jboss-releases-repository</id>
+        <name>JBoss Releases Repository</name>
+        <url>${jboss.releases.repo.url}</url>
+      </repository>
+      <snapshotRepository>
+        <id>jboss-snapshots-repository</id>
+        <name>JBoss Snapshots Repository</name>
+        <url>${jboss.snapshots.repo.url}</url>
+      </snapshotRepository>
+    </distributionManagement>
 </project>


### PR DESCRIPTION
Deployment to the JBoss Maven repository is blocked without this information.
