### PR TITLE
MODE-2125 Fixed data type conversions for the local JDBC driver.

### DIFF
--- a/modeshape-jcr/src/test/java/org/modeshape/jcr/value/binary/AbstractBinaryStoreTest.java
+++ b/modeshape-jcr/src/test/java/org/modeshape/jcr/value/binary/AbstractBinaryStoreTest.java
@@ -31,7 +31,10 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import javax.jcr.Binary;
 import javax.jcr.RepositoryException;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TestRule;
+import org.modeshape.common.junit.SkipTestRule;
 import org.modeshape.common.util.IoUtil;
 import org.modeshape.jcr.TextExtractors;
 import org.modeshape.jcr.api.text.TextExtractor;
@@ -43,6 +46,9 @@ import org.modeshape.jcr.value.BinaryValue;
  * Use this abstract class to realize test cases which can easily executed on different BinaryStores
  */
 public abstract class AbstractBinaryStoreTest {
+
+    @Rule
+    public TestRule skipTestRule = new SkipTestRule();
 
     /**
      * We need to generate the test byte arrays based on the minimum binary size, because that controls the distinction between

--- a/modeshape-jdbc-local/src/main/java/org/modeshape/jdbc/JdbcLocalI18n.java
+++ b/modeshape-jdbc-local/src/main/java/org/modeshape/jdbc/JdbcLocalI18n.java
@@ -82,6 +82,8 @@ public final class JdbcLocalI18n {
     public static I18n unableToGetNodeType;
     public static I18n noSuchNodeType;
 
+    public static I18n cannotConvertJcrValue;
+
     public static I18n repositoryNameInUse;
 
     /*

--- a/modeshape-jdbc-local/src/main/java/org/modeshape/jdbc/types/BlobTransform.java
+++ b/modeshape-jdbc-local/src/main/java/org/modeshape/jdbc/types/BlobTransform.java
@@ -26,20 +26,6 @@ public class BlobTransform implements Transform {
     @SuppressWarnings( "unused" )
     @Override
     public Object transform( Value value ) throws ValueFormatException, RepositoryException {
-        return new BlobTransfom(value, 0L);
+        return new JcrBlob(value.getBinary());
     }
-
-    class BlobTransfom extends JcrBlob {
-
-        /**
-         * @param value
-         * @param length
-         */
-        protected BlobTransfom( Value value,
-                                long length ) {
-            super(value, length);
-
-        }
-    }
-
 }

--- a/modeshape-jdbc-local/src/main/resources/org/modeshape/jdbc/JdbcLocalI18n.properties
+++ b/modeshape-jdbc-local/src/main/resources/org/modeshape/jdbc/JdbcLocalI18n.properties
@@ -57,10 +57,10 @@ currentRowNotSet = Current row not set
 noJcrTypeMapped = No JCR Type mapped for representative class {0}
 configurationFileNotSpecified = Configuration File not specified in the URL '{0}'
 
-repositoryNameInUse = The name of the Repository in use is '{0}' 
+repositoryNameInUse = The name of the Repository in use is '{0}'
 
 unableToGetNodeTypes = Unable to get NodeTypes at location '{0}'
 noNodeTypesReturned = No node types returned at location '{0}'
 unableToGetNodeType = Unable to get NodeType {0} from repository.
 noSuchNodeType = Node Type {0} was not found in the repository.
-
+cannotConvertJcrValue = Cannot convert JCR value with type '{0}' to type '{1}'. No conversion method possible.

