### PR TITLE
MODE-2143 Changed the default networking stack of ModeShape build to prefer IPv6

### DIFF
--- a/integration/modeshape-jbossas-integration-tests/pom.xml
+++ b/integration/modeshape-jbossas-integration-tests/pom.xml
@@ -15,6 +15,10 @@
     <url>http://www.modeshape.org</url>
     <properties>
         <arquillian.suspend>n</arquillian.suspend>
+
+        <!--Force Ipv4 since that's how Arquillian starts EAP -->
+        <preferIpv4>true</preferIpv4>
+        <preferIpv6>false</preferIpv6>
     </properties>
     <dependencyManagement>
         <dependencies>

--- a/modeshape-jcr/pom.xml
+++ b/modeshape-jcr/pom.xml
@@ -354,19 +354,5 @@
                 </plugins>
             </build>
         </profile>
-
-        <profile>
-            <id>ipv6_if_windows</id>
-            <activation>
-                <os>
-                    <family>Windows</family>
-                </os>
-            </activation>
-            <properties>
-                <!--Force Ipv6, because JGroups seems to be a lot faster with it on Windows-->
-                <preferIpv4>false</preferIpv4>
-                <preferIpv6>true</preferIpv6>
-            </properties>
-        </profile>
     </profiles>
 </project>

--- a/modeshape-parent/pom.xml
+++ b/modeshape-parent/pom.xml
@@ -216,8 +216,8 @@
         <dataSource.retryLimit>0</dataSource.retryLimit>
 
         <!--By default, we use whatever the underlying machine supports. However, certain sub-modules may change this -->
-        <preferIpv4>true</preferIpv4>
-        <preferIpv6>false</preferIpv6>
+        <preferIpv4>false</preferIpv4>
+        <preferIpv6>true</preferIpv6>
         <debug.argline/>
         <!--
           Global dependency version information
@@ -378,7 +378,7 @@
               Clustering-related profiles
               ###################################################################
 
-              To use, specify "-DpreferIpv6" on the Maven command line,
+              To use, specify "-DpreferIpv6" or "-DpreferIpv4" on the Maven command line,
               depending upon your environment's network configuration.
           -->
         <profile>
@@ -391,6 +391,18 @@
             <properties>
                 <preferIpv4>false</preferIpv4>
                 <preferIpv6>true</preferIpv6>
+            </properties>
+        </profile>
+        <profile>
+            <id>preferIpv4</id>
+            <activation>
+                <property>
+                    <name>preferIpv4</name>
+                </property>
+            </activation>
+            <properties>
+                <preferIpv4>true</preferIpv4>
+                <preferIpv6>false</preferIpv6>
             </properties>
         </profile>
 


### PR DESCRIPTION
Changed the default networking stack to prefer IPv6, except in the `integration/modeshape-jbossas-integration-tests` module that uses Arquillian (which is limited to IPv4 on Windows; see [JBPAPP-9281](https://issues.jboss.org/browse/JBPAPP-9281) for details) to run EAP on IPv4. In that module, we also have to force our tests to use IPv4.
