### PR TITLE
Create test case for MODE-2122 demonstrating failed persistence of generated namespaces

### DIFF
--- a/modeshape-jcr/src/test/java/org/modeshape/jcr/RepositoryPersistenceTest.java
+++ b/modeshape-jcr/src/test/java/org/modeshape/jcr/RepositoryPersistenceTest.java
@@ -18,8 +18,10 @@ package org.modeshape.jcr;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsNull.notNullValue;
 import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
+
 import java.io.File;
 import java.net.URISyntaxException;
 import java.net.URL;
@@ -31,12 +33,14 @@ import javax.jcr.Binary;
 import javax.jcr.Node;
 import javax.jcr.NodeIterator;
 import javax.jcr.Session;
+import javax.jcr.nodetype.NodeType;
 import javax.jcr.query.Query;
 import javax.jcr.query.QueryResult;
 import org.junit.Test;
 import org.modeshape.common.util.FileUtil;
 import org.modeshape.common.util.IoUtil;
 import org.modeshape.jcr.api.JcrTools;
+import org.modeshape.jcr.api.NamespaceRegistry;
 
 /**
  * A test the verifies that a repository will persist content (including binaries).
@@ -50,6 +54,59 @@ public class RepositoryPersistenceTest extends MultiPassAbstractTest {
         // remove all persisted content ...
         FileUtil.delete(persistentFolder);
         assertDataPersistenceAcrossRestarts(repositoryConfigFile);
+    }
+
+    @Test
+    public void shouldPersistGeneratedNamespacesAcrossRestart() throws Exception {
+        String repositoryConfigFile = "config/repo-config-persistent-cache.json";
+        File persistentFolder = new File("target/persistent_repository");
+        // remove all persisted content ...
+        FileUtil.delete(persistentFolder);
+
+        final JcrTools tools = new JcrTools();
+
+        startRunStop(new RepositoryOperation() {
+
+            @Override
+            public Void call() throws Exception {
+                Session session = repository.login();
+
+                final NamespaceRegistry namespaceRegistry = (NamespaceRegistry)session.getWorkspace().getNamespaceRegistry();
+
+                namespaceRegistry.registerNamespace("info:a#");
+                namespaceRegistry.registerNamespace("info:b#");
+                namespaceRegistry.registerNamespace("info:c#");
+                assertEquals("ns001", namespaceRegistry.getPrefix("info:a#"));
+                assertEquals("ns002", namespaceRegistry.getPrefix("info:b#"));
+                assertEquals("ns003", namespaceRegistry.getPrefix("info:c#"));
+
+                final Node node = session.getRootNode().addNode("ns001:xyz", NodeType.NT_UNSTRUCTURED);
+                node.setProperty("ns002:abc", "abc");
+                node.setProperty("ns003:def", "def");
+
+                session.save();
+                session.logout();
+                return null;
+            }
+        }, repositoryConfigFile);
+
+        startRunStop(new RepositoryOperation() {
+
+            @Override
+            public Void call() throws Exception {
+                Session session = repository.login();
+
+                final NamespaceRegistry namespaceRegistry = (NamespaceRegistry)session.getWorkspace().getNamespaceRegistry();
+
+                assertEquals("ns001", namespaceRegistry.getPrefix("info:a#"));
+                assertEquals("ns002", namespaceRegistry.getPrefix("info:b#"));
+                assertEquals("ns003", namespaceRegistry.getPrefix("info:c#"));
+                session.save();
+                session.logout();
+                return null;
+            }
+        }, repositoryConfigFile);
+
     }
 
     private void assertDataPersistenceAcrossRestarts( String repositoryConfigFile ) throws Exception {


### PR DESCRIPTION
This test fails with the exception:

```
javax.jcr.NamespaceException: There is no namespace with URI "info:a#"
    at org.modeshape.jcr.JcrNamespaceRegistry.getPrefix(JcrNamespaceRegistry.java:145)
    at org.modeshape.jcr.RepositoryPersistenceTest$2.call(RepositoryPersistenceTest.java:101)
    at org.modeshape.jcr.RepositoryPersistenceTest$2.call(RepositoryPersistenceTest.java:93)
    at org.modeshape.jcr.MultiPassAbstractTest.startRunStop(MultiPassAbstractTest.java:53)
    at org.modeshape.jcr.MultiPassAbstractTest.startRunStop(MultiPassAbstractTest.java:42)
    at org.modeshape.jcr.RepositoryPersistenceTest.shouldPersistGeneratedNamespacesAcrossRestart(RepositoryPersistenceTest.java:93)

```