--- a/modeshape-jdbc-local/src/test/java/org/modeshape/jdbc/AbstractJdbcDriverIntegrationTest.java
+++ b/modeshape-jdbc-local/src/test/java/org/modeshape/jdbc/AbstractJdbcDriverIntegrationTest.java
@@ -228,62 +228,62 @@ public abstract class AbstractJdbcDriverIntegrationTest extends AbstractJdbcDriv
 
         String[] expected = {
             "TABLE_CAT[String]    TABLE_SCHEM[String]    TABLE_NAME[String]    TABLE_TYPE[String]    REMARKS[String]    TYPE_CAT[String]    TYPE_SCHEM[String]    TYPE_NAME[String]    SELF_REFERENCING_COL_NAME[String]    REF_GENERATION[String]",
-            "cars    NULL    car:Car    VIEW    Is Mixin: false    NULL    NULL    NULL    null    DERIVED",
-            "cars    NULL    mix:created    VIEW    Is Mixin: true    NULL    NULL    NULL    null    DERIVED",
-            "cars    NULL    mix:etag    VIEW    Is Mixin: true    NULL    NULL    NULL    null    DERIVED",
-            "cars    NULL    mix:language    VIEW    Is Mixin: true    NULL    NULL    NULL    null    DERIVED",
-            "cars    NULL    mix:lastModified    VIEW    Is Mixin: true    NULL    NULL    NULL    null    DERIVED",
-            "cars    NULL    mix:lifecycle    VIEW    Is Mixin: true    NULL    NULL    NULL    null    DERIVED",
-            "cars    NULL    mix:lockable    VIEW    Is Mixin: true    NULL    NULL    NULL    null    DERIVED",
-            "cars    NULL    mix:managedRetention    VIEW    Is Mixin: true    NULL    NULL    NULL    null    DERIVED",
-            "cars    NULL    mix:mimeType    VIEW    Is Mixin: true    NULL    NULL    NULL    null    DERIVED",
-            "cars    NULL    mix:referenceable    VIEW    Is Mixin: true    NULL    NULL    NULL    null    DERIVED",
-            "cars    NULL    mix:shareable    VIEW    Is Mixin: true    NULL    NULL    NULL    null    DERIVED",
-            "cars    NULL    mix:simpleVersionable    VIEW    Is Mixin: true    NULL    NULL    NULL    null    DERIVED",
-            "cars    NULL    mix:title    VIEW    Is Mixin: true    NULL    NULL    NULL    null    DERIVED",
-            "cars    NULL    mix:versionable    VIEW    Is Mixin: true    NULL    NULL    NULL    null    DERIVED",
-            "cars    NULL    mode:accessControllable    VIEW    Is Mixin: true    NULL    NULL    NULL    null    DERIVED",
-            "cars    NULL    mode:derived    VIEW    Is Mixin: true    NULL    NULL    NULL    null    DERIVED",
-            "cars    NULL    mode:federation    VIEW    Is Mixin: false    NULL    NULL    NULL    null    DERIVED",
-            "cars    NULL    mode:hashed    VIEW    Is Mixin: true    NULL    NULL    NULL    null    DERIVED",
-            "cars    NULL    mode:index    VIEW    Is Mixin: false    NULL    NULL    NULL    null    DERIVED",
-            "cars    NULL    mode:indexColumn    VIEW    Is Mixin: false    NULL    NULL    NULL    null    DERIVED",
-            "cars    NULL    mode:indexProvider    VIEW    Is Mixin: false    NULL    NULL    NULL    null    DERIVED",
-            "cars    NULL    mode:indexes    VIEW    Is Mixin: false    NULL    NULL    NULL    null    DERIVED",
-            "cars    NULL    mode:lock    VIEW    Is Mixin: false    NULL    NULL    NULL    null    DERIVED",
-            "cars    NULL    mode:locks    VIEW    Is Mixin: false    NULL    NULL    NULL    null    DERIVED",
-            "cars    NULL    mode:namespace    VIEW    Is Mixin: false    NULL    NULL    NULL    mode:uri    DERIVED",
-            "cars    NULL    mode:namespaces    VIEW    Is Mixin: false    NULL    NULL    NULL    null    DERIVED",
-            "cars    NULL    mode:nodeTypes    VIEW    Is Mixin: false    NULL    NULL    NULL    null    DERIVED",
-            "cars    NULL    mode:projection    VIEW    Is Mixin: false    NULL    NULL    NULL    null    DERIVED",
-            "cars    NULL    mode:publishArea    VIEW    Is Mixin: true    NULL    NULL    NULL    null    DERIVED",
-            "cars    NULL    mode:repository    VIEW    Is Mixin: false    NULL    NULL    NULL    null    DERIVED",
-            "cars    NULL    mode:resource    VIEW    Is Mixin: false    NULL    NULL    NULL    jcr:data    DERIVED",
-            "cars    NULL    mode:root    VIEW    Is Mixin: false    NULL    NULL    NULL    null    DERIVED",
-            "cars    NULL    mode:share    VIEW    Is Mixin: false    NULL    NULL    NULL    null    DERIVED",
-            "cars    NULL    mode:system    VIEW    Is Mixin: false    NULL    NULL    NULL    null    DERIVED",
-            "cars    NULL    mode:versionHistoryFolder    VIEW    Is Mixin: false    NULL    NULL    NULL    null    DERIVED",
-            "cars    NULL    mode:versionStorage    VIEW    Is Mixin: false    NULL    NULL    NULL    null    DERIVED",
-            "cars    NULL    nt:activity    VIEW    Is Mixin: false    NULL    NULL    NULL    null    DERIVED",
-            "cars    NULL    nt:address    VIEW    Is Mixin: false    NULL    NULL    NULL    null    DERIVED",
-            "cars    NULL    nt:base    VIEW    Is Mixin: false    NULL    NULL    NULL    null    DERIVED",
-            "cars    NULL    nt:childNodeDefinition    VIEW    Is Mixin: false    NULL    NULL    NULL    null    DERIVED",
-            "cars    NULL    nt:configuration    VIEW    Is Mixin: false    NULL    NULL    NULL    null    DERIVED",
-            "cars    NULL    nt:file    VIEW    Is Mixin: false    NULL    NULL    NULL    jcr:content    DERIVED",
-            "cars    NULL    nt:folder    VIEW    Is Mixin: false    NULL    NULL    NULL    null    DERIVED",
-            "cars    NULL    nt:frozenNode    VIEW    Is Mixin: false    NULL    NULL    NULL    null    DERIVED",
-            "cars    NULL    nt:hierarchyNode    VIEW    Is Mixin: false    NULL    NULL    NULL    null    DERIVED",
-            "cars    NULL    nt:linkedFile    VIEW    Is Mixin: false    NULL    NULL    NULL    jcr:content    DERIVED",
-            "cars    NULL    nt:naturalText    VIEW    Is Mixin: false    NULL    NULL    NULL    null    DERIVED",
-            "cars    NULL    nt:nodeType    VIEW    Is Mixin: false    NULL    NULL    NULL    null    DERIVED",
-            "cars    NULL    nt:propertyDefinition    VIEW    Is Mixin: false    NULL    NULL    NULL    null    DERIVED",
-            "cars    NULL    nt:query    VIEW    Is Mixin: false    NULL    NULL    NULL    null    DERIVED",
-            "cars    NULL    nt:resource    VIEW    Is Mixin: false    NULL    NULL    NULL    jcr:data    DERIVED",
-            "cars    NULL    nt:unstructured    VIEW    Is Mixin: false    NULL    NULL    NULL    null    DERIVED",
-            "cars    NULL    nt:version    VIEW    Is Mixin: false    NULL    NULL    NULL    null    DERIVED",
-            "cars    NULL    nt:versionHistory    VIEW    Is Mixin: false    NULL    NULL    NULL    null    DERIVED",
-            "cars    NULL    nt:versionLabels    VIEW    Is Mixin: false    NULL    NULL    NULL    null    DERIVED",
-            "cars    NULL    nt:versionedChild    VIEW    Is Mixin: false    NULL    NULL    NULL    null    DERIVED"};
+            "cars    null    car:Car    VIEW    Is Mixin: false    null    null    null    null    DERIVED",
+            "cars    null    mix:created    VIEW    Is Mixin: true    null    null    null    null    DERIVED",
+            "cars    null    mix:etag    VIEW    Is Mixin: true    null    null    null    null    DERIVED",
+            "cars    null    mix:language    VIEW    Is Mixin: true    null    null    null    null    DERIVED",
+            "cars    null    mix:lastModified    VIEW    Is Mixin: true    null    null    null    null    DERIVED",
+            "cars    null    mix:lifecycle    VIEW    Is Mixin: true    null    null    null    null    DERIVED",
+            "cars    null    mix:lockable    VIEW    Is Mixin: true    null    null    null    null    DERIVED",
+            "cars    null    mix:managedRetention    VIEW    Is Mixin: true    null    null    null    null    DERIVED",
+            "cars    null    mix:mimeType    VIEW    Is Mixin: true    null    null    null    null    DERIVED",
+            "cars    null    mix:referenceable    VIEW    Is Mixin: true    null    null    null    null    DERIVED",
+            "cars    null    mix:shareable    VIEW    Is Mixin: true    null    null    null    null    DERIVED",
+            "cars    null    mix:simpleVersionable    VIEW    Is Mixin: true    null    null    null    null    DERIVED",
+            "cars    null    mix:title    VIEW    Is Mixin: true    null    null    null    null    DERIVED",
+            "cars    null    mix:versionable    VIEW    Is Mixin: true    null    null    null    null    DERIVED",
+            "cars    null    mode:accessControllable    VIEW    Is Mixin: true    null    null    null    null    DERIVED",
+            "cars    null    mode:derived    VIEW    Is Mixin: true    null    null    null    null    DERIVED",
+            "cars    null    mode:federation    VIEW    Is Mixin: false    null    null    null    null    DERIVED",
+            "cars    null    mode:hashed    VIEW    Is Mixin: true    null    null    null    null    DERIVED",
+            "cars    null    mode:index    VIEW    Is Mixin: false    null    null    null    null    DERIVED",
+            "cars    null    mode:indexColumn    VIEW    Is Mixin: false    null    null    null    null    DERIVED",
+            "cars    null    mode:indexProvider    VIEW    Is Mixin: false    null    null    null    null    DERIVED",
+            "cars    null    mode:indexes    VIEW    Is Mixin: false    null    null    null    null    DERIVED",
+            "cars    null    mode:lock    VIEW    Is Mixin: false    null    null    null    null    DERIVED",
+            "cars    null    mode:locks    VIEW    Is Mixin: false    null    null    null    null    DERIVED",
+            "cars    null    mode:namespace    VIEW    Is Mixin: false    null    null    null    mode:uri    DERIVED",
+            "cars    null    mode:namespaces    VIEW    Is Mixin: false    null    null    null    null    DERIVED",
+            "cars    null    mode:nodeTypes    VIEW    Is Mixin: false    null    null    null    null    DERIVED",
+            "cars    null    mode:projection    VIEW    Is Mixin: false    null    null    null    null    DERIVED",
+            "cars    null    mode:publishArea    VIEW    Is Mixin: true    null    null    null    null    DERIVED",
+            "cars    null    mode:repository    VIEW    Is Mixin: false    null    null    null    null    DERIVED",
+            "cars    null    mode:resource    VIEW    Is Mixin: false    null    null    null    jcr:data    DERIVED",
+            "cars    null    mode:root    VIEW    Is Mixin: false    null    null    null    null    DERIVED",
+            "cars    null    mode:share    VIEW    Is Mixin: false    null    null    null    null    DERIVED",
+            "cars    null    mode:system    VIEW    Is Mixin: false    null    null    null    null    DERIVED",
+            "cars    null    mode:versionHistoryFolder    VIEW    Is Mixin: false    null    null    null    null    DERIVED",
+            "cars    null    mode:versionStorage    VIEW    Is Mixin: false    null    null    null    null    DERIVED",
+            "cars    null    nt:activity    VIEW    Is Mixin: false    null    null    null    null    DERIVED",
+            "cars    null    nt:address    VIEW    Is Mixin: false    null    null    null    null    DERIVED",
+            "cars    null    nt:base    VIEW    Is Mixin: false    null    null    null    null    DERIVED",
+            "cars    null    nt:childNodeDefinition    VIEW    Is Mixin: false    null    null    null    null    DERIVED",
+            "cars    null    nt:configuration    VIEW    Is Mixin: false    null    null    null    null    DERIVED",
+            "cars    null    nt:file    VIEW    Is Mixin: false    null    null    null    jcr:content    DERIVED",
+            "cars    null    nt:folder    VIEW    Is Mixin: false    null    null    null    null    DERIVED",
+            "cars    null    nt:frozenNode    VIEW    Is Mixin: false    null    null    null    null    DERIVED",
+            "cars    null    nt:hierarchyNode    VIEW    Is Mixin: false    null    null    null    null    DERIVED",
+            "cars    null    nt:linkedFile    VIEW    Is Mixin: false    null    null    null    jcr:content    DERIVED",
+            "cars    null    nt:naturalText    VIEW    Is Mixin: false    null    null    null    null    DERIVED",
+            "cars    null    nt:nodeType    VIEW    Is Mixin: false    null    null    null    null    DERIVED",
+            "cars    null    nt:propertyDefinition    VIEW    Is Mixin: false    null    null    null    null    DERIVED",
+            "cars    null    nt:query    VIEW    Is Mixin: false    null    null    null    null    DERIVED",
+            "cars    null    nt:resource    VIEW    Is Mixin: false    null    null    null    jcr:data    DERIVED",
+            "cars    null    nt:unstructured    VIEW    Is Mixin: false    null    null    null    null    DERIVED",
+            "cars    null    nt:version    VIEW    Is Mixin: false    null    null    null    null    DERIVED",
+            "cars    null    nt:versionHistory    VIEW    Is Mixin: false    null    null    null    null    DERIVED",
+            "cars    null    nt:versionLabels    VIEW    Is Mixin: false    null    null    null    null    DERIVED",
+            "cars    null    nt:versionedChild    VIEW    Is Mixin: false    null    null    null    null    DERIVED"};
 
         ResultSet rs = dbmd.getTables("%", "%", "%", new String[] {});
         assertResultsSetEquals(rs, expected);
