### PR TITLE
MODE-2208 Added RBAC for ModeShape's root resource and sensitive security-related attributes.

### DIFF
--- a/deploy/jbossas/kit/jboss-eap/domain/configuration/domain-modeshape.xml
+++ b/deploy/jbossas/kit/jboss-eap/domain/configuration/domain-modeshape.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<domain xmlns="urn:jboss:domain:1.4">
+<domain xmlns="urn:jboss:domain:1.5">
     <extensions>
         <extension module="org.jboss.as.clustering.infinispan"/>
         <extension module="org.jboss.as.clustering.jgroups"/>
@@ -37,6 +37,17 @@
         <!-- IPv4 is not required, but setting this helps avoid unintended use of IPv6 -->
         <property name="java.net.preferIPv4Stack" value="true"/>
     </system-properties>
+    <management>
+        <access-control provider="simple">
+            <role-mapping>
+                <role name="SuperUser">
+                    <include>
+                        <user name="$local"/>
+                    </include>
+                </role>
+            </role-mapping>
+        </access-control>
+    </management>
     <profiles>
         <profile name="default">
             <subsystem xmlns="urn:jboss:domain:logging:1.2">

--- a/deploy/jbossas/kit/jboss-eap/standalone/configuration/standalone-modeshape-ha.xml
+++ b/deploy/jbossas/kit/jboss-eap/standalone/configuration/standalone-modeshape-ha.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<server xmlns="urn:jboss:domain:1.4">
+<server xmlns="urn:jboss:domain:1.5">
     <extensions>
         <extension module="org.jboss.as.clustering.infinispan"/>
         <extension module="org.jboss.as.clustering.jgroups"/>
@@ -54,6 +54,15 @@
                 <socket-binding http="management-http"/>
             </http-interface>
         </management-interfaces>
+        <access-control provider="simple">
+            <role-mapping>
+                <role name="SuperUser">
+                    <include>
+                        <user name="$local"/>
+                    </include>
+                </role>
+            </role-mapping>
+        </access-control>
     </management>
     <profile>
         <subsystem xmlns="urn:jboss:domain:logging:1.2">

--- a/deploy/jbossas/kit/jboss-eap/standalone/configuration/standalone-modeshape.xml
+++ b/deploy/jbossas/kit/jboss-eap/standalone/configuration/standalone-modeshape.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<server xmlns="urn:jboss:domain:1.4">
+<server xmlns="urn:jboss:domain:1.5">
     <extensions>
         <extension module="org.jboss.as.clustering.infinispan"/>
         <extension module="org.jboss.as.configadmin"/>
@@ -54,6 +54,15 @@
                 <socket-binding http="management-http"/>
             </http-interface>
         </management-interfaces>
+        <access-control provider="simple">
+            <role-mapping>
+                <role name="SuperUser">
+                    <include>
+                        <user name="$local"/>
+                    </include>
+                </role>
+            </role-mapping>
+        </access-control>
     </management>
     <profile>
         <subsystem xmlns="urn:jboss:domain:logging:1.1">

--- a/deploy/jbossas/modeshape-jbossas-subsystem/src/main/java/org/modeshape/jboss/subsystem/MappedAttributeDefinitionBuilder.java
+++ b/deploy/jbossas/modeshape-jbossas-subsystem/src/main/java/org/modeshape/jboss/subsystem/MappedAttributeDefinitionBuilder.java
@@ -29,6 +29,7 @@ import java.util.List;
 import org.jboss.as.controller.ParameterCorrector;
 import org.jboss.as.controller.SimpleAttributeDefinition;
 import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
+import org.jboss.as.controller.access.management.AccessConstraintDefinition;
 import org.jboss.as.controller.client.helpers.MeasurementUnit;
 import org.jboss.as.controller.operations.validation.ParameterValidator;
 import org.jboss.as.controller.registry.AttributeAccess.Flag;
@@ -151,6 +152,11 @@ public class MappedAttributeDefinitionBuilder extends SimpleAttributeDefinitionB
 
     public MappedAttributeDefinitionBuilder setFieldPathInRepositoryConfiguration( String... pathToField ) {
         configPath = Collections.unmodifiableList(Arrays.asList(pathToField));
+        return this;
+    }
+
+    public MappedAttributeDefinitionBuilder setAccessConstraints(AccessConstraintDefinition...constraints) {
+        super.setAccessConstraints(constraints);
         return this;
     }
 

--- a/deploy/jbossas/modeshape-jbossas-subsystem/src/main/java/org/modeshape/jboss/subsystem/MappedListAttributeDefinition.java
+++ b/deploy/jbossas/modeshape-jbossas-subsystem/src/main/java/org/modeshape/jboss/subsystem/MappedListAttributeDefinition.java
@@ -37,6 +37,7 @@ import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.SimpleAttributeDefinition;
 import org.jboss.as.controller.SimpleListAttributeDefinition;
