### PR TITLE
MODE-2173-master Fixed the checking of READ permissions for nodes retrieved from queries.

### DIFF
--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/query/JcrQueryResult.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/query/JcrQueryResult.java
@@ -283,8 +283,7 @@ public class JcrQueryResult implements org.modeshape.jcr.api.query.QueryResult {
         @Override
         public Node nextNode() {
             CachedNode cachedNode = moveToNextRow().getNode(defaultSelectorIndex);
-            Node node = context.getNode(cachedNode);
-            return node;
+            return context.getNode(cachedNode);
         }
 
         @Override


### PR DESCRIPTION
This is a similar fix as the one from the 3.x branch, but it's **not fully functional** because the fact that the query result iterators rely on `Batch` & `Sequence` makes it impossible atm to correctly implement them taking into account JCR permissions.

The updated `JcrQueryManagerTest` contains a permissions-related test case which will fail exposing this issue.