@@ -297,26 +297,26 @@ public abstract class AbstractJdbcDriverIntegrationTest extends AbstractJdbcDriv
 
         String[] expected = {
             "TABLE_CAT[String]    TABLE_SCHEM[String]    TABLE_NAME[String]    TABLE_TYPE[String]    REMARKS[String]    TYPE_CAT[String]    TYPE_SCHEM[String]    TYPE_NAME[String]    SELF_REFERENCING_COL_NAME[String]    REF_GENERATION[String]",
-            "cars    NULL    nt:activity    VIEW    Is Mixin: false    NULL    NULL    NULL    null    DERIVED",
-            "cars    NULL    nt:address    VIEW    Is Mixin: false    NULL    NULL    NULL    null    DERIVED",
-            "cars    NULL    nt:base    VIEW    Is Mixin: false    NULL    NULL    NULL    null    DERIVED",
-            "cars    NULL    nt:childNodeDefinition    VIEW    Is Mixin: false    NULL    NULL    NULL    null    DERIVED",
-            "cars    NULL    nt:configuration    VIEW    Is Mixin: false    NULL    NULL    NULL    null    DERIVED",
-            "cars    NULL    nt:file    VIEW    Is Mixin: false    NULL    NULL    NULL    jcr:content    DERIVED",
-            "cars    NULL    nt:folder    VIEW    Is Mixin: false    NULL    NULL    NULL    null    DERIVED",
-            "cars    NULL    nt:frozenNode    VIEW    Is Mixin: false    NULL    NULL    NULL    null    DERIVED",
-            "cars    NULL    nt:hierarchyNode    VIEW    Is Mixin: false    NULL    NULL    NULL    null    DERIVED",
-            "cars    NULL    nt:linkedFile    VIEW    Is Mixin: false    NULL    NULL    NULL    jcr:content    DERIVED",
-            "cars    NULL    nt:naturalText    VIEW    Is Mixin: false    NULL    NULL    NULL    null    DERIVED",
-            "cars    NULL    nt:nodeType    VIEW    Is Mixin: false    NULL    NULL    NULL    null    DERIVED",
-            "cars    NULL    nt:propertyDefinition    VIEW    Is Mixin: false    NULL    NULL    NULL    null    DERIVED",
-            "cars    NULL    nt:query    VIEW    Is Mixin: false    NULL    NULL    NULL    null    DERIVED",
-            "cars    NULL    nt:resource    VIEW    Is Mixin: false    NULL    NULL    NULL    jcr:data    DERIVED",
-            "cars    NULL    nt:unstructured    VIEW    Is Mixin: false    NULL    NULL    NULL    null    DERIVED",
-            "cars    NULL    nt:version    VIEW    Is Mixin: false    NULL    NULL    NULL    null    DERIVED",
-            "cars    NULL    nt:versionHistory    VIEW    Is Mixin: false    NULL    NULL    NULL    null    DERIVED",
-            "cars    NULL    nt:versionLabels    VIEW    Is Mixin: false    NULL    NULL    NULL    null    DERIVED",
-            "cars    NULL    nt:versionedChild    VIEW    Is Mixin: false    NULL    NULL    NULL    null    DERIVED"};
+            "cars    null    nt:activity    VIEW    Is Mixin: false    null    null    null    null    DERIVED",
+            "cars    null    nt:address    VIEW    Is Mixin: false    null    null    null    null    DERIVED",
+            "cars    null    nt:base    VIEW    Is Mixin: false    null    null    null    null    DERIVED",
+            "cars    null    nt:childNodeDefinition    VIEW    Is Mixin: false    null    null    null    null    DERIVED",
+            "cars    null    nt:configuration    VIEW    Is Mixin: false    null    null    null    null    DERIVED",
+            "cars    null    nt:file    VIEW    Is Mixin: false    null    null    null    jcr:content    DERIVED",
+            "cars    null    nt:folder    VIEW    Is Mixin: false    null    null    null    null    DERIVED",
+            "cars    null    nt:frozenNode    VIEW    Is Mixin: false    null    null    null    null    DERIVED",
+            "cars    null    nt:hierarchyNode    VIEW    Is Mixin: false    null    null    null    null    DERIVED",
+            "cars    null    nt:linkedFile    VIEW    Is Mixin: false    null    null    null    jcr:content    DERIVED",
+            "cars    null    nt:naturalText    VIEW    Is Mixin: false    null    null    null    null    DERIVED",
+            "cars    null    nt:nodeType    VIEW    Is Mixin: false    null    null    null    null    DERIVED",
+            "cars    null    nt:propertyDefinition    VIEW    Is Mixin: false    null    null    null    null    DERIVED",
+            "cars    null    nt:query    VIEW    Is Mixin: false    null    null    null    null    DERIVED",
+            "cars    null    nt:resource    VIEW    Is Mixin: false    null    null    null    jcr:data    DERIVED",
+            "cars    null    nt:unstructured    VIEW    Is Mixin: false    null    null    null    null    DERIVED",
+            "cars    null    nt:version    VIEW    Is Mixin: false    null    null    null    null    DERIVED",
+            "cars    null    nt:versionHistory    VIEW    Is Mixin: false    null    null    null    null    DERIVED",
+            "cars    null    nt:versionLabels    VIEW    Is Mixin: false    null    null    null    null    DERIVED",
+            "cars    null    nt:versionedChild    VIEW    Is Mixin: false    null    null    null    null    DERIVED"};
 
         ResultSet rs = dbmd.getTables("%", "%", "nt:%", new String[] {});
         assertResultsSetEquals(rs, expected);
@@ -329,8 +329,8 @@ public abstract class AbstractJdbcDriverIntegrationTest extends AbstractJdbcDriv
 
         String[] expected = {
             "TABLE_CAT[String]    TABLE_SCHEM[String]    TABLE_NAME[String]    TABLE_TYPE[String]    REMARKS[String]    TYPE_CAT[String]    TYPE_SCHEM[String]    TYPE_NAME[String]    SELF_REFERENCING_COL_NAME[String]    REF_GENERATION[String]",
-            "cars    NULL    mode:resource    VIEW    Is Mixin: false    NULL    NULL    NULL    jcr:data    DERIVED",
-            "cars    NULL    nt:resource    VIEW    Is Mixin: false    NULL    NULL    NULL    jcr:data    DERIVED"};
+            "cars    null    mode:resource    VIEW    Is Mixin: false    null    null    null    jcr:data    DERIVED",
+            "cars    null    nt:resource    VIEW    Is Mixin: false    null    null    null    jcr:data    DERIVED"};
 
         ResultSet rs = dbmd.getTables("%", "%", "%:resource", new String[] {});
         assertResultsSetEquals(rs, expected);