+import org.jboss.as.controller.access.management.AccessConstraintDefinition;
 import org.jboss.as.controller.client.helpers.MeasurementUnit;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.controller.descriptions.ResourceDescriptionResolver;
@@ -403,6 +404,11 @@ public class MappedListAttributeDefinition extends ListAttributeDefinition imple
 
         public Builder setFieldPathInRepositoryConfiguration( String... pathToField ) {
             configPath = Collections.unmodifiableList(Arrays.asList(pathToField));
+            return this;
+        }
+
+        public Builder setAccessConstraints(AccessConstraintDefinition...constraints) {
+            builder.setAccessConstraints(constraints);
             return this;
         }
     }

--- a/deploy/jbossas/modeshape-jbossas-subsystem/src/main/java/org/modeshape/jboss/subsystem/ModeShapeRootResource.java
+++ b/deploy/jbossas/modeshape-jbossas-subsystem/src/main/java/org/modeshape/jboss/subsystem/ModeShapeRootResource.java
@@ -23,8 +23,12 @@
  */
 package org.modeshape.jboss.subsystem;
 
+import java.util.List;
 import org.jboss.as.controller.ReloadRequiredRemoveStepHandler;
 import org.jboss.as.controller.SimpleResourceDefinition;
+import org.jboss.as.controller.access.constraint.SensitivityClassification;
+import org.jboss.as.controller.access.management.AccessConstraintDefinition;
+import org.jboss.as.controller.access.management.SensitiveTargetAccessConstraintDefinition;
 import org.jboss.as.controller.operations.common.GenericSubsystemDescribeHandler;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
 
