### PR TITLE
MODE-2167 Added the ability to turn off ACLs if all policies were removed

### DIFF
--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/AccessControlManagerImpl.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/AccessControlManagerImpl.java
@@ -56,7 +56,7 @@ import org.modeshape.jcr.value.Path;
  */
 public class AccessControlManagerImpl implements AccessControlManager {
 
-    private static final String MODE_ACCESS_CONTROLLABLE = "mode:accessControllable";
+    public static final String MODE_ACCESS_CONTROLLABLE = "mode:accessControllable";
     private static final String ACCESS_LIST_NODE = "mode:acl";
     private static final String MODE_ACCESS_LIST_NODE = "mode:Acl";
     private static final String MODE_ACCESS_LIST_ENTRY_NODE = "mode:Permission";
@@ -239,7 +239,7 @@ public class AccessControlManagerImpl implements AccessControlManager {
                 entryNode.remove();
             }
         }
-        session.repository.repositoryCache().setAccessControlEnabled(true);
+        session.aclAdded();
     }
 
     @Override
@@ -259,6 +259,7 @@ public class AccessControlManagerImpl implements AccessControlManager {
                 AbstractJcrNode aclNode = ((AbstractJcrNode)node).getNode(ACCESS_LIST_NODE, true);
                 aclNode.remove();
                 node.removeMixin(MODE_ACCESS_CONTROLLABLE);
+                session.aclRemoved();
             }
         } catch (PathNotFoundException e) {
         }

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrI18n.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrI18n.java
@@ -519,6 +519,8 @@ public final class JcrI18n {
     public static I18n upgrade3_6_0Running;
     public static I18n upgrade3_6_0CannotUpdateNodeTypes;
     public static I18n upgrade3_6_0CannotUpdateLocks;
+    public static I18n upgrade4_0_0Running;
+    public static I18n upgrade4_0_0Failed;
 
     public static I18n cannotStartJournal;
     public static I18n cannotStopJournal;

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/ModeShapeLexicon.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/ModeShapeLexicon.java
@@ -89,6 +89,7 @@ public class ModeShapeLexicon {
     public static final Name ACCESS_CONTROLLABLE = new BasicName(Namespace.URI, "accessControllable");
     public static final Name ACL = new BasicName(Namespace.URI, "Acl");
     public static final Name PERMISSION = new BasicName(Namespace.URI, "Permission");
+    public static final Name ACL_COUNT = new BasicName(Namespace.URI, "aclCount");
 
     /**
      * Deprecated names because of originally invalid node types in modeshape_builtins.cnd.

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/SystemContent.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/SystemContent.java
@@ -197,6 +197,10 @@ public class SystemContent {
         return system.mutable(versionStorageKey());
     }
 
+    public MutableCachedNode mutableSystemNode() {
+        return system.mutable(systemKey());
+    }
+
     /**
      * Stores the node types in the system area under <code>/jcr:system/jcr:nodeTypes</code>.
      * <p>

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/Upgrades.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/Upgrades.java
@@ -18,7 +18,9 @@ package org.modeshape.jcr;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+import javax.jcr.RepositoryException;
 import javax.jcr.nodetype.NodeTypeDefinition;
+import javax.jcr.query.Query;
 import org.modeshape.common.collection.Problems;
 import org.modeshape.common.collection.SimpleProblems;
 import org.modeshape.common.logging.Logger;
@@ -27,7 +29,9 @@ import org.modeshape.jcr.cache.CachedNode;
 import org.modeshape.jcr.cache.ChildReference;
 import org.modeshape.jcr.cache.ChildReferences;
 import org.modeshape.jcr.cache.MutableCachedNode;
+import org.modeshape.jcr.cache.RepositoryCache;
 import org.modeshape.jcr.cache.SessionCache;
+import org.modeshape.jcr.query.JcrQuery;
 
 /**
  * @author Randall Hauch (rhauch@redhat.com)
@@ -60,10 +64,10 @@ public class Upgrades {
     public static final Upgrades STANDARD_UPGRADES;
 
     static {
-        STANDARD_UPGRADES = new Upgrades(ModeShape_3_6_0.INSTANCE);
+        STANDARD_UPGRADES = new Upgrades(ModeShape_3_6_0.INSTANCE, ModeShape_4_0_0.INSTANCE);
     }
 
-    private final List<UpgradeOperation> operations = new ArrayList<UpgradeOperation>();
+    private final List<UpgradeOperation> operations = new ArrayList<>();
 
     protected Upgrades( UpgradeOperation... operations ) {
         int maxId = 0;
@@ -226,6 +230,56 @@ public class Upgrades {
                 return false;
             }
             return true;
+        }
+    }
+
+
+
+    /**
+     * Upgrade operation handling moving to ModeShape 4.0.0.Final. This consists of making sure that the access control metadata
+     * information is correctly stored in the repository metadata and that the {@link ModeShapeLexicon#ACL_COUNT} property
+     * correctly reflects this.
+     */
+    protected static class ModeShape_4_0_0 extends UpgradeOperation {
+        protected static final UpgradeOperation INSTANCE = new ModeShape_4_0_0();
+
+        protected ModeShape_4_0_0() {
+            super(2);
+        }
+
+        @Override
+        public void apply( Context resources ) {
+            LOGGER.info(JcrI18n.upgrade4_0_0Running);
+            RunningState runningState = resources.getRepository();
+            RepositoryCache repositoryCache = runningState.repositoryCache();
+
+            try {
+                long nodesWithAccessControl = 0;
+                for (String workspaceName : repositoryCache.getWorkspaceNames()) {
+                    JcrSession session = runningState.loginInternalSession(workspaceName);
+                    try {
+                        JcrQueryManager queryManager = session.getWorkspace().getQueryManager();
+                        Query query = queryManager.createQuery(
+                                "select [jcr:name] from [" + AccessControlManagerImpl.MODE_ACCESS_CONTROLLABLE + "]",
+                                JcrQuery.JCR_SQL2);
+                        nodesWithAccessControl = query.execute().getRows().getSize();
+                    } finally {
+                        session.logout();
+                    }
+                }
+                if (nodesWithAccessControl == 0) {
+                    repositoryCache.setAccessControlEnabled(false);
+                }
+
+                ExecutionContext context = runningState.context();
+                SessionCache systemSession = runningState.createSystemSession(context, false);
+                SystemContent systemContent = new SystemContent(systemSession);
+                MutableCachedNode systemNode = systemContent.mutableSystemNode();
+                systemNode.setProperty(systemSession, context.getPropertyFactory().create(ModeShapeLexicon.ACL_COUNT, nodesWithAccessControl));
+                systemSession.save();
+            } catch (RepositoryException e) {
+               LOGGER.error(e, JcrI18n.upgrade4_0_0Failed, e.getMessage());
+            }
         }
     }
 }

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/RepositoryCache.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/RepositoryCache.java
@@ -154,8 +154,8 @@ public class RepositoryCache implements Observable {
         this.logger = Logger.getLogger(getClass());
         this.rootNodeId = RepositoryConfiguration.ROOT_NODE_ID;
         this.name = configuration.getName();
-        this.workspaceCachesByName = new ConcurrentHashMap<String, WorkspaceCache>();
-        this.workspaceNames = new CopyOnWriteArraySet<String>(configuration.getAllWorkspaceNames());
+        this.workspaceCachesByName = new ConcurrentHashMap<>();
+        this.workspaceNames = new CopyOnWriteArraySet<>(configuration.getAllWorkspaceNames());
         this.upgrades = upgradeFunctions;
 
         //if we're running in a cluster, try to acquire a global cluster lock to perform initialization

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/document/WritableSessionCache.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/document/WritableSessionCache.java
@@ -904,8 +904,8 @@ public class WritableSessionCache extends AbstractSessionCache {
         PathCache workspacePaths = new PathCache(workspaceCache);
 
         Set<NodeKey> removedNodes = null;
-        Set<BinaryKey> unusedBinaryKeys = new HashSet<BinaryKey>();
-        Set<NodeKey> renamedExternalNodes = new HashSet<NodeKey>();
+        Set<BinaryKey> unusedBinaryKeys = new HashSet<>();
+        Set<NodeKey> renamedExternalNodes = new HashSet<>();
         for (NodeKey key : changedNodesInOrder) {
             SessionNode node = changedNodes.get(key);
             String keyStr = key.toString();
@@ -916,7 +916,7 @@ public class WritableSessionCache extends AbstractSessionCache {
                 if (persisted != null) {
                     // This was a persistent node, so we have to generate an event and deal with the remove ...
                     if (removedNodes == null) {
-                        removedNodes = new HashSet<NodeKey>();
+                        removedNodes = new HashSet<>();
                     }
                     try {
                         Name primaryType = persisted.getPrimaryType(this);

--- a/modeshape-jcr/src/main/resources/org/modeshape/jcr/JcrI18n.properties
+++ b/modeshape-jcr/src/main/resources/org/modeshape/jcr/JcrI18n.properties
@@ -502,6 +502,8 @@ cannotUnRegisterMBean = Cannot un-register MBean "{0}"
 upgrade3_6_0Running = Running ModeShape 3.6.0 upgrade function...
 upgrade3_6_0CannotUpdateNodeTypes = ModeShape 3.6.0 upgrade error: cannot update the internal node types. Reason: "{0}"
 upgrade3_6_0CannotUpdateLocks = ModeShape 3.6.0 upgrade error: cannot update existing locks. Reason: "{0}"
+upgrade4_0_0Running = Running ModeShape 4.0.0 upgrade function...
+upgrade4_0_0Failed =  ModeShape 4.0.0 failed: "{0}"
 
 cannotStartJournal = Cannot start event journal
 cannotStopJournal = Cannot stop event journal

--- a/modeshape-jcr/src/main/resources/org/modeshape/jcr/modeshape_builtins.cnd
+++ b/modeshape-jcr/src/main/resources/org/modeshape/jcr/modeshape_builtins.cnd
@@ -66,6 +66,8 @@
 - mode:alias (String) mandatory protected ignore
 
 [mode:system] > nt:base
+- * (undefined) protected
+- * (undefined) multiple protected
 + mode:namespaces (mode:namespaces) = mode:namespaces autocreated mandatory protected abort
 + mode:locks (mode:locks) = mode:locks autocreated mandatory protected abort
 + mode:repository (mode:repository) = mode:repository autocreated protected abort

--- a/modeshape-jcr/src/test/java/org/modeshape/jcr/JcrRepositoryStartupTest.java
+++ b/modeshape-jcr/src/test/java/org/modeshape/jcr/JcrRepositoryStartupTest.java
@@ -40,6 +40,10 @@ import javax.jcr.nodetype.NodeTypeManager;
 import javax.jcr.nodetype.NodeTypeTemplate;
 import javax.jcr.query.Query;
 import javax.jcr.query.QueryManager;
+import javax.jcr.security.AccessControlList;
+import javax.jcr.security.AccessControlManager;
+import javax.jcr.security.AccessControlPolicyIterator;
+import javax.jcr.security.Privilege;
 import org.infinispan.schematic.document.EditableArray;
 import org.infinispan.schematic.document.EditableDocument;
 import org.infinispan.schematic.document.Editor;
@@ -55,6 +59,8 @@ import org.modeshape.jcr.cache.ChildReferences;
 import org.modeshape.jcr.cache.MutableCachedNode;
 import org.modeshape.jcr.cache.SessionCache;
 import org.modeshape.jcr.cache.document.DocumentStore;
+import org.modeshape.jcr.security.SimplePrincipal;
+import org.modeshape.jcr.value.Property;
 import org.modeshape.jcr.value.PropertyFactory;
 
 /**
@@ -450,10 +456,7 @@ public class JcrRepositoryStartupTest extends MultiPassAbstractTest {
             @Override
             public Void call() throws Exception {
                 //modify the repository-info document to force an upgrade on the next restart
-                DocumentStore documentStore =  repository.documentStore();
-                EditableDocument editableDocument = documentStore.localStore().get("repository:info").editDocumentContent();
-                editableDocument.set("lastUpgradeId", Upgrades.ModeShape_3_6_0.INSTANCE.getId() - 1);
-                documentStore.localStore().put("repository:info", editableDocument);
+                changeLastUpgradeId(repository, Upgrades.ModeShape_3_6_0.INSTANCE.getId() - 1);
 
                 //create a non-session lock on a node
                 JcrSession session = repository.login();
@@ -687,4 +690,164 @@ public class JcrRepositoryStartupTest extends MultiPassAbstractTest {
             }
         }, repositoryConfigFile);
     }
+
+    @Test
+    @FixFor("MODE-2167")
+    public void shouldDisableACLsIfAllPoliciesAreRemoved() throws Exception {
+        FileUtil.delete("target/persistent_repository/");
+
+        String repositoryConfigFile = "config/repo-config-persistent-cache.json";
+
+        startRunStop(new RepositoryOperation() {
+            @Override
+            public Void call() throws Exception {
+                Session session = repository.login();
+                Node testNode = session.getRootNode().addNode("testNode");
+                testNode.addNode("node1");
+                testNode.addNode("node2");
+                session.save();
+
+                AccessControlManager acm = session.getAccessControlManager();
+
+                AccessControlList aclNode1 = getACL(acm, "/testNode/node1");
+                aclNode1.addAccessControlEntry(SimplePrincipal.newInstance("anonymous"),
+                                          new Privilege[] { acm.privilegeFromName(Privilege.JCR_ALL) });
+                acm.setPolicy("/testNode/node1", aclNode1);
+
+                AccessControlList aclNode2 = getACL(acm, "/testNode/node2");
+                aclNode2.addAccessControlEntry(SimplePrincipal.newInstance("anonymous"),
+                                          new Privilege[] { acm.privilegeFromName(Privilege.JCR_ALL) });
+                acm.setPolicy("/testNode/node2", aclNode2);
+
+                //access control should not be enabled yet because we haven't saved the session
+                assertFalse(repository.runningState().repositoryCache().isAccessControlEnabled());
+
+                session.save();
+                assertTrue(repository.runningState().repositoryCache().isAccessControlEnabled());
+
+                return null;
+            }
+        }, repositoryConfigFile);
+
+        startRunStop(new RepositoryOperation() {
+            @Override
+            public Void call() throws Exception {
+                assertTrue(repository.runningState().repositoryCache().isAccessControlEnabled());
+
+                Session session = repository.login();
+                AccessControlManager acm = session.getAccessControlManager();
+                //TODO author=Horia Chiorean date=25-Mar-14 description=Why null here !?!
+                acm.removePolicy("/testNode/node1", null);
+                acm.removePolicy("/testNode/node2", null);
+                session.save();
+
+                assertFalse(repository.runningState().repositoryCache().isAccessControlEnabled());
+
+                session.getNode("/testNode").remove();
+                session.save();
+                return null;
+            }
+        }, repositoryConfigFile);
+    }
+
+    @Test
+    @FixFor("MODE-2167")
+    public void shouldRun4_0_0UpgradeFunction() throws Exception {
+        FileUtil.delete("target/persistent_repository/");
+        String config = "config/repo-config-persistent-indexes-disk.json";
+        //first run is empty, so no upgrades will be performed
+        startRunStop(new RepositoryOperation() {
+            @SuppressWarnings( "deprecation" )
+            @Override
+            public Void call() throws Exception {
+                changeLastUpgradeId(repository, Upgrades.ModeShape_4_0_0.INSTANCE.getId() - 1);
+
+
+                //modify some ACLs
+                JcrSession session = repository.login();
+                session.getRootNode().addNode("testNode");
+                session.save();
+
+                AccessControlManager acm = session.getAccessControlManager();
+
+                AccessControlList acl = getACL(acm, "/testNode");
+                acl.addAccessControlEntry(SimplePrincipal.newInstance("anonymous"),
+                                          new Privilege[] { acm.privilegeFromName(Privilege.JCR_ALL) });
+                acm.setPolicy("/testNode", acl);
+                session.save();
+
+                //remove the new property from 4.0 which actually stores the ACL count to simulate a pre 4.0 repository
+                SessionCache systemSession = repository.createSystemSession(repository.runningState().context(), false);
+                SystemContent systemContent = new SystemContent(systemSession);
+                MutableCachedNode systemNode = systemContent.mutableSystemNode();
+                systemNode.removeProperty(systemSession, ModeShapeLexicon.ACL_COUNT);
+                systemSession.save();
+                return null;
+            }
+        }, config);
+
+        //second run should run the upgrade
+        startRunStop(new RepositoryOperation() {
+            @SuppressWarnings( "deprecation" )
+            @Override
+            public Void call() throws Exception {
+                //check that the upgrade function correctly added the new property
+                SessionCache systemSession = repository.createSystemSession(repository.runningState().context(), false);
+                SystemContent systemContent = new SystemContent(systemSession);
+                MutableCachedNode systemNode = systemContent.mutableSystemNode();
+                Property aclCountProp = systemNode.getProperty(ModeShapeLexicon.ACL_COUNT, systemSession);
+                assertNotNull("ACL count property not found after upgrade", aclCountProp);
+                assertEquals(1, Long.valueOf(aclCountProp.getFirstValue().toString()).longValue());
+
+                //force a 2nd upgrade
+                changeLastUpgradeId(repository, Upgrades.ModeShape_4_0_0.INSTANCE.getId() - 1);
+
+                //remove all ACLs
+                JcrSession session = repository.login();
+                AccessControlManager acm = session.getAccessControlManager();
+                //TODO author=Horia Chiorean date=25-Mar-14 description=Why null ?!
+                acm.removePolicy("/testNode", null);
+                session.save();
+
+                //remove the new property from 4.0 which actually stores the ACL count to simulate a pre 4.0 repository
+                systemNode.removeProperty(systemSession, ModeShapeLexicon.ACL_COUNT);
+                systemSession.save();
+                return null;
+            }
+        }, config);
+
+        //check that the upgrade disabled ACLs
+        startRunStop(new RepositoryOperation() {
+            @Override
+            public Void call() throws Exception {
+
+                SessionCache systemSession = repository.createSystemSession(repository.runningState().context(), true);
+                SystemContent systemContent = new SystemContent(systemSession);
+                CachedNode systemNode = systemContent.systemNode();
+                Property aclCountProp = systemNode.getProperty(ModeShapeLexicon.ACL_COUNT, systemSession);
+                assertNotNull("ACL count property not found after upgrade", aclCountProp);
+                assertEquals(0, Long.valueOf(aclCountProp.getFirstValue().toString()).longValue());
+
+                assertFalse(repository.runningState().repositoryCache().isAccessControlEnabled());
+                return null;
+            }
+        }, config);
+    }
+
+    private void changeLastUpgradeId( JcrRepository repository, int value ) {
+        //modify the repository-info document to force an upgrade on the next restart
+        DocumentStore documentStore =  repository.documentStore();
+        EditableDocument editableDocument = documentStore.localStore().get("repository:info").editDocumentContent();
+        editableDocument.set("lastUpgradeId", value);
+        documentStore.localStore().put("repository:info", editableDocument);
+    }
+
+    private AccessControlList getACL(  AccessControlManager acm, String absPath ) throws Exception {
+        AccessControlPolicyIterator it = acm.getApplicablePolicies(absPath);
+        if (it.hasNext()) {
+            return (AccessControlList)it.nextAccessControlPolicy();
+        }
+        return (AccessControlList)acm.getPolicies(absPath)[0];
+    }
+
 }

--- a/modeshape-jcr/src/test/resources/config/repo-config-persistent-indexes-disk.json
+++ b/modeshape-jcr/src/test/resources/config/repo-config-persistent-indexes-disk.json
@@ -1,0 +1,18 @@
+{
+    "name" : "Persistent Repository",
+    "storage" : {
+        "cacheName" : "persistentRepository",
+        "cacheConfiguration" : "config/infinispan-persistent.xml"
+    },
+    "workspaces" : {
+        "default" : "default",
+        "allowCreation" : true
+    },
+    "query" : {
+        "enabled" : true,
+        "indexStorage" : {
+            "type" : "filesystem",
+            "location" : "target/persistent_repository/index"
+        }
+    }
+}


### PR DESCRIPTION
The implementation was done by using an counter property stored on the `jcr:system` node. This basically tracks the total number of nodes (from all workspaces) that have ACLs.
While implementing this, I also updated the `jcr:system` node definition to store all any kind of properties (protected). This should give us greater flexibility in the future.

The code changes also contains an upgrade function to 4.0 which fixes existing repositories.