@@ -343,8 +343,8 @@ public abstract class AbstractJdbcDriverIntegrationTest extends AbstractJdbcDriv
 
         String[] expected = {
             "TABLE_CAT[String]    TABLE_SCHEM[String]    TABLE_NAME[String]    TABLE_TYPE[String]    REMARKS[String]    TYPE_CAT[String]    TYPE_SCHEM[String]    TYPE_NAME[String]    SELF_REFERENCING_COL_NAME[String]    REF_GENERATION[String]",
-            "cars    NULL    mode:nodeTypes    VIEW    Is Mixin: false    NULL    NULL    NULL    null    DERIVED",
-            "cars    NULL    nt:nodeType    VIEW    Is Mixin: false    NULL    NULL    NULL    null    DERIVED"};
+            "cars    null    mode:nodeTypes    VIEW    Is Mixin: false    null    null    null    null    DERIVED",
+            "cars    null    nt:nodeType    VIEW    Is Mixin: false    null    null    null    null    DERIVED"};
 
         ResultSet rs = dbmd.getTables("%", "%", "%nodeType%", new String[] {});
         assertResultsSetEquals(rs, expected);
@@ -357,23 +357,23 @@ public abstract class AbstractJdbcDriverIntegrationTest extends AbstractJdbcDriv
 
         String[] expected = {
             "TABLE_CAT[String]    TABLE_SCHEM[String]    TABLE_NAME[String]    COLUMN_NAME[String]    DATA_TYPE[Long]    TYPE_NAME[String]    COLUMN_SIZE[Long]    BUFFER_LENGTH[Long]    DECIMAL_DIGITS[Long]    NUM_PREC_RADIX[Long]    NULLABLE[Long]    REMARKS[String]    COLUMN_DEF[String]    SQL_DATA_TYPE[Long]    SQL_DATETIME_SUB[Long]    CHAR_OCTET_LENGTH[Long]    ORDINAL_POSITION[Long]    IS_NULLABLE[String]    SCOPE_CATLOG[String]    SCOPE_SCHEMA[String]    SCOPE_TABLE[String]    SOURCE_DATA_TYPE[Long]",
-            "cars    NULL    car:Car    car:engine    12    STRING    50    NULL    0    0    2        NULL    0    0    0    1    YES    NULL    NULL    NULL    0",
-            "cars    NULL    car:Car    car:lengthInInches    8    DOUBLE    20    NULL    0    0    2        NULL    0    0    0    2    YES    NULL    NULL    NULL    0",
-            "cars    NULL    car:Car    car:maker    12    STRING    50    NULL    0    0    2        NULL    0    0    0    3    YES    NULL    NULL    NULL    0",
-            "cars    NULL    car:Car    car:model    12    STRING    50    NULL    0    0    2        NULL    0    0    0    4    YES    NULL    NULL    NULL    0",
-            "cars    NULL    car:Car    car:mpgCity    -5    LONG    20    NULL    0    0    2        NULL    0    0    0    5    YES    NULL    NULL    NULL    0",
-            "cars    NULL    car:Car    car:mpgHighway    -5    LONG    20    NULL    0    0    2        NULL    0    0    0    6    YES    NULL    NULL    NULL    0",
-            "cars    NULL    car:Car    car:msrp    12    STRING    50    NULL    0    0    2        NULL    0    0    0    7    YES    NULL    NULL    NULL    0",
-            "cars    NULL    car:Car    car:userRating    -5    LONG    20    NULL    0    0    2        NULL    0    0    0    8    YES    NULL    NULL    NULL    0",
-            "cars    NULL    car:Car    car:valueRating    -5    LONG    20    NULL    0    0    2        NULL    0    0    0    9    YES    NULL    NULL    NULL    0",
-            "cars    NULL    car:Car    car:wheelbaseInInches    8    DOUBLE    20    NULL    0    0    2        NULL    0    0    0    10    YES    NULL    NULL    NULL    0",
-            "cars    NULL    car:Car    car:year    12    STRING    50    NULL    0    0    2        NULL    0    0    0    11    YES    NULL    NULL    NULL    0",
-            "cars    NULL    car:Car    jcr:name    12    STRING    20    NULL    0    0    2        NULL    0    0    0    12    YES    NULL    NULL    NULL    0",
-            "cars    NULL    car:Car    jcr:path    12    STRING    50    NULL    0    0    2        NULL    0    0    0    13    YES    NULL    NULL    NULL    0",
-            "cars    NULL    car:Car    jcr:primaryType    12    STRING    20    NULL    0    0    1        NULL    0    0    0    14    NO    NULL    NULL    NULL    0",
-            "cars    NULL    car:Car    jcr:score    8    DOUBLE    20    NULL    0    0    2        NULL    0    0    0    15    YES    NULL    NULL    NULL    0",
-            "cars    NULL    car:Car    mode:depth    -5    LONG    20    NULL    0    0    2        NULL    0    0    0    16    YES    NULL    NULL    NULL    0",
-            "cars    NULL    car:Car    mode:localName    12    STRING    50    NULL    0    0    2        NULL    0    0    0    17    YES    NULL    NULL    NULL    0"};
+            "cars    null    car:Car    car:engine    12    STRING    50    null    0    0    2        null    0    0    0    1    YES    null    null    null    0",
+            "cars    null    car:Car    car:lengthInInches    8    DOUBLE    20    null    0    0    2        null    0    0    0    2    YES    null    null    null    0",
+            "cars    null    car:Car    car:maker    12    STRING    50    null    0    0    2        null    0    0    0    3    YES    null    null    null    0",
+            "cars    null    car:Car    car:model    12    STRING    50    null    0    0    2        null    0    0    0    4    YES    null    null    null    0",
+            "cars    null    car:Car    car:mpgCity    -5    LONG    20    null    0    0    2        null    0    0    0    5    YES    null    null    null    0",
+            "cars    null    car:Car    car:mpgHighway    -5    LONG    20    null    0    0    2        null    0    0    0    6    YES    null    null    null    0",
+            "cars    null    car:Car    car:msrp    12    STRING    50    null    0    0    2        null    0    0    0    7    YES    null    null    null    0",
+            "cars    null    car:Car    car:userRating    -5    LONG    20    null    0    0    2        null    0    0    0    8    YES    null    null    null    0",
+            "cars    null    car:Car    car:valueRating    -5    LONG    20    null    0    0    2        null    0    0    0    9    YES    null    null    null    0",
+            "cars    null    car:Car    car:wheelbaseInInches    8    DOUBLE    20    null    0    0    2        null    0    0    0    10    YES    null    null    null    0",
+            "cars    null    car:Car    car:year    12    STRING    50    null    0    0    2        null    0    0    0    11    YES    null    null    null    0",
+            "cars    null    car:Car    jcr:name    12    STRING    20    null    0    0    2        null    0    0    0    12    YES    null    null    null    0",
+            "cars    null    car:Car    jcr:path    12    STRING    50    null    0    0    2        null    0    0    0    13    YES    null    null    null    0",
+            "cars    null    car:Car    jcr:primaryType    12    STRING    20    null    0    0    1        null    0    0    0    14    NO    null    null    null    0",
+            "cars    null    car:Car    jcr:score    8    DOUBLE    20    null    0    0    2        null    0    0    0    15    YES    null    null    null    0",
+            "cars    null    car:Car    mode:depth    -5    LONG    20    null    0    0    2        null    0    0    0    16    YES    null    null    null    0",
+            "cars    null    car:Car    mode:localName    12    STRING    50    null    0    0    2        null    0    0    0    17    YES    null    null    null    0"};
         ResultSet rs = dbmd.getColumns("%", "%", "car:Car", "%");
 
         assertResultsSetEquals(rs, expected);
