### PR TITLE
MODE-2186 Added permissions checks for the getNodes() public methods if and only if ACLs are enabled.

### DIFF
--- a/modeshape-jcr/pom.xml
+++ b/modeshape-jcr/pom.xml
@@ -142,10 +142,6 @@
             <artifactId>mongo-java-driver</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.mapdb</groupId>
-            <artifactId>mapdb</artifactId>
-        </dependency>
-        <dependency>
             <groupId>de.flapdoodle.embed</groupId>
             <artifactId>de.flapdoodle.embed.mongo</artifactId>
         </dependency>

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/AbstractJcrNode.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/AbstractJcrNode.java
@@ -853,7 +853,13 @@ abstract class AbstractJcrNode extends AbstractJcrItem implements Node {
     public NodeIterator getNodes() throws RepositoryException {
         ChildReferences childReferences = node().getChildReferences(sessionCache());
         if (childReferences.isEmpty()) return JcrEmptyNodeIterator.INSTANCE;
-        return new JcrChildNodeIterator(new ChildNodeResolver(session, key()), childReferences);
+        return new JcrChildNodeIterator(new ChildNodeResolver(session, key()), childReferences.iterator());
+    }
+
+    protected NodeIterator getNodesInternal() throws RepositoryException {
+        ChildReferences childReferences = node().getChildReferences(sessionCache());
+        if (childReferences.isEmpty()) return JcrEmptyNodeIterator.INSTANCE;
+        return new JcrChildNodeIterator(new ChildNodeResolver(session, key(), false), childReferences);
     }
 
     @Override
@@ -863,6 +869,14 @@ abstract class AbstractJcrNode extends AbstractJcrItem implements Node {
         if (namePattern.length() == 0) return JcrEmptyNodeIterator.INSTANCE;
         if ("*".equals(namePattern)) return getNodes();
         return getNodes(patternStringToGlobArray(namePattern));
+    }
+
+    protected NodeIterator getNodesInternal( String namePattern ) throws RepositoryException {
+        CheckArg.isNotNull(namePattern, "namePattern");
+        checkSession();
+        if (namePattern.length() == 0) return JcrEmptyNodeIterator.INSTANCE;
+        if ("*".equals(namePattern)) return getNodesInternal();
+        return getNodesInternal(patternStringToGlobArray(namePattern));
     }
 
     @Override
@@ -883,8 +897,25 @@ abstract class AbstractJcrNode extends AbstractJcrItem implements Node {
         return new JcrChildNodeIterator(new ChildNodeResolver(session, key()), iter);
     }
 
+    protected NodeIterator getNodesInternal( String... nameGlobs ) throws RepositoryException {
+        CheckArg.isNotNull(nameGlobs, "nameGlobs");
+        if (nameGlobs.length == 0) return JcrEmptyNodeIterator.INSTANCE;
+
+        List<?> patterns = createPatternsFor(nameGlobs);
+        Iterator<ChildReference> iter = null;
+        if (patterns.size() == 1 && patterns.get(0) instanceof String) {
+            // This is a literal, so just look up by name ...
+            Name literal = nameFrom((String)patterns.get(0));
+            iter = node().getChildReferences(sessionCache()).iterator(literal);
+        } else {
+            NamespaceRegistry registry = session.namespaces();
+            iter = node().getChildReferences(sessionCache()).iterator(patterns, registry);
+        }
+        return new JcrChildNodeIterator(new ChildNodeResolver(session, key(), false), iter);
+    }
+
     protected static String[] patternStringToGlobArray( String namePattern ) {
-        List<String> globs = new ArrayList<String>();
+        List<String> globs = new ArrayList<>();
         for (String glob : namePattern.split("\\|")) {
             String trimmedGlob = glob.trim();
             if (trimmedGlob.length() > 0) {
@@ -2630,7 +2661,7 @@ abstract class AbstractJcrNode extends AbstractJcrItem implements Node {
         // Check that any remaining child nodes that use the mixin type to be removed
         // match the residual definition for the node.
         // ------------------------------------------------------------------------------
-        for (NodeIterator iter = getNodes(); iter.hasNext();) {
+        for (NodeIterator iter = getNodesInternal(); iter.hasNext();) {
             AbstractJcrNode child = (AbstractJcrNode)iter.nextNode();
             int snsCount = (int)childCount(child.name());
             NodeDefinition childDefinition = child.getDefinition();
@@ -2682,7 +2713,7 @@ abstract class AbstractJcrNode extends AbstractJcrItem implements Node {
         for (AbstractJcrProperty prop : this.jcrProperties.values()) {
             prop.releasePropertyDefinitionId();
         }
-        for (NodeIterator iter = getNodes(); iter.hasNext();) {
+        for (NodeIterator iter = getNodesInternal(); iter.hasNext();) {
             AbstractJcrNode child = (AbstractJcrNode)iter.nextNode();
             child.releaseNodeDefinitionId();
         }
@@ -3523,17 +3554,28 @@ abstract class AbstractJcrNode extends AbstractJcrItem implements Node {
     protected static final class ChildNodeResolver implements JcrChildNodeIterator.NodeResolver {
         private final JcrSession session;
         private final NodeKey parentKey;
+        private final boolean checkPermission;
+
+        public ChildNodeResolver( JcrSession session, NodeKey parentKey, boolean checkPermission ) {
+            this.session = session;
+            this.parentKey = parentKey;
+            // we only need to check permissions if ACLs are enabled
+            this.checkPermission = checkPermission && session.repository().repositoryCache().isAccessControlEnabled();
+        }
 
         protected ChildNodeResolver( JcrSession session,
                                      NodeKey parentKey ) {
-            this.session = session;
-            this.parentKey = parentKey;
+            this(session, parentKey, true);
         }
 
         @Override
         public Node nodeFrom( ChildReference ref ) {
             try {
-                return session.node(ref.getKey(), null, parentKey);
+                AbstractJcrNode node =  session.node(ref.getKey(), null, parentKey);
+                if (checkPermission  && !node.isExternal() && !session.hasPermission(node.getPath(), ModeShapePermissions.READ)) {
+                    return null;
+                }
+                return node;
             } catch (RepositoryException e) {
                 return null;
             }

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/AccessControlManagerImpl.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/AccessControlManagerImpl.java
@@ -143,7 +143,7 @@ public class AccessControlManagerImpl implements AccessControlManager {
 
             // load entries
             AbstractJcrNode aclNode = ((AbstractJcrNode)node).getNode(ACCESS_LIST_NODE, true);
-            NodeIterator it = aclNode.getNodes();
+            NodeIterator it = aclNode.getNodesInternal();
             while (it.hasNext()) {
                 Node entryNode = it.nextNode();
 
@@ -212,6 +212,10 @@ public class AccessControlManagerImpl implements AccessControlManager {
 
         // binding given policy to the specified path as special child node
         AbstractJcrNode node = session.getNode(path, true);
+
+        if (node.isExternal()) {
+            throw new RepositoryException(JcrI18n.aclsOnExternalNodesNotAllowed.text());
+        }
         // make node access controllable and add specsial child node
         // which belongs to the access list
         node.addMixin(MODE_ACCESS_CONTROLLABLE, false);
@@ -231,7 +235,7 @@ public class AccessControlManagerImpl implements AccessControlManager {
         }
 
         // delete removed entries
-        NodeIterator it = aclNode.getNodes();
+        NodeIterator it = aclNode.getNodesInternal();
         while (it.hasNext()) {
             Node entryNode = it.nextNode();
             String name = entryNode.getProperty(PRINCIPAL_NAME).getString();
@@ -254,9 +258,12 @@ public class AccessControlManagerImpl implements AccessControlManager {
             if (!hasPrivileges(path, new Privilege[] {privileges.forName(Privilege.JCR_MODIFY_ACCESS_CONTROL)})) {
                 throw new AccessDeniedException();
             }
-            Node node = session.getNode(path);
+            AbstractJcrNode node = session.getNode(path);
+            if (node.isExternal()) {
+                throw new RepositoryException(JcrI18n.aclsOnExternalNodesNotAllowed.text());
+            }
             if (node.hasNode(ACCESS_LIST_NODE)) {
-                AbstractJcrNode aclNode = ((AbstractJcrNode)node).getNode(ACCESS_LIST_NODE, true);
+                AbstractJcrNode aclNode = node.getNode(ACCESS_LIST_NODE, true);
                 aclNode.remove();
                 node.removeMixin(MODE_ACCESS_CONTROLLABLE);
                 session.aclRemoved();
@@ -297,12 +304,12 @@ public class AccessControlManagerImpl implements AccessControlManager {
      * @return JCR defined AccessControlList object.
      * @throws RepositoryException
      */
-    private JcrAccessControlList acl( Node node ) throws RepositoryException {
+    private JcrAccessControlList acl( AbstractJcrNode node ) throws RepositoryException {
         // create new access list object
         JcrAccessControlList acl = new JcrAccessControlList(this, node.getPath());
 
         // fill access list with entries
-        NodeIterator entryNodes = node.getNodes();
+        NodeIterator entryNodes = node.getNodesInternal();
         while (entryNodes.hasNext()) {
             // pickup next entry
             Node entry = entryNodes.nextNode();

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrDocumentViewExporter.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrDocumentViewExporter.java
@@ -82,9 +82,6 @@ class JcrDocumentViewExporter extends AbstractJcrExporter {
                             ContentHandler contentHandler,
                             boolean skipBinary,
                             boolean noRecurse ) throws RepositoryException, SAXException {
-        if (!session.hasPermission(node.getPath(), ModeShapePermissions.READ)) {
-            return;
-        }
         ExecutionContext executionContext = session.context();
 
         JcrSharedNode sharedNode = asSharedNode(node);
@@ -141,6 +138,7 @@ class JcrDocumentViewExporter extends AbstractJcrExporter {
         // Write out the element ...
         startElement(contentHandler, name, atts);
         if (!noRecurse) {
+            //the node iterator should check permissions and return only those nodes on which there is READ permission
             NodeIterator nodes = node.getNodes();
             while (nodes.hasNext()) {
                 Node child = nodes.nextNode();

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrI18n.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrI18n.java
@@ -208,6 +208,7 @@ public final class JcrI18n {
     public static I18n unableToCopySourceNotExternal;
     public static I18n unableToCloneSameWsContainsExternalNode;
     public static I18n unableToCloneExternalNodesRequireRoot;
+    public static I18n aclsOnExternalNodesNotAllowed;
 
     public static I18n typeNotFound;
     public static I18n supertypeNotFound;

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrSystemViewExporter.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrSystemViewExporter.java
@@ -105,10 +105,6 @@ class JcrSystemViewExporter extends AbstractJcrExporter {
                                boolean skipBinary,
                                boolean noRecurse,
                                boolean isRoot ) throws RepositoryException, SAXException {
-        if (!session.hasPermission(node.getPath(), ModeShapePermissions.READ)) {
-            return;
-        }
-
         // start the sv:node element for this JCR node
         AttributesImpl atts = new AttributesImpl();
         String nodeName = node.getName();
@@ -151,6 +147,7 @@ class JcrSystemViewExporter extends AbstractJcrExporter {
             }
 
             if (!noRecurse) {
+                // the node iterator should check permissions and return only those nodes on which there is READ permission
                 NodeIterator nodes = node.getNodes();
                 while (nodes.hasNext()) {
                     Node child = nodes.nextNode();

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrVersionHistoryNode.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrVersionHistoryNode.java
@@ -78,7 +78,7 @@ final class JcrVersionHistoryNode extends JcrSystemNode implements VersionHistor
 
     @Override
     public VersionIterator getAllVersions() throws RepositoryException {
-        return new JcrVersionIterator(getNodes());
+        return new JcrVersionIterator(getNodesInternal());
     }
 
     @Override

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrVersionManager.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrVersionManager.java
@@ -1066,7 +1066,7 @@ final class JcrVersionManager implements org.modeshape.jcr.api.version.VersionMa
             }
         }
 
-        NodeIterator nodeIterator = node.getNodes();
+        NodeIterator nodeIterator = node.getNodesInternal();
         while (nodeIterator.hasNext()) {
             removeHistories((AbstractJcrNode)nodeIterator.nextNode(), systemSession);
         }
@@ -1762,7 +1762,7 @@ final class JcrVersionManager implements org.modeshape.jcr.api.version.VersionMa
          */
         private void doLeave( AbstractJcrNode targetNode ) throws RepositoryException {
             if (!isShallow) {
-                for (NodeIterator iter = targetNode.getNodes(); iter.hasNext();) {
+                for (NodeIterator iter = targetNode.getNodesInternal(); iter.hasNext();) {
                     doMerge((AbstractJcrNode)iter.nextNode());
                 }
             }
@@ -1791,7 +1791,7 @@ final class JcrVersionManager implements org.modeshape.jcr.api.version.VersionMa
             Set<AbstractJcrNode> targetNodesPresentInBoth = new LinkedHashSet<AbstractJcrNode>();
             Set<AbstractJcrNode> sourceNodesPresentInBoth = new LinkedHashSet<AbstractJcrNode>();
 
-            for (NodeIterator iter = targetNode.getNodes(); iter.hasNext();) {
+            for (NodeIterator iter = targetNode.getNodesInternal(); iter.hasNext();) {
                 AbstractJcrNode targetChild = (AbstractJcrNode)iter.nextNode();
                 try {
                     Path srcPath = targetChild.correspondingNodePath(sourceWorkspaceName);
@@ -1804,7 +1804,7 @@ final class JcrVersionManager implements org.modeshape.jcr.api.version.VersionMa
                     targetOnly.add(targetChild);
                 }
             }
-            for (NodeIterator iter = sourceNode.getNodes(); iter.hasNext();) {
+            for (NodeIterator iter = sourceNode.getNodesInternal(); iter.hasNext();) {
                 AbstractJcrNode sourceChild = (AbstractJcrNode)iter.nextNode();
                 if (!sourceNodesPresentInBoth.contains(sourceChild)) {
                     sourceOnly.add(sourceChild);
@@ -1873,7 +1873,7 @@ final class JcrVersionManager implements org.modeshape.jcr.api.version.VersionMa
             failures.add(targetNode);
 
             if (!isShallow) {
-                for (NodeIterator iter = targetNode.getNodes(); iter.hasNext();) {
+                for (NodeIterator iter = targetNode.getNodesInternal(); iter.hasNext();) {
                     AbstractJcrNode childNode = (AbstractJcrNode)iter.nextNode();
 
                     if (childNode.isNodeType(JcrMixLexicon.VERSIONABLE)) {

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrWorkspace.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrWorkspace.java
@@ -830,7 +830,7 @@ class JcrWorkspace implements org.modeshape.jcr.api.Workspace {
             JcrRootNode rootNode = removeSession.getRootNode();
 
             //first remove all the nodes via JCR, because we need validations to be performed
-            for (NodeIterator nodeIterator = rootNode.getNodes(); nodeIterator.hasNext(); ) {
+            for (NodeIterator nodeIterator = rootNode.getNodesInternal(); nodeIterator.hasNext(); ) {
                 AbstractJcrNode child = (AbstractJcrNode)nodeIterator.nextNode();
                 if (child.key().equals(systemKey)) {
                     //we don't remove the jcr:system node here, we just unlink it via the cache

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/SequencingRunner.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/SequencingRunner.java
@@ -145,13 +145,13 @@ final class SequencingRunner implements Runnable {
                 primaryType = selectedNode.getPrimaryNodeType().getName();
             } else {
                 // Find the parent of the output if it exists, or create the node(s) along the path if not ...
-                Node parentOfOutput = null;
+                AbstractJcrNode parentOfOutput = null;
                 try {
                     parentOfOutput = outputSession.getNode(work.getOutputPath());
                 } catch (PathNotFoundException e) {
                     LOGGER.trace("Creating missing output path for {0}", logMsg);
                     JcrTools tools = new JcrTools();
-                    parentOfOutput = tools.findOrCreateNode(outputSession, work.getOutputPath());
+                    parentOfOutput = (AbstractJcrNode)tools.findOrCreateNode(outputSession, work.getOutputPath());
                 }
 
                 // Now determine the name of top node in the output, using the last segment of the selected path ...
@@ -384,7 +384,7 @@ final class SequencingRunner implements Runnable {
 
         // if the node was not new, we need to find the new sequenced nodes
         List<AbstractJcrNode> nodes = new ArrayList<AbstractJcrNode>();
-        NodeIterator childrenIt = rootOutputNode.getNodes();
+        NodeIterator childrenIt = rootOutputNode.getNodesInternal();
         while (childrenIt.hasNext()) {
             Node child = childrenIt.nextNode();
             if (child.isNew()) {
@@ -424,7 +424,7 @@ final class SequencingRunner implements Runnable {
      * @param logMsg the log message, or null if trace/debug logging is not being used (this is passed in for efficiency reasons)
      * @throws RepositoryException if there is a problem accessing the repository content
      */
-    private void removeExistingOutputNodes( Node parentOfOutput,
+    private void removeExistingOutputNodes( AbstractJcrNode parentOfOutput,
                                             String outputNodeName,
                                             String selectedPath,
                                             String logMsg ) throws RepositoryException {
@@ -432,7 +432,7 @@ final class SequencingRunner implements Runnable {
         if (TRACE) {
             LOGGER.trace("Looking under '{0}' for existing output to be removed for {1}", parentOfOutput.getPath(), logMsg);
         }
-        NodeIterator outputIter = parentOfOutput.getNodes(outputNodeName);
+        NodeIterator outputIter = parentOfOutput.getNodesInternal(outputNodeName);
         while (outputIter.hasNext()) {
             Node outputNode = outputIter.nextNode();
             // See if this is indeed the output, which should have the 'mode:derived' mixin ...

--- a/modeshape-jcr/src/main/resources/org/modeshape/jcr/JcrI18n.properties
+++ b/modeshape-jcr/src/main/resources/org/modeshape/jcr/JcrI18n.properties
@@ -198,6 +198,7 @@ unableToCopySourceTargetMismatch =  Unable to copy the nodes because at least on
 unableToCopySourceNotExternal =  Unable to copy the nodes because the source node "{0}" is not an external node itself, but its subgraph contains external nodes.
 unableToCloneSameWsContainsExternalNode =  Unable to perform the clone operation in the same workspace because at least one of the source nodes belongs to the "{0}" source
 unableToCloneExternalNodesRequireRoot = At least one of the source nodes belongs to the "{0}" source. Only entire workspaces can be cloned if the source workspace contains external nodes
+aclsOnExternalNodesNotAllowed = ACLs are not allowed on external nodes
 
 SPEC_NAME_DESC = Content Repository for Java Technology API
 

--- a/modeshape-jcr/src/test/java/org/modeshape/connector/mock/MockConnectorTest.java
+++ b/modeshape-jcr/src/test/java/org/modeshape/connector/mock/MockConnectorTest.java
@@ -41,6 +41,8 @@ import javax.jcr.Value;
 import javax.jcr.nodetype.ConstraintViolationException;
 import javax.jcr.nodetype.NodeType;
 import javax.jcr.query.Query;
+import javax.jcr.security.AccessControlList;
+import javax.jcr.security.AccessControlManager;
 import org.junit.Before;
 import org.junit.Test;
 import org.modeshape.common.FixFor;
@@ -854,6 +856,21 @@ public class MockConnectorTest extends SingleUseAbstractTest {
         try {
             ((Node)session.getNode("/testRoot/child")).addMixin("mix:versionable");
             fail("Should not allow versionable mixin on external nodes");
+        } catch (RepositoryException e) {
+            // expected
+        }
+    }
+
+    @Test
+    public void shouldNotAllowACLsOnExternalNodes() throws Exception {
+        AccessControlManager acm = session.getAccessControlManager();
+        federationManager.createProjection("/testRoot", SOURCE_NAME, MockConnector.DOC2_LOCATION, "fed1");
+        session.getNode("/testRoot/fed1");
+        AccessControlList acl = acl("/testRoot/fed1");
+
+        try {
+            acm.setPolicy("/testRoot/fed1", acl);
+            fail("Should not allow ACLs on external nodes");
         } catch (RepositoryException e) {
             // expected
         }

--- a/modeshape-jcr/src/test/java/org/modeshape/jcr/JcrNodeTest.java
+++ b/modeshape-jcr/src/test/java/org/modeshape/jcr/JcrNodeTest.java
@@ -30,6 +30,7 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import javax.jcr.AccessDeniedException;
 import javax.jcr.ImportUUIDBehavior;
 import javax.jcr.Node;
 import javax.jcr.NodeIterator;
@@ -38,6 +39,9 @@ import javax.jcr.PropertyIterator;
 import javax.jcr.RepositoryException;
 import javax.jcr.Value;
 import javax.jcr.nodetype.ConstraintViolationException;
+import javax.jcr.security.AccessControlList;
+import javax.jcr.security.AccessControlManager;
+import javax.jcr.security.Privilege;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -45,6 +49,7 @@ import org.junit.Test;
 import org.modeshape.common.FixFor;
 import org.modeshape.jcr.api.JcrConstants;
 import org.modeshape.jcr.cache.CachedNode;
+import org.modeshape.jcr.security.SimplePrincipal;
 
 public class JcrNodeTest extends MultiUseAbstractTest {
 
@@ -658,7 +663,7 @@ public class JcrNodeTest extends MultiUseAbstractTest {
                 session.removeItem("/node/jcr:primaryType");
                 fail("Should not allow the removal of protected properties");
             } catch (ConstraintViolationException e) {
-              //expected
+                //expected
             }
         } finally {
             node.remove();
@@ -697,5 +702,52 @@ public class JcrNodeTest extends MultiUseAbstractTest {
 
         testNode.remove();
         session.save();
+    }
+
+    @Test
+    @FixFor( "MODE-2186" )
+    public void shouldCheckPermissionsWhenIteratingChildNodes() throws Exception {
+        AccessControlManager acm = session.getAccessControlManager();
+        Node parent = session.getRootNode().addNode("parent");
+
+        try {
+            Node child1 = parent.addNode("child1");
+            AccessControlList acl = acl("/parent/child1");
+            acl.addAccessControlEntry(SimplePrincipal.EVERYONE, new Privilege[] { acm.privilegeFromName(Privilege.JCR_READ) });
+            acm.setPolicy("/parent/child1", acl);
+
+            parent.addNode("child2");
+            acl = acl("/parent/child2");
+            acl.addAccessControlEntry(SimplePrincipal.EVERYONE, new Privilege[] { acm.privilegeFromName(Privilege.JCR_WRITE) });
+            acm.setPolicy("/parent/child2", acl);
+
+            session.save();
+
+            parent.getNode("child1");
+            try {
+                parent.getNode("child2");
+                fail("Permission not checked for child2");
+            } catch (AccessDeniedException e) {
+                //expected
+            }
+
+            NodeIterator nodeIterator = parent.getNodes();
+            assertEquals(1, nodeIterator.getSize());
+            Node iteratorNode = nodeIterator.nextNode();
+            assertEquals(child1.getIdentifier(), iteratorNode.getIdentifier());
+
+            nodeIterator = parent.getNodes("child*");
+            assertEquals(1, nodeIterator.getSize());
+            iteratorNode = nodeIterator.nextNode();
+            assertEquals(child1.getIdentifier(), iteratorNode.getIdentifier());
+
+            nodeIterator = parent.getNodes(new String[]{"child*"});
+            assertEquals(1, nodeIterator.getSize());
+            iteratorNode = nodeIterator.nextNode();
+            assertEquals(child1.getIdentifier(), iteratorNode.getIdentifier());
+        } finally {
+            parent.remove();
+            session.save();
+        }
     }
 }


### PR DESCRIPTION
To avoid these checks internally, `getNodesInternal()` methods were added which never perform permission checks. Also, added explicit validation which disallows ACLs (which are stored as children) for external nodes.
