### PR TITLE
MODE-2174 JCR Query empty string in comparison

### DIFF
--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/query/process/AbstractAccessComponent.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/query/process/AbstractAccessComponent.java
@@ -23,9 +23,6 @@
  */
 package org.modeshape.jcr.query.process;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
 import org.modeshape.jcr.query.QueryContext;
 import org.modeshape.jcr.query.QueryResults.Columns;
 import org.modeshape.jcr.query.QueryResults.Location;
@@ -38,6 +35,9 @@ import org.modeshape.jcr.query.plan.PlanNode.Property;
 import org.modeshape.jcr.query.plan.PlanNode.Type;
 import org.modeshape.jcr.query.validate.Schemata;
 
+import java.util.ArrayList;
+import java.util.List;
+
 /**
  * A reusable base class for {@link ProcessingComponent} implementations that does everything except obtain the correct
  * {@link Location} objects for the query results.
@@ -48,6 +48,7 @@ public abstract class AbstractAccessComponent extends ProcessingComponent {
     protected final SelectorName sourceName;
     protected final List<Column> projectedColumns;
     protected final List<Constraint> andedConstraints;
+	protected final List<Constraint> postConstraints;
     protected final Limit limit;
 
     protected AbstractAccessComponent( QueryContext context,
@@ -92,14 +93,18 @@ public abstract class AbstractAccessComponent extends ProcessingComponent {
         assert this.projectedColumns != null;
 
         // Add the criteria ...
-        List<Constraint> andedConstraints = null;
+        LuceneQueryDistributor distributor = new LuceneQueryDistributor(columns);
         for (PlanNode select : accessNode.findAllAtOrBelow(Type.SELECT)) {
             Constraint selectConstraint = select.getProperty(Property.SELECT_CRITERIA, Constraint.class);
-            if (andedConstraints == null) andedConstraints = new ArrayList<Constraint>();
-            andedConstraints.add(selectConstraint);
+
+			distributor.distribute(selectConstraint);
         }
-        this.andedConstraints = andedConstraints != null ? andedConstraints : Collections.<Constraint>emptyList();
+
+        this.andedConstraints = distributor.getLuceneConstraints();
         assert this.andedConstraints != null;
+
+		this.postConstraints = distributor.getPostConstraints();
+		assert this.postConstraints != null;
 
         // Find the limit ...
         Limit limit = Limit.NONE;

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/query/process/LuceneQueryDistributor.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/query/process/LuceneQueryDistributor.java
@@ -1,0 +1,170 @@
+package org.modeshape.jcr.query.process;
+
+import org.modeshape.jcr.api.query.qom.Operator;
+import org.modeshape.jcr.query.QueryResults;
+import org.modeshape.jcr.query.model.*;
+
+import javax.jcr.query.qom.QueryObjectModelConstants;
+import javax.jcr.query.qom.StaticOperand;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Helper class to avoid entering queries with empty strings into Lucene<br/>
+ * See issue <a href="https://issues.jboss.org/browse/MODE-2174">MODE-2174</a>
+ * @author: vadym.karko
+ * @since: 3/31/14 1:47 PM
+ */
+public class LuceneQueryDistributor
+{
+	/**
+	 * Define places in query according to position in query
+	 * <table>
+	 *     <tr><td><b>EQUALS</b></td><td><code>SELECT &#8230 WHERE x = ''</code></td></tr>
+	 *     <tr><td><b>NULL</b></td><td><code>SELECT &#8230 WHERE x IS NULL</code></td></tr>
+	 *     <tr><td><b>LENGTH</b></td><td><code>SELECT &#8230 WHERE LENGTH(x) = 0</code></td></tr>
+	 *     <tr><td><b>IN</b></td><td><code>SELECT &#8230 WHERE x IN (&#8230, '', &#8230)</code></td></tr>
+	 *     <tr><td><b>OR</b></td><td><code>SELECT &#8230 WHERE x = '' OR &#8230</code></td></tr>
+	 *     <tr><td><b>NOWHERE</b></td><td> none of mentioned above</td></tr>
+	 * </table>
+	 */
+	private enum ContainsEmpty {EQUALS, NULL, LENGTH, IN, OR, NOWHERE}
+
+	List<Constraint> luceneConstraints = null;
+	List<Constraint> postConstraints = null;
+	QueryResults.Columns columns;
+
+
+	public LuceneQueryDistributor(QueryResults.Columns columns)
+	{
+		this.columns = columns;
+	}
+
+	/**
+	 * Distributes constraint directly in Lucene or post process.<br/>
+	 * Add constraint in prepared constraints (<code>luceneConstraints</code>) if it has no empty strings,
+	 * otherwise in post processing constraints (<code>postConstraints</code>)
+	 * @param constraint constraint that should be distributed
+	 */
+	public void distribute(Constraint constraint)
+	{
+		switch (isQueryContainsEmpty(constraint))
+		{
+			case EQUALS:	// ... WHERE x = ''
+			case NULL:		// ... WHERE x IS NULL
+			case IN: 		// ... WHERE x IN ('')
+			case OR: 		// ... OR ...
+				addPostConstraints(constraint);
+			break;
+
+			case LENGTH:	// ... WHERE LENGTH(x) = 0  <=> ... WHERE x = ''
+				Length length = (Length)((Comparison) constraint).getOperand1();
+
+				Constraint emptyString = new Comparison(
+						new PropertyValue(length.selectorName(), length.getPropertyValue().getPropertyName()),
+						Operator.EQUAL_TO,
+						new Literal("")
+				);
+
+				addPostConstraints(emptyString);
+			break;
+
+			default: addLuceneConstraints(constraint); break;
+		}
+	}
+
+
+	/**
+	 * Checks if query has empty string, and if so, where exactly in query
+	 * @param constraint constraint that should be checked
+	 * @return {@link ContainsEmpty#NOWHERE} if empty string not found
+	 * @see ContainsEmpty
+	 */
+	private ContainsEmpty isQueryContainsEmpty(Constraint constraint)
+	{
+		if (constraint instanceof Comparison)
+		{
+			Comparison comparison = (Comparison)constraint;
+			String value = comparison.getOperand2().toString();
+
+			// ... WHERE x = ''
+			if ("''".equals(value)) return ContainsEmpty.EQUALS;
+
+			// ... WHERE LENGTH(x) = 0
+			if (QueryObjectModelConstants.JCR_OPERATOR_EQUAL_TO.equals(comparison.getOperator()) &&
+				"CAST('0' AS LONG)".equals(value)) return ContainsEmpty.LENGTH;
+		}
+		// ... WHERE x IS NOT NULL
+		else if (constraint instanceof Not)
+		{
+			Not not = (Not)constraint;
+
+			return isQueryContainsEmpty(not.getConstraint());
+		}
+		// ... WHERE x IS NULL
+		else if (constraint instanceof PropertyExistence)
+		{
+			PropertyExistence property = (PropertyExistence)constraint;
+			String column = columns.getColumnTypeForProperty(property.getSelectorName(), property.getPropertyName());
+
+			if ("STRING".equals(column)) return ContainsEmpty.NULL;
+		}
+		// ... WHERE x IN ('')
+		else if (constraint instanceof SetCriteria)
+		{
+			for (StaticOperand operand : ((SetCriteria) constraint).getValues())
+			{
+				if ((operand instanceof Literal) &&	("".equals(((Literal) operand).value().toString()))) return ContainsEmpty.IN;
+			}
+		}
+		// ... OR ...
+		else if (constraint instanceof Or)
+		{
+			Or or = (Or)constraint;
+			Constraint left = or.getConstraint1();
+			Constraint right = or.getConstraint2();
+
+			return ((isQueryContainsEmpty(left) != ContainsEmpty.NOWHERE) ||
+					(isQueryContainsEmpty(right) != ContainsEmpty.NOWHERE)) ? ContainsEmpty.OR : ContainsEmpty.NOWHERE;
+		}
+
+		return ContainsEmpty.NOWHERE;
+	}
+
+	/**
+	 * Pushes constraint into Lucene constraint list
+	 * @param constraint
+	 */
+	private void addLuceneConstraints(Constraint constraint)
+	{
+		if (luceneConstraints == null) luceneConstraints = new ArrayList<Constraint>();
+		luceneConstraints.add(constraint);
+	}
+
+	/**
+	 * Pushes constraint into post constraint list
+	 * @param constraint
+	 */
+	private void addPostConstraints(Constraint constraint)
+	{
+		if (postConstraints == null) postConstraints = new ArrayList<Constraint>();
+		postConstraints.add(constraint);
+	}
+
+	/**
+	 * @return Returns constraint list that should be used in direct Lucene search
+	 */
+	public List<Constraint> getLuceneConstraints()
+	{
+		return luceneConstraints != null ? luceneConstraints : Collections.<Constraint>emptyList();
+	}
+
+	/**
+	 * @return Returns constraint list that should be used in post Lucene search
+	 */
+	public List<Constraint> getPostConstraints()
+	{
+		return postConstraints != null ? postConstraints : Collections.<Constraint>emptyList();
+	}
+}

