### PR TITLE
MODE-2212 Corrected the way namespaces are read from storage

### DIFF
--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/ChildReferences.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/ChildReferences.java
@@ -168,7 +168,8 @@ public interface ChildReferences extends Iterable<ChildReference> {
     Iterator<ChildReference> iterator();
 
     /**
-     * Get an iterator over all of the children that have names matching at least one of the supplied patterns.
+     * Get an iterator over all of the children that have {@link Segment#getName() names} (excluding same-name-sibling indexes)
+     * matching at least one of the supplied patterns.
      * 
      * @param namePatterns the list of string literals or regex patterns describing the names
      * @param registry the namespace registry, used to convert names to a form compatible with the name patterns
@@ -186,9 +187,9 @@ public interface ChildReferences extends Iterable<ChildReference> {
     Iterator<ChildReference> iterator( Context context );
 
     /**
-     * Get an iterator over all of the children that have names matching at least one of the supplied patterns, using the supplied
-     * context. The resulting iterator is lazy where possible, but it may be an expensive call if there are large numbers of
-     * children.
+     * Get an iterator over all of the children that have {@link Segment#getName() names} (excluding same-name-sibling indexes)
+     * matching at least one of the supplied patterns, using the supplied context. The resulting iterator is lazy where possible,
+     * but it may be an expensive call if there are large numbers of children.
      * 
      * @param context the context in which the child should be evaluated; may be null if there is no context
      * @param namePatterns the list of string literals or regex patterns describing the names
@@ -314,8 +315,8 @@ public interface ChildReferences extends Iterable<ChildReference> {
 
         /**
          * Get the number of child references that were inserted with the given name.
-         *
-         * @param  name the {@link Name} of a child, never {@code null}
+         * 
+         * @param name the {@link Name} of a child, never {@code null}
          * @return the number of inserted child references which have the given name; never negative
          */
         int insertionCount( Name name );

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/document/AbstractChildReferences.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/document/AbstractChildReferences.java
@@ -62,6 +62,11 @@ public abstract class AbstractChildReferences implements ChildReferences {
     }
 
     @Override
+    public Iterator<ChildReference> iterator() {
+        return iterator(new BasicContext());
+    }
+
+    @Override
     public Iterator<ChildReference> iterator( Name name,
                                               Context context ) {
         return contextSensitiveIterator(iterator(name), context);
@@ -175,12 +180,7 @@ public abstract class AbstractChildReferences implements ChildReferences {
     @Override
     public Iterator<ChildReference> iterator( Collection<?> namePatterns,
                                               final NamespaceRegistry registry ) {
-        return new PatternIterator<ChildReference>(iterator(), namePatterns) {
-            @Override
-            protected String matchable( ChildReference value ) {
-                return value.getSegmentAsString(registry);
-            }
-        };
+        return iterator(new BasicContext(), namePatterns, registry);
     }
 
     @Override
@@ -190,7 +190,8 @@ public abstract class AbstractChildReferences implements ChildReferences {
         return new PatternIterator<ChildReference>(iterator(context), namePatterns) {
             @Override
             protected String matchable( ChildReference value ) {
-                return value.getSegmentAsString(registry);
+                // We only want the **name** excluding same-name-siblings ...
+                return value.getName().getString(registry);
             }
         };
     }

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/document/ImmutableChildReferences.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/document/ImmutableChildReferences.java
@@ -348,12 +348,12 @@ public class ImmutableChildReferences {
 
         @Override
         public Iterator<ChildReference> iterator( Name name ) {
-            return childReferences.get(name).iterator();
+            return contextSensitiveIterator(childReferences.get(name).iterator(), new BasicContext());
         }
 
         @Override
         public Iterator<ChildReference> iterator() {
-            return childReferences.values().iterator();
+            return contextSensitiveIterator(childReferences.values().iterator(), new BasicContext());
         }
 
         @Override
@@ -460,11 +460,12 @@ public class ImmutableChildReferences {
         }
 
         @Override
-        public Iterator<ChildReference> iterator( final Name name ) {
+        public Iterator<ChildReference> iterator( final Name name,
+                                                  final Context context ) {
             final Segment firstSegment = this.firstSegment;
             return new Iterator<ChildReference>() {
                 private Segment segment = firstSegment;
-                private Iterator<ChildReference> iter = segment != null ? segment.getReferences().iterator(name) : ImmutableChildReferences.EMPTY_ITERATOR;
+                private Iterator<ChildReference> iter = segment != null ? segment.getReferences().iterator(name, context) : ImmutableChildReferences.EMPTY_ITERATOR;
                 private ChildReference next;
 
                 @Override
@@ -477,7 +478,7 @@ public class ImmutableChildReferences {
                         while (segment != null) {
                             segment = segment.next(cache);
                             if (segment != null) {
-                                iter = segment.getReferences().iterator(name);
+                                iter = segment.getReferences().iterator(name, context);
                                 if (iter.hasNext()) {
                                     next = iter.next();
                                     return true;
@@ -511,11 +512,11 @@ public class ImmutableChildReferences {
         }
 
         @Override
-        public Iterator<ChildReference> iterator() {
+        public Iterator<ChildReference> iterator( final Context context ) {
             final Segment firstSegment = this.firstSegment;
             return new Iterator<ChildReference>() {
                 private Segment segment = firstSegment;
-                private Iterator<ChildReference> iter = segment != null ? segment.getReferences().iterator() : ImmutableChildReferences.EMPTY_ITERATOR;
+                private Iterator<ChildReference> iter = segment != null ? segment.getReferences().iterator(context) : ImmutableChildReferences.EMPTY_ITERATOR;
                 private ChildReference next;
 
                 @Override
@@ -528,7 +529,7 @@ public class ImmutableChildReferences {
                         while (segment != null) {
                             segment = segment.next(cache);
                             if (segment != null) {
-                                iter = segment.getReferences().iterator();
+                                iter = segment.getReferences().iterator(context);
                                 if (iter.hasNext()) {
                                     next = iter.next();
                                     return true;
@@ -682,6 +683,18 @@ public class ImmutableChildReferences {
         @Override
         public Iterator<ChildReference> iterator() {
             return new UnionIterator<ChildReference>(internalReferences.iterator(), externalReferences);
+        }
+
+        @Override
+        public Iterator<ChildReference> iterator( final Name name ) {
+            final ChildReferences extRefs = externalReferences;
+            Iterable<ChildReference> second = new Iterable<ChildReference>() {
+                @Override
+                public Iterator<ChildReference> iterator() {
+                    return extRefs.iterator(name);
+                }
+            };
+            return new UnionIterator<ChildReference>(internalReferences.iterator(name), second);
         }
 
         @Override

--- a/modeshape-jcr/src/test/java/org/modeshape/jcr/RepositoryPersistenceTest.java
+++ b/modeshape-jcr/src/test/java/org/modeshape/jcr/RepositoryPersistenceTest.java
@@ -21,7 +21,6 @@ import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
-
 import java.io.File;
 import java.net.URISyntaxException;
 import java.net.URL;
@@ -37,6 +36,7 @@ import javax.jcr.nodetype.NodeType;
 import javax.jcr.query.Query;
 import javax.jcr.query.QueryResult;
 import org.junit.Test;
+import org.modeshape.common.FixFor;
 import org.modeshape.common.util.FileUtil;
 import org.modeshape.common.util.IoUtil;
 import org.modeshape.jcr.api.JcrTools;
@@ -56,14 +56,13 @@ public class RepositoryPersistenceTest extends MultiPassAbstractTest {
         assertDataPersistenceAcrossRestarts(repositoryConfigFile);
     }
 
+    @FixFor( "MODE-2212" )
     @Test
     public void shouldPersistGeneratedNamespacesAcrossRestart() throws Exception {
         String repositoryConfigFile = "config/repo-config-persistent-cache.json";
         File persistentFolder = new File("target/persistent_repository");
         // remove all persisted content ...
         FileUtil.delete(persistentFolder);
-
-        final JcrTools tools = new JcrTools();
 
         startRunStop(new RepositoryOperation() {
 
@@ -121,7 +120,6 @@ public class RepositoryPersistenceTest extends MultiPassAbstractTest {
             assertThat(testFile.getPath() + " should be readable", testFile.canRead(), is(true));
             testFileSizesInBytes.put(testFile.getName(), testFile.length());
         }
-
 
         final JcrTools tools = new JcrTools();
 
@@ -202,7 +200,7 @@ public class RepositoryPersistenceTest extends MultiPassAbstractTest {
 
     @Test
     public void shouldPersistDataUsingDB() throws Exception {
-        //make sure the DB is clean (empty) when running this test; there is no effective teardown
+        // make sure the DB is clean (empty) when running this test; there is no effective teardown
         assertDataPersistenceAcrossRestarts("config/db/repo-config-jdbc.json");
     }
 


### PR DESCRIPTION
Corrected the behavior in the way that ChildReferences.iterator() works; this wasn't noticed before because we rarely use this method (most of the time we look up children by key). Also used @cbeer's test case demonstrating failed persistence of generated namespaces, which now passes.