@@ -33,6 +37,18 @@ import org.jboss.as.controller.registry.ManagementResourceRegistration;
  */
 public class ModeShapeRootResource extends SimpleResourceDefinition {
     protected final static ModeShapeRootResource INSTANCE = new ModeShapeRootResource();
+
+    /**
+     * Set the default ModeShape RBAC access as follows:
+     *  Addressing is not sensitive: any management user can address (i.e. read the configuration)
+     *  Read is sensitive: only Auditor, Administrator, SuperUser can read attributes, resources etc.
+     *  Write is sensitive: only Administrator and SuperUser can write
+     */
+    protected static final SensitivityClassification MODESHAPE_SECURITY =
+            new SensitivityClassification(ModeShapeExtension.SUBSYSTEM_NAME, "modeshape-access-control", false, true, true);
+    protected static final SensitiveTargetAccessConstraintDefinition MODESHAPE_SECURITY_DEF =
+            new SensitiveTargetAccessConstraintDefinition(MODESHAPE_SECURITY);
+
 
     private ModeShapeRootResource() {
         super(ModeShapeExtension.SUBSYSTEM_PATH, ModeShapeExtension.getResourceDescriptionResolver(),
@@ -45,5 +61,10 @@ public class ModeShapeRootResource extends SimpleResourceDefinition {
         resourceRegistration.registerOperationHandler(GenericSubsystemDescribeHandler.DEFINITION,
                                                       GenericSubsystemDescribeHandler.INSTANCE,
                                                       false);
+    }
+
+    @Override
+    public List<AccessConstraintDefinition> getAccessConstraints() {
+        return MODESHAPE_SECURITY_DEF.wrapAsList();
     }
 }

--- a/deploy/jbossas/modeshape-jbossas-subsystem/src/main/java/org/modeshape/jboss/subsystem/ModelAttributes.java
+++ b/deploy/jbossas/modeshape-jbossas-subsystem/src/main/java/org/modeshape/jboss/subsystem/ModelAttributes.java
@@ -29,6 +29,7 @@ import org.jboss.as.controller.ListAttributeDefinition;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.SimpleAttributeDefinition;
 import org.jboss.as.controller.SimpleListAttributeDefinition;
+import org.jboss.as.controller.access.management.SensitiveTargetAccessConstraintDefinition;
 import org.jboss.as.controller.client.helpers.MeasurementUnit;
 import org.jboss.as.controller.operations.validation.EnumValidator;
 import org.jboss.as.controller.operations.validation.ModelTypeValidator;
@@ -157,13 +158,16 @@ public class ModelAttributes {
                                                                                                                                                                                                  .add(new ModelNode().set(ModeShapeRoles.READWRITE)))
                                                                                                                                                                  .setValidator(ROLE_NAME_VALIDATOR)
                                                                                                                                                                  .setFlags(AttributeAccess.Flag.RESTART_NONE)
+                                                                                                                                                                 .setAccessConstraints(SensitiveTargetAccessConstraintDefinition.SECURITY_DOMAIN_REF)
                                                                                                                                                                  .build())
                                                                                                        .setAllowNull(true)
                                                                                                        .setMinSize(0)
                                                                                                        .setMaxSize(100)
-                                                                                                       .setFieldPathInRepositoryConfiguration(FieldName.SECURITY,
-                                                                                                                                              FieldName.ANONYMOUS,
-                                                                                                                                              FieldName.ANONYMOUS_ROLES)
+                                                                                                       .setFieldPathInRepositoryConfiguration(
+                                                                                                               FieldName.SECURITY,
+                                                                                                               FieldName.ANONYMOUS,
+                                                                                                               FieldName.ANONYMOUS_ROLES)
+                                                                                                       .setAccessConstraints(SensitiveTargetAccessConstraintDefinition.SECURITY_DOMAIN_REF)
                                                                                                        .build();
 
     public static final SimpleAttributeDefinition ANONYMOUS_USERNAME = new MappedAttributeDefinitionBuilder(
@@ -173,6 +177,7 @@ public class ModelAttributes {
                                                                                                                              .setAllowNull(true)
                                                                                                                              .setDefaultValue(new ModelNode().set("<anonymous>"))
                                                                                                                              .setFlags(AttributeAccess.Flag.RESTART_NONE)
+                                                                                                                             .setAccessConstraints(SensitiveTargetAccessConstraintDefinition.SECURITY_DOMAIN_REF)
                                                                                                                              .setFieldPathInRepositoryConfiguration(FieldName.SECURITY,
                                                                                                                                                                     FieldName.ANONYMOUS,
                                                                                                                                                                     FieldName.ANONYMOUS_USERNAME)
@@ -786,6 +791,7 @@ public class ModelAttributes {
                                                                                                                           .setAllowNull(true)
                                                                                                                           .setDefaultValue(new ModelNode().set("modeshape-security"))
                                                                                                                           .setFlags(AttributeAccess.Flag.RESTART_NONE)
+                                                                                                                          .setAccessConstraints(SensitiveTargetAccessConstraintDefinition.SECURITY_DOMAIN_REF)
                                                                                                                           .setFieldPathInRepositoryConfiguration(FieldName.SECURITY,
                                                                                                                                                                  FieldName.JAAS,
                                                                                                                                                                  FieldName.JAAS_POLICY_NAME)
@@ -822,6 +828,7 @@ public class ModelAttributes {
                                                                                                                                         .setAllowNull(true)
                                                                                                                                         .setDefaultValue(new ModelNode().set(false))
                                                                                                                                         .setFlags(AttributeAccess.Flag.RESTART_NONE)
+                                                                                                                                        .setAccessConstraints(SensitiveTargetAccessConstraintDefinition.SECURITY_DOMAIN_REF)
                                                                                                                                         .setFieldPathInRepositoryConfiguration(FieldName.SECURITY,
                                                                                                                                                                                FieldName.ANONYMOUS,
                                                                                                                                                                                FieldName.USE_ANONYMOUS_ON_FAILED_LOGINS)

--- a/integration/modeshape-jbossas-integration-tests/src/main/resources/kit/jboss-eap/standalone/configuration/standalone-modeshape.xml
+++ b/integration/modeshape-jbossas-integration-tests/src/main/resources/kit/jboss-eap/standalone/configuration/standalone-modeshape.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<server xmlns="urn:jboss:domain:1.4">
+<server xmlns="urn:jboss:domain:1.5">
     <extensions>
         <extension module="org.jboss.as.clustering.infinispan"/>
         <extension module="org.jboss.as.clustering.jgroups"/>
@@ -56,6 +56,15 @@
                 <socket-binding http="management-http"/>
             </http-interface>
         </management-interfaces>
+        <access-control provider="simple">
+            <role-mapping>
+                <role name="SuperUser">
+                    <include>
+                        <user name="$local"/>
+                    </include>
+                </role>
+            </role-mapping>
+        </access-control>
     </management>
     <profile>
         <subsystem xmlns="urn:jboss:domain:logging:1.1">

--- a/modeshape-jcr/src/test/java/org/modeshape/jcr/JcrSessionTest.java
+++ b/modeshape-jcr/src/test/java/org/modeshape/jcr/JcrSessionTest.java
@@ -1233,11 +1233,13 @@ public class JcrSessionTest extends SingleUseAbstractTest {
         contentNode.setProperty("jcr:data", session().getValueFactory().createBinary("test".getBytes()));
 
         session().save();
+        Thread.sleep(200);
 
         queryAndExpectResults("SELECT * FROM [nt:file] WHERE [jcr:path] LIKE '/folder/%'", 1);
 
         folder.getSession().move(folder.getPath(), "/folder_1");
         folder.getSession().save();
+        Thread.sleep(200);
 
         queryAndExpectResults("SELECT * FROM [nt:file] WHERE [jcr:path] LIKE '/folder_1/%'", 1);
     }


### PR DESCRIPTION
The following elements were configured as sensitive:
- `ModeShapeRootResource` - which should be inherited by all children resources & attributes
- the attributes: `security-domain`, `anonymous-roles`, `anonymous-username` and `use-anonymous-upon-failed-authentication` were classified as `SECURITY_DOMAIN_REF` sensitive, as they all pertain to the authentication & authorization aspect.
