### PR TITLE
MODE-2208-wildfly Added RBAC for ModeShape's root resource and sensitive security-related attributes.

### DIFF
--- a/deploy/jbossas/modeshape-jbossas-subsystem/src/main/java/org/modeshape/jboss/subsystem/MappedAttributeDefinitionBuilder.java
+++ b/deploy/jbossas/modeshape-jbossas-subsystem/src/main/java/org/modeshape/jboss/subsystem/MappedAttributeDefinitionBuilder.java
@@ -21,6 +21,7 @@ import java.util.List;
 import org.jboss.as.controller.ParameterCorrector;
 import org.jboss.as.controller.SimpleAttributeDefinition;
 import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
+import org.jboss.as.controller.access.management.AccessConstraintDefinition;
 import org.jboss.as.controller.client.helpers.MeasurementUnit;
 import org.jboss.as.controller.operations.validation.ParameterValidator;
 import org.jboss.as.controller.registry.AttributeAccess.Flag;
@@ -35,30 +36,12 @@ public class MappedAttributeDefinitionBuilder extends SimpleAttributeDefinitionB
     private List<String> configPath;
 
     /**
-     * @param basis
-     */
-    public MappedAttributeDefinitionBuilder( SimpleAttributeDefinition basis ) {
-        super(basis);
-    }
-
-    /**
      * @param attributeName
      * @param type
      */
     public MappedAttributeDefinitionBuilder( String attributeName,
                                              ModelType type ) {
         super(attributeName, type);
-    }
-
-    /**
-     * @param attributeName
-     * @param type
-     * @param allowNull
-     */
-    public MappedAttributeDefinitionBuilder( String attributeName,
-                                             ModelType type,
-                                             boolean allowNull ) {
-        super(attributeName, type, allowNull);
     }
 
     @Override
@@ -143,6 +126,11 @@ public class MappedAttributeDefinitionBuilder extends SimpleAttributeDefinitionB
 
     public MappedAttributeDefinitionBuilder setFieldPathInRepositoryConfiguration( String... pathToField ) {
         configPath = Collections.unmodifiableList(Arrays.asList(pathToField));
+        return this;
+    }
+
+    public MappedAttributeDefinitionBuilder setAccessConstraints(AccessConstraintDefinition...constraints) {
+        super.setAccessConstraints(constraints);
         return this;
     }
 

--- a/deploy/jbossas/modeshape-jbossas-subsystem/src/main/java/org/modeshape/jboss/subsystem/MappedListAttributeDefinition.java
+++ b/deploy/jbossas/modeshape-jbossas-subsystem/src/main/java/org/modeshape/jboss/subsystem/MappedListAttributeDefinition.java
@@ -29,6 +29,7 @@ import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.SimpleAttributeDefinition;
 import org.jboss.as.controller.SimpleListAttributeDefinition;
+import org.jboss.as.controller.access.management.AccessConstraintDefinition;
 import org.jboss.as.controller.client.helpers.MeasurementUnit;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.controller.descriptions.ResourceDescriptionResolver;
@@ -401,6 +402,11 @@ public class MappedListAttributeDefinition extends ListAttributeDefinition imple
 
         public Builder setFieldPathInRepositoryConfiguration( String... pathToField ) {
             configPath = Collections.unmodifiableList(Arrays.asList(pathToField));
+            return this;
+        }
+
+        public Builder setAccessConstraints(AccessConstraintDefinition...constraints) {
+            builder.setAccessConstraints(constraints);
             return this;
         }
     }

--- a/deploy/jbossas/modeshape-jbossas-subsystem/src/main/java/org/modeshape/jboss/subsystem/ModeShapeRootResource.java
+++ b/deploy/jbossas/modeshape-jbossas-subsystem/src/main/java/org/modeshape/jboss/subsystem/ModeShapeRootResource.java
@@ -15,8 +15,12 @@
  */
 package org.modeshape.jboss.subsystem;
 
+import java.util.List;
 import org.jboss.as.controller.ReloadRequiredRemoveStepHandler;
 import org.jboss.as.controller.SimpleResourceDefinition;
+import org.jboss.as.controller.access.constraint.SensitivityClassification;
+import org.jboss.as.controller.access.management.AccessConstraintDefinition;
+import org.jboss.as.controller.access.management.SensitiveTargetAccessConstraintDefinition;
 import org.jboss.as.controller.operations.common.GenericSubsystemDescribeHandler;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
 