@@ -387,23 +387,23 @@ public abstract class AbstractJdbcDriverIntegrationTest extends AbstractJdbcDriv
 
         String[] expected = {
             "TABLE_CAT[String]    TABLE_SCHEM[String]    TABLE_NAME[String]    COLUMN_NAME[String]    DATA_TYPE[Long]    TYPE_NAME[String]    COLUMN_SIZE[Long]    BUFFER_LENGTH[Long]    DECIMAL_DIGITS[Long]    NUM_PREC_RADIX[Long]    NULLABLE[Long]    REMARKS[String]    COLUMN_DEF[String]    SQL_DATA_TYPE[Long]    SQL_DATETIME_SUB[Long]    CHAR_OCTET_LENGTH[Long]    ORDINAL_POSITION[Long]    IS_NULLABLE[String]    SCOPE_CATLOG[String]    SCOPE_SCHEMA[String]    SCOPE_TABLE[String]    SOURCE_DATA_TYPE[Long]",
-            "cars    NULL    car:Car    car:engine    12    STRING    50    NULL    0    0    2        NULL    0    0    0    1    YES    NULL    NULL    NULL    0",
-            "cars    NULL    car:Car    car:lengthInInches    8    DOUBLE    20    NULL    0    0    2        NULL    0    0    0    2    YES    NULL    NULL    NULL    0",
-            "cars    NULL    car:Car    car:maker    12    STRING    50    NULL    0    0    2        NULL    0    0    0    3    YES    NULL    NULL    NULL    0",
-            "cars    NULL    car:Car    car:model    12    STRING    50    NULL    0    0    2        NULL    0    0    0    4    YES    NULL    NULL    NULL    0",
-            "cars    NULL    car:Car    car:mpgCity    -5    LONG    20    NULL    0    0    2        NULL    0    0    0    5    YES    NULL    NULL    NULL    0",
-            "cars    NULL    car:Car    car:mpgHighway    -5    LONG    20    NULL    0    0    2        NULL    0    0    0    6    YES    NULL    NULL    NULL    0",
-            "cars    NULL    car:Car    car:msrp    12    STRING    50    NULL    0    0    2        NULL    0    0    0    7    YES    NULL    NULL    NULL    0",
-            "cars    NULL    car:Car    car:userRating    -5    LONG    20    NULL    0    0    2        NULL    0    0    0    8    YES    NULL    NULL    NULL    0",
-            "cars    NULL    car:Car    car:valueRating    -5    LONG    20    NULL    0    0    2        NULL    0    0    0    9    YES    NULL    NULL    NULL    0",
-            "cars    NULL    car:Car    car:wheelbaseInInches    8    DOUBLE    20    NULL    0    0    2        NULL    0    0    0    10    YES    NULL    NULL    NULL    0",
-            "cars    NULL    car:Car    car:year    12    STRING    50    NULL    0    0    2        NULL    0    0    0    11    YES    NULL    NULL    NULL    0",
-            "cars    NULL    car:Car    jcr:name    12    STRING    20    NULL    0    0    2        NULL    0    0    0    12    YES    NULL    NULL    NULL    0",
-            "cars    NULL    car:Car    jcr:path    12    STRING    50    NULL    0    0    2        NULL    0    0    0    13    YES    NULL    NULL    NULL    0",
-            "cars    NULL    car:Car    jcr:primaryType    12    STRING    20    NULL    0    0    1        NULL    0    0    0    14    NO    NULL    NULL    NULL    0",
-            "cars    NULL    car:Car    jcr:score    8    DOUBLE    20    NULL    0    0    2        NULL    0    0    0    15    YES    NULL    NULL    NULL    0",
-            "cars    NULL    car:Car    mode:depth    -5    LONG    20    NULL    0    0    2        NULL    0    0    0    16    YES    NULL    NULL    NULL    0",
-            "cars    NULL    car:Car    mode:localName    12    STRING    50    NULL    0    0    2        NULL    0    0    0    17    YES    NULL    NULL    NULL    0"};
+            "cars    null    car:Car    car:engine    12    STRING    50    null    0    0    2        null    0    0    0    1    YES    null    null    null    0",
+            "cars    null    car:Car    car:lengthInInches    8    DOUBLE    20    null    0    0    2        null    0    0    0    2    YES    null    null    null    0",
+            "cars    null    car:Car    car:maker    12    STRING    50    null    0    0    2        null    0    0    0    3    YES    null    null    null    0",
+            "cars    null    car:Car    car:model    12    STRING    50    null    0    0    2        null    0    0    0    4    YES    null    null    null    0",
+            "cars    null    car:Car    car:mpgCity    -5    LONG    20    null    0    0    2        null    0    0    0    5    YES    null    null    null    0",
+            "cars    null    car:Car    car:mpgHighway    -5    LONG    20    null    0    0    2        null    0    0    0    6    YES    null    null    null    0",
+            "cars    null    car:Car    car:msrp    12    STRING    50    null    0    0    2        null    0    0    0    7    YES    null    null    null    0",
+            "cars    null    car:Car    car:userRating    -5    LONG    20    null    0    0    2        null    0    0    0    8    YES    null    null    null    0",
+            "cars    null    car:Car    car:valueRating    -5    LONG    20    null    0    0    2        null    0    0    0    9    YES    null    null    null    0",
+            "cars    null    car:Car    car:wheelbaseInInches    8    DOUBLE    20    null    0    0    2        null    0    0    0    10    YES    null    null    null    0",
+            "cars    null    car:Car    car:year    12    STRING    50    null    0    0    2        null    0    0    0    11    YES    null    null    null    0",
+            "cars    null    car:Car    jcr:name    12    STRING    20    null    0    0    2        null    0    0    0    12    YES    null    null    null    0",
+            "cars    null    car:Car    jcr:path    12    STRING    50    null    0    0    2        null    0    0    0    13    YES    null    null    null    0",
+            "cars    null    car:Car    jcr:primaryType    12    STRING    20    null    0    0    1        null    0    0    0    14    NO    null    null    null    0",
+            "cars    null    car:Car    jcr:score    8    DOUBLE    20    null    0    0    2        null    0    0    0    15    YES    null    null    null    0",
+            "cars    null    car:Car    mode:depth    -5    LONG    20    null    0    0    2        null    0    0    0    16    YES    null    null    null    0",
+            "cars    null    car:Car    mode:localName    12    STRING    50    null    0    0    2        null    0    0    0    17    YES    null    null    null    0"};
 
         ResultSet rs = dbmd.getColumns("%", "%", "car%", "%");
 
@@ -418,7 +418,7 @@ public abstract class AbstractJdbcDriverIntegrationTest extends AbstractJdbcDriv
 
         String[] expected = {
             "TABLE_CAT[String]    TABLE_SCHEM[String]    TABLE_NAME[String]    COLUMN_NAME[String]    DATA_TYPE[Long]    TYPE_NAME[String]    COLUMN_SIZE[Long]    BUFFER_LENGTH[Long]    DECIMAL_DIGITS[Long]    NUM_PREC_RADIX[Long]    NULLABLE[Long]    REMARKS[String]    COLUMN_DEF[String]    SQL_DATA_TYPE[Long]    SQL_DATETIME_SUB[Long]    CHAR_OCTET_LENGTH[Long]    ORDINAL_POSITION[Long]    IS_NULLABLE[String]    SCOPE_CATLOG[String]    SCOPE_SCHEMA[String]    SCOPE_TABLE[String]    SOURCE_DATA_TYPE[Long]",
-            "cars    NULL    car:Car    car:msrp    12    STRING    50    NULL    0    0    2        NULL    0    0    0    1    YES    NULL    NULL    NULL    0"};
+            "cars    null    car:Car    car:msrp    12    STRING    50    null    0    0    2        null    0    0    0    1    YES    null    null    null    0"};
 
         ResultSet rs = dbmd.getColumns("%", "%", "car:Car", "car:msrp");
         assertResultsSetEquals(rs, expected);

