### PR TITLE
MODE-2202 Refactored multi-session transactional tests to use separate threads

### DIFF
--- a/modeshape-jcr/src/test/java/org/modeshape/jcr/JcrRepositoryTest.java
+++ b/modeshape-jcr/src/test/java/org/modeshape/jcr/JcrRepositoryTest.java
@@ -33,6 +33,7 @@ import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.Set;
 import java.util.TreeSet;
+import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
@@ -81,6 +82,7 @@ public class JcrRepositoryTest {
     private RepositoryConfiguration config;
     private JcrRepository repository;
     private JcrSession session;
+    protected boolean print = false;
 
     @Before
     public void beforeEach() throws Exception {
@@ -90,6 +92,7 @@ public class JcrRepositoryTest {
         config = new RepositoryConfiguration("repoName", environment);
         repository = new JcrRepository(config);
         repository.start();
+        print = false;
     }
 
     @After
@@ -773,165 +776,287 @@ public class JcrRepositoryTest {
         assertThat(future.get(), is(true)); // get() blocks until done
     }
 
-    @FixFor( "MODE-1498" )
+    @FixFor( {"MODE-1498", "MODE-2202"} )
     @Test
-    public void shouldWorkWithUserDefinedTransactions() throws Exception {
+    public void shouldWorkWithUserDefinedTransactionsInSeparateThreads() throws Exception {
+        CyclicBarrier barrier = new CyclicBarrier(2);
+        CyclicBarrier completionBarrier = new CyclicBarrier(3);
         session = createSession();
 
-        Session session2 = createSession();
-        try {
+        // THREAD 1 ...
+        SessionWorker worker1 = new SessionWorker(session, barrier, completionBarrier, "thread 1") {
+            @Override
+            protected void execute( Session session ) throws Exception {
+                // STEP 1: Setup the listener, and check that the new nodes are not visible to the other session ...
+                SimpleListener listener = addListener(3); // we'll create 3 nodes ...
+                assertThat(listener.getActualEventCount(), is(0));
+                nodeDoesNotExist(session, "/", "txnNode1");
+                nodeDoesNotExist(session, "/", "txnNode2");
+                barrier.await();
 
-            // Create a listener to count the changes ...
-            SimpleListener listener = addListener(3); // we'll create 3 nodes ...
-            assertThat(listener.getActualEventCount(), is(0));
+                // STEP 2: Make changes using a transaction, but do not commit the transaction ...
+                final TransactionManager txnMgr = getTransactionManager();
+                txnMgr.begin();
+                assertThat(listener.getActualEventCount(), is(0));
+                Node txnNode1 = session.getRootNode().addNode("txnNode1");
+                Node txnNode1a = txnNode1.addNode("txnNodeA");
+                assertThat(txnNode1a, is(notNullValue()));
+                assertThat(session.getRootNode().hasNode("txnNode1"), is(true));
+                assertThat(session.getRootNode().hasNode("txnNode2"), is(false));
+                session.save();
+                assertThat(session.getRootNode().hasNode("txnNode1"), is(true));
+                assertThat(session.getRootNode().hasNode("txnNode2"), is(false));
+                assertThat(listener.getActualEventCount(), is(0));
+                barrier.await();
 
-            // Check that the node is not visible to the other session ...
-            session.refresh(false);
-            nodeDoesNotExist(session2, "/", "txnNode1");
-            nodeDoesNotExist(session2, "/", "txnNode2");
+                // STEP 3: Wait for other session to verify that it can't see the new node we created but have not committed...
+                // Meanwhile, sleep a bit to let any incorrect events propagate through the system. Our listener still should
+                // not see the event, since we didn't commit ...
+                Thread.sleep(100L);
+                assertThat(listener.getActualEventCount(), is(0));
+                barrier.await();
 
-            // Start a transaction ...
-            final TransactionManager txnMgr = getTransactionManager();
-            txnMgr.begin();
-            assertThat(listener.getActualEventCount(), is(0));
-            Node txnNode1 = session.getRootNode().addNode("txnNode1");
-            Node txnNode1a = txnNode1.addNode("txnNodeA");
-            assertThat(txnNode1a, is(notNullValue()));
-            session.save();
-            assertThat(listener.getActualEventCount(), is(0));
+                // STEP 4: Create another new node using this transaction ...
+                Node txnNode2 = session.getRootNode().addNode("txnNode2");
+                assertThat(txnNode2, is(notNullValue()));
+                session.save();
+                assertThat(listener.getActualEventCount(), is(0));
+                assertThat(session.getRootNode().hasNode("txnNode1"), is(true));
+                assertThat(session.getRootNode().hasNode("txnNode2"), is(true));
+                barrier.await();
 
-            // Check that the node is not visible to the other session ...
-            nodeDoesNotExist(session2, "/", "txnNode1");
-            nodeDoesNotExist(session2, "/", "txnNode2");
-            session2.refresh(false);
-            nodeDoesNotExist(session2, "/", "txnNode1");
-            nodeDoesNotExist(session2, "/", "txnNode2");
+                // STEP 5: Wait for other session to verify that it can't see the new node we created but have not committed...
+                // Meanwhile, sleep a bit to let any incorrect events propagate through the system. Our listener still should
+                // not see the event, since we didn't commit ...
+                Thread.sleep(100L);
+                assertThat(listener.getActualEventCount(), is(0));
+                assertThat(session.getRootNode().hasNode("txnNode1"), is(true));
+                assertThat(session.getRootNode().hasNode("txnNode2"), is(true));
+                barrier.await();
 
-            // sleep a bit to let any incorrect events propagate through the system ...
-            Thread.sleep(100L);
-            assertThat(listener.getActualEventCount(), is(0));
+                // STEP 6: Commit the txn ...
+                txnMgr.commit();
+                barrier.await();
 
-            Node txnNode2 = session.getRootNode().addNode("txnNode2");
-            assertThat(txnNode2, is(notNullValue()));
-            session.save();
-            assertThat(listener.getActualEventCount(), is(0));
-            assertThat(session.getRootNode().hasNode("txnNode1"), is(true));
-            assertThat(session.getRootNode().hasNode("txnNode2"), is(true));
+                // STEP 7: Verify the commit resulted in the things we expect ...
+                listener.waitForEvents();
+                nodeExists(session, "/", "txnNode1");
+                nodeExists(session, "/", "txnNode2");
+            }
+        };
 
-            // Check that the node is not visible to the other session ...
-            nodeDoesNotExist(session2, "/", "txnNode1");
-            nodeDoesNotExist(session2, "/", "txnNode2");
-            session2.refresh(false);
-            nodeDoesNotExist(session2, "/", "txnNode1");
-            nodeDoesNotExist(session2, "/", "txnNode2");
+        // THREAD 2 ...
+        SessionWorker worker2 = new SessionWorker(createSession(), barrier, completionBarrier, "thread 2") {
+            @Override
+            protected void execute( Session session ) throws Exception {
+                // STEP 1: Check that the new nodes are not visible to the other session ...
+                nodeDoesNotExist(session, "/", "txnNode1");
+                nodeDoesNotExist(session, "/", "txnNode2");
+                barrier.await();
 
-            // sleep a bit to let any incorrect events propagate through the system ...
-            Thread.sleep(100L);
-            assertThat(listener.getActualEventCount(), is(0));
+                // STEP 2: Wait for changes to be made in the other transaction ...
+                Thread.sleep(50L);
+                barrier.await();
 
-            assertThat(session.getRootNode().hasNode("txnNode1"), is(true));
-            assertThat(session.getRootNode().hasNode("txnNode2"), is(true));
+                // STEP 3: Check that we cannot see the new node created by the other session in the still-ongoing txn ...
+                nodeDoesNotExist(session, "/", "txnNode1");
+                nodeDoesNotExist(session, "/", "txnNode2");
+                session.refresh(false);
+                nodeDoesNotExist(session, "/", "txnNode1");
+                nodeDoesNotExist(session, "/", "txnNode2");
+                barrier.await();
 
-            // Now commit the transaction ...
-            txnMgr.commit();
-            listener.waitForEvents();
+                // STEP 4: Wait for changes to be made in the other transaction ...
+                Thread.sleep(50L);
+                barrier.await();
 
-            nodeExists(session, "/", "txnNode1");
-            nodeExists(session, "/", "txnNode2");
+                // STEP 5: Check that we cannot see the new node created by the other session in the still-ongoing txn ...
+                nodeDoesNotExist(session, "/", "txnNode1");
+                nodeDoesNotExist(session, "/", "txnNode2");
+                session.refresh(false);
+                nodeDoesNotExist(session, "/", "txnNode1");
+                nodeDoesNotExist(session, "/", "txnNode2");
+                barrier.await();
 
-            // Check that the node IS visible to the other session ...
-            nodeExists(session2, "/", "txnNode1");
-            nodeExists(session2, "/", "txnNode2");
-            session2.refresh(false);
-            nodeExists(session2, "/", "txnNode1");
-            nodeExists(session2, "/", "txnNode2");
+                // STEP 6: Wait for the transaction to be committed
+                Thread.sleep(50L);
+                barrier.await();
 
-        } finally {
-            session2.logout();
-        }
+                // STEP 7: Check that the nodes are now visible to this session ...
+                nodeExists(session, "/", "txnNode1");
+                nodeExists(session, "/", "txnNode2");
+                session.refresh(false);
+                nodeExists(session, "/", "txnNode1");
+                nodeExists(session, "/", "txnNode2");
+            }
+        };
+
+        new Thread(worker1).start();
+        new Thread(worker2).start();
+
+        // Wait for the threads to complete ...
+        completionBarrier.await();
     }
 
-    @FixFor( "MODE-1498" )
+    @FixFor( {"MODE-1498", "MODE-2202"} )
     @Test
-    public void shouldWorkWithUserDefinedTransactionsThatUseRollback() throws Exception {
+    public void shouldWorkWithUserDefinedTransactionsThatUseRollbackInSeparateThreads() throws Exception {
+        CyclicBarrier barrier = new CyclicBarrier(2);
+        CyclicBarrier completionBarrier = new CyclicBarrier(3);
         session = createSession();
 
-        Session session2 = createSession();
-        try {
+        // THREAD 1 ...
+        SessionWorker worker1 = new SessionWorker(session, barrier, completionBarrier, "thread 1") {
+            @Override
+            protected void execute( Session session ) throws Exception {
+                // STEP 1: Setup the listener, and check that the new nodes are not visible to the other session ...
+                SimpleListener listener = addListener(3); // we'll create 3 nodes ...
+                assertThat(listener.getActualEventCount(), is(0));
+                nodeDoesNotExist(session, "/", "txnNode1");
+                nodeDoesNotExist(session, "/", "txnNode2");
+                barrier.await();
 
-            // Create a listener to count the changes ...
-            SimpleListener listener = addListener(3); // we'll create 3 nodes ...
-            assertThat(listener.getActualEventCount(), is(0));
+                // STEP 2: Make changes using a transaction, but do not commit the transaction ...
+                final TransactionManager txnMgr = getTransactionManager();
+                txnMgr.begin();
+                assertThat(listener.getActualEventCount(), is(0));
+                Node txnNode1 = session.getRootNode().addNode("txnNode1");
+                Node txnNode1a = txnNode1.addNode("txnNodeA");
+                assertThat(txnNode1a, is(notNullValue()));
+                assertThat(session.getRootNode().hasNode("txnNode1"), is(true));
+                assertThat(session.getRootNode().hasNode("txnNode2"), is(false));
+                session.save();
+                assertThat(session.getRootNode().hasNode("txnNode1"), is(true));
+                assertThat(session.getRootNode().hasNode("txnNode2"), is(false));
+                assertThat(listener.getActualEventCount(), is(0));
+                barrier.await();
 
-            // Check that the node is not visible to the other session ...
-            session.refresh(false);
-            nodeDoesNotExist(session2, "/", "txnNode1");
-            nodeDoesNotExist(session2, "/", "txnNode2");
+                // STEP 3: Wait for other session to verify that it can't see the new node we created but have not committed...
+                // Meanwhile, sleep a bit to let any incorrect events propagate through the system. Our listener still should
+                // not see the event, since we didn't commit ...
+                Thread.sleep(100L);
+                assertThat(listener.getActualEventCount(), is(0));
+                barrier.await();
 
-            // Start a transaction ...
-            final TransactionManager txnMgr = getTransactionManager();
-            txnMgr.begin();
-            assertThat(listener.getActualEventCount(), is(0));
-            Node txnNode1 = session.getRootNode().addNode("txnNode1");
-            Node txnNode1a = txnNode1.addNode("txnNodeA");
-            assertThat(txnNode1a, is(notNullValue()));
-            session.save();
-            assertThat(listener.getActualEventCount(), is(0));
+                // STEP 4: Create another new node using this transaction ...
+                Node txnNode2 = session.getRootNode().addNode("txnNode2");
+                assertThat(txnNode2, is(notNullValue()));
+                session.save();
+                assertThat(listener.getActualEventCount(), is(0));
+                assertThat(session.getRootNode().hasNode("txnNode1"), is(true));
+                assertThat(session.getRootNode().hasNode("txnNode2"), is(true));
+                barrier.await();
 
-            // Check that the node is not visible to the other session ...
-            nodeDoesNotExist(session2, "/", "txnNode1");
-            nodeDoesNotExist(session2, "/", "txnNode2");
-            session2.refresh(false);
-            nodeDoesNotExist(session2, "/", "txnNode1");
-            nodeDoesNotExist(session2, "/", "txnNode2");
+                // STEP 5: Wait for other session to verify that it can't see the new node we created but have not committed...
+                // Meanwhile, sleep a bit to let any incorrect events propagate through the system. Our listener still should
+                // not see the event, since we didn't commit ...
+                Thread.sleep(100L);
+                assertThat(listener.getActualEventCount(), is(0));
+                assertThat(session.getRootNode().hasNode("txnNode1"), is(true));
+                assertThat(session.getRootNode().hasNode("txnNode2"), is(true));
+                barrier.await();
 
-            // sleep a bit to let any incorrect events propagate through the system ...
-            Thread.sleep(100L);
-            assertThat(listener.getActualEventCount(), is(0));
+                // STEP 6: Rollback the txn ...
+                txnMgr.rollback();
+                barrier.await();
 
-            Node txnNode2 = session.getRootNode().addNode("txnNode2");
-            assertThat(txnNode2, is(notNullValue()));
-            session.save();
-            assertThat(listener.getActualEventCount(), is(0));
-            assertThat(session.getRootNode().hasNode("txnNode1"), is(true));
-            assertThat(session.getRootNode().hasNode("txnNode2"), is(true));
+                // STEP 7: Check that there were no events and that the nodes are not visible anymore ...
+                Thread.sleep(100L);
+                assertThat(listener.getActualEventCount(), is(0));
+                assertThat(session.getRootNode().hasNode("txnNode1"), is(false));
+                assertThat(session.getRootNode().hasNode("txnNode2"), is(false));
+                session.refresh(false);
+                assertThat(session.getRootNode().hasNode("txnNode1"), is(false));
+                assertThat(session.getRootNode().hasNode("txnNode2"), is(false));
+            }
+        };
 
-            // Check that the node is not visible to the other session ...
-            nodeDoesNotExist(session2, "/", "txnNode1");
-            nodeDoesNotExist(session2, "/", "txnNode2");
-            session2.refresh(false);
-            nodeDoesNotExist(session2, "/", "txnNode1");
-            nodeDoesNotExist(session2, "/", "txnNode2");
+        // THREAD 2 ...
+        SessionWorker worker2 = new SessionWorker(createSession(), barrier, completionBarrier, "thread 2") {
+            @Override
+            protected void execute( Session session ) throws Exception {
+                // STEP 1: Check that the new nodes are not visible to the other session ...
+                nodeDoesNotExist(session, "/", "txnNode1");
+                nodeDoesNotExist(session, "/", "txnNode2");
+                barrier.await();
 
-            // sleep a bit to let any incorrect events propagate through the system ...
-            Thread.sleep(100L);
-            assertThat(listener.getActualEventCount(), is(0));
+                // STEP 2: Wait for changes to be made in the other transaction ...
+                Thread.sleep(50L);
+                barrier.await();
 
-            assertThat(session.getRootNode().hasNode("txnNode1"), is(true));
-            assertThat(session.getRootNode().hasNode("txnNode2"), is(true));
+                // STEP 3: Check that we cannot see the new node created by the other session in the still-ongoing txn ...
+                nodeDoesNotExist(session, "/", "txnNode1");
+                nodeDoesNotExist(session, "/", "txnNode2");
+                session.refresh(false);
+                nodeDoesNotExist(session, "/", "txnNode1");
+                nodeDoesNotExist(session, "/", "txnNode2");
+                barrier.await();
 
-            // Now commit the transaction ...
-            txnMgr.rollback();
+                // STEP 4: Wait for changes to be made in the other transaction ...
+                Thread.sleep(50L);
+                barrier.await();
 
-            // There should have been no events ...
-            Thread.sleep(100L);
-            assertThat(listener.getActualEventCount(), is(0));
+                // STEP 5: Check that we cannot see the new node created by the other session in the still-ongoing txn ...
+                nodeDoesNotExist(session, "/", "txnNode1");
+                nodeDoesNotExist(session, "/", "txnNode2");
+                session.refresh(false);
+                nodeDoesNotExist(session, "/", "txnNode1");
+                nodeDoesNotExist(session, "/", "txnNode2");
+                barrier.await();
 
-            // The nodes does not exist in the session because the session was saved and those changes were rolled back ...
-            assertThat(session.getRootNode().hasNode("txnNode1"), is(false));
-            assertThat(session.getRootNode().hasNode("txnNode2"), is(false));
-            session.refresh(false);
-            assertThat(session.getRootNode().hasNode("txnNode1"), is(false));
-            assertThat(session.getRootNode().hasNode("txnNode2"), is(false));
+                // STEP 6: Wait for the transaction to be rolled back ...
+                Thread.sleep(50L);
+                barrier.await();
 
-            // Check that the node IS NOT visible to the other session ...
-            session2.refresh(false);
-            nodeDoesNotExist(session2, "/", "txnNode1");
-            nodeDoesNotExist(session2, "/", "txnNode2");
+                // STEP 7: Check that the node IS NOT visible to this session ...
+                nodeDoesNotExist(session, "/", "txnNode1");
+                nodeDoesNotExist(session, "/", "txnNode2");
+                session.refresh(false);
+                nodeDoesNotExist(session, "/", "txnNode1");
+                nodeDoesNotExist(session, "/", "txnNode2");
+            }
+        };
 
-        } finally {
-            session2.logout();
+        new Thread(worker1).start();
+        new Thread(worker2).start();
+
+        // Wait for the threads to complete ...
+        completionBarrier.await();
+    }
+
+    protected abstract class SessionWorker implements Runnable {
+
+        protected final CyclicBarrier barrier;
+        private final CyclicBarrier completionBarrier;
+        protected final JcrSession session;
+        private final String desc;
+
+        protected SessionWorker( JcrSession session,
+                                 CyclicBarrier barrier,
+                                 CyclicBarrier completionBarrier,
+                                 String desc ) {
+            this.barrier = barrier;
+            this.session = session;
+            this.completionBarrier = completionBarrier;
+            this.desc = desc;
         }
+
+        @Override
+        public void run() {
+            if (session == null) return;
+            if (print) System.out.println("Start " + desc);
+            try {
+                execute(session);
+                completionBarrier.await();
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            } finally {
+                session.logout();
+                if (print) System.out.println("Stop " + desc);
+            }
+        }
+
+        protected abstract void execute( Session session ) throws Exception;
     }
 
     @FixFor( "MODE-1828" )


### PR DESCRIPTION
The `JcrRepositoryTest` class contains two test methods that verified the behavior of two sessions when one of them is using a transaction, specifically that the changes made by a session using a transaction become visible (via events, navigation or query) to another session only when the transaction commits and that the changes never become visible if the transaction is rolled back.

The previous version of the tests used a single thread by interleaving actions for each of the separate sessions and checks. Unfortunately, this is unrealistic, since technically both sessions might be able to "see" the transaction if that transaction is associated with the thread.

MODE-2202 was logged by @hchiorean because one of these tests (in particular, the rollback test) was failing because it would leak the changes made by the session using a transaction so that they are incorrectly visible to the other session. I was not able to reproduce this failure locally.

By debugging the code, I did verify, at least on my machine, that no events were being prematurely fired from the session before the transaction was committed, and that the workspace caches were _not_ incorrectly receiving events and purging entries from their state. Besides, the workspace caches would only contain the truly persisted-and-committed changes; it is the `TransactionalWorkspaceCache` instance used by that transaction that is responsible for keeping these saved-but-not-yet-committed changes, and even if that were not the case (this is cleared at several points during the transaction), the Infinispan cache should still be providing the transactional context with an MVCC view of the persisted-but-not-yet-committed documents.

I did notice something unusual during my debugging sessions. Even though I was not able to reproduce the test failure as reported in MODE-2202, if the test thread were paused for at least 60 seconds immediately after saving (but before committing or rolling back) the changes, the second session that should not see the changes actually **was able** to see the changes. After investigating further, my hypothesis is that the workspace cache was evicting the cached representation after 60 seconds of non-use (thanks to the workspace cache's eviction policy), so when the session attempted to verify that the changes could not be seen, it couldn't find the parent node's document in the workspace cache and had to load it from the Infinispan cache, and this document actually contained the changes that were persisted-but-not-yet-committed.

So something is definitely wrong: **the Infinispan cache and its MVCC feature should provide the transaction and only that transaction with a unique view containing all persisted-but-not-yet-committed documents; none of these persisted-but-yet-committed documents should be visible to those outside the transaction.** So if Infinispan **is** exposing the persisted-but-not-yet-committed documents (entries) to the other session, then one of two things is wrong:
1. Either there is a new bug in Infinispan 6.0 that is leading it to expose the MVCC changes to clients not affiliated with the transaction; or
2. Infinispan is convoluting the second session (which we think is in a separate transactional context) as being part of the other session's transactional context.

My belief is that we're actually seeing the second case: the `DummyTransactionManager` (which is what we're using in these tests) is associating the transaction **with the thread**. And because our tests do not suspend the transaction before using the second session, Infinispan lets both sessions see the MVCC changes affiliated with the transaction.

IMO, our unit tests are the source of the problem. We should not use a single thread for multiple sessions in separate transactional contexts. Instead, the tests should use a **separate thread** for each transactions. 

This commit implements this fix to the unit tests, and after a little debugging I've confirmed that the tests work (even when running them 1000x in a row in the same VM) and that even after waiting the 60 seconds for the non-changed documents to be evicted from the workspace cache after changes are made using one of the sessions, the other session that should not see these changes in the documents it sees actually does not see the changes.

@hchiorean, please run these tests and uncomment the `main` method that runs the updated `shouldWorkWithUserDefinedTransactionsThatUseRollbackInSeparateThreads()` test 1000x. If it works for you, I would claim that what you saw was solely due to an incorrectly-written test.