@@ -25,6 +29,18 @@ import org.jboss.as.controller.registry.ManagementResourceRegistration;
  */
 public class ModeShapeRootResource extends SimpleResourceDefinition {
     protected final static ModeShapeRootResource INSTANCE = new ModeShapeRootResource();
+
+    /**
+     * Set the default ModeShape RBAC access as follows:
+     *  Addressing is not sensitive: any management user can address (i.e. read the configuration)
+     *  Read is sensitive: only Auditor, Administrator, SuperUser can read attributes, resources etc.
+     *  Write is sensitive: only Administrator and SuperUser can write
+     */
+    protected static final SensitivityClassification MODESHAPE_SECURITY =
+            new SensitivityClassification(ModeShapeExtension.SUBSYSTEM_NAME, "modeshape-access-control", false, true, true);
+    protected static final SensitiveTargetAccessConstraintDefinition MODESHAPE_SECURITY_DEF =
+            new SensitiveTargetAccessConstraintDefinition(MODESHAPE_SECURITY);
+
 
     private ModeShapeRootResource() {
         super(ModeShapeExtension.SUBSYSTEM_PATH, ModeShapeExtension.getResourceDescriptionResolver(),
@@ -37,5 +53,10 @@ public class ModeShapeRootResource extends SimpleResourceDefinition {
         resourceRegistration.registerOperationHandler(GenericSubsystemDescribeHandler.DEFINITION,
                                                       GenericSubsystemDescribeHandler.INSTANCE,
                                                       false);
+    }
+
+    @Override
+    public List<AccessConstraintDefinition> getAccessConstraints() {
+        return MODESHAPE_SECURITY_DEF.wrapAsList();
     }
 }

--- a/deploy/jbossas/modeshape-jbossas-subsystem/src/main/java/org/modeshape/jboss/subsystem/ModelAttributes.java
+++ b/deploy/jbossas/modeshape-jbossas-subsystem/src/main/java/org/modeshape/jboss/subsystem/ModelAttributes.java
@@ -21,6 +21,7 @@ import org.jboss.as.controller.ListAttributeDefinition;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.SimpleAttributeDefinition;
 import org.jboss.as.controller.SimpleListAttributeDefinition;
+import org.jboss.as.controller.access.management.SensitiveTargetAccessConstraintDefinition;
 import org.jboss.as.controller.client.helpers.MeasurementUnit;
 import org.jboss.as.controller.operations.validation.EnumValidator;
 import org.jboss.as.controller.operations.validation.ModelTypeValidator;
@@ -93,13 +94,16 @@ public class ModelAttributes {
                                                                                                                                                                                                  .add(new ModelNode().set(ModeShapeRoles.READWRITE)))
                                                                                                                                                                  .setValidator(ROLE_NAME_VALIDATOR)
                                                                                                                                                                  .setFlags(AttributeAccess.Flag.RESTART_NONE)
+                                                                                                                                                                 .setAccessConstraints(SensitiveTargetAccessConstraintDefinition.SECURITY_DOMAIN_REF)
                                                                                                                                                                  .build())
                                                                                                        .setAllowNull(true)
                                                                                                        .setMinSize(0)
                                                                                                        .setMaxSize(100)
-                                                                                                       .setFieldPathInRepositoryConfiguration(FieldName.SECURITY,
-                                                                                                                                              FieldName.ANONYMOUS,
-                                                                                                                                              FieldName.ANONYMOUS_ROLES)
+                                                                                                       .setFieldPathInRepositoryConfiguration(
+                                                                                                               FieldName.SECURITY,
+                                                                                                               FieldName.ANONYMOUS,
+                                                                                                               FieldName.ANONYMOUS_ROLES)
+                                                                                                       .setAccessConstraints(SensitiveTargetAccessConstraintDefinition.SECURITY_DOMAIN_REF)
                                                                                                        .build();
 
     public static final SimpleAttributeDefinition ANONYMOUS_USERNAME = new MappedAttributeDefinitionBuilder(
@@ -109,6 +113,7 @@ public class ModelAttributes {
                                                                                                                              .setAllowNull(true)
                                                                                                                              .setDefaultValue(new ModelNode().set("<anonymous>"))
                                                                                                                              .setFlags(AttributeAccess.Flag.RESTART_NONE)
+                                                                                                                             .setAccessConstraints(SensitiveTargetAccessConstraintDefinition.SECURITY_DOMAIN_REF)
                                                                                                                              .setFieldPathInRepositoryConfiguration(FieldName.SECURITY,
                                                                                                                                                                     FieldName.ANONYMOUS,
                                                                                                                                                                     FieldName.ANONYMOUS_USERNAME)
@@ -551,6 +556,7 @@ public class ModelAttributes {
                                                                                                                           .setAllowNull(true)
                                                                                                                           .setDefaultValue(new ModelNode().set("modeshape-security"))
                                                                                                                           .setFlags(AttributeAccess.Flag.RESTART_NONE)
+                                                                                                                          .setAccessConstraints(SensitiveTargetAccessConstraintDefinition.SECURITY_DOMAIN_REF)
                                                                                                                           .setFieldPathInRepositoryConfiguration(FieldName.SECURITY,
                                                                                                                                                                  FieldName.JAAS,
                                                                                                                                                                  FieldName.JAAS_POLICY_NAME)
@@ -579,6 +585,7 @@ public class ModelAttributes {
                                                                                                                                         .setAllowNull(true)
                                                                                                                                         .setDefaultValue(new ModelNode().set(false))
                                                                                                                                         .setFlags(AttributeAccess.Flag.RESTART_NONE)
+                                                                                                                                        .setAccessConstraints(SensitiveTargetAccessConstraintDefinition.SECURITY_DOMAIN_REF)
                                                                                                                                         .setFieldPathInRepositoryConfiguration(FieldName.SECURITY,
                                                                                                                                                                                FieldName.ANONYMOUS,
                                                                                                                                                                                FieldName.USE_ANONYMOUS_ON_FAILED_LOGINS)


### PR DESCRIPTION
The following elements were configured as sensitive:
- `ModeShapeRootResource` - which should be inherited by all children resources & attributes
- the attributes: `security-domain`, `anonymous-roles`, `anonymous-username` and `use-anonymous-upon-failed-authentication` were classified as `SECURITY_DOMAIN_REF` sensitive, as they all pertain to the authentication & authorization aspect.