--- a/modeshape-jcr/src/test/java/org/modeshape/jcr/QueryEmptyStringTest.java
+++ b/modeshape-jcr/src/test/java/org/modeshape/jcr/QueryEmptyStringTest.java
@@ -1,0 +1,343 @@
+package org.modeshape.jcr;
+
+import junit.framework.Assert;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import javax.jcr.Node;
+import javax.jcr.NodeIterator;
+import javax.jcr.RepositoryException;
+import javax.jcr.query.Query;
+import javax.jcr.query.QueryResult;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * See MODE-2174: JCR Query in Modeshape returns no result when empty string used in comparison
+ * @author: vadym.karko
+ * @since: 3/21/14 12:35 PM
+ */
+public class QueryEmptyStringTest extends MultiUseAbstractTest
+{
+	private static final String SQL = "SELECT [jcr:name], [car:model], [car:maker] FROM [car:Car] ";
+
+	@BeforeClass
+	public static void setUp() throws Exception
+	{
+		RepositoryConfiguration config = new RepositoryConfiguration("config/simple-repo-config.json");
+		startRepository(config);
+		registerNodeTypes("cnd/cars.cnd");
+
+		Node root = session.getRootNode();
+		Node item;
+
+		item = root.addNode("Aston Martin", "car:Car");
+		item.setProperty("car:maker", "Aston Martin");
+		item.setProperty("car:model", "DB9");
+
+		item = root.addNode("Infiniti", "car:Car");
+		item.setProperty("car:maker", "Infiniti");
+
+		item = root.addNode("EMPTY", "car:Car");
+		item.setProperty("car:maker", "");
+
+		item = root.addNode("NULL", "car:Car");
+
+		/**
+		 * jcr:name			|	car:maker		|	car:model
+		 * ---------------------------------------------------
+		 * 'Aston Martin'	|	'Aston Martin'	|	'DB9'
+		 * 'Infiniti'		|	'Infiniti'		|	null
+		 * 'EMPTY'			|	''				|	null
+		 * 'NULL'			|	null			|	null
+		 */
+
+		session.save();
+	}
+
+	@AfterClass
+	public static void tearDown() throws Exception
+	{
+		stopRepository();
+	}
+
+	@Before
+	public void before() throws RepositoryException
+	{
+		System.out.println("\nBefore:");
+
+		Query query = session.getWorkspace().getQueryManager().createQuery(SQL, Query.JCR_SQL2);
+		QueryResult result = query.execute();
+
+		printResults(result);
+	}
+
+	private List<String> collectNames(QueryResult result) throws RepositoryException
+	{
+		NodeIterator iterator = result.getNodes();
+		List<String> actual = new ArrayList<String>();
+		while (iterator.hasNext()) actual.add(iterator.nextNode().getName());
+
+		return actual;
+	}
+
+	@Override
+	protected void printResults(QueryResult results)
+	{
+		print = true;
+		super.printResults(results);
+	}
+
+
+	@Test
+	public void shouldEqualsEmpty() throws Exception
+	{
+		String sql = SQL + "WHERE [car:maker] = ''";
+		System.out.println("\nSQL: " + sql);
+
+		Query query = session.getWorkspace().getQueryManager().createQuery(sql, Query.JCR_SQL2);
+		QueryResult result = query.execute();
+
+		printResults(result);
+
+		Assert.assertEquals("Should contains rows", 1, result.getRows().getSize());
+		List<String> actual = collectNames(result);
+		Assert.assertTrue("Should contains EMPTY", actual.contains("EMPTY"));
+	}
+
+	@Test
+	public void shouldIsNotNull() throws Exception
+	{
+		String sql = SQL + "WHERE [car:maker] IS NOT NULL";
+		System.out.println("\nSQL: " + sql +"\n");
+
+		Query query = session.getWorkspace().getQueryManager().createQuery(sql, Query.JCR_SQL2);
+		QueryResult result = query.execute();
+
+		printResults(result);
+
+		Assert.assertEquals("Should contains rows", 3, result.getRows().getSize());
+		List<String> actual = collectNames(result);
+		Assert.assertTrue("Should contains EMPTY", actual.contains("EMPTY"));
+		Assert.assertTrue("Should contains Aston Martin", actual.contains("Aston Martin"));
+		Assert.assertTrue("Should contains Infiniti", actual.contains("Infiniti"));
+	}
+
+	@Test
+	public void shouldIsNull() throws Exception
+	{
+		String sql = SQL + "WHERE [car:maker] IS NULL";
+		System.out.println("\nSQL: " + sql +"\n");
+
+		Query query = session.getWorkspace().getQueryManager().createQuery(sql, Query.JCR_SQL2);
+		QueryResult result = query.execute();
+
+		printResults(result);
+
+		Assert.assertEquals(1, result.getRows().getSize());
+		List<String> actual = collectNames(result);
+		Assert.assertTrue("Should contains NULL", actual.contains("NULL"));
+	}
+
+	@Test
+	public void shouldLengthEqualsZero() throws Exception
+	{
+		String sql = SQL + "WHERE LENGTH([car:maker]) = 0";
+		System.out.println("\nSQL: " + sql +"\n");
+
+		Query query = session.getWorkspace().getQueryManager().createQuery(sql, Query.JCR_SQL2);
+		QueryResult result = query.execute();
+
+		printResults(result);
+
+		Assert.assertEquals(1, result.getRows().getSize());
+		List<String> actual = collectNames(result);
+		Assert.assertTrue("Should contains EMPTY", actual.contains("EMPTY"));
+	}
+
+	@Test
+	public void shouldLikeEmpty() throws Exception
+	{
+		String sql = SQL + "WHERE [car:maker] LIKE ''";
+		System.out.println("\nSQL: " + sql +"\n");
+
+		Query query = session.getWorkspace().getQueryManager().createQuery(sql, Query.JCR_SQL2);
+		QueryResult result = query.execute();
+
+		printResults(result);
+
+		Assert.assertEquals(1, result.getRows().getSize());
+		List<String> actual = collectNames(result);
+		Assert.assertTrue("Should contains EMPTY", actual.contains("EMPTY"));
+	}
+
+	@Test
+	public void shouldInEmpty() throws Exception
+	{
+		String sql = SQL + "WHERE [car:maker] IN ('')";
+		System.out.println("\nSQL: " + sql +"\n");
+
+		Query query = session.getWorkspace().getQueryManager().createQuery(sql, Query.JCR_SQL2);
+		QueryResult result = query.execute();
+
+		printResults(result);
+
+		Assert.assertEquals(1, result.getRows().getSize());
+		List<String> actual = collectNames(result);
+		Assert.assertTrue("Should contains EMPTY", actual.contains("EMPTY"));
+	}
+
+	@Test
+	public void shouldInEmptyAndString() throws Exception
+	{
+		String sql = SQL + "WHERE [car:maker] IN ('Aston Martin', '')";
+		System.out.println("\nSQL: " + sql +"\n");
+
+		Query query = session.getWorkspace().getQueryManager().createQuery(sql, Query.JCR_SQL2);
+		QueryResult result = query.execute();
+
+		printResults(result);
+
+
+		Assert.assertEquals("Should contains rows", 2, result.getRows().getSize());
+		List<String> actual = collectNames(result);
+		Assert.assertTrue("Should contains EMPTY", actual.contains("EMPTY"));
+		Assert.assertTrue("Should contains Aston Martin", actual.contains("Aston Martin"));
+	}
+
+	@Test
+	public void shouldOrEqualsEmpty() throws Exception
+	{
+		String sql = SQL + "WHERE [car:maker] = '' OR [car:maker] = 'Infiniti'";
+		System.out.println("\nSQL: " + sql +"\n");
+
+		Query query = session.getWorkspace().getQueryManager().createQuery(sql, Query.JCR_SQL2);
+		QueryResult result = query.execute();
+
+		printResults(result);
+
+
+		Assert.assertEquals("Should contains rows", 2, result.getRows().getSize());
+		List<String> actual = collectNames(result);
+		Assert.assertTrue("Should contains EMPTY", actual.contains("EMPTY"));
+		Assert.assertTrue("Should contains Infiniti", actual.contains("Infiniti"));
+	}
+
+	@Test
+	public void shouldOrIsNull() throws Exception
+	{
+		String sql = SQL + "WHERE [car:maker] IS NULL OR [car:model] = 'DB9'";
+		System.out.println("\nSQL: " + sql +"\n");
+
+		Query query = session.getWorkspace().getQueryManager().createQuery(sql, Query.JCR_SQL2);
+		QueryResult result = query.execute();
+
+		printResults(result);
+
+
+		Assert.assertEquals("Should contains rows", 2, result.getRows().getSize());
+		List<String> actual = collectNames(result);
+		Assert.assertTrue("Should contains Aston Martin", actual.contains("Aston Martin"));
+		Assert.assertTrue("Should contains NULL", actual.contains("NULL"));
+	}
+
+	@Test
+	public void shouldOrIsNotNull() throws Exception
+	{
+		String sql = SQL + "WHERE [car:maker] IS NOT NULL OR [car:model] = 'DB9'";
+		System.out.println("\nSQL: " + sql +"\n");
+
+		Query query = session.getWorkspace().getQueryManager().createQuery(sql, Query.JCR_SQL2);
+		QueryResult result = query.execute();
+
+		printResults(result);
+
+
+		Assert.assertEquals("Should contains rows", 3, result.getRows().getSize());
+		List<String> actual = collectNames(result);
+		Assert.assertTrue("Should contains EMPTY", actual.contains("EMPTY"));
+		Assert.assertTrue("Should contains Infiniti", actual.contains("Infiniti"));
+		Assert.assertTrue("Should contains Aston Martin", actual.contains("Aston Martin"));
+	}
+
+	@Test
+	public void shouldAndEqualsEmpty() throws Exception
+	{
+		String sql = SQL + "WHERE [car:maker] = '' AND [car:model] IS NULL";
+		System.out.println("\nSQL: " + sql +"\n");
+
+		Query query = session.getWorkspace().getQueryManager().createQuery(sql, Query.JCR_SQL2);
+		QueryResult result = query.execute();
+
+		printResults(result);
+
+		Assert.assertEquals("Should contains rows", 1, result.getRows().getSize());
+		List<String> actual = collectNames(result);
+		Assert.assertTrue("Should contains EMPTY", actual.contains("EMPTY"));
+	}
+
+	@Test
+	public void shouldAndIsNotNull() throws Exception
+	{
+		String sql = SQL + "WHERE [car:maker] IS NOT NULL AND [car:model] = 'DB9'";
+		System.out.println("\nSQL: " + sql +"\n");
+
+		Query query = session.getWorkspace().getQueryManager().createQuery(sql, Query.JCR_SQL2);
+		QueryResult result = query.execute();
+
+		printResults(result);
+
+		Assert.assertEquals("Should contains rows", 1, result.getRows().getSize());
+		List<String> actual = collectNames(result);
+		Assert.assertTrue("Should contains Aston Martin", actual.contains("Aston Martin"));
+	}
+
+	@Test
+	public void shouldAndIsNull() throws Exception
+	{
+		String sql = SQL + "WHERE [car:maker] IS NULL AND [car:model] IS NULL";
+		System.out.println("\nSQL: " + sql +"\n");
+
+		Query query = session.getWorkspace().getQueryManager().createQuery(sql, Query.JCR_SQL2);
+		QueryResult result = query.execute();
+
+		printResults(result);
+
+		Assert.assertEquals("Should contains rows", 1, result.getRows().getSize());
+		List<String> actual = collectNames(result);
+		Assert.assertTrue("Should contains NULL", actual.contains("NULL"));
+	}
+
+	@Test
+	public void shouldPaging() throws Exception
+	{
+		String sql = SQL + "WHERE [car:maker] IN ('Aston Martin', '') ORDER BY [jcr:name]";
+		System.out.println("\nSQL: " + sql +"\n");
+
+		Query query = session.getWorkspace().getQueryManager().createQuery(sql, Query.JCR_SQL2);
+		query.setLimit(1);
+
+		System.out.println("PAGE 1:");
+		query.setOffset(0);
+		QueryResult result = query.execute();
+
+		printResults(result);
+
+		Assert.assertEquals("Should contains rows", 1, result.getRows().getSize());
+		List<String> actual = collectNames(result);
+		Assert.assertTrue("Should contains Aston Martin", actual.contains("Aston Martin"));
+
+
+		System.out.println("PAGE 2:");
+		query.setOffset(1);
+		result = query.execute();
+
+		printResults(result);
+
+		Assert.assertEquals("Should contains rows", 1, result.getRows().getSize());
+		actual = collectNames(result);
+		Assert.assertTrue("Should contains EMPTY", actual.contains("EMPTY"));
+	}
+}


### PR DESCRIPTION
This is a fix solution of a bug [MODE-2174](https://issues.jboss.org/browse/MODE-2174) "JCR Query in Modeshape returns no result when empty string used in comparison" for ModeShape **3.7.x** version.

This approach is based on using Lucene post processing constraints. Every query is checked for presence of empty string constraint (see class `LuceneQueryDistributor`) and if so, then push this constraint into post processing.