--- a/modeshape-jdbc-local/src/test/java/org/modeshape/jdbc/JcrResultSetTest.java
+++ b/modeshape-jdbc-local/src/test/java/org/modeshape/jdbc/JcrResultSetTest.java
@@ -21,9 +21,11 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import java.io.IOException;
+import java.sql.Blob;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.SQLFeatureNotSupportedException;
+import java.sql.Timestamp;
 import java.util.Calendar;
 import java.util.GregorianCalendar;
 import java.util.Map;
@@ -38,8 +40,7 @@ import org.modeshape.common.util.IoUtil;
 import org.modeshape.jdbc.util.TimestampWithTimezone;
 
 /**
- * 
- *
+ *  Unit test for {@link org.modeshape.jdbc.JcrResultSet}
  */
 public class JcrResultSetTest {
 
@@ -468,7 +469,11 @@ public class JcrResultSetTest {
             Object[] tuple = TestUtil.TUPLES.get(i);
             // need to start at 1 because ResultSet is 1 based.
             for (int x = 1; x <= numCols; x++) {
-                assertThat(resultSet.getBytes(x), is((tuple[x - 1] != null ? (tuple[x - 1].toString()).getBytes() : null)));
+                Object expectedValue = tuple[x - 1];
+                if (expectedValue != null && !(expectedValue instanceof byte[])) {
+                    expectedValue = expectedValue.toString().getBytes();
+                }
+                assertThat(resultSet.getBytes(x), is(expectedValue));
             }
         }
     }
@@ -481,8 +486,12 @@ public class JcrResultSetTest {
             Object[] tuple = TestUtil.TUPLES.get(i);
 
             for (int x = 0; x < numCols; x++) {
+                Object expectedValue = tuple[x];
+                if (expectedValue != null && !(expectedValue instanceof byte[])) {
+                    expectedValue = expectedValue.toString().getBytes();
+                }
                 assertThat(resultSet.getBytes(TestUtil.COLUMN_NAMES[x]),
-                           is((tuple[x] != null ? (tuple[x].toString()).getBytes() : null)));
+                           is(expectedValue));
             }
         }
     }
@@ -509,7 +518,7 @@ public class JcrResultSetTest {
     }
 
     @Test
