### PR TITLE
MODE-2179 Fixed the streaming of binary values for MS SQL Server.

### DIFF
--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/value/binary/Database.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/value/binary/Database.java
@@ -566,20 +566,21 @@ public class Database {
         }
     }
 
-    /**
-     * Provides access to query data
-     * 
-     * @param rs retrieved single value
-     * @return result as input stream.
-     * @throws BinaryStoreException
-     */
-    public static InputStream asStream( ResultSet rs ) throws BinaryStoreException {
+    protected InputStream readStream( ResultSet rs ) throws BinaryStoreException {
         boolean error = false;
         try {
             if (!rs.next()) {
                 return null;
             }
-            return rs.getBinaryStream(1);
+            switch (databaseType) {
+                case SQLSERVER: {
+                    //see https://issues.jboss.org/browse/MODE-2179
+                    return rs.getBlob(1).getBinaryStream();
+                }
+                default: {
+                    return rs.getBinaryStream(1);
+                }
+            }
         } catch (SQLException e) {
             error = true;
             throw new BinaryStoreException(e);

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/value/binary/DatabaseBinaryStore.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/value/binary/DatabaseBinaryStore.java
@@ -170,7 +170,7 @@ public class DatabaseBinaryStore extends AbstractBinaryStore {
     @Override
     public InputStream getInputStream( BinaryKey key ) throws BinaryStoreException {
         ResultSet rs = Database.executeQuery(database.retrieveContentSQL(key, true));
-        InputStream inputStream = Database.asStream(rs); // closes result set
+        InputStream inputStream = database.readStream(rs); // closes result set
         if (inputStream == null) {
             try {
                 throw new BinaryStoreException(JcrI18n.unableToFindBinaryValue.text(key, database.getConnection().getCatalog()));

--- a/modeshape-jcr/src/test/java/org/modeshape/jcr/RepositoryPersistenceTest.java
+++ b/modeshape-jcr/src/test/java/org/modeshape/jcr/RepositoryPersistenceTest.java
@@ -17,6 +17,7 @@ package org.modeshape.jcr;
 
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsNull.notNullValue;
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 import java.io.File;
@@ -35,6 +36,7 @@ import javax.jcr.query.QueryResult;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.modeshape.common.util.FileUtil;
+import org.modeshape.common.util.IoUtil;
 import org.modeshape.jcr.api.JcrTools;
 
 /**
@@ -89,7 +91,9 @@ public class RepositoryPersistenceTest extends MultiPassAbstractTest {
                     Node fileNode = testNode.getNode(name);
                     assertThat(fileNode, is(notNullValue()));
                     Binary binary = fileNode.getNode("jcr:content").getProperty("jcr:data").getBinary();
-                    assertThat(binary.getSize(), is(testFileSizesInBytes.get(name)));
+                    byte[] expectedBytes = IoUtil.readBytes(testFile);
+                    byte[] actualBytes = IoUtil.readBytes(binary.getStream());
+                    assertArrayEquals(expectedBytes, actualBytes);
                 }
 
                 Query query = session.getWorkspace().getQueryManager().createQuery("SELECT * FROM [nt:file]", Query.JCR_SQL2);


### PR DESCRIPTION
The performance of `getBlob` is really down to the driver implementation, but in theory it should be better than explicitly loading the data in memory up-front.