-    public void shouldCallGetObjectUsingColumnName() throws SQLException {
+    public void shouldCallGetObjectUsingColumnName() throws Exception {
         int numCols = TestUtil.COLUMN_NAMES.length;
         for (int i = 0; i < TestUtil.TUPLES.size(); i++) {
             assertThat(resultSet.next(), is(true));
@@ -517,9 +526,15 @@ public class JcrResultSetTest {
 
             for (int x = 0; x < numCols; x++) {
                 Object o = resultSet.getObject(TestUtil.COLUMN_NAMES[x]);
-                // doing .toString() to compare the Object value to the TestQueryResultMetaData
-                // which has primitives
-                assertThat((o != null ? o.toString() : null), is((tuple[x] != null ? tuple[x].toString() : null)));
+                Object expectedValue = tuple[x];
+                if (expectedValue instanceof Calendar) {
+                    expectedValue = new Timestamp(((Calendar) expectedValue).getTimeInMillis());
+                }
+                if (expectedValue instanceof byte[]) {
+                    assertThat(o instanceof Blob, is(true));
+                    o = IoUtil.readBytes(((Blob)o).getBinaryStream());
+                }
+                assertThat((o != null ? o: null), is((expectedValue != null ? expectedValue : null)));
             }
         }
     }
@@ -898,70 +913,6 @@ public class JcrResultSetTest {
      * @throws SQLException
      */
     @Test( expected = SQLFeatureNotSupportedException.class )
-    public void featureNotSupportedCallingGetBigDecimalIdx() throws SQLException {
-        resultSet.getBigDecimal(1);
-    }
-
-    /**
-     * @throws SQLException
-     */
-    @Test( expected = SQLFeatureNotSupportedException.class )
-    public void featureNotSupportedCallingGetBigDecimalColName() throws SQLException {
-        resultSet.getBigDecimal("colname");
-    }
-
-    /**
-     * @throws SQLException
-     */
-    @Test( expected = SQLFeatureNotSupportedException.class )
-    public void featureNotSupportedCallingGetBigDecimalIdxScale() throws SQLException {
-        resultSet.getBigDecimal(1, 1);
-    }
-
-    /**
-     * @throws SQLException
-     */
-    @Test( expected = SQLFeatureNotSupportedException.class )
-    public void featureNotSupportedCallingGetBigDecimalColNameScale() throws SQLException {
-        resultSet.getBigDecimal("colname", 1);
-    }
-
-    /**
-     * @throws SQLException
-     */
-    @Test( expected = SQLFeatureNotSupportedException.class )
-    public void featureNotSupportedCallingGetBlobIdx() throws SQLException {
-        resultSet.getBlob(1);
-    }
-
-    /**
-     * @throws SQLException
-     */
-    @Test( expected = SQLFeatureNotSupportedException.class )
-    public void featureNotSupportedCallingGetBlobColName() throws SQLException {
-        resultSet.getBlob("colname");
-    }
-
-    /**
-     * @throws SQLException
-     */
-    @Test( expected = SQLFeatureNotSupportedException.class )
-    public void featureNotSupportedCallingGetByteIdx() throws SQLException {
-        resultSet.getByte(1);
-    }
-
-    /**
-     * @throws SQLException
-     */
-    @Test( expected = SQLFeatureNotSupportedException.class )
-    public void featureNotSupportedCallingGetByteColName() throws SQLException {
-        resultSet.getByte("colname");
-    }
-
-    /**
-     * @throws SQLException
-     */
-    @Test( expected = SQLFeatureNotSupportedException.class )
     public void featureNotSupportedCallingGetCharacterStreamIdx() throws SQLException {
         resultSet.getCharacterStream(1);
     }
@@ -988,22 +939,6 @@ public class JcrResultSetTest {
     @Test( expected = SQLFeatureNotSupportedException.class )
     public void featureNotSupportedCallingGetClobColName() throws SQLException {
         resultSet.getClob("colname");
-    }
-
-    /**
-     * @throws SQLException
-     */
-    @Test( expected = SQLFeatureNotSupportedException.class )
-    public void featureNotSupportedCallingGetFloatIdx() throws SQLException {
-        resultSet.getFloat(1);
-    }
-
-    /**
-     * @throws SQLException
-     */
-    @Test( expected = SQLFeatureNotSupportedException.class )
-    public void featureNotSupportedCallingGetFloatColNameCal() throws SQLException {
-        resultSet.getFloat("colname");
     }
 
     /**
@@ -1116,38 +1051,6 @@ public class JcrResultSetTest {
     @Test( expected = SQLFeatureNotSupportedException.class )
     public void featureNotSupportedCallingGetSQLXMLColName() throws SQLException {
         resultSet.getSQLXML("colname");
-    }
-
-    /**
-     * @throws SQLException
-     */
-    @Test( expected = SQLFeatureNotSupportedException.class )
-    public void featureNotSupportedCallingGetShortIdx() throws SQLException {
-        resultSet.getShort(1);
-    }
-
-    /**
-     * @throws SQLException
-     */
-    @Test( expected = SQLFeatureNotSupportedException.class )
-    public void featureNotSupportedCallingGetShortColName() throws SQLException {
-        resultSet.getShort("colname");
-    }
-
-    /**
-     * @throws SQLException
-     */
-    @Test( expected = SQLFeatureNotSupportedException.class )
-    public void featureNotSupportedCallingGetURLIdx() throws SQLException {
-        resultSet.getURL(1);
-    }
-
-    /**
-     * @throws SQLException
-     */
-    @Test( expected = SQLFeatureNotSupportedException.class )
-    public void featureNotSupportedCallingGetURLColName() throws SQLException {
-        resultSet.getURL("colname");
     }
 
     /**

--- a/modeshape-jdbc-local/src/test/java/org/modeshape/jdbc/TestUtil.java
+++ b/modeshape-jdbc-local/src/test/java/org/modeshape/jdbc/TestUtil.java
@@ -16,9 +16,6 @@
 package org.modeshape.jdbc;
 
 import static org.mockito.Mockito.when;
-import java.io.InputStream;
-import java.math.BigDecimal;
-import java.sql.Date;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
@@ -30,19 +27,16 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.TimeZone;
-import javax.jcr.Binary;
 import javax.jcr.ItemNotFoundException;
 import javax.jcr.Node;
 import javax.jcr.NodeIterator;
 import javax.jcr.PropertyType;
 import javax.jcr.RepositoryException;
 import javax.jcr.Value;
-import javax.jcr.ValueFormatException;
 import javax.jcr.query.QueryResult;
 import javax.jcr.query.Row;
 import javax.jcr.query.RowIterator;
 import org.mockito.Mockito;
-import org.modeshape.jcr.InMemoryTestBinary;
 
 /**
  * This provides common result set metadata used by various tests
@@ -257,11 +251,6 @@ class QueryResultNodeIterator implements NodeIterator {
         this.size = nodes.size();
     }
 
-    /**
-     * {@inheritDoc}
-     * 
-     * @see javax.jcr.NodeIterator#nextNode()
-     */
     @Override
     public Node nextNode() {
         Node node = nodes.next();
@@ -269,62 +258,32 @@ class QueryResultNodeIterator implements NodeIterator {
         return node;
     }
 
-    /**
-     * {@inheritDoc}
-     * 
-     * @see javax.jcr.RangeIterator#getPosition()
-     */
     @Override
     public long getPosition() {
         return position;
     }
 
-    /**
-     * {@inheritDoc}
-     * 
-     * @see javax.jcr.RangeIterator#getSize()
-     */
     @Override
     public long getSize() {
         return size;
     }
 
-    /**
-     * {@inheritDoc}
-     * 
-     * @see javax.jcr.RangeIterator#skip(long)
-     */
     @Override
     public void skip( long skipNum ) {
         for (long i = 0L; i != skipNum; ++i)
             nextNode();
     }
 
-    /**
-     * {@inheritDoc}
-     * 
-     * @see java.util.Iterator#hasNext()
-     */
     @Override
     public boolean hasNext() {
         return nodes.hasNext();
     }
 
-    /**
-     * {@inheritDoc}
-     * 
-     * @see java.util.Iterator#next()
-     */
     @Override
     public Object next() {
         return nextNode();
     }
 
-    /**
-     * {@inheritDoc}
-     * 
-     * @see java.util.Iterator#remove()
-     */
     @Override
     public void remove() {
         throw new UnsupportedOperationException();
@@ -350,15 +309,6 @@ class QueryResultRowIterator implements RowIterator {
 
     }
 
-    public boolean hasSelector( String selectorName ) {
-        return false;
-    }
-
-    /**
-     * {@inheritDoc}
-     * 
-     * @see javax.jcr.query.RowIterator#nextRow()
-     */
     @Override
     public Row nextRow() {
         if (nextRow == null) {
@@ -374,31 +324,16 @@ class QueryResultRowIterator implements RowIterator {
         return result;
     }
 
-    /**
-     * {@inheritDoc}
-     * 
-     * @see javax.jcr.RangeIterator#getPosition()
-     */
     @Override
     public long getPosition() {
         return position;
     }
 
-    /**
-     * {@inheritDoc}
-     * 
-     * @see javax.jcr.RangeIterator#getSize()
-     */
     @Override
     public long getSize() {
         return numRows;
     }
 
-    /**
-     * {@inheritDoc}
-     * 
-     * @see javax.jcr.RangeIterator#skip(long)
-     */
     @Override
     public void skip( long skipNum ) {
         for (long i = 0L; i != skipNum; ++i) {
@@ -407,11 +342,6 @@ class QueryResultRowIterator implements RowIterator {
         position += skipNum;
     }
 
-    /**
-     * {@inheritDoc}
-     * 
-     * @see java.util.Iterator#hasNext()
-     */
     @Override
     public boolean hasNext() {
         if (nextRow != null) {
@@ -432,30 +362,15 @@ class QueryResultRowIterator implements RowIterator {
         return false;
     }
 
-    /**
-     * @param tuple
-     * @return Row
-     * @throws RepositoryException
-     */
     private Row getNextRow( Object[] tuple ) throws RepositoryException {
         return new QueryResultRow(this, nodes, tuple);
     }
 
-    /**
-     * {@inheritDoc}
-     * 
-     * @see java.util.Iterator#next()
-     */
     @Override
     public Object next() {
         return nextRow();
     }
 
-    /**
-     * {@inheritDoc}
-     * 
-     * @see java.util.Iterator#remove()
-     */
     @Override
     public void remove() {
         throw new UnsupportedOperationException();
@@ -475,11 +390,6 @@ class QueryResultRow implements javax.jcr.query.Row {
         this.nodes = nodes;
     }
 
-    /**
-     * {@inheritDoc}
-     * 
-     * @see javax.jcr.query.Row#getNode()
-     */
     @Override
     public Node getNode() throws RepositoryException {
         if (nodes.length == 1) return nodes[0];
@@ -496,22 +406,12 @@ class QueryResultRow implements javax.jcr.query.Row {
         return null;
     }
 
-    /**
-     * {@inheritDoc}
-     * 
-     * @see javax.jcr.query.Row#getPath()
-     */
     @Override
     public String getPath() throws RepositoryException {
         if (nodes.length == 1) return nodes[0].getPath();
         throw new RepositoryException("More than one selector");
     }
 
-    /**
-     * {@inheritDoc}
-     * 
-     * @see javax.jcr.query.Row#getPath(java.lang.String)
-     */
     @Override
     public String getPath( String selectorName ) throws RepositoryException {
         for (int i = 0; i < nodes.length; i++) {
@@ -522,159 +422,34 @@ class QueryResultRow implements javax.jcr.query.Row {
         return null;
     }
 
-    /**
-     * {@inheritDoc}
-     * 
-     * @see javax.jcr.query.Row#getScore()
-     */
     @Override
     public double getScore() /*throws RepositoryException*/{
         throw new UnsupportedOperationException();
     }
 
-    /**
-     * {@inheritDoc}
-     * 
-     * @see javax.jcr.query.Row#getScore(java.lang.String)
-     */
     @Override
     public double getScore( String selectorName ) /* throws RepositoryException */{
         throw new UnsupportedOperationException();
     }
 
-    /**
-     * @throws ItemNotFoundException
-     */
     @Override
     public Value getValue( String arg0 ) throws ItemNotFoundException {
         for (int i = 0; i < TestUtil.COLUMN_NAMES.length; i++) {
             if (TestUtil.COLUMN_NAMES[i].equals(arg0)) {
-                return createValue(tuple[i]);
+                return JdbcJcrValueFactory.createValue(tuple[i]);
             }
         }
 
         throw new ItemNotFoundException("Item " + arg0 + " not found");
     }
 
-    /**
-     * @throws RepositoryException
-     */
     @Override
     public Value[] getValues() throws RepositoryException {
         Value[] values = new Value[tuple.length];
         for (int i = 0; i < tuple.length; i++) {
-            values[i] = createValue(tuple[i]);
+            values[i] =  JdbcJcrValueFactory.createValue(tuple[i]);
 
         }
         return values;
-    }
-
-    private Value createValue( final Object value ) {
-
-        if (value == null) return null;
-
-        Value rtnvalue = new Value() {
-            final Object valueObject = value;
-
-            @Override
-            public boolean getBoolean() throws ValueFormatException, IllegalStateException, RepositoryException {
-                if (value instanceof Boolean) {
-                    return ((Boolean)valueObject).booleanValue();
-                }
-                throw new ValueFormatException("Value not a Boolean");
-            }
-
-            @Override
-            public Calendar getDate() throws ValueFormatException, IllegalStateException, RepositoryException {
-                if (value instanceof Date) {
-
-                    Calendar t = new GregorianCalendar();
-                    t.clear();
-                    t.setTimeZone(TimeZone.getTimeZone(TestUtil.TIME_ZONE));
-                    t.setTimeInMillis(((Date)value).getTime());
-                    return t;
-
-                } else if (value instanceof Calendar) {
-
-                    return (Calendar)value;
-
-                }
-                throw new ValueFormatException("Value not instance of Date");
-            }
-
-            @Override
-            public double getDouble() throws ValueFormatException, IllegalStateException, RepositoryException {
-                if (value instanceof Double) {
-                    return ((Double)valueObject).doubleValue();
-                }
-
-                throw new ValueFormatException("Value not a Double");
-            }
-
-            @Override
-            public long getLong() throws ValueFormatException, IllegalStateException, RepositoryException {
-                if (value instanceof Long) {
-                    return ((Long)valueObject).longValue();
-                }
-                throw new ValueFormatException("Value not a Long");
-            }
-
-            /**
-             * {@inheritDoc}
-             * 
-             * @see javax.jcr.Value#getBinary()
-             */
-            @Override
-            public Binary getBinary() throws RepositoryException {
-                if (value instanceof Binary) {
-                    return ((Binary)valueObject);
-                }
-                if (value instanceof byte[]) {
-                    return new InMemoryTestBinary((byte[])value);
-                }
-                throw new ValueFormatException("Value not a Binary");
-            }
-
-            /**
-             * {@inheritDoc}
-             * 
-             * @see javax.jcr.Value#getDecimal()
-             */
-            @Override
-            public BigDecimal getDecimal() throws ValueFormatException, RepositoryException {
-                if (value instanceof BigDecimal) {
-                    return ((BigDecimal)valueObject);
-                }
-                throw new ValueFormatException("Value not a Decimal");
-            }
-
-            @Override
-            public InputStream getStream() throws IllegalStateException, RepositoryException {
-                if (value instanceof Binary) {
-                    return ((Binary)valueObject).getStream();
-                }
-                if (value instanceof InputStream) {
-                    return ((InputStream)valueObject);
-                }
-                throw new ValueFormatException("Value not an InputStream");
-            }
-
-            @Override
-            public String getString() throws IllegalStateException {
-                if (value instanceof String) {
-                    return (String)valueObject;
-                }
-                return valueObject.toString();
-            }
-
-            @Override
-            public int getType() {
-                return 1;
-            }
-
-        };
-
-        return rtnvalue;
-
     }
 }

--- a/modeshape-jdbc/src/test/java/org/modeshape/jdbc/JcrHttpDriverIntegrationTest.java
+++ b/modeshape-jdbc/src/test/java/org/modeshape/jdbc/JcrHttpDriverIntegrationTest.java
@@ -15,13 +15,9 @@
  */
 package org.modeshape.jdbc;
 
-import org.junit.After;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
-import org.junit.Before;
-import org.junit.Test;
-import org.modeshape.common.FixFor;
 import java.sql.Connection;
 import java.sql.DatabaseMetaData;
 import java.sql.DriverManager;
@@ -29,6 +25,10 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.Properties;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.modeshape.common.FixFor;
 
 /**
  * Integration test with the http protocol of the {@link JcrDriver}.
@@ -70,10 +70,71 @@ public class JcrHttpDriverIntegrationTest  {
     }
 
     @Test
+    @FixFor( "MODE-2125" )
     public void shouldRetrieveMetaData() throws SQLException {
         Connection connection = connectToRemoteRepository();
-        DatabaseMetaData metaData = connection.getMetaData();
-        assertNotNull(metaData);
+        DatabaseMetaData metadata = connection.getMetaData();
+        assertNotNull(metadata);
+
+        //reads tables and columns
+        readTables(metadata);
+    }
+
+    private void readTables( DatabaseMetaData metadata ) throws SQLException {
+        ResultSet tables = metadata.getTables(null, null, null, null);
+        try {
+            while (tables.next()) {
+                String tableCatalog = tables.getString(1);
+                String tableSchema = tables.getString(2);
+                String tableName = tables.getString(3);
+                String tableType = tables.getString(4);
+                String remarks = tables.getString(5);
+                String typeCat = tables.getString(6);
+                String typeSchema = tables.getString(7);
+                String typeName = tables.getString(8);
+                String selfRefColumnName = tables.getString(9);
+                String refGeneration = tables.getString(10);
+
+                readColumns(metadata, tableCatalog, tableSchema, tableName);
+            }
+        } finally {
+            tables.close();
+        }
+    }
+
+    private void readColumns( DatabaseMetaData metadata, String catalog, String schema, String table )
+            throws SQLException {
+        ResultSet columns = metadata.getColumns(catalog, schema, table, null);
+        try {
+            while (columns.next()) {
+                String tableCatalog = columns.getString(1);
+                String tableSchema = columns.getString(2);
+                String tableName = columns.getString(3);
+                String columnName = columns.getString(4);
+                int type = columns.getInt(5);
+                String typeName = columns.getString(6);
+                int columnSize = columns.getInt(7);
+                int bufferLength = columns.getInt(8);
+                int decimalDigits = columns.getInt(9);
+                int radix = columns.getInt(10);
+                int nullable = columns.getInt(11);
+                String remarks = columns.getString(12);
+                String columnDef = columns.getString(13);
+                int sqlDataType = columns.getInt(14);
+                int sqlDataTimeSub = columns.getInt(15);
+                int charOctetLength = columns.getInt(16);
+                int ordinalPost = columns.getInt(17);
+                String isNullable = columns.getString(18);
+                String scopeCat = columns.getString(19);
+                String scopeSchema = columns.getString(20);
+                String scopeTable = columns.getString(21);
+                short scopeDataType = columns.getShort(22);
+//                String isAutoIncrement = columns.getString(23);
+//                String isGenerated = columns.getString(24);
+            }
+        } finally {
+            columns.close();
+        }
     }
 
     @Test

--- a/web/modeshape-web-jcr-rest-client/src/main/java/org/modeshape/web/jcr/rest/client/domain/QueryRow.java
+++ b/web/modeshape-web-jcr-rest-client/src/main/java/org/modeshape/web/jcr/rest/client/domain/QueryRow.java
@@ -46,11 +46,6 @@ public class QueryRow {
         return queryTypes.get(columnName);
     }
 
-    /**
-     * {@inheritDoc}
-     * 
-     * @see java.lang.Object#toString()
-     */
     @Override
     public String toString() {
         return values.toString();

--- a/web/modeshape-web-jcr-rest-client/src/main/java/org/modeshape/web/jcr/rest/client/json/JsonRestClient.java
+++ b/web/modeshape-web-jcr-rest-client/src/main/java/org/modeshape/web/jcr/rest/client/json/JsonRestClient.java
@@ -332,26 +332,10 @@ public final class JsonRestClient implements IRestClient {
         // because the http://<url> needs the workspace when it appends the depth option
         // this logic must be used to obtain one.
         Collection<Workspace> workspaces = getWorkspaces(repository);
-        Workspace workspace = null;
-        Workspace systemWs = null;
-        for (Workspace wspace : workspaces) {
-            if (wspace.getName().equalsIgnoreCase("default")) {
-                workspace = wspace;
-                break;
-            }
-            if (workspace == null && !wspace.getName().equalsIgnoreCase("system")) {
-                workspace = wspace;
-            }
-
-            if (wspace.getName().equalsIgnoreCase("system")) {
-                systemWs = wspace;
-            }
+        if (workspaces.isEmpty()) {
+            return Collections.emptyMap();
         }
-        assert systemWs != null;
-        if (workspace == null) {
-            workspace = systemWs;
-        }
-
+        Workspace workspace = workspaces.iterator().next();
         NodeTypeNode nodetypeNode = new NodeTypeNode(workspace);
         HttpClientConnection connection = connect(workspace.getServer(), nodetypeNode.getUrl(), RequestMethod.GET);
 


### PR DESCRIPTION
Also, added `ResultSet` support for the `getByte`, `getShort`, `getUrl`, `getFloat` and `getBlob` methods.

The code was not changed to use JDK 7 specific idioms, making it easier to merge in JDK 6 branches.
