### PR TITLE
MODE-2218 Corrected the REST client's methods that obtain the node types from recent servers

### DIFF
--- a/web/modeshape-web-jcr-rest-client/src/test/java/org/modeshape/web/jcr/rest/client/json/NodeTypeNodeTest.java
+++ b/web/modeshape-web-jcr-rest-client/src/test/java/org/modeshape/web/jcr/rest/client/json/NodeTypeNodeTest.java
@@ -23,6 +23,8 @@
  */
 package org.modeshape.web.jcr.rest.client.json;
 
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
 import java.io.File;
 import java.util.Collections;
 import java.util.Comparator;
@@ -54,11 +56,45 @@ public class NodeTypeNodeTest {
     }
 
     @Test
-    public void shouldParseJSONResponseContainingNodeTypes() throws Exception {
+    public void shouldParseJSONResponseContainingOldNodeTypes() throws Exception {
         String response = IoUtil.read(new File("src/test/resources/jcr_nodeTypes.txt"));
         Map<String, NodeType> nodeTypes = factory.getNodeTypes(response);
         // print = true;
         printNodeTypes(nodeTypes);
+        verifyNodeTypes(nodeTypes);
+    }
+
+    @Test
+    public void shouldParseJSONResponseContainingNewNodeTypes() throws Exception {
+        String response = IoUtil.read(new File("src/test/resources/jcr_nodeTypes_new.txt"));
+        Map<String, NodeType> nodeTypes = factory.getNodeTypes(response);
+        // print = true;
+        printNodeTypes(nodeTypes);
+        verifyNodeTypes(nodeTypes);
+    }
+
+    protected void verifyNodeTypes( Map<String, NodeType> nodeTypes ) {
+        // Just verify two built-in node types ...
+        NodeType created = nodeTypes.get("mix:created");
+        assertThat(created.getPropertyDefinitions().length, is(2));
+        assertThat(created.getChildNodeDefinitions().length, is(0));
+        assertThat(created.getPropertyDefinitions()[0].getName(), is("jcr:created"));
+        assertThat(created.getPropertyDefinitions()[1].getName(), is("jcr:createdBy"));
+
+        NodeType nodeType = nodeTypes.get("nt:nodeType");
+        assertThat(nodeType.getPropertyDefinitions().length, is(9));
+        assertThat(nodeType.getChildNodeDefinitions().length, is(2));
+        assertThat(nodeType.getPropertyDefinitions()[0].getName(), is("jcr:nodeTypeName"));
+        assertThat(nodeType.getPropertyDefinitions()[1].getName(), is("jcr:isAbstract"));
+        assertThat(nodeType.getPropertyDefinitions()[2].getName(), is("jcr:isMixin"));
+        assertThat(nodeType.getPropertyDefinitions()[3].getName(), is("jcr:supertypes"));
+        assertThat(nodeType.getPropertyDefinitions()[4].getName(), is("jcr:primaryItemName"));
+        assertThat(nodeType.getPropertyDefinitions()[5].getName(), is("jcr:hasOrderableChildNodes"));
+        assertThat(nodeType.getPropertyDefinitions()[6].getName(), is("jcr:primaryType"));
+        assertThat(nodeType.getPropertyDefinitions()[7].getName(), is("jcr:mixinTypes"));
+        assertThat(nodeType.getPropertyDefinitions()[8].getName(), is("jcr:isQueryable"));
+        assertThat(nodeType.getChildNodeDefinitions()[0].getName(), is("jcr:childNodeDefinition"));
+        assertThat(nodeType.getChildNodeDefinitions()[1].getName(), is("jcr:propertyDefinition"));
     }
 
     protected void printNodeTypes( Map<String, NodeType> nodeTypes ) {
@@ -70,17 +106,28 @@ public class NodeTypeNodeTest {
                                 NodeType o2 ) {
                 String name1 = o1.getName();
                 String name2 = o2.getName();
-                if (name1.startsWith("jcr:")) return -1;
+                if (name1.equals(name2)) return 0;
+                if (name1.startsWith("jcr:")) {
+                    return name2.startsWith("jcr:") ? name1.compareTo(name2) : -1;
+                }
                 if (name2.startsWith("jcr:")) return 1;
-                if (name1.startsWith("mix:")) return -1;
+                if (name1.startsWith("mix:")) {
+                    return name2.startsWith("mix:") ? name1.compareTo(name2) : -1;
+                }
                 if (name2.startsWith("mix:")) return 1;
-                if (name1.startsWith("nt:")) return -1;
+                if (name1.startsWith("nt:")) {
+                    return name2.startsWith("nt:") ? name1.compareTo(name2) : -1;
+                }
                 if (name2.startsWith("nt:")) return 1;
-                if (name1.startsWith("mode:")) return -1;
+                if (name1.startsWith("mode:")) {
+                    return name2.startsWith("mode:") ? name1.compareTo(name2) : -1;
+                }
                 if (name2.startsWith("mode:")) return 1;
-                if (name1.startsWith("modeint:")) return -1;
+                if (name1.startsWith("modeint:")) {
+                    return name2.startsWith("modeint:") ? name1.compareTo(name2) : -1;
+                }
                 if (name2.startsWith("modeint:")) return 1;
-                return o1.getName().compareTo(o2.getName());
+                return name1.compareTo(name2);
             }
         });
         printNodeTypes(types);

--- a/web/modeshape-web-jcr-rest-client/src/test/resources/jcr_nodeTypes_new.txt
+++ b/web/modeshape-web-jcr-rest-client/src/test/resources/jcr_nodeTypes_new.txt
@@ -1,0 +1,23635 @@
+{
+  "properties": {"jcr:primaryType": "mode:nodeTypes"},
+  "children": {
+    "nt:base": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "nt:base",
+        "jcr:isAbstract": "true",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "false",
+        "jcr:supertypes": []
+      },
+      "children": {
+        "jcr:primaryType": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COMPUTE",
+          "jcr:multiple": "false",
+          "jcr:protected": "true",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "NAME",
+          "jcr:mandatory": "true",
+          "jcr:autoCreated": "true",
+          "jcr:name": "jcr:primaryType"
+        }},
+        "jcr:mixinTypes": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COMPUTE",
+          "jcr:multiple": "true",
+          "jcr:protected": "true",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "NAME",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "jcr:mixinTypes"
+        }}
+      }
+    },
+    "nt:unstructured": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "nt:unstructured",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "true",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "false",
+        "jcr:supertypes": ["nt:base"]
+      },
+      "children": {
+        "*": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "true",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "UNDEFINED",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false"
+        }},
+        "*[2]": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "UNDEFINED",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false"
+        }},
+        "*[3]": {"properties": {
+          "jcr:requiredPrimaryTypes": ["nt:base"],
+          "jcr:primaryType": "nt:childNodeDefinition",
+          "jcr:onParentVersion": "VERSION",
+          "jcr:defaultPrimaryType": "nt:unstructured",
+          "jcr:sameNameSiblings": "true",
+          "jcr:protected": "false",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false"
+        }}
+      }
+    },
+    "mix:created": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "mix:created",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "true",
+        "jcr:supertypes": []
+      },
+      "children": {
+        "jcr:created": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "true",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "DATE",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "jcr:created"
+        }},
+        "jcr:createdBy": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "true",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "jcr:createdBy"
+        }}
+      }
+    },
+    "nt:hierarchyNode": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "nt:hierarchyNode",
+      "jcr:isAbstract": "true",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "false",
+      "jcr:supertypes": [
+        "nt:base",
+        "mix:created"
+      ]
+    }},
+    "nt:file": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "nt:file",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "false",
+        "jcr:supertypes": ["nt:hierarchyNode"],
+        "jcr:primaryItemName": "jcr:content"
+      },
+      "children": {"jcr:content": {"properties": {
+        "jcr:requiredPrimaryTypes": ["nt:base"],
+        "jcr:primaryType": "nt:childNodeDefinition",
+        "jcr:onParentVersion": "COPY",
+        "jcr:sameNameSiblings": "false",
+        "jcr:protected": "false",
+        "jcr:mandatory": "true",
+        "jcr:autoCreated": "false",
+        "jcr:name": "jcr:content"
+      }}}
+    },
+    "nt:linkedFile": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "nt:linkedFile",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "false",
+        "jcr:supertypes": ["nt:hierarchyNode"],
+        "jcr:primaryItemName": "jcr:content"
+      },
+      "children": {"jcr:content": {"properties": {
+        "jcr:primaryType": "nt:propertyDefinition",
+        "jcr:onParentVersion": "COPY",
+        "jcr:multiple": "false",
+        "jcr:protected": "false",
+        "jcr:availableQueryOperators": [
+          "jcr.operator.equal.to",
+          "jcr.operator.greater.than",
+          "jcr.operator.greater.than.or.equal.to",
+          "jcr.operator.less.than",
+          "jcr.operator.less.than.or.equal.to",
+          "jcr.operator.like",
+          "jcr.operator.not.equal.to"
+        ],
+        "jcr:requiredType": "REFERENCE",
+        "jcr:mandatory": "true",
+        "jcr:autoCreated": "false",
+        "jcr:name": "jcr:content"
+      }}}
+    },
+    "nt:folder": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "nt:folder",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "false",
+        "jcr:supertypes": ["nt:hierarchyNode"]
+      },
+      "children": {"*": {"properties": {
+        "jcr:requiredPrimaryTypes": ["nt:hierarchyNode"],
+        "jcr:primaryType": "nt:childNodeDefinition",
+        "jcr:onParentVersion": "VERSION",
+        "jcr:sameNameSiblings": "false",
+        "jcr:protected": "false",
+        "jcr:mandatory": "false",
+        "jcr:autoCreated": "false"
+      }}}
+    },
+    "mix:referenceable": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "mix:referenceable",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "true",
+        "jcr:supertypes": []
+      },
+      "children": {"jcr:uuid": {"properties": {
+        "jcr:primaryType": "nt:propertyDefinition",
+        "jcr:onParentVersion": "INITIALIZE",
+        "jcr:multiple": "false",
+        "jcr:protected": "true",
+        "jcr:availableQueryOperators": [
+          "jcr.operator.equal.to",
+          "jcr.operator.greater.than",
+          "jcr.operator.greater.than.or.equal.to",
+          "jcr.operator.less.than",
+          "jcr.operator.less.than.or.equal.to",
+          "jcr.operator.like",
+          "jcr.operator.not.equal.to"
+        ],
+        "jcr:requiredType": "STRING",
+        "jcr:mandatory": "true",
+        "jcr:autoCreated": "true",
+        "jcr:name": "jcr:uuid"
+      }}}
+    },
+    "mix:mimeType": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "mix:mimeType",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "true",
+        "jcr:supertypes": []
+      },
+      "children": {
+        "jcr:mimeType": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "jcr:mimeType"
+        }},
+        "jcr:encoding": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "jcr:encoding"
+        }}
+      }
+    },
+    "mix:lastModified": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "mix:lastModified",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "true",
+        "jcr:supertypes": []
+      },
+      "children": {
+        "jcr:lastModified": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "DATE",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "jcr:lastModified"
+        }},
+        "jcr:lastModifiedBy": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "jcr:lastModifiedBy"
+        }}
+      }
+    },
+    "nt:resource": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "nt:resource",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "false",
+        "jcr:supertypes": [
+          "nt:base",
+          "mix:mimeType",
+          "mix:lastModified"
+        ],
+        "jcr:primaryItemName": "jcr:data"
+      },
+      "children": {"jcr:data": {"properties": {
+        "jcr:primaryType": "nt:propertyDefinition",
+        "jcr:onParentVersion": "COPY",
+        "jcr:multiple": "false",
+        "jcr:protected": "false",
+        "jcr:availableQueryOperators": [
+          "jcr.operator.equal.to",
+          "jcr.operator.greater.than",
+          "jcr.operator.greater.than.or.equal.to",
+          "jcr.operator.less.than",
+          "jcr.operator.less.than.or.equal.to",
+          "jcr.operator.like",
+          "jcr.operator.not.equal.to"
+        ],
+        "jcr:requiredType": "BINARY",
+        "jcr:mandatory": "true",
+        "jcr:autoCreated": "false",
+        "jcr:name": "jcr:data"
+      }}}
+    },
+    "nt:nodeType": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "nt:nodeType",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "false",
+        "jcr:supertypes": ["nt:base"]
+      },
+      "children": {
+        "jcr:nodeTypeName": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "true",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "NAME",
+          "jcr:mandatory": "true",
+          "jcr:autoCreated": "false",
+          "jcr:name": "jcr:nodeTypeName"
+        }},
+        "jcr:supertypes": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "true",
+          "jcr:protected": "true",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "NAME",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "jcr:supertypes"
+        }},
+        "jcr:isAbstract": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "true",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "BOOLEAN",
+          "jcr:mandatory": "true",
+          "jcr:autoCreated": "false",
+          "jcr:name": "jcr:isAbstract"
+        }},
+        "jcr:isMixin": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "true",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "BOOLEAN",
+          "jcr:mandatory": "true",
+          "jcr:autoCreated": "false",
+          "jcr:name": "jcr:isMixin"
+        }},
+        "jcr:isQueryable": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "true",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "BOOLEAN",
+          "jcr:mandatory": "true",
+          "jcr:autoCreated": "false",
+          "jcr:name": "jcr:isQueryable"
+        }},
+        "jcr:hasOrderableChildNodes": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "true",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "BOOLEAN",
+          "jcr:mandatory": "true",
+          "jcr:autoCreated": "false",
+          "jcr:name": "jcr:hasOrderableChildNodes"
+        }},
+        "jcr:primaryItemName": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "true",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "NAME",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "jcr:primaryItemName"
+        }},
+        "jcr:propertyDefinition": {"properties": {
+          "jcr:requiredPrimaryTypes": ["nt:propertyDefinition"],
+          "jcr:primaryType": "nt:childNodeDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:defaultPrimaryType": "nt:propertyDefinition",
+          "jcr:sameNameSiblings": "true",
+          "jcr:protected": "true",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "jcr:propertyDefinition"
+        }},
+        "jcr:childNodeDefinition": {"properties": {
+          "jcr:requiredPrimaryTypes": ["nt:childNodeDefinition"],
+          "jcr:primaryType": "nt:childNodeDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:defaultPrimaryType": "nt:childNodeDefinition",
+          "jcr:sameNameSiblings": "true",
+          "jcr:protected": "true",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "jcr:childNodeDefinition"
+        }}
+      }
+    },
+    "nt:propertyDefinition": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "nt:propertyDefinition",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "false",
+        "jcr:supertypes": ["nt:base"]
+      },
+      "children": {
+        "jcr:name": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "true",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "NAME",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "jcr:name"
+        }},
+        "jcr:autoCreated": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "true",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "BOOLEAN",
+          "jcr:mandatory": "true",
+          "jcr:autoCreated": "false",
+          "jcr:name": "jcr:autoCreated"
+        }},
+        "jcr:mandatory": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "true",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "BOOLEAN",
+          "jcr:mandatory": "true",
+          "jcr:autoCreated": "false",
+          "jcr:name": "jcr:mandatory"
+        }},
+        "jcr:isFullTextSearchable": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "true",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "BOOLEAN",
+          "jcr:mandatory": "true",
+          "jcr:autoCreated": "false",
+          "jcr:name": "jcr:isFullTextSearchable"
+        }},
+        "jcr:isQueryOrderable": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "true",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "BOOLEAN",
+          "jcr:mandatory": "true",
+          "jcr:autoCreated": "false",
+          "jcr:name": "jcr:isQueryOrderable"
+        }},
+        "jcr:onParentVersion": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "true",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:valueConstraints": [
+            "COPY",
+            "VERSION",
+            "INITIALIZE",
+            "COMPUTE",
+            "IGNORE",
+            "ABORT"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "true",
+          "jcr:autoCreated": "false",
+          "jcr:name": "jcr:onParentVersion"
+        }},
+        "jcr:protected": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "true",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "BOOLEAN",
+          "jcr:mandatory": "true",
+          "jcr:autoCreated": "false",
+          "jcr:name": "jcr:protected"
+        }},
+        "jcr:requiredType": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "true",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:valueConstraints": [
+            "STRING",
+            "URI",
+            "BINARY",
+            "LONG",
+            "DOUBLE",
+            "DECIMAL",
+            "BOOLEAN",
+            "DATE",
+            "NAME",
+            "PATH",
+            "REFERENCE",
+            "WEAKREFERENCE",
+            "UNDEFINED"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "true",
+          "jcr:autoCreated": "false",
+          "jcr:name": "jcr:requiredType"
+        }},
+        "jcr:valueConstraints": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "true",
+          "jcr:protected": "true",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "jcr:valueConstraints"
+        }},
+        "jcr:availableQueryOperators": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "true",
+          "jcr:protected": "true",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "NAME",
+          "jcr:mandatory": "true",
+          "jcr:autoCreated": "false",
+          "jcr:name": "jcr:availableQueryOperators"
+        }},
+        "jcr:defaultValues": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "true",
+          "jcr:protected": "true",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "UNDEFINED",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "jcr:defaultValues"
+        }},
+        "jcr:multiple": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "true",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "BOOLEAN",
+          "jcr:mandatory": "true",
+          "jcr:autoCreated": "false",
+          "jcr:name": "jcr:multiple"
+        }}
+      }
+    },
+    "nt:childNodeDefinition": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "nt:childNodeDefinition",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "false",
+        "jcr:supertypes": ["nt:base"]
+      },
+      "children": {
+        "jcr:name": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "true",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "NAME",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "jcr:name"
+        }},
+        "jcr:autoCreated": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "true",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "BOOLEAN",
+          "jcr:mandatory": "true",
+          "jcr:autoCreated": "false",
+          "jcr:name": "jcr:autoCreated"
+        }},
+        "jcr:mandatory": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "true",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "BOOLEAN",
+          "jcr:mandatory": "true",
+          "jcr:autoCreated": "false",
+          "jcr:name": "jcr:mandatory"
+        }},
+        "jcr:onParentVersion": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "true",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:valueConstraints": [
+            "COPY",
+            "VERSION",
+            "INITIALIZE",
+            "COMPUTE",
+            "IGNORE",
+            "ABORT"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "true",
+          "jcr:autoCreated": "false",
+          "jcr:name": "jcr:onParentVersion"
+        }},
+        "jcr:protected": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "true",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "BOOLEAN",
+          "jcr:mandatory": "true",
+          "jcr:autoCreated": "false",
+          "jcr:name": "jcr:protected"
+        }},
+        "jcr:requiredPrimaryTypes": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "true",
+          "jcr:protected": "true",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "NAME",
+          "jcr:mandatory": "true",
+          "jcr:defaultValues": ["nt:base"],
+          "jcr:autoCreated": "false",
+          "jcr:name": "jcr:requiredPrimaryTypes"
+        }},
+        "jcr:defaultPrimaryType": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "true",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "NAME",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "jcr:defaultPrimaryType"
+        }},
+        "jcr:sameNameSiblings": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "true",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "BOOLEAN",
+          "jcr:mandatory": "true",
+          "jcr:autoCreated": "false",
+          "jcr:name": "jcr:sameNameSiblings"
+        }}
+      }
+    },
+    "nt:versionHistory": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "nt:versionHistory",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "false",
+        "jcr:supertypes": [
+          "nt:base",
+          "mix:referenceable"
+        ]
+      },
+      "children": {
+        "jcr:versionableUuid": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "ABORT",
+          "jcr:multiple": "false",
+          "jcr:protected": "true",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "true",
+          "jcr:autoCreated": "true",
+          "jcr:name": "jcr:versionableUuid"
+        }},
+        "jcr:copiedFrom": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "ABORT",
+          "jcr:multiple": "false",
+          "jcr:protected": "true",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:valueConstraints": ["nt:version"],
+          "jcr:requiredType": "WEAKREFERENCE",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "jcr:copiedFrom"
+        }},
+        "jcr:rootVersion": {"properties": {
+          "jcr:requiredPrimaryTypes": ["nt:version"],
+          "jcr:primaryType": "nt:childNodeDefinition",
+          "jcr:onParentVersion": "ABORT",
+          "jcr:defaultPrimaryType": "nt:version",
+          "jcr:sameNameSiblings": "false",
+          "jcr:protected": "true",
+          "jcr:mandatory": "true",
+          "jcr:autoCreated": "true",
+          "jcr:name": "jcr:rootVersion"
+        }},
+        "jcr:versionLabels": {"properties": {
+          "jcr:requiredPrimaryTypes": ["nt:versionLabels"],
+          "jcr:primaryType": "nt:childNodeDefinition",
+          "jcr:onParentVersion": "ABORT",
+          "jcr:defaultPrimaryType": "nt:versionLabels",
+          "jcr:sameNameSiblings": "false",
+          "jcr:protected": "true",
+          "jcr:mandatory": "true",
+          "jcr:autoCreated": "true",
+          "jcr:name": "jcr:versionLabels"
+        }},
+        "*": {"properties": {
+          "jcr:requiredPrimaryTypes": ["nt:version"],
+          "jcr:primaryType": "nt:childNodeDefinition",
+          "jcr:onParentVersion": "ABORT",
+          "jcr:defaultPrimaryType": "nt:version",
+          "jcr:sameNameSiblings": "false",
+          "jcr:protected": "true",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false"
+        }}
+      }
+    },
+    "nt:versionLabels": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "nt:versionLabels",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "false",
+        "jcr:supertypes": ["nt:base"]
+      },
+      "children": {"*": {"properties": {
+        "jcr:primaryType": "nt:propertyDefinition",
+        "jcr:onParentVersion": "ABORT",
+        "jcr:multiple": "false",
+        "jcr:protected": "true",
+        "jcr:availableQueryOperators": [
+          "jcr.operator.equal.to",
+          "jcr.operator.greater.than",
+          "jcr.operator.greater.than.or.equal.to",
+          "jcr.operator.less.than",
+          "jcr.operator.less.than.or.equal.to",
+          "jcr.operator.like",
+          "jcr.operator.not.equal.to"
+        ],
+        "jcr:valueConstraints": ["nt:version"],
+        "jcr:requiredType": "REFERENCE",
+        "jcr:mandatory": "false",
+        "jcr:autoCreated": "false"
+      }}}
+    },
+    "nt:version": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "nt:version",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "false",
+        "jcr:supertypes": [
+          "nt:base",
+          "mix:referenceable"
+        ]
+      },
+      "children": {
+        "jcr:created": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "ABORT",
+          "jcr:multiple": "false",
+          "jcr:protected": "true",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "DATE",
+          "jcr:mandatory": "true",
+          "jcr:autoCreated": "true",
+          "jcr:name": "jcr:created"
+        }},
+        "jcr:predecessors": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "ABORT",
+          "jcr:multiple": "true",
+          "jcr:protected": "true",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:valueConstraints": ["nt:version"],
+          "jcr:requiredType": "REFERENCE",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "jcr:predecessors"
+        }},
+        "jcr:successors": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "ABORT",
+          "jcr:multiple": "true",
+          "jcr:protected": "true",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:valueConstraints": ["nt:version"],
+          "jcr:requiredType": "REFERENCE",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "jcr:successors"
+        }},
+        "jcr:activity": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "ABORT",
+          "jcr:multiple": "false",
+          "jcr:protected": "true",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:valueConstraints": ["nt:activity"],
+          "jcr:requiredType": "REFERENCE",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "jcr:activity"
+        }},
+        "jcr:frozenNode": {"properties": {
+          "jcr:requiredPrimaryTypes": ["nt:frozenNode"],
+          "jcr:primaryType": "nt:childNodeDefinition",
+          "jcr:onParentVersion": "ABORT",
+          "jcr:sameNameSiblings": "false",
+          "jcr:protected": "true",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "jcr:frozenNode"
+        }}
+      }
+    },
+    "nt:frozenNode": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "nt:frozenNode",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "true",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "false",
+        "jcr:supertypes": [
+          "nt:base",
+          "mix:referenceable"
+        ]
+      },
+      "children": {
+        "jcr:frozenPrimaryType": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "ABORT",
+          "jcr:multiple": "false",
+          "jcr:protected": "true",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "NAME",
+          "jcr:mandatory": "true",
+          "jcr:autoCreated": "true",
+          "jcr:name": "jcr:frozenPrimaryType"
+        }},
+        "jcr:frozenMixinTypes": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "ABORT",
+          "jcr:multiple": "true",
+          "jcr:protected": "true",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "NAME",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "jcr:frozenMixinTypes"
+        }},
+        "jcr:frozenUuid": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "ABORT",
+          "jcr:multiple": "false",
+          "jcr:protected": "true",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "true",
+          "jcr:autoCreated": "true",
+          "jcr:name": "jcr:frozenUuid"
+        }},
+        "*": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "ABORT",
+          "jcr:multiple": "false",
+          "jcr:protected": "true",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "UNDEFINED",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false"
+        }},
+        "*[2]": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "ABORT",
+          "jcr:multiple": "true",
+          "jcr:protected": "true",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "UNDEFINED",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false"
+        }},
+        "*[3]": {"properties": {
+          "jcr:requiredPrimaryTypes": ["nt:base"],
+          "jcr:primaryType": "nt:childNodeDefinition",
+          "jcr:onParentVersion": "ABORT",
+          "jcr:sameNameSiblings": "true",
+          "jcr:protected": "true",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false"
+        }}
+      }
+    },
+    "nt:versionedChild": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "nt:versionedChild",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "false",
+        "jcr:supertypes": ["nt:base"]
+      },
+      "children": {"jcr:childVersionHistory": {"properties": {
+        "jcr:primaryType": "nt:propertyDefinition",
+        "jcr:onParentVersion": "ABORT",
+        "jcr:multiple": "false",
+        "jcr:protected": "true",
+        "jcr:availableQueryOperators": [
+          "jcr.operator.equal.to",
+          "jcr.operator.greater.than",
+          "jcr.operator.greater.than.or.equal.to",
+          "jcr.operator.less.than",
+          "jcr.operator.less.than.or.equal.to",
+          "jcr.operator.like",
+          "jcr.operator.not.equal.to"
+        ],
+        "jcr:valueConstraints": ["nt:versionHistory"],
+        "jcr:requiredType": "REFERENCE",
+        "jcr:mandatory": "true",
+        "jcr:autoCreated": "true",
+        "jcr:name": "jcr:childVersionHistory"
+      }}}
+    },
+    "nt:query": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "nt:query",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "false",
+        "jcr:supertypes": ["nt:base"]
+      },
+      "children": {
+        "jcr:statement": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "jcr:statement"
+        }},
+        "jcr:language": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "jcr:language"
+        }}
+      }
+    },
+    "nt:activity": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "nt:activity",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "false",
+        "jcr:supertypes": [
+          "nt:base",
+          "mix:referenceable"
+        ]
+      },
+      "children": {"jcr:activityTitle": {"properties": {
+        "jcr:primaryType": "nt:propertyDefinition",
+        "jcr:onParentVersion": "COPY",
+        "jcr:multiple": "false",
+        "jcr:protected": "true",
+        "jcr:availableQueryOperators": [
+          "jcr.operator.equal.to",
+          "jcr.operator.greater.than",
+          "jcr.operator.greater.than.or.equal.to",
+          "jcr.operator.less.than",
+          "jcr.operator.less.than.or.equal.to",
+          "jcr.operator.like",
+          "jcr.operator.not.equal.to"
+        ],
+        "jcr:requiredType": "STRING",
+        "jcr:mandatory": "true",
+        "jcr:autoCreated": "true",
+        "jcr:name": "jcr:activityTitle"
+      }}}
+    },
+    "mix:simpleVersionable": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "mix:simpleVersionable",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "true",
+        "jcr:supertypes": []
+      },
+      "children": {"jcr:isCheckedOut": {"properties": {
+        "jcr:primaryType": "nt:propertyDefinition",
+        "jcr:onParentVersion": "IGNORE",
+        "jcr:multiple": "false",
+        "jcr:protected": "true",
+        "jcr:availableQueryOperators": [
+          "jcr.operator.equal.to",
+          "jcr.operator.greater.than",
+          "jcr.operator.greater.than.or.equal.to",
+          "jcr.operator.less.than",
+          "jcr.operator.less.than.or.equal.to",
+          "jcr.operator.like",
+          "jcr.operator.not.equal.to"
+        ],
+        "jcr:requiredType": "BOOLEAN",
+        "jcr:mandatory": "true",
+        "jcr:defaultValues": ["true"],
+        "jcr:autoCreated": "true",
+        "jcr:name": "jcr:isCheckedOut"
+      }}}
+    },
+    "mix:versionable": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "mix:versionable",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "true",
+        "jcr:supertypes": [
+          "mix:simpleVersionable",
+          "mix:referenceable"
+        ]
+      },
+      "children": {
+        "jcr:versionHistory": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "IGNORE",
+          "jcr:multiple": "false",
+          "jcr:protected": "true",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:valueConstraints": ["nt:versionHistory"],
+          "jcr:requiredType": "REFERENCE",
+          "jcr:mandatory": "true",
+          "jcr:autoCreated": "false",
+          "jcr:name": "jcr:versionHistory"
+        }},
+        "jcr:baseVersion": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "IGNORE",
+          "jcr:multiple": "false",
+          "jcr:protected": "true",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:valueConstraints": ["nt:version"],
+          "jcr:requiredType": "REFERENCE",
+          "jcr:mandatory": "true",
+          "jcr:autoCreated": "false",
+          "jcr:name": "jcr:baseVersion"
+        }},
+        "jcr:predecessors": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "IGNORE",
+          "jcr:multiple": "true",
+          "jcr:protected": "true",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:valueConstraints": ["nt:version"],
+          "jcr:requiredType": "REFERENCE",
+          "jcr:mandatory": "true",
+          "jcr:autoCreated": "false",
+          "jcr:name": "jcr:predecessors"
+        }},
+        "jcr:mergeFailed": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "ABORT",
+          "jcr:multiple": "true",
+          "jcr:protected": "true",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "REFERENCE",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "jcr:mergeFailed"
+        }},
+        "jcr:activity": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "true",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:valueConstraints": ["nt:version"],
+          "jcr:requiredType": "REFERENCE",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "jcr:activity"
+        }},
+        "jcr:configuration": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "IGNORE",
+          "jcr:multiple": "false",
+          "jcr:protected": "true",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:valueConstraints": ["nt:configuration"],
+          "jcr:requiredType": "REFERENCE",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "jcr:configuration"
+        }}
+      }
+    },
+    "nt:configuration": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "nt:configuration",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "false",
+        "jcr:supertypes": [
+          "nt:base",
+          "mix:versionable"
+        ]
+      },
+      "children": {"jcr:root": {"properties": {
+        "jcr:primaryType": "nt:propertyDefinition",
+        "jcr:onParentVersion": "COPY",
+        "jcr:multiple": "false",
+        "jcr:protected": "true",
+        "jcr:availableQueryOperators": [
+          "jcr.operator.equal.to",
+          "jcr.operator.greater.than",
+          "jcr.operator.greater.than.or.equal.to",
+          "jcr.operator.less.than",
+          "jcr.operator.less.than.or.equal.to",
+          "jcr.operator.like",
+          "jcr.operator.not.equal.to"
+        ],
+        "jcr:requiredType": "REFERENCE",
+        "jcr:mandatory": "true",
+        "jcr:autoCreated": "true",
+        "jcr:name": "jcr:root"
+      }}}
+    },
+    "nt:address": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "nt:address",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "false",
+        "jcr:supertypes": ["nt:base"]
+      },
+      "children": {
+        "jcr:protocol": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "jcr:protocol"
+        }},
+        "jcr:host": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "jcr:host"
+        }},
+        "jcr:port": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "jcr:port"
+        }},
+        "jcr:repository": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "jcr:repository"
+        }},
+        "jcr:workspace": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "jcr:workspace"
+        }},
+        "jcr:path": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "PATH",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "jcr:path"
+        }},
+        "jcr:id": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "WEAKREFERENCE",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "jcr:id"
+        }}
+      }
+    },
+    "nt:naturalText": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "nt:naturalText",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "false",
+        "jcr:supertypes": ["nt:base"]
+      },
+      "children": {
+        "jcr:text": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "jcr:text"
+        }},
+        "jcr:messageId": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "jcr:messageId"
+        }}
+      }
+    },
+    "mix:etag": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "mix:etag",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "true",
+        "jcr:supertypes": []
+      },
+      "children": {"jcr:etag": {"properties": {
+        "jcr:primaryType": "nt:propertyDefinition",
+        "jcr:onParentVersion": "COPY",
+        "jcr:multiple": "false",
+        "jcr:protected": "true",
+        "jcr:availableQueryOperators": [
+          "jcr.operator.equal.to",
+          "jcr.operator.greater.than",
+          "jcr.operator.greater.than.or.equal.to",
+          "jcr.operator.less.than",
+          "jcr.operator.less.than.or.equal.to",
+          "jcr.operator.like",
+          "jcr.operator.not.equal.to"
+        ],
+        "jcr:requiredType": "STRING",
+        "jcr:mandatory": "false",
+        "jcr:autoCreated": "true",
+        "jcr:name": "jcr:etag"
+      }}}
+    },
+    "mix:lockable": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "mix:lockable",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "true",
+        "jcr:supertypes": []
+      },
+      "children": {
+        "jcr:lockOwner": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "IGNORE",
+          "jcr:multiple": "false",
+          "jcr:protected": "true",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "jcr:lockOwner"
+        }},
+        "jcr:lockIsDeep": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "IGNORE",
+          "jcr:multiple": "false",
+          "jcr:protected": "true",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "BOOLEAN",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "jcr:lockIsDeep"
+        }}
+      }
+    },
+    "mix:lifecycle": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "mix:lifecycle",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "true",
+        "jcr:supertypes": []
+      },
+      "children": {
+        "jcr:lifecyclePolicy": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "INITIALIZE",
+          "jcr:multiple": "false",
+          "jcr:protected": "true",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "REFERENCE",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "jcr:lifecyclePolicy"
+        }},
+        "jcr:currentLifecycleState": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "INITIALIZE",
+          "jcr:multiple": "false",
+          "jcr:protected": "true",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "jcr:currentLifecycleState"
+        }}
+      }
+    },
+    "mix:managedRetention": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "mix:managedRetention",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "true",
+        "jcr:supertypes": ["mix:referenceable"]
+      },
+      "children": {
+        "jcr:hold": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "true",
+          "jcr:protected": "true",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "jcr:hold"
+        }},
+        "jcr:isDeep": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "true",
+          "jcr:protected": "true",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "BOOLEAN",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "jcr:isDeep"
+        }},
+        "jcr:retentionPolicy": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "true",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "REFERENCE",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "jcr:retentionPolicy"
+        }}
+      }
+    },
+    "mix:shareable": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "mix:shareable",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": ["mix:referenceable"]
+    }},
+    "mix:title": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "mix:title",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "true",
+        "jcr:supertypes": []
+      },
+      "children": {
+        "jcr:title": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "jcr:title"
+        }},
+        "jcr:description": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "jcr:description"
+        }}
+      }
+    },
+    "mix:language": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "mix:language",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "true",
+        "jcr:supertypes": []
+      },
+      "children": {"jcr:language": {"properties": {
+        "jcr:primaryType": "nt:propertyDefinition",
+        "jcr:onParentVersion": "COPY",
+        "jcr:multiple": "false",
+        "jcr:protected": "false",
+        "jcr:availableQueryOperators": [
+          "jcr.operator.equal.to",
+          "jcr.operator.greater.than",
+          "jcr.operator.greater.than.or.equal.to",
+          "jcr.operator.less.than",
+          "jcr.operator.less.than.or.equal.to",
+          "jcr.operator.like",
+          "jcr.operator.not.equal.to"
+        ],
+        "jcr:requiredType": "STRING",
+        "jcr:mandatory": "false",
+        "jcr:autoCreated": "false",
+        "jcr:name": "jcr:language"
+      }}}
+    },
+    "mode:namespace": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "mode:namespace",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "false",
+        "jcr:supertypes": ["nt:base"],
+        "jcr:primaryItemName": "mode:uri"
+      },
+      "children": {
+        "mode:uri": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "VERSION",
+          "jcr:multiple": "false",
+          "jcr:protected": "true",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "mode:uri"
+        }},
+        "mode:generated": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "VERSION",
+          "jcr:multiple": "false",
+          "jcr:protected": "true",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "BOOLEAN",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "mode:generated"
+        }}
+      }
+    },
+    "mode:namespaces": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "mode:namespaces",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "false",
+        "jcr:supertypes": ["nt:base"]
+      },
+      "children": {"*": {"properties": {
+        "jcr:requiredPrimaryTypes": ["mode:namespace"],
+        "jcr:primaryType": "nt:childNodeDefinition",
+        "jcr:onParentVersion": "VERSION",
+        "jcr:defaultPrimaryType": "mode:namespace",
+        "jcr:sameNameSiblings": "false",
+        "jcr:protected": "true",
+        "jcr:mandatory": "false",
+        "jcr:autoCreated": "false"
+      }}}
+    },
+    "mode:nodeTypes": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "mode:nodeTypes",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "false",
+        "jcr:supertypes": ["nt:base"]
+      },
+      "children": {"*": {"properties": {
+        "jcr:requiredPrimaryTypes": ["nt:nodeType"],
+        "jcr:primaryType": "nt:childNodeDefinition",
+        "jcr:onParentVersion": "VERSION",
+        "jcr:defaultPrimaryType": "nt:nodeType",
+        "jcr:sameNameSiblings": "false",
+        "jcr:protected": "true",
+        "jcr:mandatory": "false",
+        "jcr:autoCreated": "false"
+      }}}
+    },
+    "mode:lock": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "mode:lock",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "false",
+        "jcr:supertypes": ["nt:base"]
+      },
+      "children": {
+        "mode:lockToken": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "IGNORE",
+          "jcr:multiple": "false",
+          "jcr:protected": "true",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "mode:lockToken"
+        }},
+        "jcr:lockOwner": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "IGNORE",
+          "jcr:multiple": "false",
+          "jcr:protected": "true",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "jcr:lockOwner"
+        }},
+        "mode:lockingSession": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "IGNORE",
+          "jcr:multiple": "false",
+          "jcr:protected": "true",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "mode:lockingSession"
+        }},
+        "mode:expirationDate": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "IGNORE",
+          "jcr:multiple": "false",
+          "jcr:protected": "true",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "DATE",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "mode:expirationDate"
+        }},
+        "mode:isSessionScoped": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "IGNORE",
+          "jcr:multiple": "false",
+          "jcr:protected": "true",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "BOOLEAN",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "mode:isSessionScoped"
+        }},
+        "jcr:lockIsDeep": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "IGNORE",
+          "jcr:multiple": "false",
+          "jcr:protected": "true",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "BOOLEAN",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "jcr:lockIsDeep"
+        }},
+        "mode:isHeldBySession": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "IGNORE",
+          "jcr:multiple": "false",
+          "jcr:protected": "true",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "BOOLEAN",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "mode:isHeldBySession"
+        }},
+        "mode:workspace": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "IGNORE",
+          "jcr:multiple": "false",
+          "jcr:protected": "true",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "mode:workspace"
+        }}
+      }
+    },
+    "mode:locks": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "mode:locks",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "false",
+        "jcr:supertypes": ["nt:base"]
+      },
+      "children": {"*": {"properties": {
+        "jcr:requiredPrimaryTypes": ["mode:lock"],
+        "jcr:primaryType": "nt:childNodeDefinition",
+        "jcr:onParentVersion": "IGNORE",
+        "jcr:defaultPrimaryType": "mode:lock",
+        "jcr:sameNameSiblings": "false",
+        "jcr:protected": "true",
+        "jcr:mandatory": "false",
+        "jcr:autoCreated": "false"
+      }}}
+    },
+    "mode:versionHistoryFolder": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "mode:versionHistoryFolder",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "false",
+        "jcr:supertypes": ["nt:base"]
+      },
+      "children": {
+        "*": {"properties": {
+          "jcr:requiredPrimaryTypes": ["nt:versionHistory"],
+          "jcr:primaryType": "nt:childNodeDefinition",
+          "jcr:onParentVersion": "IGNORE",
+          "jcr:defaultPrimaryType": "nt:versionHistory",
+          "jcr:sameNameSiblings": "false",
+          "jcr:protected": "true",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false"
+        }},
+        "*[2]": {"properties": {
+          "jcr:requiredPrimaryTypes": ["mode:versionHistoryFolder"],
+          "jcr:primaryType": "nt:childNodeDefinition",
+          "jcr:onParentVersion": "IGNORE",
+          "jcr:sameNameSiblings": "false",
+          "jcr:protected": "true",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false"
+        }}
+      }
+    },
+    "mode:versionStorage": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "mode:versionStorage",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "false",
+      "jcr:supertypes": ["mode:versionHistoryFolder"]
+    }},
+    "mode:repository": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "mode:repository",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "false",
+      "jcr:supertypes": [
+        "nt:base",
+        "mix:created"
+      ]
+    }},
+    "mode:federation": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "mode:federation",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "false",
+        "jcr:supertypes": ["nt:base"]
+      },
+      "children": {"mode:projection": {"properties": {
+        "jcr:requiredPrimaryTypes": ["mode:projection"],
+        "jcr:primaryType": "nt:childNodeDefinition",
+        "jcr:onParentVersion": "IGNORE",
+        "jcr:defaultPrimaryType": "mode:projection",
+        "jcr:sameNameSiblings": "true",
+        "jcr:protected": "true",
+        "jcr:mandatory": "false",
+        "jcr:autoCreated": "false",
+        "jcr:name": "mode:projection"
+      }}}
+    },
+    "mode:projection": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "mode:projection",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "false",
+        "jcr:supertypes": ["nt:base"]
+      },
+      "children": {
+        "mode:externalNodeKey": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "IGNORE",
+          "jcr:multiple": "false",
+          "jcr:protected": "true",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "true",
+          "jcr:autoCreated": "false",
+          "jcr:name": "mode:externalNodeKey"
+        }},
+        "mode:projectedNodeKey": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "IGNORE",
+          "jcr:multiple": "false",
+          "jcr:protected": "true",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "true",
+          "jcr:autoCreated": "false",
+          "jcr:name": "mode:projectedNodeKey"
+        }},
+        "mode:alias": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "IGNORE",
+          "jcr:multiple": "false",
+          "jcr:protected": "true",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "true",
+          "jcr:autoCreated": "false",
+          "jcr:name": "mode:alias"
+        }}
+      }
+    },
+    "mode:system": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "mode:system",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "false",
+        "jcr:supertypes": ["nt:base"]
+      },
+      "children": {
+        "*": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "true",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "UNDEFINED",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false"
+        }},
+        "*[2]": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "true",
+          "jcr:protected": "true",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "UNDEFINED",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false"
+        }},
+        "mode:namespaces": {"properties": {
+          "jcr:requiredPrimaryTypes": ["mode:namespaces"],
+          "jcr:primaryType": "nt:childNodeDefinition",
+          "jcr:onParentVersion": "ABORT",
+          "jcr:defaultPrimaryType": "mode:namespaces",
+          "jcr:sameNameSiblings": "false",
+          "jcr:protected": "true",
+          "jcr:mandatory": "true",
+          "jcr:autoCreated": "true",
+          "jcr:name": "mode:namespaces"
+        }},
+        "mode:locks": {"properties": {
+          "jcr:requiredPrimaryTypes": ["mode:locks"],
+          "jcr:primaryType": "nt:childNodeDefinition",
+          "jcr:onParentVersion": "ABORT",
+          "jcr:defaultPrimaryType": "mode:locks",
+          "jcr:sameNameSiblings": "false",
+          "jcr:protected": "true",
+          "jcr:mandatory": "true",
+          "jcr:autoCreated": "true",
+          "jcr:name": "mode:locks"
+        }},
+        "mode:repository": {"properties": {
+          "jcr:requiredPrimaryTypes": ["mode:repository"],
+          "jcr:primaryType": "nt:childNodeDefinition",
+          "jcr:onParentVersion": "ABORT",
+          "jcr:defaultPrimaryType": "mode:repository",
+          "jcr:sameNameSiblings": "false",
+          "jcr:protected": "true",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "true",
+          "jcr:name": "mode:repository"
+        }},
+        "mode:federation": {"properties": {
+          "jcr:requiredPrimaryTypes": ["mode:federation"],
+          "jcr:primaryType": "nt:childNodeDefinition",
+          "jcr:onParentVersion": "ABORT",
+          "jcr:defaultPrimaryType": "mode:federation",
+          "jcr:sameNameSiblings": "false",
+          "jcr:protected": "true",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "true",
+          "jcr:name": "mode:federation"
+        }},
+        "jcr:nodeTypes": {"properties": {
+          "jcr:requiredPrimaryTypes": ["mode:nodeTypes"],
+          "jcr:primaryType": "nt:childNodeDefinition",
+          "jcr:onParentVersion": "ABORT",
+          "jcr:defaultPrimaryType": "mode:nodeTypes",
+          "jcr:sameNameSiblings": "false",
+          "jcr:protected": "true",
+          "jcr:mandatory": "true",
+          "jcr:autoCreated": "true",
+          "jcr:name": "jcr:nodeTypes"
+        }},
+        "jcr:versionStorage": {"properties": {
+          "jcr:requiredPrimaryTypes": ["mode:versionStorage"],
+          "jcr:primaryType": "nt:childNodeDefinition",
+          "jcr:onParentVersion": "ABORT",
+          "jcr:defaultPrimaryType": "mode:versionStorage",
+          "jcr:sameNameSiblings": "false",
+          "jcr:protected": "true",
+          "jcr:mandatory": "true",
+          "jcr:autoCreated": "true",
+          "jcr:name": "jcr:versionStorage"
+        }}
+      }
+    },
+    "mode:root": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "mode:root",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "true",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "false",
+        "jcr:supertypes": [
+          "nt:base",
+          "mix:referenceable"
+        ]
+      },
+      "children": {
+        "*": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "VERSION",
+          "jcr:multiple": "true",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "UNDEFINED",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false"
+        }},
+        "*[2]": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "VERSION",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "UNDEFINED",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false"
+        }},
+        "jcr:system": {"properties": {
+          "jcr:requiredPrimaryTypes": ["mode:system"],
+          "jcr:primaryType": "nt:childNodeDefinition",
+          "jcr:onParentVersion": "IGNORE",
+          "jcr:defaultPrimaryType": "mode:system",
+          "jcr:sameNameSiblings": "false",
+          "jcr:protected": "true",
+          "jcr:mandatory": "true",
+          "jcr:autoCreated": "true",
+          "jcr:name": "jcr:system"
+        }},
+        "*[3]": {"properties": {
+          "jcr:requiredPrimaryTypes": ["nt:base"],
+          "jcr:primaryType": "nt:childNodeDefinition",
+          "jcr:onParentVersion": "VERSION",
+          "jcr:defaultPrimaryType": "nt:unstructured",
+          "jcr:sameNameSiblings": "true",
+          "jcr:protected": "false",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false"
+        }}
+      }
+    },
+    "mode:resource": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "mode:resource",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "false",
+        "jcr:supertypes": [
+          "nt:base",
+          "mix:mimeType",
+          "mix:lastModified"
+        ],
+        "jcr:primaryItemName": "jcr:data"
+      },
+      "children": {"jcr:data": {"properties": {
+        "jcr:primaryType": "nt:propertyDefinition",
+        "jcr:onParentVersion": "COPY",
+        "jcr:multiple": "false",
+        "jcr:protected": "false",
+        "jcr:availableQueryOperators": [
+          "jcr.operator.equal.to",
+          "jcr.operator.greater.than",
+          "jcr.operator.greater.than.or.equal.to",
+          "jcr.operator.less.than",
+          "jcr.operator.less.than.or.equal.to",
+          "jcr.operator.like",
+          "jcr.operator.not.equal.to"
+        ],
+        "jcr:requiredType": "BINARY",
+        "jcr:mandatory": "true",
+        "jcr:autoCreated": "false",
+        "jcr:name": "jcr:data"
+      }}}
+    },
+    "mode:share": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "mode:share",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "false",
+        "jcr:supertypes": [
+          "nt:base",
+          "mix:referenceable"
+        ]
+      },
+      "children": {"mode:sharedUuid": {"properties": {
+        "jcr:primaryType": "nt:propertyDefinition",
+        "jcr:onParentVersion": "INITIALIZE",
+        "jcr:multiple": "false",
+        "jcr:protected": "true",
+        "jcr:availableQueryOperators": [
+          "jcr.operator.equal.to",
+          "jcr.operator.greater.than",
+          "jcr.operator.greater.than.or.equal.to",
+          "jcr.operator.less.than",
+          "jcr.operator.less.than.or.equal.to",
+          "jcr.operator.like",
+          "jcr.operator.not.equal.to"
+        ],
+        "jcr:requiredType": "REFERENCE",
+        "jcr:mandatory": "true",
+        "jcr:autoCreated": "false",
+        "jcr:name": "mode:sharedUuid"
+      }}}
+    },
+    "mode:hashed": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "mode:hashed",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "true",
+        "jcr:supertypes": []
+      },
+      "children": {"mode:sha1": {"properties": {
+        "jcr:primaryType": "nt:propertyDefinition",
+        "jcr:onParentVersion": "COPY",
+        "jcr:multiple": "false",
+        "jcr:protected": "false",
+        "jcr:availableQueryOperators": [
+          "jcr.operator.equal.to",
+          "jcr.operator.greater.than",
+          "jcr.operator.greater.than.or.equal.to",
+          "jcr.operator.less.than",
+          "jcr.operator.less.than.or.equal.to",
+          "jcr.operator.like",
+          "jcr.operator.not.equal.to"
+        ],
+        "jcr:requiredType": "STRING",
+        "jcr:mandatory": "false",
+        "jcr:autoCreated": "false",
+        "jcr:name": "mode:sha1"
+      }}}
+    },
+    "mode:publishArea": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "mode:publishArea",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": ["mix:title"]
+    }},
+    "mode:derived": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "mode:derived",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "true",
+        "jcr:supertypes": []
+      },
+      "children": {
+        "mode:derivedFrom": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "PATH",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "mode:derivedFrom"
+        }},
+        "mode:derivedAt": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "DATE",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "mode:derivedAt"
+        }}
+      }
+    },
+    "mode:accessControllable": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "mode:accessControllable",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "true",
+        "jcr:supertypes": []
+      },
+      "children": {"mode:acl": {"properties": {
+        "jcr:requiredPrimaryTypes": ["mode:Acl"],
+        "jcr:primaryType": "nt:childNodeDefinition",
+        "jcr:onParentVersion": "COPY",
+        "jcr:sameNameSiblings": "false",
+        "jcr:protected": "true",
+        "jcr:mandatory": "false",
+        "jcr:autoCreated": "false",
+        "jcr:name": "mode:acl"
+      }}}
+    },
+    "mode:Acl": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "mode:Acl",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "false",
+        "jcr:isMixin": "false",
+        "jcr:supertypes": ["nt:base"]
+      },
+      "children": {"*": {"properties": {
+        "jcr:requiredPrimaryTypes": ["mode:Permission"],
+        "jcr:primaryType": "nt:childNodeDefinition",
+        "jcr:onParentVersion": "COPY",
+        "jcr:sameNameSiblings": "false",
+        "jcr:protected": "true",
+        "jcr:mandatory": "false",
+        "jcr:autoCreated": "false"
+      }}}
+    },
+    "mode:Permission": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "mode:Permission",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "false",
+        "jcr:isMixin": "false",
+        "jcr:supertypes": ["nt:base"]
+      },
+      "children": {
+        "name": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "name"
+        }},
+        "privileges": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "true",
+          "jcr:protected": "true",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "privileges"
+        }}
+      }
+    },
+    "modexml:document": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "modexml:document",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "false",
+        "jcr:supertypes": [
+          "nt:unstructured",
+          "mix:mimeType"
+        ]
+      },
+      "children": {"modexml:cDataContent": {"properties": {
+        "jcr:primaryType": "nt:propertyDefinition",
+        "jcr:onParentVersion": "COPY",
+        "jcr:multiple": "false",
+        "jcr:protected": "false",
+        "jcr:availableQueryOperators": [
+          "jcr.operator.equal.to",
+          "jcr.operator.greater.than",
+          "jcr.operator.greater.than.or.equal.to",
+          "jcr.operator.less.than",
+          "jcr.operator.less.than.or.equal.to",
+          "jcr.operator.like",
+          "jcr.operator.not.equal.to"
+        ],
+        "jcr:requiredType": "STRING",
+        "jcr:mandatory": "false",
+        "jcr:autoCreated": "false",
+        "jcr:name": "modexml:cDataContent"
+      }}}
+    },
+    "modexml:comment": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "modexml:comment",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "false",
+        "jcr:supertypes": ["nt:unstructured"]
+      },
+      "children": {"modexml:commentContent": {"properties": {
+        "jcr:primaryType": "nt:propertyDefinition",
+        "jcr:onParentVersion": "COPY",
+        "jcr:multiple": "false",
+        "jcr:protected": "false",
+        "jcr:availableQueryOperators": [
+          "jcr.operator.equal.to",
+          "jcr.operator.greater.than",
+          "jcr.operator.greater.than.or.equal.to",
+          "jcr.operator.less.than",
+          "jcr.operator.less.than.or.equal.to",
+          "jcr.operator.like",
+          "jcr.operator.not.equal.to"
+        ],
+        "jcr:requiredType": "STRING",
+        "jcr:mandatory": "false",
+        "jcr:autoCreated": "false",
+        "jcr:name": "modexml:commentContent"
+      }}}
+    },
+    "modexml:element": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "modexml:element",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "false",
+      "jcr:supertypes": ["nt:unstructured"]
+    }},
+    "modexml:elementContent": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "modexml:elementContent",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "false",
+        "jcr:supertypes": ["nt:unstructured"]
+      },
+      "children": {"modexml:elementContent": {"properties": {
+        "jcr:primaryType": "nt:propertyDefinition",
+        "jcr:onParentVersion": "COPY",
+        "jcr:multiple": "false",
+        "jcr:protected": "false",
+        "jcr:availableQueryOperators": [
+          "jcr.operator.equal.to",
+          "jcr.operator.greater.than",
+          "jcr.operator.greater.than.or.equal.to",
+          "jcr.operator.less.than",
+          "jcr.operator.less.than.or.equal.to",
+          "jcr.operator.like",
+          "jcr.operator.not.equal.to"
+        ],
+        "jcr:requiredType": "STRING",
+        "jcr:mandatory": "false",
+        "jcr:autoCreated": "false",
+        "jcr:name": "modexml:elementContent"
+      }}}
+    },
+    "modexml:cData": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "modexml:cData",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "false",
+        "jcr:supertypes": ["nt:unstructured"]
+      },
+      "children": {"modexml:cDataContent": {"properties": {
+        "jcr:primaryType": "nt:propertyDefinition",
+        "jcr:onParentVersion": "COPY",
+        "jcr:multiple": "false",
+        "jcr:protected": "false",
+        "jcr:availableQueryOperators": [
+          "jcr.operator.equal.to",
+          "jcr.operator.greater.than",
+          "jcr.operator.greater.than.or.equal.to",
+          "jcr.operator.less.than",
+          "jcr.operator.less.than.or.equal.to",
+          "jcr.operator.like",
+          "jcr.operator.not.equal.to"
+        ],
+        "jcr:requiredType": "STRING",
+        "jcr:mandatory": "false",
+        "jcr:autoCreated": "false",
+        "jcr:name": "modexml:cDataContent"
+      }}}
+    },
+    "modexml:processingInstruction": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "modexml:processingInstruction",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "false",
+        "jcr:supertypes": ["nt:unstructured"]
+      },
+      "children": {
+        "modexml:processingInstruction": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "modexml:processingInstruction"
+        }},
+        "modexml:target": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "modexml:target"
+        }}
+      }
+    },
+    "modedtd:entity": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "modedtd:entity",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "false",
+        "jcr:supertypes": ["nt:unstructured"]
+      },
+      "children": {
+        "modexml:name": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "modexml:name"
+        }},
+        "modexml:value": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "modexml:value"
+        }},
+        "modexml:publicId": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "modexml:publicId"
+        }},
+        "modexml:systemId": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "modexml:systemId"
+        }}
+      }
+    },
+    "mp3:metadata": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "mp3:metadata",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "false",
+        "jcr:supertypes": [
+          "nt:unstructured",
+          "mix:mimeType"
+        ]
+      },
+      "children": {
+        "mp3:title": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "mp3:title"
+        }},
+        "mp3:author": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "mp3:author"
+        }},
+        "mp3:album": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "mp3:album"
+        }},
+        "mp3:year": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "LONG",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "mp3:year"
+        }},
+        "mp3:comment": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "mp3:comment"
+        }}
+      }
+    },
+    "sramp:baseArtifactType": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "sramp:baseArtifactType",
+        "jcr:isAbstract": "true",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "true",
+        "jcr:supertypes": [
+          "mix:created",
+          "mix:lastModified",
+          "mix:referenceable",
+          "mix:versionable"
+        ]
+      },
+      "children": {
+        "sramp:classifiedBy": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "true",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:valueConstraints": ["owl:class"],
+          "jcr:requiredType": "REFERENCE",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "sramp:classifiedBy"
+        }},
+        "sramp:description": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "sramp:description"
+        }},
+        "*": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false"
+        }},
+        "*[2]": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "true",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false"
+        }}
+      }
+    },
+    "sramp:documentArtifactType": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "sramp:documentArtifactType",
+        "jcr:isAbstract": "true",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "true",
+        "jcr:supertypes": ["sramp:baseArtifactType"]
+      },
+      "children": {
+        "sramp:contentType": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "sramp:contentType"
+        }},
+        "sramp:contentSize": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "LONG",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "sramp:contentSize"
+        }}
+      }
+    },
+    "sramp:xmlDocument": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "sramp:xmlDocument",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "true",
+        "jcr:supertypes": ["sramp:documentArtifactType"]
+      },
+      "children": {"sramp:contentEncoding": {"properties": {
+        "jcr:primaryType": "nt:propertyDefinition",
+        "jcr:onParentVersion": "COPY",
+        "jcr:multiple": "false",
+        "jcr:protected": "false",
+        "jcr:availableQueryOperators": [
+          "jcr.operator.equal.to",
+          "jcr.operator.greater.than",
+          "jcr.operator.greater.than.or.equal.to",
+          "jcr.operator.less.than",
+          "jcr.operator.less.than.or.equal.to",
+          "jcr.operator.like",
+          "jcr.operator.not.equal.to"
+        ],
+        "jcr:requiredType": "STRING",
+        "jcr:mandatory": "false",
+        "jcr:autoCreated": "false",
+        "jcr:name": "sramp:contentEncoding"
+      }}}
+    },
+    "sramp:document": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "sramp:document",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": ["sramp:documentArtifactType"]
+    }},
+    "sramp:derivedArtifactType": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "sramp:derivedArtifactType",
+        "jcr:isAbstract": "true",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "true",
+        "jcr:supertypes": ["sramp:baseArtifactType"]
+      },
+      "children": {"sramp:relatedDocuments": {"properties": {
+        "jcr:primaryType": "nt:propertyDefinition",
+        "jcr:onParentVersion": "COPY",
+        "jcr:multiple": "false",
+        "jcr:protected": "false",
+        "jcr:availableQueryOperators": [
+          "jcr.operator.equal.to",
+          "jcr.operator.greater.than",
+          "jcr.operator.greater.than.or.equal.to",
+          "jcr.operator.less.than",
+          "jcr.operator.less.than.or.equal.to",
+          "jcr.operator.like",
+          "jcr.operator.not.equal.to"
+        ],
+        "jcr:valueConstraints": ["sramp:documentArtifactType"],
+        "jcr:requiredType": "REFERENCE",
+        "jcr:mandatory": "false",
+        "jcr:autoCreated": "false",
+        "jcr:name": "sramp:relatedDocuments"
+      }}}
+    },
+    "sramp:userDefinedArtifactType": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "sramp:userDefinedArtifactType",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "true",
+        "jcr:supertypes": ["sramp:baseArtifactType"]
+      },
+      "children": {"sramp:userType": {"properties": {
+        "jcr:primaryType": "nt:propertyDefinition",
+        "jcr:onParentVersion": "COPY",
+        "jcr:multiple": "false",
+        "jcr:protected": "false",
+        "jcr:availableQueryOperators": [
+          "jcr.operator.equal.to",
+          "jcr.operator.greater.than",
+          "jcr.operator.greater.than.or.equal.to",
+          "jcr.operator.less.than",
+          "jcr.operator.less.than.or.equal.to",
+          "jcr.operator.like",
+          "jcr.operator.not.equal.to"
+        ],
+        "jcr:requiredType": "STRING",
+        "jcr:mandatory": "true",
+        "jcr:autoCreated": "false",
+        "jcr:name": "sramp:userType"
+      }}}
+    },
+    "sramp:storedQuery": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "sramp:storedQuery",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "false",
+        "jcr:supertypes": ["nt:query"]
+      },
+      "children": {"sramp:propertyList": {"properties": {
+        "jcr:primaryType": "nt:propertyDefinition",
+        "jcr:onParentVersion": "COPY",
+        "jcr:multiple": "true",
+        "jcr:protected": "false",
+        "jcr:availableQueryOperators": [
+          "jcr.operator.equal.to",
+          "jcr.operator.greater.than",
+          "jcr.operator.greater.than.or.equal.to",
+          "jcr.operator.less.than",
+          "jcr.operator.less.than.or.equal.to",
+          "jcr.operator.like",
+          "jcr.operator.not.equal.to"
+        ],
+        "jcr:requiredType": "STRING",
+        "jcr:mandatory": "false",
+        "jcr:autoCreated": "false",
+        "jcr:name": "sramp:propertyList"
+      }}}
+    },
+    "sramp:relatedTo": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "sramp:relatedTo",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "true",
+        "jcr:supertypes": []
+      },
+      "children": {"*": {"properties": {
+        "jcr:primaryType": "nt:propertyDefinition",
+        "jcr:onParentVersion": "COPY",
+        "jcr:multiple": "true",
+        "jcr:protected": "false",
+        "jcr:availableQueryOperators": [
+          "jcr.operator.equal.to",
+          "jcr.operator.greater.than",
+          "jcr.operator.greater.than.or.equal.to",
+          "jcr.operator.less.than",
+          "jcr.operator.less.than.or.equal.to",
+          "jcr.operator.like",
+          "jcr.operator.not.equal.to"
+        ],
+        "jcr:requiredType": "WEAKREFERENCE",
+        "jcr:mandatory": "false",
+        "jcr:autoCreated": "false"
+      }}}
+    },
+    "xs:component": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "xs:component",
+        "jcr:isAbstract": "true",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "false",
+        "jcr:supertypes": [
+          "nt:base",
+          "sramp:derivedArtifactType"
+        ]
+      },
+      "children": {
+        "xs:id": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "xs:id"
+        }},
+        "*": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "true",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "UNDEFINED",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false"
+        }},
+        "*[2]": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "UNDEFINED",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false"
+        }}
+      }
+    },
+    "xs:namespaced": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "xs:namespaced",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "true",
+        "jcr:supertypes": []
+      },
+      "children": {"xs:namespace": {"properties": {
+        "jcr:primaryType": "nt:propertyDefinition",
+        "jcr:onParentVersion": "COPY",
+        "jcr:multiple": "false",
+        "jcr:protected": "false",
+        "jcr:availableQueryOperators": [
+          "jcr.operator.equal.to",
+          "jcr.operator.greater.than",
+          "jcr.operator.greater.than.or.equal.to",
+          "jcr.operator.less.than",
+          "jcr.operator.less.than.or.equal.to",
+          "jcr.operator.like",
+          "jcr.operator.not.equal.to"
+        ],
+        "jcr:requiredType": "URI",
+        "jcr:mandatory": "false",
+        "jcr:autoCreated": "false",
+        "jcr:name": "xs:namespace"
+      }}}
+    },
+    "xs:located": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "xs:located",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "true",
+        "jcr:supertypes": []
+      },
+      "children": {"xs:schemaLocation": {"properties": {
+        "jcr:primaryType": "nt:propertyDefinition",
+        "jcr:onParentVersion": "COPY",
+        "jcr:multiple": "false",
+        "jcr:protected": "false",
+        "jcr:availableQueryOperators": [
+          "jcr.operator.equal.to",
+          "jcr.operator.greater.than",
+          "jcr.operator.greater.than.or.equal.to",
+          "jcr.operator.less.than",
+          "jcr.operator.less.than.or.equal.to",
+          "jcr.operator.like",
+          "jcr.operator.not.equal.to"
+        ],
+        "jcr:requiredType": "STRING",
+        "jcr:mandatory": "false",
+        "jcr:autoCreated": "false",
+        "jcr:name": "xs:schemaLocation"
+      }}}
+    },
+    "xs:import": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "xs:import",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "false",
+      "jcr:supertypes": [
+        "xs:component",
+        "xs:located",
+        "xs:namespaced"
+      ]
+    }},
+    "xs:include": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "xs:include",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "false",
+      "jcr:supertypes": [
+        "xs:component",
+        "xs:located"
+      ]
+    }},
+    "xs:redefine": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "xs:redefine",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "false",
+      "jcr:supertypes": [
+        "xs:component",
+        "xs:located"
+      ]
+    }},
+    "xs:named": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "xs:named",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "true",
+        "jcr:supertypes": ["xs:namespaced"]
+      },
+      "children": {"xs:ncName": {"properties": {
+        "jcr:primaryType": "nt:propertyDefinition",
+        "jcr:onParentVersion": "COPY",
+        "jcr:multiple": "false",
+        "jcr:protected": "false",
+        "jcr:availableQueryOperators": [
+          "jcr.operator.equal.to",
+          "jcr.operator.greater.than",
+          "jcr.operator.greater.than.or.equal.to",
+          "jcr.operator.less.than",
+          "jcr.operator.less.than.or.equal.to",
+          "jcr.operator.like",
+          "jcr.operator.not.equal.to"
+        ],
+        "jcr:requiredType": "STRING",
+        "jcr:mandatory": "false",
+        "jcr:autoCreated": "false",
+        "jcr:name": "xs:ncName"
+      }}}
+    },
+    "xs:typeDefinition": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "xs:typeDefinition",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "false",
+      "jcr:supertypes": ["xs:component"]
+    }},
+    "xs:typed": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "xs:typed",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "true",
+        "jcr:supertypes": []
+      },
+      "children": {
+        "xs:typeName": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "xs:typeName"
+        }},
+        "xs:typeNamespace": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "URI",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "xs:typeNamespace"
+        }},
+        "xs:type": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:valueConstraints": ["xs:typeDefinition"],
+          "jcr:requiredType": "WEAKREFERENCE",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "xs:type"
+        }}
+      }
+    },
+    "xs:anyAttribute": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "xs:anyAttribute",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "false",
+        "jcr:supertypes": ["xs:component"]
+      },
+      "children": {
+        "xs:minOccurs": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:valueConstraints": ["[0,)"],
+          "jcr:requiredType": "LONG",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "xs:minOccurs"
+        }},
+        "xs:maxOccurs": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:valueConstraints": ["[0,)"],
+          "jcr:requiredType": "LONG",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "xs:maxOccurs"
+        }},
+        "xs:namespace": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "true",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "URI",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "xs:namespace"
+        }},
+        "xs:processContents": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:valueConstraints": [
+            "lax",
+            "strict",
+            "skip"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:defaultValues": ["strict"],
+          "jcr:autoCreated": "false",
+          "jcr:name": "xs:processContents"
+        }}
+      }
+    },
+    "xs:modelGroup": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "xs:modelGroup",
+        "jcr:isAbstract": "true",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "false",
+        "jcr:supertypes": ["xs:component"]
+      },
+      "children": {
+        "xs:minOccurs": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:valueConstraints": ["[0,)"],
+          "jcr:requiredType": "LONG",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "xs:minOccurs"
+        }},
+        "xs:maxOccurs": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:valueConstraints": ["[0,)"],
+          "jcr:requiredType": "LONG",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "xs:maxOccurs"
+        }},
+        "xs:refName": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "xs:refName"
+        }},
+        "xs:refNamespace": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "URI",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "xs:refNamespace"
+        }},
+        "xs:ref": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:valueConstraints": ["xs:modelGroup"],
+          "jcr:requiredType": "WEAKREFERENCE",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "xs:ref"
+        }},
+        "*": {"properties": {
+          "jcr:requiredPrimaryTypes": ["xs:elementDeclaration"],
+          "jcr:primaryType": "nt:childNodeDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:sameNameSiblings": "false",
+          "jcr:protected": "false",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false"
+        }}
+      }
+    },
+    "xs:group": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "xs:group",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "false",
+        "jcr:supertypes": ["xs:modelGroup"]
+      },
+      "children": {"xs:anyAttribute": {"properties": {
+        "jcr:requiredPrimaryTypes": ["xs:anyAttribute"],
+        "jcr:primaryType": "nt:childNodeDefinition",
+        "jcr:onParentVersion": "COPY",
+        "jcr:sameNameSiblings": "false",
+        "jcr:protected": "false",
+        "jcr:mandatory": "false",
+        "jcr:autoCreated": "false",
+        "jcr:name": "xs:anyAttribute"
+      }}}
+    },
+    "xs:all": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "xs:all",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "false",
+      "jcr:supertypes": ["xs:modelGroup"]
+    }},
+    "xs:sequence": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "xs:sequence",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "false",
+        "jcr:supertypes": ["xs:modelGroup"]
+      },
+      "children": {
+        "xs:sequence": {"properties": {
+          "jcr:requiredPrimaryTypes": ["xs:sequence"],
+          "jcr:primaryType": "nt:childNodeDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:sameNameSiblings": "false",
+          "jcr:protected": "false",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "xs:sequence"
+        }},
+        "xs:choice": {"properties": {
+          "jcr:requiredPrimaryTypes": ["xs:choice"],
+          "jcr:primaryType": "nt:childNodeDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:sameNameSiblings": "false",
+          "jcr:protected": "false",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "xs:choice"
+        }},
+        "xs:all": {"properties": {
+          "jcr:requiredPrimaryTypes": ["xs:all"],
+          "jcr:primaryType": "nt:childNodeDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:sameNameSiblings": "false",
+          "jcr:protected": "false",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "xs:all"
+        }},
+        "xs:anyAttribute": {"properties": {
+          "jcr:requiredPrimaryTypes": ["xs:anyAttribute"],
+          "jcr:primaryType": "nt:childNodeDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:sameNameSiblings": "false",
+          "jcr:protected": "false",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "xs:anyAttribute"
+        }}
+      }
+    },
+    "xs:choice": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "xs:choice",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "false",
+        "jcr:supertypes": ["xs:modelGroup"]
+      },
+      "children": {
+        "xs:sequence": {"properties": {
+          "jcr:requiredPrimaryTypes": ["xs:sequence"],
+          "jcr:primaryType": "nt:childNodeDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:sameNameSiblings": "false",
+          "jcr:protected": "false",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "xs:sequence"
+        }},
+        "xs:choice": {"properties": {
+          "jcr:requiredPrimaryTypes": ["xs:choice"],
+          "jcr:primaryType": "nt:childNodeDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:sameNameSiblings": "false",
+          "jcr:protected": "false",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "xs:choice"
+        }},
+        "xs:all": {"properties": {
+          "jcr:requiredPrimaryTypes": ["xs:all"],
+          "jcr:primaryType": "nt:childNodeDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:sameNameSiblings": "false",
+          "jcr:protected": "false",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "xs:all"
+        }},
+        "xs:anyAttribute": {"properties": {
+          "jcr:requiredPrimaryTypes": ["xs:anyAttribute"],
+          "jcr:primaryType": "nt:childNodeDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:sameNameSiblings": "false",
+          "jcr:protected": "false",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "xs:anyAttribute"
+        }}
+      }
+    },
+    "xs:complexContent": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "xs:complexContent",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "false",
+        "jcr:supertypes": ["xs:component"]
+      },
+      "children": {
+        "xs:method": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:valueConstraints": [
+            "restriction",
+            "extension"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "xs:method"
+        }},
+        "*": {"properties": {
+          "jcr:requiredPrimaryTypes": ["xs:attributeDeclaration"],
+          "jcr:primaryType": "nt:childNodeDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:sameNameSiblings": "false",
+          "jcr:protected": "false",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false"
+        }},
+        "*[2]": {"properties": {
+          "jcr:requiredPrimaryTypes": ["xs:attributeGroup"],
+          "jcr:primaryType": "nt:childNodeDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:sameNameSiblings": "false",
+          "jcr:protected": "false",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false"
+        }},
+        "*[3]": {"properties": {
+          "jcr:requiredPrimaryTypes": ["xs:group"],
+          "jcr:primaryType": "nt:childNodeDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:sameNameSiblings": "false",
+          "jcr:protected": "false",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false"
+        }},
+        "xs:anyAttribute": {"properties": {
+          "jcr:requiredPrimaryTypes": ["xs:anyAttribute"],
+          "jcr:primaryType": "nt:childNodeDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:sameNameSiblings": "false",
+          "jcr:protected": "false",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "xs:anyAttribute"
+        }},
+        "xs:sequence": {"properties": {
+          "jcr:requiredPrimaryTypes": ["xs:sequence"],
+          "jcr:primaryType": "nt:childNodeDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:sameNameSiblings": "false",
+          "jcr:protected": "false",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "xs:sequence"
+        }},
+        "xs:choice": {"properties": {
+          "jcr:requiredPrimaryTypes": ["xs:choice"],
+          "jcr:primaryType": "nt:childNodeDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:sameNameSiblings": "false",
+          "jcr:protected": "false",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "xs:choice"
+        }},
+        "xs:all": {"properties": {
+          "jcr:requiredPrimaryTypes": ["xs:all"],
+          "jcr:primaryType": "nt:childNodeDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:sameNameSiblings": "false",
+          "jcr:protected": "false",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "xs:all"
+        }}
+      }
+    },
+    "xs:simpleContent": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "xs:simpleContent",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "false",
+        "jcr:supertypes": ["xs:component"]
+      },
+      "children": {
+        "xs:method": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:valueConstraints": [
+            "restriction",
+            "extension"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "xs:method"
+        }},
+        "xs:minValueExclusive": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "UNDEFINED",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "xs:minValueExclusive"
+        }},
+        "xs:minValueInclusive": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "UNDEFINED",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "xs:minValueInclusive"
+        }},
+        "xs:maxValueExclusive": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "UNDEFINED",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "xs:maxValueExclusive"
+        }},
+        "xs:maxValueInclusive": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "UNDEFINED",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "xs:maxValueInclusive"
+        }},
+        "xs:totalDigits": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:valueConstraints": ["[0,]"],
+          "jcr:requiredType": "LONG",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "xs:totalDigits"
+        }},
+        "xs:fractionDigits": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:valueConstraints": ["[0,]"],
+          "jcr:requiredType": "LONG",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "xs:fractionDigits"
+        }},
+        "xs:length": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "LONG",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "xs:length"
+        }},
+        "xs:maxLength": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:valueConstraints": ["[0,]"],
+          "jcr:requiredType": "LONG",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "xs:maxLength"
+        }},
+        "xs:minLength": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:valueConstraints": ["[0,]"],
+          "jcr:requiredType": "LONG",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "xs:minLength"
+        }},
+        "xs:enumeratedValues": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "true",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "xs:enumeratedValues"
+        }},
+        "xs:whitespace": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:valueConstraints": [
+            "preserve",
+            "collapse",
+            "replace"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "xs:whitespace"
+        }},
+        "xs:pattern": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "xs:pattern"
+        }},
+        "*": {"properties": {
+          "jcr:requiredPrimaryTypes": ["xs:attributeDeclaration"],
+          "jcr:primaryType": "nt:childNodeDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:sameNameSiblings": "true",
+          "jcr:protected": "false",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false"
+        }},
+        "*[2]": {"properties": {
+          "jcr:requiredPrimaryTypes": ["xs:attributeGroup"],
+          "jcr:primaryType": "nt:childNodeDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:sameNameSiblings": "true",
+          "jcr:protected": "false",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false"
+        }},
+        "*[3]": {"properties": {
+          "jcr:requiredPrimaryTypes": ["xs:simpleTypeDefinition"],
+          "jcr:primaryType": "nt:childNodeDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:sameNameSiblings": "true",
+          "jcr:protected": "false",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false"
+        }},
+        "xs:anyAttribute": {"properties": {
+          "jcr:requiredPrimaryTypes": ["xs:anyAttribute"],
+          "jcr:primaryType": "nt:childNodeDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:sameNameSiblings": "false",
+          "jcr:protected": "false",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "xs:anyAttribute"
+        }}
+      }
+    },
+    "xs:attributeGroup": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "xs:attributeGroup",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "false",
+        "jcr:supertypes": ["xs:component"]
+      },
+      "children": {
+        "xs:ncName": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "xs:ncName"
+        }},
+        "xs:namespace": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "URI",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "xs:namespace"
+        }},
+        "xs:refName": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "xs:refName"
+        }},
+        "xs:refNamespace": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "URI",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "xs:refNamespace"
+        }},
+        "xs:ref": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:valueConstraints": ["xs:attributeGroup"],
+          "jcr:requiredType": "WEAKREFERENCE",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "xs:ref"
+        }},
+        "*": {"properties": {
+          "jcr:requiredPrimaryTypes": ["xs:attributeDeclaration"],
+          "jcr:primaryType": "nt:childNodeDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:sameNameSiblings": "true",
+          "jcr:protected": "false",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false"
+        }},
+        "*[2]": {"properties": {
+          "jcr:requiredPrimaryTypes": ["xs:attributeGroup"],
+          "jcr:primaryType": "nt:childNodeDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:sameNameSiblings": "true",
+          "jcr:protected": "false",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false"
+        }},
+        "xs:anyAttribute": {"properties": {
+          "jcr:requiredPrimaryTypes": ["xs:anyAttribute"],
+          "jcr:primaryType": "nt:childNodeDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:sameNameSiblings": "false",
+          "jcr:protected": "false",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "xs:anyAttribute"
+        }}
+      }
+    },
+    "xs:complexTypeDefinition": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "xs:complexTypeDefinition",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "false",
+        "jcr:supertypes": [
+          "xs:typeDefinition",
+          "xs:named"
+        ]
+      },
+      "children": {
+        "xs:abstract": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "BOOLEAN",
+          "jcr:mandatory": "false",
+          "jcr:defaultValues": ["false"],
+          "jcr:autoCreated": "false",
+          "jcr:name": "xs:abstract"
+        }},
+        "xs:mixed": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "BOOLEAN",
+          "jcr:mandatory": "false",
+          "jcr:defaultValues": ["false"],
+          "jcr:autoCreated": "false",
+          "jcr:name": "xs:mixed"
+        }},
+        "xs:block": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "true",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:valueConstraints": [
+            "restriction",
+            "extension",
+            "all"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "xs:block"
+        }},
+        "xs:final": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "true",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:valueConstraints": [
+            "restriction",
+            "extension",
+            "all"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "xs:final"
+        }},
+        "*": {"properties": {
+          "jcr:requiredPrimaryTypes": ["xs:attributeDeclaration"],
+          "jcr:primaryType": "nt:childNodeDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:sameNameSiblings": "true",
+          "jcr:protected": "false",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false"
+        }},
+        "*[2]": {"properties": {
+          "jcr:requiredPrimaryTypes": ["xs:attributeGroup"],
+          "jcr:primaryType": "nt:childNodeDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:sameNameSiblings": "true",
+          "jcr:protected": "false",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false"
+        }},
+        "*[3]": {"properties": {
+          "jcr:requiredPrimaryTypes": ["xs:complexContent"],
+          "jcr:primaryType": "nt:childNodeDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:sameNameSiblings": "true",
+          "jcr:protected": "false",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false"
+        }},
+        "*[4]": {"properties": {
+          "jcr:requiredPrimaryTypes": ["xs:simpleContent"],
+          "jcr:primaryType": "nt:childNodeDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:sameNameSiblings": "true",
+          "jcr:protected": "false",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false"
+        }},
+        "*[5]": {"properties": {
+          "jcr:requiredPrimaryTypes": ["xs:group"],
+          "jcr:primaryType": "nt:childNodeDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:sameNameSiblings": "true",
+          "jcr:protected": "false",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false"
+        }},
+        "xs:anyAttribute": {"properties": {
+          "jcr:requiredPrimaryTypes": ["xs:anyAttribute"],
+          "jcr:primaryType": "nt:childNodeDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:sameNameSiblings": "false",
+          "jcr:protected": "false",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "xs:anyAttribute"
+        }},
+        "xs:sequence": {"properties": {
+          "jcr:requiredPrimaryTypes": ["xs:sequence"],
+          "jcr:primaryType": "nt:childNodeDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:sameNameSiblings": "false",
+          "jcr:protected": "false",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "xs:sequence"
+        }},
+        "xs:choice": {"properties": {
+          "jcr:requiredPrimaryTypes": ["xs:choice"],
+          "jcr:primaryType": "nt:childNodeDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:sameNameSiblings": "false",
+          "jcr:protected": "false",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "xs:choice"
+        }},
+        "xs:all": {"properties": {
+          "jcr:requiredPrimaryTypes": ["xs:all"],
+          "jcr:primaryType": "nt:childNodeDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:sameNameSiblings": "false",
+          "jcr:protected": "false",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "xs:all"
+        }}
+      }
+    },
+    "xs:simpleTypeDefinition": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "xs:simpleTypeDefinition",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "false",
+        "jcr:supertypes": [
+          "xs:typeDefinition",
+          "xs:named"
+        ]
+      },
+      "children": {
+        "xs:baseTypeName": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "xs:baseTypeName"
+        }},
+        "xs:baseTypeNamespace": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "URI",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "xs:baseTypeNamespace"
+        }},
+        "xs:baseType": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:valueConstraints": ["xs:typeDefinition"],
+          "jcr:requiredType": "WEAKREFERENCE",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "xs:baseType"
+        }},
+        "xs:final": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "true",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:valueConstraints": [
+            "restriction",
+            "list",
+            "union",
+            "all"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "xs:final"
+        }}
+      }
+    },
+    "xs:attributeDeclaration": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "xs:attributeDeclaration",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "false",
+        "jcr:supertypes": [
+          "xs:component",
+          "xs:named",
+          "xs:typed"
+        ]
+      },
+      "children": {
+        "xs:length": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "LONG",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "xs:length"
+        }},
+        "xs:maxLength": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "LONG",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "xs:maxLength"
+        }},
+        "xs:minLength": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "LONG",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "xs:minLength"
+        }},
+        "xs:enumeratedValues": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "true",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "xs:enumeratedValues"
+        }},
+        "xs:whitespace": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:valueConstraints": [
+            "preserve",
+            "collapse",
+            "replace"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "xs:whitespace"
+        }},
+        "xs:maxValueExclusive": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "UNDEFINED",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "xs:maxValueExclusive"
+        }},
+        "xs:minValueExclusive": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "UNDEFINED",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "xs:minValueExclusive"
+        }},
+        "xs:maxValueInclusive": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "UNDEFINED",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "xs:maxValueInclusive"
+        }},
+        "xs:minValueInclusive": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "UNDEFINED",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "xs:minValueInclusive"
+        }},
+        "xs:totalDigits": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "LONG",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "xs:totalDigits"
+        }},
+        "xs:fractionDigits": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "LONG",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "xs:fractionDigits"
+        }},
+        "xs:pattern": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "xs:pattern"
+        }},
+        "xs:use": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "xs:use"
+        }}
+      }
+    },
+    "xs:selector": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "xs:selector",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "false",
+        "jcr:supertypes": ["xs:component"]
+      },
+      "children": {"xs:xpath": {"properties": {
+        "jcr:primaryType": "nt:propertyDefinition",
+        "jcr:onParentVersion": "COPY",
+        "jcr:multiple": "false",
+        "jcr:protected": "false",
+        "jcr:availableQueryOperators": [
+          "jcr.operator.equal.to",
+          "jcr.operator.greater.than",
+          "jcr.operator.greater.than.or.equal.to",
+          "jcr.operator.less.than",
+          "jcr.operator.less.than.or.equal.to",
+          "jcr.operator.like",
+          "jcr.operator.not.equal.to"
+        ],
+        "jcr:requiredType": "STRING",
+        "jcr:mandatory": "true",
+        "jcr:autoCreated": "false",
+        "jcr:name": "xs:xpath"
+      }}}
+    },
+    "xs:field": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "xs:field",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "false",
+        "jcr:supertypes": ["xs:component"]
+      },
+      "children": {"xs:xpath": {"properties": {
+        "jcr:primaryType": "nt:propertyDefinition",
+        "jcr:onParentVersion": "COPY",
+        "jcr:multiple": "false",
+        "jcr:protected": "false",
+        "jcr:availableQueryOperators": [
+          "jcr.operator.equal.to",
+          "jcr.operator.greater.than",
+          "jcr.operator.greater.than.or.equal.to",
+          "jcr.operator.less.than",
+          "jcr.operator.less.than.or.equal.to",
+          "jcr.operator.like",
+          "jcr.operator.not.equal.to"
+        ],
+        "jcr:requiredType": "STRING",
+        "jcr:mandatory": "true",
+        "jcr:autoCreated": "false",
+        "jcr:name": "xs:xpath"
+      }}}
+    },
+    "xs:identityConstraintDefinition": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "xs:identityConstraintDefinition",
+        "jcr:isAbstract": "true",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "false",
+        "jcr:supertypes": ["xs:component"]
+      },
+      "children": {
+        "xs:ncName": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "true",
+          "jcr:autoCreated": "false",
+          "jcr:name": "xs:ncName"
+        }},
+        "selector": {"properties": {
+          "jcr:requiredPrimaryTypes": ["xs:selector"],
+          "jcr:primaryType": "nt:childNodeDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:sameNameSiblings": "false",
+          "jcr:protected": "false",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "selector"
+        }},
+        "field": {"properties": {
+          "jcr:requiredPrimaryTypes": ["xs:field"],
+          "jcr:primaryType": "nt:childNodeDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:sameNameSiblings": "true",
+          "jcr:protected": "false",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "field"
+        }}
+      }
+    },
+    "xs:unique": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "xs:unique",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "false",
+      "jcr:supertypes": ["xs:identityConstraintDefinition"]
+    }},
+    "xs:key": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "xs:key",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "false",
+      "jcr:supertypes": ["xs:identityConstraintDefinition"]
+    }},
+    "xs:keyref": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "xs:keyref",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "false",
+        "jcr:supertypes": ["xs:identityConstraintDefinition"]
+      },
+      "children": {"xs:refer": {"properties": {
+        "jcr:primaryType": "nt:propertyDefinition",
+        "jcr:onParentVersion": "COPY",
+        "jcr:multiple": "false",
+        "jcr:protected": "false",
+        "jcr:availableQueryOperators": [
+          "jcr.operator.equal.to",
+          "jcr.operator.greater.than",
+          "jcr.operator.greater.than.or.equal.to",
+          "jcr.operator.less.than",
+          "jcr.operator.less.than.or.equal.to",
+          "jcr.operator.like",
+          "jcr.operator.not.equal.to"
+        ],
+        "jcr:requiredType": "STRING",
+        "jcr:mandatory": "true",
+        "jcr:autoCreated": "false",
+        "jcr:name": "xs:refer"
+      }}}
+    },
+    "xs:elementDeclaration": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "xs:elementDeclaration",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "false",
+        "jcr:supertypes": [
+          "xs:component",
+          "xs:named",
+          "xs:typed"
+        ]
+      },
+      "children": {
+        "xs:abstract": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "BOOLEAN",
+          "jcr:mandatory": "false",
+          "jcr:defaultValues": ["false"],
+          "jcr:autoCreated": "false",
+          "jcr:name": "xs:abstract"
+        }},
+        "xs:nillable": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "BOOLEAN",
+          "jcr:mandatory": "false",
+          "jcr:defaultValues": ["false"],
+          "jcr:autoCreated": "false",
+          "jcr:name": "xs:nillable"
+        }},
+        "xs:final": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "true",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:valueConstraints": [
+            "all",
+            "extension",
+            "restriction"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "xs:final"
+        }},
+        "xs:block": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "true",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:valueConstraints": [
+            "all",
+            "extension",
+            "restriction",
+            "substitution"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "xs:block"
+        }},
+        "xs:default": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "xs:default"
+        }},
+        "xs:fixed": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "xs:fixed"
+        }},
+        "xs:form": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:valueConstraints": [
+            "qualified",
+            "unqualified"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "xs:form"
+        }},
+        "xs:minOccurs": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:valueConstraints": ["[0,)"],
+          "jcr:requiredType": "LONG",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "xs:minOccurs"
+        }},
+        "xs:maxOccurs": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:valueConstraints": ["[0,)"],
+          "jcr:requiredType": "LONG",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "xs:maxOccurs"
+        }},
+        "xs:refName": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "xs:refName"
+        }},
+        "xs:refNamespace": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "URI",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "xs:refNamespace"
+        }},
+        "xs:ref": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:valueConstraints": ["xs:elementDeclaration"],
+          "jcr:requiredType": "WEAKREFERENCE",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "xs:ref"
+        }},
+        "xs:substitutionGroupName": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "xs:substitutionGroupName"
+        }},
+        "xs:substitutionGroup": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:valueConstraints": ["xs:elementDeclaration"],
+          "jcr:requiredType": "WEAKREFERENCE",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "xs:substitutionGroup"
+        }},
+        "*": {"properties": {
+          "jcr:requiredPrimaryTypes": ["xs:typeDefinition"],
+          "jcr:primaryType": "nt:childNodeDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:sameNameSiblings": "false",
+          "jcr:protected": "false",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false"
+        }},
+        "*[2]": {"properties": {
+          "jcr:requiredPrimaryTypes": ["xs:identityConstraintDefinition"],
+          "jcr:primaryType": "nt:childNodeDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:sameNameSiblings": "false",
+          "jcr:protected": "false",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false"
+        }}
+      }
+    },
+    "xs:schemaDocument": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "xs:schemaDocument",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "false",
+        "jcr:supertypes": [
+          "nt:base",
+          "sramp:xmlDocument"
+        ]
+      },
+      "children": {
+        "xs:id": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "xs:id"
+        }},
+        "xs:targetNamespace": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "URI",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "xs:targetNamespace"
+        }},
+        "xs:version": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "xs:version"
+        }},
+        "xs:attributeFormDefault": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:valueConstraints": [
+            "qualified",
+            "unqualified"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:defaultValues": ["unqualified"],
+          "jcr:autoCreated": "false",
+          "jcr:name": "xs:attributeFormDefault"
+        }},
+        "xs:elementFormDefault": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:valueConstraints": [
+            "qualified",
+            "unqualified"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:defaultValues": ["unqualified"],
+          "jcr:autoCreated": "false",
+          "jcr:name": "xs:elementFormDefault"
+        }},
+        "xs:finalDefault": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "true",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:valueConstraints": [
+            "all",
+            "extension",
+            "restriction",
+            "list",
+            "union"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "xs:finalDefault"
+        }},
+        "xs:blockDefault": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "true",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:valueConstraints": [
+            "all",
+            "extension",
+            "restriction",
+            "substitution"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "xs:blockDefault"
+        }},
+        "xs:importedXsds": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "true",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:valueConstraints": ["xs:xsdDocument"],
+          "jcr:requiredType": "WEAKREFERENCE",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "xs:importedXsds"
+        }},
+        "xs:includedXsds": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "true",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:valueConstraints": ["xs:xsdDocument"],
+          "jcr:requiredType": "WEAKREFERENCE",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "xs:includedXsds"
+        }},
+        "xs:redefinedXsds": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "true",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:valueConstraints": ["xs:xsdDocument"],
+          "jcr:requiredType": "WEAKREFERENCE",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "xs:redefinedXsds"
+        }},
+        "*": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "true",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "UNDEFINED",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false"
+        }},
+        "*[2]": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "UNDEFINED",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false"
+        }},
+        "*[3]": {"properties": {
+          "jcr:requiredPrimaryTypes": ["xs:import"],
+          "jcr:primaryType": "nt:childNodeDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:sameNameSiblings": "true",
+          "jcr:protected": "false",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false"
+        }},
+        "*[4]": {"properties": {
+          "jcr:requiredPrimaryTypes": ["xs:include"],
+          "jcr:primaryType": "nt:childNodeDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:sameNameSiblings": "true",
+          "jcr:protected": "false",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false"
+        }},
+        "*[5]": {"properties": {
+          "jcr:requiredPrimaryTypes": ["xs:redefine"],
+          "jcr:primaryType": "nt:childNodeDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:sameNameSiblings": "true",
+          "jcr:protected": "false",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false"
+        }},
+        "*[6]": {"properties": {
+          "jcr:requiredPrimaryTypes": ["xs:attributeDeclaration"],
+          "jcr:primaryType": "nt:childNodeDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:sameNameSiblings": "true",
+          "jcr:protected": "false",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false"
+        }},
+        "*[7]": {"properties": {
+          "jcr:requiredPrimaryTypes": ["xs:elementDeclaration"],
+          "jcr:primaryType": "nt:childNodeDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:sameNameSiblings": "true",
+          "jcr:protected": "false",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false"
+        }},
+        "*[8]": {"properties": {
+          "jcr:requiredPrimaryTypes": ["xs:attributeGroup"],
+          "jcr:primaryType": "nt:childNodeDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:sameNameSiblings": "true",
+          "jcr:protected": "false",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false"
+        }},
+        "*[9]": {"properties": {
+          "jcr:requiredPrimaryTypes": ["xs:group"],
+          "jcr:primaryType": "nt:childNodeDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:sameNameSiblings": "true",
+          "jcr:protected": "false",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false"
+        }},
+        "*[10]": {"properties": {
+          "jcr:requiredPrimaryTypes": ["xs:simpleTypeDefinition"],
+          "jcr:primaryType": "nt:childNodeDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:sameNameSiblings": "true",
+          "jcr:protected": "false",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false"
+        }},
+        "*[11]": {"properties": {
+          "jcr:requiredPrimaryTypes": ["xs:complexTypeDefinition"],
+          "jcr:primaryType": "nt:childNodeDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:sameNameSiblings": "true",
+          "jcr:protected": "false",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false"
+        }}
+      }
+    },
+    "wsdl:wsdlExtension": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "wsdl:wsdlExtension",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "false",
+        "jcr:supertypes": [
+          "nt:base",
+          "sramp:derivedArtifactType"
+        ]
+      },
+      "children": {
+        "wsdl:ncName": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "wsdl:ncName"
+        }},
+        "wsdl:namespace": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "URI",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "wsdl:namespace"
+        }}
+      }
+    },
+    "wsdl:wsdlDerivedArtifactType": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "wsdl:wsdlDerivedArtifactType",
+        "jcr:isAbstract": "true",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "false",
+        "jcr:supertypes": [
+          "nt:base",
+          "sramp:derivedArtifactType"
+        ]
+      },
+      "children": {
+        "wsdl:namespace": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "URI",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "wsdl:namespace"
+        }},
+        "*": {"properties": {
+          "jcr:requiredPrimaryTypes": ["wsdl:wsdlExtension"],
+          "jcr:primaryType": "nt:childNodeDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:sameNameSiblings": "false",
+          "jcr:protected": "false",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false"
+        }}
+      }
+    },
+    "wsdl:namedWsdlDerivedArtifactType": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "wsdl:namedWsdlDerivedArtifactType",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "false",
+        "jcr:supertypes": ["wsdl:wsdlDerivedArtifactType"]
+      },
+      "children": {"wsdl:ncName": {"properties": {
+        "jcr:primaryType": "nt:propertyDefinition",
+        "jcr:onParentVersion": "COPY",
+        "jcr:multiple": "false",
+        "jcr:protected": "false",
+        "jcr:availableQueryOperators": [
+          "jcr.operator.equal.to",
+          "jcr.operator.greater.than",
+          "jcr.operator.greater.than.or.equal.to",
+          "jcr.operator.less.than",
+          "jcr.operator.less.than.or.equal.to",
+          "jcr.operator.like",
+          "jcr.operator.not.equal.to"
+        ],
+        "jcr:requiredType": "STRING",
+        "jcr:mandatory": "false",
+        "jcr:autoCreated": "false",
+        "jcr:name": "wsdl:ncName"
+      }}}
+    },
+    "wsdl:part": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "wsdl:part",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "false",
+        "jcr:supertypes": ["wsdl:namedWsdlDerivedArtifactType"]
+      },
+      "children": {
+        "wsdl:element": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:valueConstraints": ["xs:elementDeclaration"],
+          "jcr:requiredType": "REFERENCE",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "wsdl:element"
+        }},
+        "wsdl:elementName": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "wsdl:elementName"
+        }},
+        "wsdl:elementNamespace": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "URI",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "wsdl:elementNamespace"
+        }},
+        "wsdl:type": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:valueConstraints": ["xs:simpleTypeDefinition"],
+          "jcr:requiredType": "REFERENCE",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "wsdl:type"
+        }},
+        "wsdl:typeName": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "wsdl:typeName"
+        }},
+        "wsdl:typeNamespace": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "URI",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "wsdl:typeNamespace"
+        }}
+      }
+    },
+    "wsdl:message": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "wsdl:message",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "false",
+        "jcr:supertypes": ["wsdl:namedWsdlDerivedArtifactType"]
+      },
+      "children": {"*": {"properties": {
+        "jcr:requiredPrimaryTypes": ["wsdl:part"],
+        "jcr:primaryType": "nt:childNodeDefinition",
+        "jcr:onParentVersion": "COPY",
+        "jcr:defaultPrimaryType": "wsdl:part",
+        "jcr:sameNameSiblings": "true",
+        "jcr:protected": "false",
+        "jcr:mandatory": "false",
+        "jcr:autoCreated": "false"
+      }}}
+    },
+    "wsdl:operationInput": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "wsdl:operationInput",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "false",
+        "jcr:supertypes": ["wsdl:namedWsdlDerivedArtifactType"]
+      },
+      "children": {"wsdl:message": {"properties": {
+        "jcr:primaryType": "nt:propertyDefinition",
+        "jcr:onParentVersion": "COPY",
+        "jcr:multiple": "false",
+        "jcr:protected": "false",
+        "jcr:availableQueryOperators": [
+          "jcr.operator.equal.to",
+          "jcr.operator.greater.than",
+          "jcr.operator.greater.than.or.equal.to",
+          "jcr.operator.less.than",
+          "jcr.operator.less.than.or.equal.to",
+          "jcr.operator.like",
+          "jcr.operator.not.equal.to"
+        ],
+        "jcr:valueConstraints": ["wsdl:message"],
+        "jcr:requiredType": "REFERENCE",
+        "jcr:mandatory": "false",
+        "jcr:autoCreated": "false",
+        "jcr:name": "wsdl:message"
+      }}}
+    },
+    "wsdl:operationOutput": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "wsdl:operationOutput",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "false",
+        "jcr:supertypes": ["wsdl:namedWsdlDerivedArtifactType"]
+      },
+      "children": {"wsdl:message": {"properties": {
+        "jcr:primaryType": "nt:propertyDefinition",
+        "jcr:onParentVersion": "COPY",
+        "jcr:multiple": "false",
+        "jcr:protected": "false",
+        "jcr:availableQueryOperators": [
+          "jcr.operator.equal.to",
+          "jcr.operator.greater.than",
+          "jcr.operator.greater.than.or.equal.to",
+          "jcr.operator.less.than",
+          "jcr.operator.less.than.or.equal.to",
+          "jcr.operator.like",
+          "jcr.operator.not.equal.to"
+        ],
+        "jcr:valueConstraints": ["wsdl:message"],
+        "jcr:requiredType": "REFERENCE",
+        "jcr:mandatory": "false",
+        "jcr:autoCreated": "false",
+        "jcr:name": "wsdl:message"
+      }}}
+    },
+    "wsdl:fault": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "wsdl:fault",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "false",
+        "jcr:supertypes": ["wsdl:namedWsdlDerivedArtifactType"]
+      },
+      "children": {"wsdl:message": {"properties": {
+        "jcr:primaryType": "nt:propertyDefinition",
+        "jcr:onParentVersion": "COPY",
+        "jcr:multiple": "false",
+        "jcr:protected": "false",
+        "jcr:availableQueryOperators": [
+          "jcr.operator.equal.to",
+          "jcr.operator.greater.than",
+          "jcr.operator.greater.than.or.equal.to",
+          "jcr.operator.less.than",
+          "jcr.operator.less.than.or.equal.to",
+          "jcr.operator.like",
+          "jcr.operator.not.equal.to"
+        ],
+        "jcr:valueConstraints": ["wsdl:message"],
+        "jcr:requiredType": "REFERENCE",
+        "jcr:mandatory": "true",
+        "jcr:autoCreated": "false",
+        "jcr:name": "wsdl:message"
+      }}}
+    },
+    "wsdl:operation": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "wsdl:operation",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "false",
+        "jcr:supertypes": ["wsdl:namedWsdlDerivedArtifactType"]
+      },
+      "children": {
+        "wsdl:parameterOrder": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "true",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "wsdl:parameterOrder"
+        }},
+        "wsdl:input": {"properties": {
+          "jcr:requiredPrimaryTypes": ["wsdl:operationInput"],
+          "jcr:primaryType": "nt:childNodeDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:defaultPrimaryType": "wsdl:operationInput",
+          "jcr:sameNameSiblings": "false",
+          "jcr:protected": "false",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "wsdl:input"
+        }},
+        "wsdl:output": {"properties": {
+          "jcr:requiredPrimaryTypes": ["wsdl:operationOutput"],
+          "jcr:primaryType": "nt:childNodeDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:defaultPrimaryType": "wsdl:operationOutput",
+          "jcr:sameNameSiblings": "false",
+          "jcr:protected": "false",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "wsdl:output"
+        }},
+        "wsdl:fault": {"properties": {
+          "jcr:requiredPrimaryTypes": ["wsdl:fault"],
+          "jcr:primaryType": "nt:childNodeDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:defaultPrimaryType": "wsdl:fault",
+          "jcr:sameNameSiblings": "true",
+          "jcr:protected": "false",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "wsdl:fault"
+        }}
+      }
+    },
+    "wsdl:portType": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "wsdl:portType",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "false",
+        "jcr:supertypes": ["wsdl:namedWsdlDerivedArtifactType"]
+      },
+      "children": {"*": {"properties": {
+        "jcr:requiredPrimaryTypes": ["wsdl:operation"],
+        "jcr:primaryType": "nt:childNodeDefinition",
+        "jcr:onParentVersion": "COPY",
+        "jcr:sameNameSiblings": "true",
+        "jcr:protected": "false",
+        "jcr:mandatory": "false",
+        "jcr:autoCreated": "false"
+      }}}
+    },
+    "wsdl:bindingOperationOutput": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "wsdl:bindingOperationOutput",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "false",
+        "jcr:supertypes": ["wsdl:namedWsdlDerivedArtifactType"]
+      },
+      "children": {
+        "wsdl:output": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:valueConstraints": ["wsdl:operationOutput"],
+          "jcr:requiredType": "REFERENCE",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "wsdl:output"
+        }},
+        "wsdl:outputName": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "wsdl:outputName"
+        }}
+      }
+    },
+    "wsdl:bindingOperationInput": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "wsdl:bindingOperationInput",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "false",
+        "jcr:supertypes": ["wsdl:namedWsdlDerivedArtifactType"]
+      },
+      "children": {
+        "wsdl:input": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:valueConstraints": ["wsdl:operationInput"],
+          "jcr:requiredType": "REFERENCE",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "wsdl:input"
+        }},
+        "wsdl:inputName": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "wsdl:inputName"
+        }}
+      }
+    },
+    "wsdl:bindingOperationFault": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "wsdl:bindingOperationFault",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "false",
+      "jcr:supertypes": ["wsdl:namedWsdlDerivedArtifactType"]
+    }},
+    "wsdl:bindingOperation": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "wsdl:bindingOperation",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "false",
+        "jcr:supertypes": ["wsdl:namedWsdlDerivedArtifactType"]
+      },
+      "children": {
+        "wsdl:input": {"properties": {
+          "jcr:requiredPrimaryTypes": ["wsdl:bindingOperationInput"],
+          "jcr:primaryType": "nt:childNodeDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:defaultPrimaryType": "wsdl:bindingOperationInput",
+          "jcr:sameNameSiblings": "false",
+          "jcr:protected": "false",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "wsdl:input"
+        }},
+        "wsdl:output": {"properties": {
+          "jcr:requiredPrimaryTypes": ["wsdl:bindingOperationOutput"],
+          "jcr:primaryType": "nt:childNodeDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:defaultPrimaryType": "wsdl:bindingOperationOutput",
+          "jcr:sameNameSiblings": "false",
+          "jcr:protected": "false",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "wsdl:output"
+        }},
+        "wsdl:fault": {"properties": {
+          "jcr:requiredPrimaryTypes": ["wsdl:bindingOperationFault"],
+          "jcr:primaryType": "nt:childNodeDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:defaultPrimaryType": "wsdl:bindingOperationFault",
+          "jcr:sameNameSiblings": "true",
+          "jcr:protected": "false",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "wsdl:fault"
+        }}
+      }
+    },
+    "wsdl:binding": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "wsdl:binding",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "false",
+        "jcr:supertypes": ["wsdl:namedWsdlDerivedArtifactType"]
+      },
+      "children": {
+        "wsdl:type": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:valueConstraints": ["wsdl:portType"],
+          "jcr:requiredType": "REFERENCE",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "wsdl:type"
+        }},
+        "*": {"properties": {
+          "jcr:requiredPrimaryTypes": ["wsdl:bindingOperation"],
+          "jcr:primaryType": "nt:childNodeDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:sameNameSiblings": "true",
+          "jcr:protected": "false",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false"
+        }}
+      }
+    },
+    "wsdl:port": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "wsdl:port",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "false",
+        "jcr:supertypes": ["wsdl:namedWsdlDerivedArtifactType"]
+      },
+      "children": {
+        "wsdl:binding": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:valueConstraints": ["wsdl:binding"],
+          "jcr:requiredType": "REFERENCE",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "wsdl:binding"
+        }},
+        "wsdl:bindingName": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "wsdl:bindingName"
+        }},
+        "wsdl:bindingNamespace": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "URI",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "wsdl:bindingNamespace"
+        }}
+      }
+    },
+    "wsdl:service": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "wsdl:service",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "false",
+        "jcr:supertypes": ["wsdl:namedWsdlDerivedArtifactType"]
+      },
+      "children": {"*": {"properties": {
+        "jcr:requiredPrimaryTypes": ["wsdl:port"],
+        "jcr:primaryType": "nt:childNodeDefinition",
+        "jcr:onParentVersion": "COPY",
+        "jcr:sameNameSiblings": "true",
+        "jcr:protected": "false",
+        "jcr:mandatory": "false",
+        "jcr:autoCreated": "false"
+      }}}
+    },
+    "wsdl:referencedXsd": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "wsdl:referencedXsd",
+        "jcr:isAbstract": "true",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "false",
+        "jcr:supertypes": [
+          "nt:base",
+          "sramp:derivedArtifactType"
+        ]
+      },
+      "children": {
+        "xs:id": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "xs:id"
+        }},
+        "xs:schemaLocation": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "xs:schemaLocation"
+        }},
+        "*": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "true",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "UNDEFINED",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false"
+        }},
+        "*[2]": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "UNDEFINED",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false"
+        }}
+      }
+    },
+    "wsdl:importedXsd": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "wsdl:importedXsd",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "false",
+        "jcr:supertypes": ["wsdl:referencedXsd"]
+      },
+      "children": {"xs:namespace": {"properties": {
+        "jcr:primaryType": "nt:propertyDefinition",
+        "jcr:onParentVersion": "COPY",
+        "jcr:multiple": "false",
+        "jcr:protected": "false",
+        "jcr:availableQueryOperators": [
+          "jcr.operator.equal.to",
+          "jcr.operator.greater.than",
+          "jcr.operator.greater.than.or.equal.to",
+          "jcr.operator.less.than",
+          "jcr.operator.less.than.or.equal.to",
+          "jcr.operator.like",
+          "jcr.operator.not.equal.to"
+        ],
+        "jcr:requiredType": "URI",
+        "jcr:mandatory": "true",
+        "jcr:autoCreated": "false",
+        "jcr:name": "xs:namespace"
+      }}}
+    },
+    "wsdl:includedXsd": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "wsdl:includedXsd",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "false",
+      "jcr:supertypes": ["wsdl:referencedXsd"]
+    }},
+    "wsdl:redefinedXsd": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "wsdl:redefinedXsd",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "false",
+      "jcr:supertypes": ["wsdl:referencedXsd"]
+    }},
+    "wsdl:container": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "wsdl:container",
+        "jcr:isAbstract": "true",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "false",
+        "jcr:supertypes": [
+          "nt:base",
+          "sramp:derivedArtifactType"
+        ]
+      },
+      "children": {
+        "*": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false"
+        }},
+        "*[2]": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "true",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false"
+        }}
+      }
+    },
+    "wsdl:messages": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "wsdl:messages",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "false",
+        "jcr:supertypes": ["wsdl:container"]
+      },
+      "children": {"*": {"properties": {
+        "jcr:requiredPrimaryTypes": ["wsdl:message"],
+        "jcr:primaryType": "nt:childNodeDefinition",
+        "jcr:onParentVersion": "COPY",
+        "jcr:defaultPrimaryType": "wsdl:message",
+        "jcr:sameNameSiblings": "true",
+        "jcr:protected": "false",
+        "jcr:mandatory": "false",
+        "jcr:autoCreated": "false"
+      }}}
+    },
+    "wsdl:portTypes": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "wsdl:portTypes",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "false",
+        "jcr:supertypes": ["wsdl:container"]
+      },
+      "children": {"*": {"properties": {
+        "jcr:requiredPrimaryTypes": ["wsdl:portType"],
+        "jcr:primaryType": "nt:childNodeDefinition",
+        "jcr:onParentVersion": "COPY",
+        "jcr:defaultPrimaryType": "wsdl:portType",
+        "jcr:sameNameSiblings": "true",
+        "jcr:protected": "false",
+        "jcr:mandatory": "false",
+        "jcr:autoCreated": "false"
+      }}}
+    },
+    "wsdl:bindings": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "wsdl:bindings",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "false",
+        "jcr:supertypes": ["wsdl:container"]
+      },
+      "children": {"*": {"properties": {
+        "jcr:requiredPrimaryTypes": ["wsdl:binding"],
+        "jcr:primaryType": "nt:childNodeDefinition",
+        "jcr:onParentVersion": "COPY",
+        "jcr:defaultPrimaryType": "wsdl:binding",
+        "jcr:sameNameSiblings": "true",
+        "jcr:protected": "false",
+        "jcr:mandatory": "false",
+        "jcr:autoCreated": "false"
+      }}}
+    },
+    "wsdl:services": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "wsdl:services",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "false",
+        "jcr:supertypes": ["wsdl:container"]
+      },
+      "children": {"*": {"properties": {
+        "jcr:requiredPrimaryTypes": ["wsdl:service"],
+        "jcr:primaryType": "nt:childNodeDefinition",
+        "jcr:onParentVersion": "COPY",
+        "jcr:defaultPrimaryType": "wsdl:service",
+        "jcr:sameNameSiblings": "true",
+        "jcr:protected": "false",
+        "jcr:mandatory": "false",
+        "jcr:autoCreated": "false"
+      }}}
+    },
+    "wsdl:wsdlDocument": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "wsdl:wsdlDocument",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "false",
+        "jcr:supertypes": [
+          "nt:base",
+          "sramp:xmlDocument"
+        ]
+      },
+      "children": {
+        "wsdl:importedXsds": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "true",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:valueConstraints": ["xs:schemaDocument"],
+          "jcr:requiredType": "WEAKREFERENCE",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "wsdl:importedXsds"
+        }},
+        "wsdl:includedXsds": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "true",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:valueConstraints": ["xs:schemaDocument"],
+          "jcr:requiredType": "WEAKREFERENCE",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "wsdl:includedXsds"
+        }},
+        "wsdl:redefinedXsds": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "true",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:valueConstraints": ["xs:schemaDocument"],
+          "jcr:requiredType": "WEAKREFERENCE",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "wsdl:redefinedXsds"
+        }},
+        "wsdl:importedWsdls": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "true",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:valueConstraints": ["wsdl:wsdlDocument"],
+          "jcr:requiredType": "WEAKREFERENCE",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "wsdl:importedWsdls"
+        }},
+        "wsdl:schema": {"properties": {
+          "jcr:requiredPrimaryTypes": ["xs:schemaDocument"],
+          "jcr:primaryType": "nt:childNodeDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:defaultPrimaryType": "xs:schemaDocument",
+          "jcr:sameNameSiblings": "true",
+          "jcr:protected": "false",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "wsdl:schema"
+        }},
+        "wsdl:importedXsd": {"properties": {
+          "jcr:requiredPrimaryTypes": ["wsdl:importedXsd"],
+          "jcr:primaryType": "nt:childNodeDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:sameNameSiblings": "true",
+          "jcr:protected": "false",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "wsdl:importedXsd"
+        }},
+        "wsdl:includedXsd": {"properties": {
+          "jcr:requiredPrimaryTypes": ["wsdl:includedXsd"],
+          "jcr:primaryType": "nt:childNodeDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:sameNameSiblings": "true",
+          "jcr:protected": "false",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "wsdl:includedXsd"
+        }},
+        "wsdl:redefinedXsd": {"properties": {
+          "jcr:requiredPrimaryTypes": ["wsdl:redefinedXsd"],
+          "jcr:primaryType": "nt:childNodeDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:sameNameSiblings": "true",
+          "jcr:protected": "false",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "wsdl:redefinedXsd"
+        }},
+        "wsdl:messages": {"properties": {
+          "jcr:requiredPrimaryTypes": ["wsdl:messages"],
+          "jcr:primaryType": "nt:childNodeDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:defaultPrimaryType": "wsdl:messages",
+          "jcr:sameNameSiblings": "false",
+          "jcr:protected": "false",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "wsdl:messages"
+        }},
+        "wsdl:portTypes": {"properties": {
+          "jcr:requiredPrimaryTypes": ["wsdl:portTypes"],
+          "jcr:primaryType": "nt:childNodeDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:defaultPrimaryType": "wsdl:portTypes",
+          "jcr:sameNameSiblings": "false",
+          "jcr:protected": "false",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "wsdl:portTypes"
+        }},
+        "wsdl:bindings": {"properties": {
+          "jcr:requiredPrimaryTypes": ["wsdl:bindings"],
+          "jcr:primaryType": "nt:childNodeDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:defaultPrimaryType": "wsdl:bindings",
+          "jcr:sameNameSiblings": "false",
+          "jcr:protected": "false",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "wsdl:bindings"
+        }},
+        "wsdl:services": {"properties": {
+          "jcr:requiredPrimaryTypes": ["wsdl:services"],
+          "jcr:primaryType": "nt:childNodeDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:defaultPrimaryType": "wsdl:services",
+          "jcr:sameNameSiblings": "false",
+          "jcr:protected": "false",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "wsdl:services"
+        }}
+      }
+    },
+    "wsdl:httpExtension": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "wsdl:httpExtension",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "false",
+      "jcr:supertypes": ["wsdl:wsdlExtension"]
+    }},
+    "wsdl:httpAddress": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "wsdl:httpAddress",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "false",
+        "jcr:supertypes": ["wsdl:httpExtension"]
+      },
+      "children": {"wsdl:location": {"properties": {
+        "jcr:primaryType": "nt:propertyDefinition",
+        "jcr:onParentVersion": "COPY",
+        "jcr:multiple": "false",
+        "jcr:protected": "false",
+        "jcr:availableQueryOperators": [
+          "jcr.operator.equal.to",
+          "jcr.operator.greater.than",
+          "jcr.operator.greater.than.or.equal.to",
+          "jcr.operator.less.than",
+          "jcr.operator.less.than.or.equal.to",
+          "jcr.operator.like",
+          "jcr.operator.not.equal.to"
+        ],
+        "jcr:requiredType": "URI",
+        "jcr:mandatory": "true",
+        "jcr:autoCreated": "false",
+        "jcr:name": "wsdl:location"
+      }}}
+    },
+    "wsdl:httpBinding": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "wsdl:httpBinding",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "false",
+        "jcr:supertypes": ["wsdl:httpExtension"]
+      },
+      "children": {"wsdl:verb": {"properties": {
+        "jcr:primaryType": "nt:propertyDefinition",
+        "jcr:onParentVersion": "COPY",
+        "jcr:multiple": "false",
+        "jcr:protected": "false",
+        "jcr:availableQueryOperators": [
+          "jcr.operator.equal.to",
+          "jcr.operator.greater.than",
+          "jcr.operator.greater.than.or.equal.to",
+          "jcr.operator.less.than",
+          "jcr.operator.less.than.or.equal.to",
+          "jcr.operator.like",
+          "jcr.operator.not.equal.to"
+        ],
+        "jcr:requiredType": "STRING",
+        "jcr:mandatory": "true",
+        "jcr:autoCreated": "false",
+        "jcr:name": "wsdl:verb"
+      }}}
+    },
+    "wsdl:httpOperation": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "wsdl:httpOperation",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "false",
+        "jcr:supertypes": ["wsdl:httpExtension"]
+      },
+      "children": {"wsdl:location": {"properties": {
+        "jcr:primaryType": "nt:propertyDefinition",
+        "jcr:onParentVersion": "COPY",
+        "jcr:multiple": "false",
+        "jcr:protected": "false",
+        "jcr:availableQueryOperators": [
+          "jcr.operator.equal.to",
+          "jcr.operator.greater.than",
+          "jcr.operator.greater.than.or.equal.to",
+          "jcr.operator.less.than",
+          "jcr.operator.less.than.or.equal.to",
+          "jcr.operator.like",
+          "jcr.operator.not.equal.to"
+        ],
+        "jcr:requiredType": "URI",
+        "jcr:mandatory": "true",
+        "jcr:autoCreated": "false",
+        "jcr:name": "wsdl:location"
+      }}}
+    },
+    "wsdl:httpUrlEncoded": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "wsdl:httpUrlEncoded",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "false",
+      "jcr:supertypes": ["wsdl:httpExtension"]
+    }},
+    "wsdl:httpUrlReplacement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "wsdl:httpUrlReplacement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "false",
+      "jcr:supertypes": ["wsdl:httpExtension"]
+    }},
+    "wsdl:soapExtension": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "wsdl:soapExtension",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "false",
+      "jcr:supertypes": ["wsdl:wsdlExtension"]
+    }},
+    "wsdl:soapAddress": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "wsdl:soapAddress",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "false",
+        "jcr:supertypes": ["wsdl:soapExtension"]
+      },
+      "children": {"wsdl:soapLocation": {"properties": {
+        "jcr:primaryType": "nt:propertyDefinition",
+        "jcr:onParentVersion": "COPY",
+        "jcr:multiple": "false",
+        "jcr:protected": "false",
+        "jcr:availableQueryOperators": [
+          "jcr.operator.equal.to",
+          "jcr.operator.greater.than",
+          "jcr.operator.greater.than.or.equal.to",
+          "jcr.operator.less.than",
+          "jcr.operator.less.than.or.equal.to",
+          "jcr.operator.like",
+          "jcr.operator.not.equal.to"
+        ],
+        "jcr:requiredType": "URI",
+        "jcr:mandatory": "true",
+        "jcr:autoCreated": "false",
+        "jcr:name": "wsdl:soapLocation"
+      }}}
+    },
+    "wsdl:soapBinding": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "wsdl:soapBinding",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "false",
+        "jcr:supertypes": ["wsdl:soapExtension"]
+      },
+      "children": {
+        "wsdl:style": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "wsdl:style"
+        }},
+        "wsdl:transport": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "URI",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "wsdl:transport"
+        }}
+      }
+    },
+    "wsdl:soapOperation": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "wsdl:soapOperation",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "false",
+        "jcr:supertypes": ["wsdl:soapExtension"]
+      },
+      "children": {
+        "wsdl:style": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "wsdl:style"
+        }},
+        "wsdl:soapAction": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "URI",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "wsdl:soapAction"
+        }}
+      }
+    },
+    "wsdl:soapBody": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "wsdl:soapBody",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "false",
+        "jcr:supertypes": ["wsdl:soapExtension"]
+      },
+      "children": {
+        "wsdl:encodingStyle": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "true",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "URI",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "wsdl:encodingStyle"
+        }},
+        "wsdl:parts": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "true",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "wsdl:parts"
+        }},
+        "wsdl:use": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:valueConstraints": [
+            "literal",
+            "encoded"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "wsdl:use"
+        }}
+      }
+    },
+    "wsdl:soapFault": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "wsdl:soapFault",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "false",
+        "jcr:supertypes": ["wsdl:soapExtension"]
+      },
+      "children": {
+        "wsdl:encodingStyle": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "true",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "URI",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "wsdl:encodingStyle"
+        }},
+        "wsdl:use": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:valueConstraints": [
+            "literal",
+            "encoded"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "wsdl:use"
+        }}
+      }
+    },
+    "wsdl:soapHeader": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "wsdl:soapHeader",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "false",
+        "jcr:supertypes": ["wsdl:soapExtension"]
+      },
+      "children": {
+        "wsdl:message": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "wsdl:message"
+        }},
+        "wsdl:part": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "wsdl:part"
+        }},
+        "wsdl:encodingStyle": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "true",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "URI",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "wsdl:encodingStyle"
+        }},
+        "wsdl:use": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:valueConstraints": [
+            "literal",
+            "encoded"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "wsdl:use"
+        }},
+        "*": {"properties": {
+          "jcr:requiredPrimaryTypes": ["wsdl:soapHeaderFault"],
+          "jcr:primaryType": "nt:childNodeDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:defaultPrimaryType": "wsdl:soapHeaderFault",
+          "jcr:sameNameSiblings": "false",
+          "jcr:protected": "false",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false"
+        }}
+      }
+    },
+    "wsdl:soapHeaderFault": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "wsdl:soapHeaderFault",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "false",
+        "jcr:supertypes": ["wsdl:soapExtension"]
+      },
+      "children": {
+        "wsdl:encodingStyle": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "true",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "URI",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "wsdl:encodingStyle"
+        }},
+        "wsdl:use": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:valueConstraints": [
+            "literal",
+            "encoded"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "wsdl:use"
+        }}
+      }
+    },
+    "wsdl:mimeExtension": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "wsdl:mimeExtension",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "false",
+      "jcr:supertypes": ["wsdl:wsdlExtension"]
+    }},
+    "wsdl:mimeMultipartRelated": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "wsdl:mimeMultipartRelated",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "false",
+        "jcr:supertypes": ["wsdl:mimeExtension"]
+      },
+      "children": {"wsdl:mimePart": {"properties": {
+        "jcr:requiredPrimaryTypes": ["wsdl:mimePart"],
+        "jcr:primaryType": "nt:childNodeDefinition",
+        "jcr:onParentVersion": "COPY",
+        "jcr:sameNameSiblings": "true",
+        "jcr:protected": "false",
+        "jcr:mandatory": "false",
+        "jcr:autoCreated": "false",
+        "jcr:name": "wsdl:mimePart"
+      }}}
+    },
+    "wsdl:mimePart": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "wsdl:mimePart",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "false",
+        "jcr:supertypes": ["wsdl:mimeExtension"]
+      },
+      "children": {"*": {"properties": {
+        "jcr:requiredPrimaryTypes": ["wsdl:mimeExtension"],
+        "jcr:primaryType": "nt:childNodeDefinition",
+        "jcr:onParentVersion": "COPY",
+        "jcr:sameNameSiblings": "true",
+        "jcr:protected": "false",
+        "jcr:mandatory": "false",
+        "jcr:autoCreated": "false"
+      }}}
+    },
+    "wsdl:mimeContent": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "wsdl:mimeContent",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "false",
+        "jcr:supertypes": ["wsdl:mimeExtension"]
+      },
+      "children": {
+        "wsdl:mimeType": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "wsdl:mimeType"
+        }},
+        "wsdl:mimePart": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "wsdl:mimePart"
+        }}
+      }
+    },
+    "wsdl:mimeXml": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "wsdl:mimeXml",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "false",
+        "jcr:supertypes": ["wsdl:mimeExtension"]
+      },
+      "children": {"wsdl:mimePart": {"properties": {
+        "jcr:primaryType": "nt:propertyDefinition",
+        "jcr:onParentVersion": "COPY",
+        "jcr:multiple": "false",
+        "jcr:protected": "false",
+        "jcr:availableQueryOperators": [
+          "jcr.operator.equal.to",
+          "jcr.operator.greater.than",
+          "jcr.operator.greater.than.or.equal.to",
+          "jcr.operator.less.than",
+          "jcr.operator.less.than.or.equal.to",
+          "jcr.operator.like",
+          "jcr.operator.not.equal.to"
+        ],
+        "jcr:requiredType": "STRING",
+        "jcr:mandatory": "false",
+        "jcr:autoCreated": "false",
+        "jcr:name": "wsdl:mimePart"
+      }}}
+    },
+    "cnd:nodeType": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "cnd:nodeType",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "false",
+        "jcr:supertypes": ["nt:base"]
+      },
+      "children": {
+        "cnd:nodeTypeName": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "NAME",
+          "jcr:mandatory": "true",
+          "jcr:autoCreated": "false",
+          "jcr:name": "cnd:nodeTypeName"
+        }},
+        "cnd:supertypes": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "true",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "NAME",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "cnd:supertypes"
+        }},
+        "cnd:isAbstract": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "BOOLEAN",
+          "jcr:mandatory": "true",
+          "jcr:autoCreated": "false",
+          "jcr:name": "cnd:isAbstract"
+        }},
+        "cnd:isMixin": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "BOOLEAN",
+          "jcr:mandatory": "true",
+          "jcr:autoCreated": "false",
+          "jcr:name": "cnd:isMixin"
+        }},
+        "cnd:isQueryable": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "BOOLEAN",
+          "jcr:mandatory": "true",
+          "jcr:autoCreated": "false",
+          "jcr:name": "cnd:isQueryable"
+        }},
+        "cnd:hasOrderableChildNodes": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "BOOLEAN",
+          "jcr:mandatory": "true",
+          "jcr:autoCreated": "false",
+          "jcr:name": "cnd:hasOrderableChildNodes"
+        }},
+        "cnd:primaryItemName": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "NAME",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "cnd:primaryItemName"
+        }},
+        "cnd:propertyDefinition": {"properties": {
+          "jcr:requiredPrimaryTypes": ["cnd:propertyDefinition"],
+          "jcr:primaryType": "nt:childNodeDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:defaultPrimaryType": "cnd:propertyDefinition",
+          "jcr:sameNameSiblings": "true",
+          "jcr:protected": "false",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "cnd:propertyDefinition"
+        }},
+        "cnd:childNodeDefinition": {"properties": {
+          "jcr:requiredPrimaryTypes": ["cnd:childNodeDefinition"],
+          "jcr:primaryType": "nt:childNodeDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:defaultPrimaryType": "cnd:childNodeDefinition",
+          "jcr:sameNameSiblings": "true",
+          "jcr:protected": "false",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "cnd:childNodeDefinition"
+        }}
+      }
+    },
+    "cnd:propertyDefinition": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "cnd:propertyDefinition",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "false",
+        "jcr:supertypes": ["nt:base"]
+      },
+      "children": {
+        "cnd:name": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "NAME",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "cnd:name"
+        }},
+        "cnd:autoCreated": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "BOOLEAN",
+          "jcr:mandatory": "true",
+          "jcr:autoCreated": "false",
+          "jcr:name": "cnd:autoCreated"
+        }},
+        "cnd:mandatory": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "BOOLEAN",
+          "jcr:mandatory": "true",
+          "jcr:autoCreated": "false",
+          "jcr:name": "cnd:mandatory"
+        }},
+        "cnd:isFullTextSearchable": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "BOOLEAN",
+          "jcr:mandatory": "true",
+          "jcr:autoCreated": "false",
+          "jcr:name": "cnd:isFullTextSearchable"
+        }},
+        "cnd:isQueryOrderable": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "BOOLEAN",
+          "jcr:mandatory": "true",
+          "jcr:autoCreated": "false",
+          "jcr:name": "cnd:isQueryOrderable"
+        }},
+        "cnd:onParentVersion": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:valueConstraints": [
+            "COPY",
+            "VERSION",
+            "INITIALIZE",
+            "COMPUTE",
+            "IGNORE",
+            "ABORT"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "true",
+          "jcr:autoCreated": "false",
+          "jcr:name": "cnd:onParentVersion"
+        }},
+        "cnd:protected": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "BOOLEAN",
+          "jcr:mandatory": "true",
+          "jcr:autoCreated": "false",
+          "jcr:name": "cnd:protected"
+        }},
+        "cnd:requiredType": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:valueConstraints": [
+            "STRING",
+            "BINARY",
+            "LONG",
+            "DOUBLE",
+            "BOOLEAN",
+            "DATE",
+            "NAME",
+            "PATH",
+            "REFERENCE",
+            "UNDEFINED"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "true",
+          "jcr:autoCreated": "false",
+          "jcr:name": "cnd:requiredType"
+        }},
+        "cnd:valueConstraints": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "true",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "cnd:valueConstraints"
+        }},
+        "cnd:availableQueryOperators": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "true",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "NAME",
+          "jcr:mandatory": "true",
+          "jcr:autoCreated": "false",
+          "jcr:name": "cnd:availableQueryOperators"
+        }},
+        "cnd:defaultValues": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "true",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "UNDEFINED",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "cnd:defaultValues"
+        }},
+        "cnd:multiple": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "BOOLEAN",
+          "jcr:mandatory": "true",
+          "jcr:autoCreated": "false",
+          "jcr:name": "cnd:multiple"
+        }}
+      }
+    },
+    "cnd:childNodeDefinition": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "cnd:childNodeDefinition",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "false",
+        "jcr:supertypes": ["nt:base"]
+      },
+      "children": {
+        "cnd:name": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "NAME",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "cnd:name"
+        }},
+        "cnd:autoCreated": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "BOOLEAN",
+          "jcr:mandatory": "true",
+          "jcr:autoCreated": "false",
+          "jcr:name": "cnd:autoCreated"
+        }},
+        "cnd:mandatory": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "BOOLEAN",
+          "jcr:mandatory": "true",
+          "jcr:autoCreated": "false",
+          "jcr:name": "cnd:mandatory"
+        }},
+        "cnd:onParentVersion": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:valueConstraints": [
+            "COPY",
+            "VERSION",
+            "INITIALIZE",
+            "COMPUTE",
+            "IGNORE",
+            "ABORT"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "true",
+          "jcr:autoCreated": "false",
+          "jcr:name": "cnd:onParentVersion"
+        }},
+        "cnd:protected": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "BOOLEAN",
+          "jcr:mandatory": "true",
+          "jcr:autoCreated": "false",
+          "jcr:name": "cnd:protected"
+        }},
+        "cnd:requiredPrimaryTypes": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "true",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "NAME",
+          "jcr:mandatory": "true",
+          "jcr:defaultValues": ["nt:base"],
+          "jcr:autoCreated": "false",
+          "jcr:name": "cnd:requiredPrimaryTypes"
+        }},
+        "cnd:defaultPrimaryType": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "NAME",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "cnd:defaultPrimaryType"
+        }},
+        "cnd:sameNameSiblings": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "BOOLEAN",
+          "jcr:mandatory": "true",
+          "jcr:autoCreated": "false",
+          "jcr:name": "cnd:sameNameSiblings"
+        }}
+      }
+    },
+    "zip:file": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "zip:file",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "false",
+      "jcr:supertypes": [
+        "nt:folder",
+        "mix:mimeType"
+      ]
+    }},
+    "zip:content": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "zip:content",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "false",
+        "jcr:supertypes": [
+          "nt:unstructured",
+          "mix:mimeType"
+        ]
+      },
+      "children": {
+        "*": {"properties": {
+          "jcr:requiredPrimaryTypes": ["nt:folder"],
+          "jcr:primaryType": "nt:childNodeDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:sameNameSiblings": "false",
+          "jcr:protected": "false",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false"
+        }},
+        "*[2]": {"properties": {
+          "jcr:requiredPrimaryTypes": ["nt:file"],
+          "jcr:primaryType": "nt:childNodeDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:sameNameSiblings": "false",
+          "jcr:protected": "false",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false"
+        }}
+      }
+    },
+    "xmi:referenceable": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "xmi:referenceable",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "true",
+        "jcr:supertypes": []
+      },
+      "children": {"xmi:uuid": {"properties": {
+        "jcr:primaryType": "nt:propertyDefinition",
+        "jcr:onParentVersion": "COPY",
+        "jcr:multiple": "false",
+        "jcr:protected": "false",
+        "jcr:availableQueryOperators": [
+          "jcr.operator.equal.to",
+          "jcr.operator.greater.than",
+          "jcr.operator.greater.than.or.equal.to",
+          "jcr.operator.less.than",
+          "jcr.operator.less.than.or.equal.to",
+          "jcr.operator.like",
+          "jcr.operator.not.equal.to"
+        ],
+        "jcr:requiredType": "STRING",
+        "jcr:mandatory": "true",
+        "jcr:autoCreated": "false",
+        "jcr:name": "xmi:uuid"
+      }}}
+    },
+    "xmi:model": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "xmi:model",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "true",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "true",
+        "jcr:supertypes": [
+          "xmi:referenceable",
+          "mix:referenceable"
+        ]
+      },
+      "children": {
+        "xmi:version": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "DOUBLE",
+          "jcr:mandatory": "false",
+          "jcr:defaultValues": ["2.0"],
+          "jcr:autoCreated": "true",
+          "jcr:name": "xmi:version"
+        }},
+        "*": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "true",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "UNDEFINED",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false"
+        }},
+        "*[2]": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "UNDEFINED",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false"
+        }},
+        "*[3]": {"properties": {
+          "jcr:requiredPrimaryTypes": ["nt:base"],
+          "jcr:primaryType": "nt:childNodeDefinition",
+          "jcr:onParentVersion": "VERSION",
+          "jcr:defaultPrimaryType": "nt:unstructured",
+          "jcr:sameNameSiblings": "true",
+          "jcr:protected": "false",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false"
+        }}
+      }
+    },
+    "modelExtensionDefinition:propertyDefinition": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "modelExtensionDefinition:propertyDefinition",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "true",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "false",
+        "jcr:supertypes": ["nt:unstructured"]
+      },
+      "children": {
+        "modelExtensionDefinition:advanced": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "BOOLEAN",
+          "jcr:mandatory": "false",
+          "jcr:defaultValues": ["false"],
+          "jcr:autoCreated": "true",
+          "jcr:name": "modelExtensionDefinition:advanced"
+        }},
+        "modelExtensionDefinition:defaultValue": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "modelExtensionDefinition:defaultValue"
+        }},
+        "modelExtensionDefinition:index": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "BOOLEAN",
+          "jcr:mandatory": "false",
+          "jcr:defaultValues": ["true"],
+          "jcr:autoCreated": "true",
+          "jcr:name": "modelExtensionDefinition:index"
+        }},
+        "modelExtensionDefinition:fixedValue": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "modelExtensionDefinition:fixedValue"
+        }},
+        "modelExtensionDefinition:masked": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "BOOLEAN",
+          "jcr:mandatory": "false",
+          "jcr:defaultValues": ["false"],
+          "jcr:autoCreated": "true",
+          "jcr:name": "modelExtensionDefinition:masked"
+        }},
+        "modelExtensionDefinition:required": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "BOOLEAN",
+          "jcr:mandatory": "false",
+          "jcr:defaultValues": ["false"],
+          "jcr:autoCreated": "true",
+          "jcr:name": "modelExtensionDefinition:required"
+        }},
+        "modelExtensionDefinition:runtimeType": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:defaultValues": ["string"],
+          "jcr:autoCreated": "true",
+          "jcr:name": "modelExtensionDefinition:runtimeType"
+        }},
+        "modelExtensionDefinition:description": {"properties": {
+          "jcr:requiredPrimaryTypes": ["modelExtensionDefinition:localizedDescription"],
+          "jcr:primaryType": "nt:childNodeDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:sameNameSiblings": "true",
+          "jcr:protected": "false",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "modelExtensionDefinition:description"
+        }},
+        "modelExtensionDefinition:displayName": {"properties": {
+          "jcr:requiredPrimaryTypes": ["modelExtensionDefinition:localizedName"],
+          "jcr:primaryType": "nt:childNodeDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:sameNameSiblings": "true",
+          "jcr:protected": "false",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "modelExtensionDefinition:displayName"
+        }}
+      }
+    },
+    "modelExtensionDefinition:localized": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "modelExtensionDefinition:localized",
+        "jcr:isAbstract": "true",
+        "jcr:hasOrderableChildNodes": "true",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "false",
+        "jcr:supertypes": [
+          "nt:base",
+          "xmi:referenceable"
+        ]
+      },
+      "children": {
+        "modelExtensionDefinition:locale": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "true",
+          "jcr:autoCreated": "false",
+          "jcr:name": "modelExtensionDefinition:locale"
+        }},
+        "modelExtensionDefinition:translation": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "true",
+          "jcr:autoCreated": "false",
+          "jcr:name": "modelExtensionDefinition:translation"
+        }}
+      }
+    },
+    "modelExtensionDefinition:localizedDescription": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "modelExtensionDefinition:localizedDescription",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "false",
+      "jcr:supertypes": ["modelExtensionDefinition:localized"]
+    }},
+    "modelExtensionDefinition:localizedName": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "modelExtensionDefinition:localizedName",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "false",
+      "jcr:supertypes": ["modelExtensionDefinition:localized"]
+    }},
+    "modelExtensionDefinition:extendedMetaclass": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "modelExtensionDefinition:extendedMetaclass",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "false",
+        "jcr:supertypes": ["nt:unstructured"]
+      },
+      "children": {"*": {"properties": {
+        "jcr:requiredPrimaryTypes": ["modelExtensionDefinition:propertyDefinition"],
+        "jcr:primaryType": "nt:childNodeDefinition",
+        "jcr:onParentVersion": "COPY",
+        "jcr:sameNameSiblings": "false",
+        "jcr:protected": "false",
+        "jcr:mandatory": "false",
+        "jcr:autoCreated": "false"
+      }}}
+    },
+    "modelExtensionDefinition:modelExtensionDefinition": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "modelExtensionDefinition:modelExtensionDefinition",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "false",
+        "jcr:supertypes": ["nt:unstructured"]
+      },
+      "children": {
+        "modelExtensionDefinition:metamodel": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "true",
+          "jcr:autoCreated": "false",
+          "jcr:name": "modelExtensionDefinition:metamodel"
+        }},
+        "modelExtensionDefinition:namespacePrefix": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "true",
+          "jcr:autoCreated": "false",
+          "jcr:name": "modelExtensionDefinition:namespacePrefix"
+        }},
+        "modelExtensionDefinition:namespaceUri": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "true",
+          "jcr:autoCreated": "false",
+          "jcr:name": "modelExtensionDefinition:namespaceUri"
+        }},
+        "modelExtensionDefinition:version": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "LONG",
+          "jcr:mandatory": "true",
+          "jcr:autoCreated": "false",
+          "jcr:name": "modelExtensionDefinition:version"
+        }},
+        "modelExtensionDefinition:description": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "modelExtensionDefinition:description"
+        }},
+        "modelExtensionDefinition:modelTypes": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "true",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:valueConstraints": [
+            "PHYSICAL",
+            "VIRTUAL"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "modelExtensionDefinition:modelTypes"
+        }},
+        "*": {"properties": {
+          "jcr:requiredPrimaryTypes": ["modelExtensionDefinition:extendedMetaclass"],
+          "jcr:primaryType": "nt:childNodeDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:sameNameSiblings": "false",
+          "jcr:protected": "false",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false"
+        }}
+      }
+    },
+    "mmcore:model": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "mmcore:model",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "true",
+        "jcr:supertypes": [
+          "xmi:model",
+          "mode:hashed"
+        ]
+      },
+      "children": {
+        "mmcore:modelType": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:valueConstraints": [
+            "PHYSICAL",
+            "VIRTUAL",
+            "TYPE",
+            "VDB_ARCHIVE",
+            "UNKNOWN",
+            "FUNCTION",
+            "CONFIGURATION",
+            "METAMODEL",
+            "EXTENSION",
+            "LOGICAL",
+            "MATERIALIZATION"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:defaultValues": ["UNKNOWN"],
+          "jcr:autoCreated": "true",
+          "jcr:name": "mmcore:modelType"
+        }},
+        "mmcore:primaryMetamodelUri": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "mmcore:primaryMetamodelUri"
+        }},
+        "mmcore:description": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "mmcore:description"
+        }},
+        "mmcore:nameInSource": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "mmcore:nameInSource"
+        }},
+        "mmcore:maxSetSize": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "LONG",
+          "jcr:mandatory": "false",
+          "jcr:defaultValues": ["100"],
+          "jcr:autoCreated": "true",
+          "jcr:name": "mmcore:maxSetSize"
+        }},
+        "mmcore:visible": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "BOOLEAN",
+          "jcr:mandatory": "false",
+          "jcr:defaultValues": ["true"],
+          "jcr:autoCreated": "true",
+          "jcr:name": "mmcore:visible"
+        }},
+        "mmcore:supportsDistinct": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "BOOLEAN",
+          "jcr:mandatory": "false",
+          "jcr:defaultValues": ["true"],
+          "jcr:autoCreated": "true",
+          "jcr:name": "mmcore:supportsDistinct"
+        }},
+        "mmcore:supportsJoin": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "BOOLEAN",
+          "jcr:mandatory": "false",
+          "jcr:defaultValues": ["true"],
+          "jcr:autoCreated": "true",
+          "jcr:name": "mmcore:supportsJoin"
+        }},
+        "mmcore:supportsOrderBy": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "BOOLEAN",
+          "jcr:mandatory": "false",
+          "jcr:defaultValues": ["true"],
+          "jcr:autoCreated": "true",
+          "jcr:name": "mmcore:supportsOrderBy"
+        }},
+        "mmcore:supportsOuterJoin": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "BOOLEAN",
+          "jcr:mandatory": "false",
+          "jcr:defaultValues": ["true"],
+          "jcr:autoCreated": "true",
+          "jcr:name": "mmcore:supportsOuterJoin"
+        }},
+        "mmcore:supportsWhereAll": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "BOOLEAN",
+          "jcr:mandatory": "false",
+          "jcr:defaultValues": ["true"],
+          "jcr:autoCreated": "true",
+          "jcr:name": "mmcore:supportsWhereAll"
+        }},
+        "mmcore:producerName": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "mmcore:producerName"
+        }},
+        "mmcore:producerVersion": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "mmcore:producerVersion"
+        }},
+        "mmcore:originalFile": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "mmcore:originalFile"
+        }},
+        "mmcore:modelExtensionDefinitions": {"properties": {
+          "jcr:requiredPrimaryTypes": ["mmcore:modelExtensionDefinitions"],
+          "jcr:primaryType": "nt:childNodeDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:sameNameSiblings": "false",
+          "jcr:protected": "false",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "mmcore:modelExtensionDefinitions"
+        }}
+      }
+    },
+    "mmcore:modelExtensionDefinitions": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "mmcore:modelExtensionDefinitions",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "false",
+        "jcr:supertypes": ["nt:unstructured"]
+      },
+      "children": {"*": {"properties": {
+        "jcr:requiredPrimaryTypes": ["modelExtensionDefinition:modelExtensionDefinition"],
+        "jcr:primaryType": "nt:childNodeDefinition",
+        "jcr:onParentVersion": "COPY",
+        "jcr:sameNameSiblings": "false",
+        "jcr:protected": "false",
+        "jcr:mandatory": "false",
+        "jcr:autoCreated": "false"
+      }}}
+    },
+    "mmcore:import": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "mmcore:import",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "true",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "false",
+        "jcr:supertypes": [
+          "nt:unstructured",
+          "xmi:referenceable"
+        ]
+      },
+      "children": {
+        "mmcore:modelType": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:valueConstraints": [
+            "PHYSICAL",
+            "VIRTUAL",
+            "TYPE",
+            "VDB_ARCHIVE",
+            "UNKNOWN",
+            "FUNCTION",
+            "CONFIGURATION",
+            "METAMODEL",
+            "EXTENSION",
+            "LOGICAL",
+            "MATERIALIZATION"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:defaultValues": ["UNKNOWN"],
+          "jcr:autoCreated": "true",
+          "jcr:name": "mmcore:modelType"
+        }},
+        "mmcore:primaryMetamodelUri": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "mmcore:primaryMetamodelUri"
+        }},
+        "mmcore:path": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "mmcore:path"
+        }},
+        "mmcore:modelLocation": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "mmcore:modelLocation"
+        }}
+      }
+    },
+    "mmcore:annotated": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "mmcore:annotated",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "true",
+        "jcr:supertypes": []
+      },
+      "children": {
+        "mmcore:description": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "mmcore:description"
+        }},
+        "mmcore:keywords": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "true",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "mmcore:keywords"
+        }}
+      }
+    },
+    "mmcore:tags": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "mmcore:tags",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "true",
+        "jcr:supertypes": []
+      },
+      "children": {
+        "*": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "true",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "UNDEFINED",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false"
+        }},
+        "*[2]": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "UNDEFINED",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false"
+        }}
+      }
+    },
+    "jdbcs:source": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "jdbcs:source",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "false",
+        "jcr:supertypes": [
+          "nt:unstructured",
+          "xmi:referenceable"
+        ]
+      },
+      "children": {
+        "jdbcs:name": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "jdbcs:name"
+        }},
+        "jdbcs:driverName": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "jdbcs:driverName"
+        }},
+        "jdbcs:driverClass": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "jdbcs:driverClass"
+        }},
+        "jdbcs:username": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "jdbcs:username"
+        }},
+        "jdbcs:url": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "jdbcs:url"
+        }}
+      }
+    },
+    "jdbcs:imported": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "jdbcs:imported",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "false",
+        "jcr:supertypes": [
+          "nt:unstructured",
+          "xmi:referenceable"
+        ]
+      },
+      "children": {
+        "jdbcs:createCatalogsInModel": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "BOOLEAN",
+          "jcr:mandatory": "false",
+          "jcr:defaultValues": ["true"],
+          "jcr:autoCreated": "true",
+          "jcr:name": "jdbcs:createCatalogsInModel"
+        }},
+        "jdbcs:createSchemasInModel": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "BOOLEAN",
+          "jcr:mandatory": "false",
+          "jcr:defaultValues": ["true"],
+          "jcr:autoCreated": "true",
+          "jcr:name": "jdbcs:createSchemasInModel"
+        }},
+        "jdbcs:convertCaseInModel": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:valueConstraints": [
+            "NONE",
+            "TO_UPPERCASE",
+            "TO_LOWERCASE"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "jdbcs:convertCaseInModel"
+        }},
+        "jdbcs:generateSourceNamesInModel": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:valueConstraints": [
+            "NONE",
+            "UNQUALIFIED",
+            "FULLY_QUALIFIED"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:defaultValues": ["UNQUALIFIED"],
+          "jcr:autoCreated": "true",
+          "jcr:name": "jdbcs:generateSourceNamesInModel"
+        }},
+        "jdbcs:includedCatalogPaths": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "true",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "jdbcs:includedCatalogPaths"
+        }},
+        "jdbcs:includedSchemaPaths": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "true",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "jdbcs:includedSchemaPaths"
+        }},
+        "jdbcs:excludedObjectPaths": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "true",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "jdbcs:excludedObjectPaths"
+        }},
+        "jdbcs:includeForeignKeys": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "BOOLEAN",
+          "jcr:mandatory": "false",
+          "jcr:defaultValues": ["true"],
+          "jcr:autoCreated": "true",
+          "jcr:name": "jdbcs:includeForeignKeys"
+        }},
+        "jdbcs:includeIndexes": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "BOOLEAN",
+          "jcr:mandatory": "false",
+          "jcr:defaultValues": ["true"],
+          "jcr:autoCreated": "true",
+          "jcr:name": "jdbcs:includeIndexes"
+        }},
+        "jdbcs:includeProcedures": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "BOOLEAN",
+          "jcr:mandatory": "false",
+          "jcr:defaultValues": ["false"],
+          "jcr:autoCreated": "true",
+          "jcr:name": "jdbcs:includeProcedures"
+        }},
+        "jdbcs:includeApproximateIndexes": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "BOOLEAN",
+          "jcr:mandatory": "false",
+          "jcr:defaultValues": ["true"],
+          "jcr:autoCreated": "true",
+          "jcr:name": "jdbcs:includeApproximateIndexes"
+        }},
+        "jdbcs:includeUniqueIndexes": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "BOOLEAN",
+          "jcr:mandatory": "false",
+          "jcr:defaultValues": ["false"],
+          "jcr:autoCreated": "true",
+          "jcr:name": "jdbcs:includeUniqueIndexes"
+        }},
+        "jdbcs:includedTableTypes": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "true",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "jdbcs:includedTableTypes"
+        }}
+      }
+    },
+    "relational:relationalEntity": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "relational:relationalEntity",
+        "jcr:isAbstract": "true",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "true",
+        "jcr:supertypes": ["xmi:referenceable"]
+      },
+      "children": {"relational:nameInSource": {"properties": {
+        "jcr:primaryType": "nt:propertyDefinition",
+        "jcr:onParentVersion": "COPY",
+        "jcr:multiple": "false",
+        "jcr:protected": "false",
+        "jcr:availableQueryOperators": [
+          "jcr.operator.equal.to",
+          "jcr.operator.greater.than",
+          "jcr.operator.greater.than.or.equal.to",
+          "jcr.operator.less.than",
+          "jcr.operator.less.than.or.equal.to",
+          "jcr.operator.like",
+          "jcr.operator.not.equal.to"
+        ],
+        "jcr:requiredType": "STRING",
+        "jcr:mandatory": "false",
+        "jcr:autoCreated": "false",
+        "jcr:name": "relational:nameInSource"
+      }}}
+    },
+    "relational:relationship": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "relational:relationship",
+      "jcr:isAbstract": "true",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "false",
+      "jcr:supertypes": [
+        "nt:unstructured",
+        "relational:relationalEntity"
+      ]
+    }},
+    "relational:column": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "relational:column",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "false",
+        "jcr:supertypes": [
+          "nt:unstructured",
+          "relational:relationalEntity"
+        ]
+      },
+      "children": {
+        "relational:nativeType": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "relational:nativeType"
+        }},
+        "relational:type": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "WEAKREFERENCE",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "relational:type"
+        }},
+        "relational:typeHref": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "relational:typeHref"
+        }},
+        "relational:typeXmiUuid": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "relational:typeXmiUuid"
+        }},
+        "relational:typeName": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "relational:typeName"
+        }},
+        "relational:length": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "LONG",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "relational:length"
+        }},
+        "relational:fixedLength": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "BOOLEAN",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "relational:fixedLength"
+        }},
+        "relational:precision": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "LONG",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "relational:precision"
+        }},
+        "relational:scale": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "LONG",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "relational:scale"
+        }},
+        "relational:nullable": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:valueConstraints": [
+            "NO_NULLS",
+            "NULLABLE",
+            "NULLABLE_UNKNOWN"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:defaultValues": ["NULLABLE"],
+          "jcr:autoCreated": "true",
+          "jcr:name": "relational:nullable"
+        }},
+        "relational:autoIncremented": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "BOOLEAN",
+          "jcr:mandatory": "false",
+          "jcr:defaultValues": ["false"],
+          "jcr:autoCreated": "true",
+          "jcr:name": "relational:autoIncremented"
+        }},
+        "relational:defaultValue": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "relational:defaultValue"
+        }},
+        "relational:minimumValue": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "relational:minimumValue"
+        }},
+        "relational:maximumValue": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "relational:maximumValue"
+        }},
+        "relational:format": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "relational:format"
+        }},
+        "relational:characterSetName": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "relational:characterSetName"
+        }},
+        "relational:collationName": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "relational:collationName"
+        }},
+        "relational:selectable": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "BOOLEAN",
+          "jcr:mandatory": "false",
+          "jcr:defaultValues": ["true"],
+          "jcr:autoCreated": "true",
+          "jcr:name": "relational:selectable"
+        }},
+        "relational:updateable": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "BOOLEAN",
+          "jcr:mandatory": "false",
+          "jcr:defaultValues": ["true"],
+          "jcr:autoCreated": "true",
+          "jcr:name": "relational:updateable"
+        }},
+        "relational:caseSensitive": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "BOOLEAN",
+          "jcr:mandatory": "false",
+          "jcr:defaultValues": ["true"],
+          "jcr:autoCreated": "true",
+          "jcr:name": "relational:caseSensitive"
+        }},
+        "relational:searchability": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:valueConstraints": [
+            "SEARCHABLE",
+            "ALL_EXCEPT_LIKE",
+            "LIKE_ONLY",
+            "UNSEARCHABLE"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:defaultValues": ["SEARCHABLE"],
+          "jcr:autoCreated": "true",
+          "jcr:name": "relational:searchability"
+        }},
+        "relational:currency": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "BOOLEAN",
+          "jcr:mandatory": "false",
+          "jcr:defaultValues": ["false"],
+          "jcr:autoCreated": "true",
+          "jcr:name": "relational:currency"
+        }},
+        "relational:radix": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "LONG",
+          "jcr:mandatory": "false",
+          "jcr:defaultValues": ["10"],
+          "jcr:autoCreated": "true",
+          "jcr:name": "relational:radix"
+        }},
+        "relational:signed": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "BOOLEAN",
+          "jcr:mandatory": "false",
+          "jcr:defaultValues": ["true"],
+          "jcr:autoCreated": "true",
+          "jcr:name": "relational:signed"
+        }},
+        "relational:distinctValueCount": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "LONG",
+          "jcr:mandatory": "false",
+          "jcr:defaultValues": ["-1"],
+          "jcr:autoCreated": "true",
+          "jcr:name": "relational:distinctValueCount"
+        }},
+        "relational:nullValueCount": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "LONG",
+          "jcr:mandatory": "false",
+          "jcr:defaultValues": ["-1"],
+          "jcr:autoCreated": "true",
+          "jcr:name": "relational:nullValueCount"
+        }},
+        "relational:uniqueKeys": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "true",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "WEAKREFERENCE",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "relational:uniqueKeys"
+        }},
+        "relational:uniqueKeyHrefs": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "true",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "relational:uniqueKeyHrefs"
+        }},
+        "relational:uniqueKeyXmiUuids": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "true",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "relational:uniqueKeyXmiUuids"
+        }},
+        "relational:uniqueKeyNames": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "true",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "relational:uniqueKeyNames"
+        }},
+        "relational:indexes": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "true",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "WEAKREFERENCE",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "relational:indexes"
+        }},
+        "relational:indexHrefs": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "true",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "relational:indexHrefs"
+        }},
+        "relational:indexXmiUuids": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "true",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "relational:indexXmiUuids"
+        }},
+        "relational:indexNames": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "true",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "relational:indexNames"
+        }},
+        "relational:foreignKeys": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "true",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "WEAKREFERENCE",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "relational:foreignKeys"
+        }},
+        "relational:foreignKeyHrefs": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "true",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "relational:foreignKeyHrefs"
+        }},
+        "relational:foreignKeyXmiUuids": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "true",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "relational:foreignKeyXmiUuids"
+        }},
+        "relational:foreignKeyNames": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "true",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "relational:foreignKeyNames"
+        }},
+        "relational:accessPatterns": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "true",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "WEAKREFERENCE",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "relational:accessPatterns"
+        }},
+        "relational:accessPatternHrefs": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "true",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "relational:accessPatternHrefs"
+        }},
+        "relational:accessPatternXmiUuids": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "true",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "relational:accessPatternXmiUuids"
+        }},
+        "relational:accessPatternNames": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "true",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "relational:accessPatternNames"
+        }}
+      }
+    },
+    "relational:columnSet": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "relational:columnSet",
+        "jcr:isAbstract": "true",
+        "jcr:hasOrderableChildNodes": "true",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "false",
+        "jcr:supertypes": [
+          "nt:unstructured",
+          "relational:relationalEntity"
+        ]
+      },
+      "children": {"*": {"properties": {
+        "jcr:requiredPrimaryTypes": ["relational:column"],
+        "jcr:primaryType": "nt:childNodeDefinition",
+        "jcr:onParentVersion": "COPY",
+        "jcr:defaultPrimaryType": "relational:column",
+        "jcr:sameNameSiblings": "false",
+        "jcr:protected": "false",
+        "jcr:mandatory": "false",
+        "jcr:autoCreated": "false"
+      }}}
+    },
+    "relational:uniqueKey": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "relational:uniqueKey",
+        "jcr:isAbstract": "true",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "false",
+        "jcr:supertypes": [
+          "nt:unstructured",
+          "relational:relationalEntity"
+        ]
+      },
+      "children": {
+        "relational:columns": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "true",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "WEAKREFERENCE",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "relational:columns"
+        }},
+        "relational:columnXmiUuids": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "true",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "relational:columnXmiUuids"
+        }},
+        "relational:columnNames": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "true",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "relational:columnNames"
+        }},
+        "relational:foreignKeys": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "true",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "WEAKREFERENCE",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "relational:foreignKeys"
+        }},
+        "relational:foreignKeyHrefs": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "true",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "relational:foreignKeyHrefs"
+        }},
+        "relational:foreignKeyXmiUuids": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "true",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "relational:foreignKeyXmiUuids"
+        }},
+        "relational:foreignKeyNames": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "true",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "relational:foreignKeyNames"
+        }}
+      }
+    },
+    "relational:primaryKey": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "relational:primaryKey",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "false",
+      "jcr:supertypes": ["relational:uniqueKey"]
+    }},
+    "relational:foreignKey": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "relational:foreignKey",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "false",
+        "jcr:supertypes": ["relational:relationship"]
+      },
+      "children": {
+        "relational:foreignKeyMultiplicity": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:valueConstraints": [
+            "ONE",
+            "MANY",
+            "ZERO_TO_ONE",
+            "ZERO_TO_MANY",
+            "UNSPECIFIED"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:defaultValues": ["ZERO_TO_MANY"],
+          "jcr:autoCreated": "true",
+          "jcr:name": "relational:foreignKeyMultiplicity"
+        }},
+        "relational:primaryKeyMultiplicity": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:valueConstraints": [
+            "ONE",
+            "MANY",
+            "ZERO_TO_ONE",
+            "ZERO_TO_MANY",
+            "UNSPECIFIED"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:defaultValues": ["ONE"],
+          "jcr:autoCreated": "true",
+          "jcr:name": "relational:primaryKeyMultiplicity"
+        }},
+        "relational:columns": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "true",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "WEAKREFERENCE",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "relational:columns"
+        }},
+        "relational:columnXmiUuids": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "true",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "relational:columnXmiUuids"
+        }},
+        "relational:columnNames": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "true",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "relational:columnNames"
+        }},
+        "relational:uniqueKeys": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "true",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "WEAKREFERENCE",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "relational:uniqueKeys"
+        }},
+        "relational:uniqueKeyHrefs": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "true",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "relational:uniqueKeyHrefs"
+        }},
+        "relational:uniqueKeyXmiUuids": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "true",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "relational:uniqueKeyXmiUuids"
+        }},
+        "relational:uniqueKeyNames": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "true",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "relational:uniqueKeyNames"
+        }}
+      }
+    },
+    "relational:index": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "relational:index",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "false",
+        "jcr:supertypes": [
+          "nt:unstructured",
+          "relational:relationalEntity"
+        ]
+      },
+      "children": {
+        "relational:filterCondition": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "relational:filterCondition"
+        }},
+        "relational:nullable": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "BOOLEAN",
+          "jcr:mandatory": "false",
+          "jcr:defaultValues": ["true"],
+          "jcr:autoCreated": "true",
+          "jcr:name": "relational:nullable"
+        }},
+        "relational:autoUpdate": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "BOOLEAN",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "relational:autoUpdate"
+        }},
+        "relational:unique": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "BOOLEAN",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "relational:unique"
+        }},
+        "relational:columns": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "true",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "WEAKREFERENCE",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "relational:columns"
+        }},
+        "relational:columnXmiUuids": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "true",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "relational:columnXmiUuids"
+        }},
+        "relational:columnNames": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "true",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "relational:columnNames"
+        }}
+      }
+    },
+    "relational:accessPattern": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "relational:accessPattern",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "true",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "false",
+        "jcr:supertypes": [
+          "nt:unstructured",
+          "relational:relationalEntity"
+        ]
+      },
+      "children": {
+        "relational:columns": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "true",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "WEAKREFERENCE",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "relational:columns"
+        }},
+        "relational:columnXmiUuids": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "true",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "relational:columnXmiUuids"
+        }},
+        "relational:columnNames": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "true",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "relational:columnNames"
+        }}
+      }
+    },
+    "relational:table": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "relational:table",
+        "jcr:isAbstract": "true",
+        "jcr:hasOrderableChildNodes": "true",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "false",
+        "jcr:supertypes": ["relational:columnSet"]
+      },
+      "children": {
+        "relational:system": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "BOOLEAN",
+          "jcr:mandatory": "false",
+          "jcr:defaultValues": ["false"],
+          "jcr:autoCreated": "true",
+          "jcr:name": "relational:system"
+        }},
+        "relational:cardinality": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "LONG",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "relational:cardinality"
+        }},
+        "relational:supportsUpdate": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "BOOLEAN",
+          "jcr:mandatory": "false",
+          "jcr:defaultValues": ["true"],
+          "jcr:autoCreated": "true",
+          "jcr:name": "relational:supportsUpdate"
+        }},
+        "relational:materialized": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "BOOLEAN",
+          "jcr:mandatory": "false",
+          "jcr:defaultValues": ["false"],
+          "jcr:autoCreated": "true",
+          "jcr:name": "relational:materialized"
+        }},
+        "*": {"properties": {
+          "jcr:requiredPrimaryTypes": ["relational:primaryKey"],
+          "jcr:primaryType": "nt:childNodeDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:defaultPrimaryType": "relational:primaryKey",
+          "jcr:sameNameSiblings": "false",
+          "jcr:protected": "false",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false"
+        }},
+        "*[2]": {"properties": {
+          "jcr:requiredPrimaryTypes": ["relational:foreignKey"],
+          "jcr:primaryType": "nt:childNodeDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:defaultPrimaryType": "relational:foreignKey",
+          "jcr:sameNameSiblings": "false",
+          "jcr:protected": "false",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false"
+        }},
+        "*[3]": {"properties": {
+          "jcr:requiredPrimaryTypes": ["relational:accessPattern"],
+          "jcr:primaryType": "nt:childNodeDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:defaultPrimaryType": "relational:accessPattern",
+          "jcr:sameNameSiblings": "true",
+          "jcr:protected": "false",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false"
+        }}
+      }
+    },
+    "relational:baseTable": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "relational:baseTable",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "true",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "false",
+      "jcr:supertypes": ["relational:table"]
+    }},
+    "relational:view": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "relational:view",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "true",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "false",
+      "jcr:supertypes": ["relational:table"]
+    }},
+    "relational:procedureParameter": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "relational:procedureParameter",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "false",
+        "jcr:supertypes": [
+          "nt:unstructured",
+          "relational:relationalEntity"
+        ]
+      },
+      "children": {
+        "relational:direction": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:valueConstraints": [
+            "IN",
+            "OUT",
+            "INOUT",
+            "RETURN",
+            "UNKNOWN"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "relational:direction"
+        }},
+        "relational:defaultValue": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "relational:defaultValue"
+        }},
+        "relational:nativeType": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "relational:nativeType"
+        }},
+        "relational:type": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "WEAKREFERENCE",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "relational:type"
+        }},
+        "relational:typeXmiUuid": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "relational:typeXmiUuid"
+        }},
+        "relational:typeName": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "relational:typeName"
+        }},
+        "relational:length": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "LONG",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "relational:length"
+        }},
+        "relational:precision": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "LONG",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "relational:precision"
+        }},
+        "relational:scale": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "LONG",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "relational:scale"
+        }},
+        "relational:nullable": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:valueConstraints": [
+            "NO_NULLS",
+            "NULLABLE",
+            "NULLABLE_UNKNOWN"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:defaultValues": ["NULLABLE"],
+          "jcr:autoCreated": "true",
+          "jcr:name": "relational:nullable"
+        }},
+        "relational:radix": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "LONG",
+          "jcr:mandatory": "false",
+          "jcr:defaultValues": ["10"],
+          "jcr:autoCreated": "true",
+          "jcr:name": "relational:radix"
+        }}
+      }
+    },
+    "relational:procedureResult": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "relational:procedureResult",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "true",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "false",
+      "jcr:supertypes": ["relational:columnSet"]
+    }},
+    "relational:procedure": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "relational:procedure",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "true",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "false",
+        "jcr:supertypes": [
+          "nt:unstructured",
+          "relational:relationalEntity"
+        ]
+      },
+      "children": {
+        "relational:function": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "BOOLEAN",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "relational:function"
+        }},
+        "relational:updateCount": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:valueConstraints": [
+            "AUTO",
+            "ZERO",
+            "ONE",
+            "MULTIPLE"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "relational:updateCount"
+        }},
+        "*": {"properties": {
+          "jcr:requiredPrimaryTypes": ["relational:procedureParameter"],
+          "jcr:primaryType": "nt:childNodeDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:defaultPrimaryType": "relational:procedureParameter",
+          "jcr:sameNameSiblings": "true",
+          "jcr:protected": "false",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false"
+        }},
+        "*[2]": {"properties": {
+          "jcr:requiredPrimaryTypes": ["relational:procedureResult"],
+          "jcr:primaryType": "nt:childNodeDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:defaultPrimaryType": "relational:procedureResult",
+          "jcr:sameNameSiblings": "false",
+          "jcr:protected": "false",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false"
+        }}
+      }
+    },
+    "relational:schema": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "relational:schema",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "true",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "false",
+        "jcr:supertypes": [
+          "nt:unstructured",
+          "relational:relationalEntity"
+        ]
+      },
+      "children": {
+        "*": {"properties": {
+          "jcr:requiredPrimaryTypes": ["relational:table"],
+          "jcr:primaryType": "nt:childNodeDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:defaultPrimaryType": "relational:baseTable",
+          "jcr:sameNameSiblings": "false",
+          "jcr:protected": "false",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false"
+        }},
+        "*[2]": {"properties": {
+          "jcr:requiredPrimaryTypes": ["relational:procedure"],
+          "jcr:primaryType": "nt:childNodeDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:defaultPrimaryType": "relational:procedure",
+          "jcr:sameNameSiblings": "true",
+          "jcr:protected": "false",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false"
+        }},
+        "*[3]": {"properties": {
+          "jcr:requiredPrimaryTypes": ["relational:index"],
+          "jcr:primaryType": "nt:childNodeDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:defaultPrimaryType": "relational:index",
+          "jcr:sameNameSiblings": "false",
+          "jcr:protected": "false",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false"
+        }}
+      }
+    },
+    "relational:catalog": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "relational:catalog",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "true",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "false",
+        "jcr:supertypes": [
+          "nt:unstructured",
+          "relational:relationalEntity"
+        ]
+      },
+      "children": {
+        "*": {"properties": {
+          "jcr:requiredPrimaryTypes": ["relational:schema"],
+          "jcr:primaryType": "nt:childNodeDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:defaultPrimaryType": "relational:schema",
+          "jcr:sameNameSiblings": "false",
+          "jcr:protected": "false",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false"
+        }},
+        "*[2]": {"properties": {
+          "jcr:requiredPrimaryTypes": ["relational:table"],
+          "jcr:primaryType": "nt:childNodeDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:defaultPrimaryType": "relational:baseTable",
+          "jcr:sameNameSiblings": "false",
+          "jcr:protected": "false",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false"
+        }},
+        "*[3]": {"properties": {
+          "jcr:requiredPrimaryTypes": ["relational:procedure"],
+          "jcr:primaryType": "nt:childNodeDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:defaultPrimaryType": "relational:procedure",
+          "jcr:sameNameSiblings": "true",
+          "jcr:protected": "false",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false"
+        }},
+        "*[4]": {"properties": {
+          "jcr:requiredPrimaryTypes": ["relational:index"],
+          "jcr:primaryType": "nt:childNodeDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:defaultPrimaryType": "relational:index",
+          "jcr:sameNameSiblings": "false",
+          "jcr:protected": "false",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false"
+        }}
+      }
+    },
+    "transform:transformed": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "transform:transformed",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "true",
+        "jcr:supertypes": []
+      },
+      "children": {
+        "transform:transformedFrom": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "true",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "WEAKREFERENCE",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "transform:transformedFrom"
+        }},
+        "transform:transformedFromHrefs": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "true",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "transform:transformedFromHrefs"
+        }},
+        "transform:transformedFromXmiUuids": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "true",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "transform:transformedFromXmiUuids"
+        }},
+        "transform:transformedFromNames": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "true",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "transform:transformedFromNames"
+        }}
+      }
+    },
+    "transform:withSql": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "transform:withSql",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "true",
+        "jcr:supertypes": []
+      },
+      "children": {
+        "transform:selectSql": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "transform:selectSql"
+        }},
+        "transform:insertSql": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "transform:insertSql"
+        }},
+        "transform:updateSql": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "transform:updateSql"
+        }},
+        "transform:deleteSql": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "transform:deleteSql"
+        }},
+        "transform:insertAllowed": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "BOOLEAN",
+          "jcr:mandatory": "false",
+          "jcr:defaultValues": ["true"],
+          "jcr:autoCreated": "true",
+          "jcr:name": "transform:insertAllowed"
+        }},
+        "transform:updateAllowed": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "BOOLEAN",
+          "jcr:mandatory": "false",
+          "jcr:defaultValues": ["true"],
+          "jcr:autoCreated": "true",
+          "jcr:name": "transform:updateAllowed"
+        }},
+        "transform:deleteAllowed": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "BOOLEAN",
+          "jcr:mandatory": "false",
+          "jcr:defaultValues": ["true"],
+          "jcr:autoCreated": "true",
+          "jcr:name": "transform:deleteAllowed"
+        }},
+        "transform:outputLocked": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "BOOLEAN",
+          "jcr:mandatory": "false",
+          "jcr:defaultValues": ["false"],
+          "jcr:autoCreated": "true",
+          "jcr:name": "transform:outputLocked"
+        }},
+        "transform:insertSqlDefault": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "BOOLEAN",
+          "jcr:mandatory": "false",
+          "jcr:defaultValues": ["true"],
+          "jcr:autoCreated": "true",
+          "jcr:name": "transform:insertSqlDefault"
+        }},
+        "transform:updateSqlDefault": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "BOOLEAN",
+          "jcr:mandatory": "false",
+          "jcr:defaultValues": ["true"],
+          "jcr:autoCreated": "true",
+          "jcr:name": "transform:updateSqlDefault"
+        }},
+        "transform:deleteSqlDefault": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "BOOLEAN",
+          "jcr:mandatory": "false",
+          "jcr:defaultValues": ["true"],
+          "jcr:autoCreated": "true",
+          "jcr:name": "transform:deleteSqlDefault"
+        }}
+      }
+    },
+    "vdb:virtualDatabase": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "vdb:virtualDatabase",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "false",
+        "jcr:supertypes": [
+          "nt:unstructured",
+          "mode:hashed"
+        ]
+      },
+      "children": {
+        "vdb:description": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "vdb:description"
+        }},
+        "vdb:version": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "LONG",
+          "jcr:mandatory": "false",
+          "jcr:defaultValues": ["1"],
+          "jcr:autoCreated": "true",
+          "jcr:name": "vdb:version"
+        }},
+        "vdb:preview": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "BOOLEAN",
+          "jcr:mandatory": "false",
+          "jcr:defaultValues": ["false"],
+          "jcr:autoCreated": "true",
+          "jcr:name": "vdb:preview"
+        }},
+        "vdb:originalFile": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "true",
+          "jcr:autoCreated": "false",
+          "jcr:name": "vdb:originalFile"
+        }},
+        "vdb:translators": {"properties": {
+          "jcr:requiredPrimaryTypes": ["vdb:translators"],
+          "jcr:primaryType": "nt:childNodeDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:sameNameSiblings": "false",
+          "jcr:protected": "false",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "vdb:translators"
+        }},
+        "vdb:dataRoles": {"properties": {
+          "jcr:requiredPrimaryTypes": ["vdb:dataRoles"],
+          "jcr:primaryType": "nt:childNodeDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:sameNameSiblings": "false",
+          "jcr:protected": "false",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "vdb:dataRoles"
+        }},
+        "vdb:entries": {"properties": {
+          "jcr:requiredPrimaryTypes": ["vdb:entries"],
+          "jcr:primaryType": "nt:childNodeDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:sameNameSiblings": "false",
+          "jcr:protected": "false",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "vdb:entries"
+        }},
+        "vdb:importVdbs": {"properties": {
+          "jcr:requiredPrimaryTypes": ["vdb:importVdbs"],
+          "jcr:primaryType": "nt:childNodeDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:sameNameSiblings": "false",
+          "jcr:protected": "false",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "vdb:importVdbs"
+        }}
+      }
+    },
+    "vdb:abstractModel": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "vdb:abstractModel",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "true",
+        "jcr:supertypes": []
+      },
+      "children": {
+        "vdb:description": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "vdb:description"
+        }},
+        "vdb:visible": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "BOOLEAN",
+          "jcr:mandatory": "false",
+          "jcr:defaultValues": ["true"],
+          "jcr:autoCreated": "true",
+          "jcr:name": "vdb:visible"
+        }},
+        "vdb:pathInVdb": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "vdb:pathInVdb"
+        }},
+        "vdb:sourceTranslator": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "vdb:sourceTranslator"
+        }},
+        "vdb:sourceJndiName": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "vdb:sourceJndiName"
+        }},
+        "vdb:sourceName": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "vdb:sourceName"
+        }}
+      }
+    },
+    "vdb:model": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "vdb:model",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "false",
+        "jcr:supertypes": [
+          "nt:base",
+          "vdb:abstractModel",
+          "mmcore:model"
+        ]
+      },
+      "children": {
+        "vdb:checksum": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "LONG",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "vdb:checksum"
+        }},
+        "vdb:builtIn": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "BOOLEAN",
+          "jcr:mandatory": "false",
+          "jcr:defaultValues": ["false"],
+          "jcr:autoCreated": "true",
+          "jcr:name": "vdb:builtIn"
+        }},
+        "vdb:markers": {"properties": {
+          "jcr:requiredPrimaryTypes": ["vdb:markers"],
+          "jcr:primaryType": "nt:childNodeDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:defaultPrimaryType": "vdb:markers",
+          "jcr:sameNameSiblings": "false",
+          "jcr:protected": "false",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "vdb:markers"
+        }}
+      }
+    },
+    "vdb:declarativeModel": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "vdb:declarativeModel",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "false",
+        "jcr:supertypes": [
+          "nt:unstructured",
+          "vdb:abstractModel",
+          "mix:referenceable"
+        ]
+      },
+      "children": {
+        "mmcore:modelType": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:valueConstraints": [
+            "PHYSICAL",
+            "VIRTUAL"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:defaultValues": ["PHYSICAL"],
+          "jcr:autoCreated": "true",
+          "jcr:name": "mmcore:modelType"
+        }},
+        "vdb:metadataType": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:defaultValues": ["DDL"],
+          "jcr:autoCreated": "true",
+          "jcr:name": "vdb:metadataType"
+        }},
+        "vdb:modelDefinition": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "vdb:modelDefinition"
+        }}
+      }
+    },
+    "vdb:markers": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "vdb:markers",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "false",
+        "jcr:supertypes": ["nt:unstructured"]
+      },
+      "children": {"vdb:marker": {"properties": {
+        "jcr:requiredPrimaryTypes": ["vdb:marker"],
+        "jcr:primaryType": "nt:childNodeDefinition",
+        "jcr:onParentVersion": "COPY",
+        "jcr:defaultPrimaryType": "vdb:marker",
+        "jcr:sameNameSiblings": "true",
+        "jcr:protected": "false",
+        "jcr:mandatory": "false",
+        "jcr:autoCreated": "false",
+        "jcr:name": "vdb:marker"
+      }}}
+    },
+    "vdb:marker": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "vdb:marker",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "false",
+        "jcr:supertypes": ["nt:unstructured"]
+      },
+      "children": {
+        "vdb:severity": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:valueConstraints": [
+            "WARNING",
+            "ERROR",
+            "INFO"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:defaultValues": ["WARNING"],
+          "jcr:autoCreated": "true",
+          "jcr:name": "vdb:severity"
+        }},
+        "vdb:path": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "true",
+          "jcr:autoCreated": "false",
+          "jcr:name": "vdb:path"
+        }},
+        "vdb:message": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "true",
+          "jcr:autoCreated": "false",
+          "jcr:name": "vdb:message"
+        }}
+      }
+    },
+    "vdb:translators": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "vdb:translators",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "false",
+        "jcr:supertypes": ["nt:unstructured"]
+      },
+      "children": {"vdb:translator": {"properties": {
+        "jcr:requiredPrimaryTypes": ["vdb:translator"],
+        "jcr:primaryType": "nt:childNodeDefinition",
+        "jcr:onParentVersion": "COPY",
+        "jcr:sameNameSiblings": "false",
+        "jcr:protected": "false",
+        "jcr:mandatory": "false",
+        "jcr:autoCreated": "false",
+        "jcr:name": "vdb:translator"
+      }}}
+    },
+    "vdb:translator": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "vdb:translator",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "false",
+        "jcr:supertypes": ["nt:unstructured"]
+      },
+      "children": {
+        "vdb:type": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "true",
+          "jcr:autoCreated": "false",
+          "jcr:name": "vdb:type"
+        }},
+        "vdb:description": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "vdb:description"
+        }}
+      }
+    },
+    "vdb:dataRoles": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "vdb:dataRoles",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "false",
+        "jcr:supertypes": ["nt:unstructured"]
+      },
+      "children": {"vdb:dataRole": {"properties": {
+        "jcr:requiredPrimaryTypes": ["vdb:dataRole"],
+        "jcr:primaryType": "nt:childNodeDefinition",
+        "jcr:onParentVersion": "COPY",
+        "jcr:sameNameSiblings": "false",
+        "jcr:protected": "false",
+        "jcr:mandatory": "false",
+        "jcr:autoCreated": "false",
+        "jcr:name": "vdb:dataRole"
+      }}}
+    },
+    "vdb:dataRole": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "vdb:dataRole",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "false",
+        "jcr:supertypes": ["nt:unstructured"]
+      },
+      "children": {
+        "vdb:description": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "vdb:description"
+        }},
+        "vdb:anyAuthenticated": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "BOOLEAN",
+          "jcr:mandatory": "false",
+          "jcr:defaultValues": ["false"],
+          "jcr:autoCreated": "true",
+          "jcr:name": "vdb:anyAuthenticated"
+        }},
+        "vdb:allowCreateTemporaryTables": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "BOOLEAN",
+          "jcr:mandatory": "false",
+          "jcr:defaultValues": ["false"],
+          "jcr:autoCreated": "true",
+          "jcr:name": "vdb:allowCreateTemporaryTables"
+        }},
+        "vdb:mappedRoleNames": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "true",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "vdb:mappedRoleNames"
+        }},
+        "vdb:permission": {"properties": {
+          "jcr:requiredPrimaryTypes": ["vdb:permission"],
+          "jcr:primaryType": "nt:childNodeDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:defaultPrimaryType": "vdb:permission",
+          "jcr:sameNameSiblings": "true",
+          "jcr:protected": "false",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "vdb:permission"
+        }}
+      }
+    },
+    "vdb:entries": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "vdb:entries",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "false",
+        "jcr:supertypes": ["nt:unstructured"]
+      },
+      "children": {"vdb:vdbEntry": {"properties": {
+        "jcr:requiredPrimaryTypes": ["vdb:entry"],
+        "jcr:primaryType": "nt:childNodeDefinition",
+        "jcr:onParentVersion": "COPY",
+        "jcr:sameNameSiblings": "true",
+        "jcr:protected": "false",
+        "jcr:mandatory": "false",
+        "jcr:autoCreated": "false",
+        "jcr:name": "vdb:vdbEntry"
+      }}}
+    },
+    "vdb:entry": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "vdb:entry",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "false",
+        "jcr:supertypes": ["nt:unstructured"]
+      },
+      "children": {
+        "vdb:path": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "true",
+          "jcr:autoCreated": "false",
+          "jcr:name": "vdb:path"
+        }},
+        "vdb:description": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "vdb:description"
+        }}
+      }
+    },
+    "vdb:permissions": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "vdb:permissions",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "false",
+        "jcr:supertypes": ["nt:unstructured"]
+      },
+      "children": {"vdb:permission": {"properties": {
+        "jcr:requiredPrimaryTypes": ["vdb:permission"],
+        "jcr:primaryType": "nt:childNodeDefinition",
+        "jcr:onParentVersion": "COPY",
+        "jcr:sameNameSiblings": "false",
+        "jcr:protected": "false",
+        "jcr:mandatory": "false",
+        "jcr:autoCreated": "false",
+        "jcr:name": "vdb:permission"
+      }}}
+    },
+    "vdb:permission": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "vdb:permission",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "false",
+        "jcr:supertypes": ["nt:unstructured"]
+      },
+      "children": {
+        "vdb:allowCreate": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "BOOLEAN",
+          "jcr:mandatory": "false",
+          "jcr:defaultValues": ["false"],
+          "jcr:autoCreated": "true",
+          "jcr:name": "vdb:allowCreate"
+        }},
+        "vdb:allowRead": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "BOOLEAN",
+          "jcr:mandatory": "false",
+          "jcr:defaultValues": ["false"],
+          "jcr:autoCreated": "true",
+          "jcr:name": "vdb:allowRead"
+        }},
+        "vdb:allowUpdate": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "BOOLEAN",
+          "jcr:mandatory": "false",
+          "jcr:defaultValues": ["false"],
+          "jcr:autoCreated": "true",
+          "jcr:name": "vdb:allowUpdate"
+        }},
+        "vdb:allowDelete": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "BOOLEAN",
+          "jcr:mandatory": "false",
+          "jcr:defaultValues": ["false"],
+          "jcr:autoCreated": "true",
+          "jcr:name": "vdb:allowDelete"
+        }},
+        "vdb:allowExecute": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "BOOLEAN",
+          "jcr:mandatory": "false",
+          "jcr:defaultValues": ["false"],
+          "jcr:autoCreated": "true",
+          "jcr:name": "vdb:allowExecute"
+        }},
+        "vdb:allowAlter": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "BOOLEAN",
+          "jcr:mandatory": "false",
+          "jcr:defaultValues": ["false"],
+          "jcr:autoCreated": "true",
+          "jcr:name": "vdb:allowAlter"
+        }}
+      }
+    },
+    "vdb:importVdbs": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "vdb:importVdbs",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "false",
+        "jcr:supertypes": ["nt:unstructured"]
+      },
+      "children": {"vdb:importVdb": {"properties": {
+        "jcr:requiredPrimaryTypes": ["vdb:importVdb"],
+        "jcr:primaryType": "nt:childNodeDefinition",
+        "jcr:onParentVersion": "COPY",
+        "jcr:sameNameSiblings": "false",
+        "jcr:protected": "false",
+        "jcr:mandatory": "false",
+        "jcr:autoCreated": "false",
+        "jcr:name": "vdb:importVdb"
+      }}}
+    },
+    "vdb:importVdb": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "vdb:importVdb",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "false",
+        "jcr:supertypes": ["nt:unstructured"]
+      },
+      "children": {
+        "vdb:version": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "LONG",
+          "jcr:mandatory": "true",
+          "jcr:autoCreated": "false",
+          "jcr:name": "vdb:version"
+        }},
+        "vdb:importDataPolicies": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "BOOLEAN",
+          "jcr:mandatory": "false",
+          "jcr:defaultValues": ["true"],
+          "jcr:autoCreated": "true",
+          "jcr:name": "vdb:importDataPolicies"
+        }}
+      }
+    },
+    "ddl:operation": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "ddl:operation",
+      "jcr:isAbstract": "true",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": []
+    }},
+    "ddl:operand": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "ddl:operand",
+      "jcr:isAbstract": "true",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": []
+    }},
+    "ddl:statement": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "ddl:statement",
+        "jcr:isAbstract": "true",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "true",
+        "jcr:supertypes": []
+      },
+      "children": {
+        "ddl:expression": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "true",
+          "jcr:autoCreated": "false",
+          "jcr:name": "ddl:expression"
+        }},
+        "ddl:originalExpression": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "ddl:originalExpression"
+        }},
+        "ddl:startLineNumber": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "LONG",
+          "jcr:mandatory": "true",
+          "jcr:autoCreated": "false",
+          "jcr:name": "ddl:startLineNumber"
+        }},
+        "ddl:startColumnNumber": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "LONG",
+          "jcr:mandatory": "true",
+          "jcr:autoCreated": "false",
+          "jcr:name": "ddl:startColumnNumber"
+        }},
+        "ddl:startCharIndex": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "LONG",
+          "jcr:mandatory": "true",
+          "jcr:autoCreated": "false",
+          "jcr:name": "ddl:startCharIndex"
+        }},
+        "ddl:length": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "LONG",
+          "jcr:mandatory": "true",
+          "jcr:autoCreated": "false",
+          "jcr:name": "ddl:length"
+        }},
+        "ddl:problem": {"properties": {
+          "jcr:requiredPrimaryTypes": ["ddl:ddlProblem"],
+          "jcr:primaryType": "nt:childNodeDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:defaultPrimaryType": "ddl:ddlProblem",
+          "jcr:sameNameSiblings": "true",
+          "jcr:protected": "false",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "ddl:problem"
+        }}
+      }
+    },
+    "ddl:creatable": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "ddl:creatable",
+      "jcr:isAbstract": "true",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": ["ddl:operation"]
+    }},
+    "ddl:alterable": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "ddl:alterable",
+      "jcr:isAbstract": "true",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": ["ddl:operation"]
+    }},
+    "ddl:droppable": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "ddl:droppable",
+        "jcr:isAbstract": "true",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "true",
+        "jcr:supertypes": ["ddl:operation"]
+      },
+      "children": {
+        "ddl:dropBehavior": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "ddl:dropBehavior"
+        }},
+        "ddl:dropOption": {"properties": {
+          "jcr:requiredPrimaryTypes": ["ddl:statementOption"],
+          "jcr:primaryType": "nt:childNodeDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:defaultPrimaryType": "ddl:statementOption",
+          "jcr:sameNameSiblings": "true",
+          "jcr:protected": "false",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "ddl:dropOption"
+        }}
+      }
+    },
+    "ddl:insertable": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "ddl:insertable",
+      "jcr:isAbstract": "true",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": ["ddl:operation"]
+    }},
+    "ddl:settable": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "ddl:settable",
+      "jcr:isAbstract": "true",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": ["ddl:operation"]
+    }},
+    "ddl:grantable": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "ddl:grantable",
+      "jcr:isAbstract": "true",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": ["ddl:operation"]
+    }},
+    "ddl:revokable": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "ddl:revokable",
+      "jcr:isAbstract": "true",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": ["ddl:operation"]
+    }},
+    "ddl:renamable": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "ddl:renamable",
+        "jcr:isAbstract": "true",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "true",
+        "jcr:supertypes": ["ddl:operation"]
+      },
+      "children": {"ddl:newName": {"properties": {
+        "jcr:primaryType": "nt:propertyDefinition",
+        "jcr:onParentVersion": "COPY",
+        "jcr:multiple": "false",
+        "jcr:protected": "false",
+        "jcr:availableQueryOperators": [
+          "jcr.operator.equal.to",
+          "jcr.operator.greater.than",
+          "jcr.operator.greater.than.or.equal.to",
+          "jcr.operator.less.than",
+          "jcr.operator.less.than.or.equal.to",
+          "jcr.operator.like",
+          "jcr.operator.not.equal.to"
+        ],
+        "jcr:requiredType": "STRING",
+        "jcr:mandatory": "false",
+        "jcr:autoCreated": "false",
+        "jcr:name": "ddl:newName"
+      }}}
+    },
+    "ddl:schemaOperand": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "ddl:schemaOperand",
+      "jcr:isAbstract": "true",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": ["ddl:operand"]
+    }},
+    "ddl:tableOperand": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "ddl:tableOperand",
+      "jcr:isAbstract": "true",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": ["ddl:operand"]
+    }},
+    "ddl:domainOperand": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "ddl:domainOperand",
+      "jcr:isAbstract": "true",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": ["ddl:operand"]
+    }},
+    "ddl:viewOperand": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "ddl:viewOperand",
+      "jcr:isAbstract": "true",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": ["ddl:operand"]
+    }},
+    "ddl:assertionOperand": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "ddl:assertionOperand",
+      "jcr:isAbstract": "true",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": ["ddl:operand"]
+    }},
+    "ddl:characterSetOperand": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "ddl:characterSetOperand",
+      "jcr:isAbstract": "true",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": ["ddl:operand"]
+    }},
+    "ddl:collationOperand": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "ddl:collationOperand",
+      "jcr:isAbstract": "true",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": ["ddl:operand"]
+    }},
+    "ddl:translationOperand": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "ddl:translationOperand",
+      "jcr:isAbstract": "true",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": ["ddl:operand"]
+    }},
+    "ddl:columnOperand": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "ddl:columnOperand",
+      "jcr:isAbstract": "true",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": ["ddl:operand"]
+    }},
+    "ddl:tableConstraintOperand": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "ddl:tableConstraintOperand",
+      "jcr:isAbstract": "true",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": ["ddl:operand"]
+    }},
+    "ddl:referenceOperand": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "ddl:referenceOperand",
+      "jcr:isAbstract": "true",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": ["ddl:operand"]
+    }},
+    "ddl:simpleProperty": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "ddl:simpleProperty",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "true",
+        "jcr:supertypes": []
+      },
+      "children": {"ddl:propValue": {"properties": {
+        "jcr:primaryType": "nt:propertyDefinition",
+        "jcr:onParentVersion": "COPY",
+        "jcr:multiple": "false",
+        "jcr:protected": "false",
+        "jcr:availableQueryOperators": [
+          "jcr.operator.equal.to",
+          "jcr.operator.greater.than",
+          "jcr.operator.greater.than.or.equal.to",
+          "jcr.operator.less.than",
+          "jcr.operator.less.than.or.equal.to",
+          "jcr.operator.like",
+          "jcr.operator.not.equal.to"
+        ],
+        "jcr:requiredType": "STRING",
+        "jcr:mandatory": "true",
+        "jcr:autoCreated": "false",
+        "jcr:name": "ddl:propValue"
+      }}}
+    },
+    "ddl:constraintAttribute": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "ddl:constraintAttribute",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": ["ddl:simpleProperty"]
+    }},
+    "ddl:statementOption": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "ddl:statementOption",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "true",
+        "jcr:supertypes": []
+      },
+      "children": {"ddl:value": {"properties": {
+        "jcr:primaryType": "nt:propertyDefinition",
+        "jcr:onParentVersion": "COPY",
+        "jcr:multiple": "false",
+        "jcr:protected": "false",
+        "jcr:availableQueryOperators": [
+          "jcr.operator.equal.to",
+          "jcr.operator.greater.than",
+          "jcr.operator.greater.than.or.equal.to",
+          "jcr.operator.less.than",
+          "jcr.operator.less.than.or.equal.to",
+          "jcr.operator.like",
+          "jcr.operator.not.equal.to"
+        ],
+        "jcr:requiredType": "STRING",
+        "jcr:mandatory": "true",
+        "jcr:autoCreated": "false",
+        "jcr:name": "ddl:value"
+      }}}
+    },
+    "ddl:unknownStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "ddl:unknownStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": []
+    }},
+    "ddl:ddlProblem": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "ddl:ddlProblem",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "true",
+        "jcr:supertypes": []
+      },
+      "children": {
+        "ddl:problemLevel": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "LONG",
+          "jcr:mandatory": "true",
+          "jcr:autoCreated": "false",
+          "jcr:name": "ddl:problemLevel"
+        }},
+        "ddl:message": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "true",
+          "jcr:autoCreated": "false",
+          "jcr:name": "ddl:message"
+        }}
+      }
+    },
+    "ddl:columnDefinition": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "ddl:columnDefinition",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "true",
+        "jcr:supertypes": [
+          "ddl:creatable",
+          "ddl:columnOperand"
+        ]
+      },
+      "children": {
+        "ddl:datatypeName": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "ddl:datatypeName"
+        }},
+        "ddl:datatypeLength": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "LONG",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "ddl:datatypeLength"
+        }},
+        "ddl:datatypePrecision": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "LONG",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "ddl:datatypePrecision"
+        }},
+        "ddl:datatypeScale": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "LONG",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "ddl:datatypeScale"
+        }},
+        "ddl:nullable": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "ddl:nullable"
+        }},
+        "ddl:defaultOption": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:valueConstraints": [
+            "LITERAL",
+            "DATETIME",
+            "USER",
+            "CURRENT_USER",
+            "SESSION_USER",
+            "SYSTEM_USER",
+            "NULL"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "ddl:defaultOption"
+        }},
+        "ddl:defaultValue": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "ddl:defaultValue"
+        }},
+        "ddl:defaultPrecision": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "LONG",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "ddl:defaultPrecision"
+        }},
+        "ddl:collationName": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "ddl:collationName"
+        }},
+        "ddl:dropBehavior": {"properties": {
+          "jcr:requiredPrimaryTypes": ["ddl:simpleProperty"],
+          "jcr:primaryType": "nt:childNodeDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:defaultPrimaryType": "ddl:simpleProperty",
+          "jcr:sameNameSiblings": "false",
+          "jcr:protected": "false",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "ddl:dropBehavior"
+        }},
+        "ddl:columnAttribute": {"properties": {
+          "jcr:requiredPrimaryTypes": ["ddl:simpleProperty"],
+          "jcr:primaryType": "nt:childNodeDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:defaultPrimaryType": "ddl:simpleProperty",
+          "jcr:sameNameSiblings": "true",
+          "jcr:protected": "false",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "ddl:columnAttribute"
+        }}
+      }
+    },
+    "ddl:tableConstraint": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "ddl:tableConstraint",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "true",
+        "jcr:supertypes": [
+          "ddl:creatable",
+          "ddl:tableConstraintOperand"
+        ]
+      },
+      "children": {
+        "ddl:constraintType": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:valueConstraints": [
+            "UNIQUE",
+            "PRIMARY KEY",
+            "FOREIGN KEY",
+            "CHECK"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "ddl:constraintType"
+        }},
+        "ddl:deferrable": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:valueConstraints": [
+            "DEFERRABLE",
+            "NOT DEFERRABLE"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "ddl:deferrable"
+        }},
+        "ddl:checkSearchCondition": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:valueConstraints": [
+            "INITIALLY DEFERRED",
+            "INITIALLY IMMEDIATE"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "ddl:checkSearchCondition"
+        }},
+        "*": {"properties": {
+          "jcr:requiredPrimaryTypes": ["ddl:columnReference"],
+          "jcr:primaryType": "nt:childNodeDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:defaultPrimaryType": "ddl:columnReference",
+          "jcr:sameNameSiblings": "true",
+          "jcr:protected": "false",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false"
+        }},
+        "*[2]": {"properties": {
+          "jcr:requiredPrimaryTypes": ["ddl:tableReference"],
+          "jcr:primaryType": "nt:childNodeDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:defaultPrimaryType": "ddl:tableReference",
+          "jcr:sameNameSiblings": "false",
+          "jcr:protected": "false",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false"
+        }},
+        "*[3]": {"properties": {
+          "jcr:requiredPrimaryTypes": ["ddl:fkColumnReference"],
+          "jcr:primaryType": "nt:childNodeDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:defaultPrimaryType": "ddl:fkColumnReference",
+          "jcr:sameNameSiblings": "true",
+          "jcr:protected": "false",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false"
+        }},
+        "ddl:constAttribute": {"properties": {
+          "jcr:requiredPrimaryTypes": ["ddl:constraintAttribute"],
+          "jcr:primaryType": "nt:childNodeDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:defaultPrimaryType": "ddl:constraintAttribute",
+          "jcr:sameNameSiblings": "true",
+          "jcr:protected": "false",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "ddl:constAttribute"
+        }}
+      }
+    },
+    "ddl:columnReference": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "ddl:columnReference",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": ["ddl:referenceOperand"]
+    }},
+    "ddl:tableReference": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "ddl:tableReference",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": ["ddl:referenceOperand"]
+    }},
+    "ddl:fkColumnReference": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "ddl:fkColumnReference",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": ["ddl:referenceOperand"]
+    }},
+    "ddl:grantee": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "ddl:grantee",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": ["ddl:referenceOperand"]
+    }},
+    "ddl:createSchemaStatement": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "ddl:createSchemaStatement",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "true",
+        "jcr:supertypes": [
+          "ddl:statement",
+          "ddl:creatable",
+          "ddl:schemaOperand"
+        ]
+      },
+      "children": {
+        "ddl:defaultCharacterSetName": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "ddl:defaultCharacterSetName"
+        }},
+        "*": {"properties": {
+          "jcr:requiredPrimaryTypes": ["ddl:statement"],
+          "jcr:primaryType": "nt:childNodeDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:defaultPrimaryType": "ddl:statement",
+          "jcr:sameNameSiblings": "true",
+          "jcr:protected": "false",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false"
+        }}
+      }
+    },
+    "ddl:createTableStatement": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "ddl:createTableStatement",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "true",
+        "jcr:supertypes": [
+          "ddl:statement",
+          "ddl:creatable",
+          "ddl:tableOperand"
+        ]
+      },
+      "children": {
+        "ddl:temporary": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:valueConstraints": [
+            "GLOBAL",
+            "LOCAL"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "ddl:temporary"
+        }},
+        "ddl:onCommitValue": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:valueConstraints": [
+            "DELETE ROWS",
+            "PRESERVE ROWS"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "ddl:onCommitValue"
+        }},
+        "*": {"properties": {
+          "jcr:requiredPrimaryTypes": ["ddl:columnDefinition"],
+          "jcr:primaryType": "nt:childNodeDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:defaultPrimaryType": "ddl:columnDefinition",
+          "jcr:sameNameSiblings": "true",
+          "jcr:protected": "false",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false"
+        }},
+        "*[2]": {"properties": {
+          "jcr:requiredPrimaryTypes": ["ddl:tableConstraint"],
+          "jcr:primaryType": "nt:childNodeDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:defaultPrimaryType": "ddl:tableConstraint",
+          "jcr:sameNameSiblings": "true",
+          "jcr:protected": "false",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false"
+        }},
+        "*[3]": {"properties": {
+          "jcr:requiredPrimaryTypes": ["ddl:statementOption"],
+          "jcr:primaryType": "nt:childNodeDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:defaultPrimaryType": "ddl:statementOption",
+          "jcr:sameNameSiblings": "true",
+          "jcr:protected": "false",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false"
+        }}
+      }
+    },
+    "ddl:createViewStatement": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "ddl:createViewStatement",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "true",
+        "jcr:supertypes": [
+          "ddl:statement",
+          "ddl:creatable",
+          "ddl:viewOperand"
+        ]
+      },
+      "children": {
+        "ddl:checkOption": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "ddl:checkOption"
+        }},
+        "*": {"properties": {
+          "jcr:requiredPrimaryTypes": ["ddl:columnReference"],
+          "jcr:primaryType": "nt:childNodeDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:defaultPrimaryType": "ddl:columnReference",
+          "jcr:sameNameSiblings": "true",
+          "jcr:protected": "false",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false"
+        }}
+      }
+    },
+    "ddl:createDomainStatement": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "ddl:createDomainStatement",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "true",
+        "jcr:supertypes": [
+          "ddl:statement",
+          "ddl:creatable",
+          "ddl:domainOperand"
+        ]
+      },
+      "children": {
+        "ddl:datatypeName": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "true",
+          "jcr:autoCreated": "false",
+          "jcr:name": "ddl:datatypeName"
+        }},
+        "ddl:datatypeLength": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "LONG",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "ddl:datatypeLength"
+        }},
+        "ddl:datatypePrecision": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "LONG",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "ddl:datatypePrecision"
+        }},
+        "ddl:datatypeScale": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "LONG",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "ddl:datatypeScale"
+        }},
+        "ddl:defaultOption": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:valueConstraints": [
+            "LITERAL",
+            "DATETIME",
+            "USER",
+            "CURRENT_USER",
+            "SESSION_USER",
+            "SYSTEM_USER",
+            "NULL"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "ddl:defaultOption"
+        }},
+        "ddl:defaultValue": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "ddl:defaultValue"
+        }},
+        "ddl:defaultPrecision": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "LONG",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "ddl:defaultPrecision"
+        }},
+        "ddl:collationName": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "ddl:collationName"
+        }}
+      }
+    },
+    "ddl:createAssertionStatement": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "ddl:createAssertionStatement",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "true",
+        "jcr:supertypes": [
+          "ddl:statement",
+          "ddl:creatable",
+          "ddl:tableConstraintOperand"
+        ]
+      },
+      "children": {
+        "ddl:searchCondition": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "true",
+          "jcr:autoCreated": "false",
+          "jcr:name": "ddl:searchCondition"
+        }},
+        "ddl:constAttribute": {"properties": {
+          "jcr:requiredPrimaryTypes": ["ddl:constraintAttribute"],
+          "jcr:primaryType": "nt:childNodeDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:defaultPrimaryType": "ddl:constraintAttribute",
+          "jcr:sameNameSiblings": "true",
+          "jcr:protected": "false",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "ddl:constAttribute"
+        }}
+      }
+    },
+    "ddl:createCharacterSetStatement": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "ddl:createCharacterSetStatement",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "true",
+        "jcr:supertypes": [
+          "ddl:statement",
+          "ddl:creatable",
+          "ddl:characterSetOperand"
+        ]
+      },
+      "children": {
+        "ddl:existingName": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "true",
+          "jcr:autoCreated": "false",
+          "jcr:name": "ddl:existingName"
+        }},
+        "ddl:collateClause": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "ddl:collateClause"
+        }},
+        "ddl:limitedCollationDefinition": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "ddl:limitedCollationDefinition"
+        }}
+      }
+    },
+    "ddl:createCollationStatement": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "ddl:createCollationStatement",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "true",
+        "jcr:supertypes": [
+          "ddl:statement",
+          "ddl:creatable",
+          "ddl:collationOperand"
+        ]
+      },
+      "children": {
+        "ddl:characterSetName": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "true",
+          "jcr:autoCreated": "false",
+          "jcr:name": "ddl:characterSetName"
+        }},
+        "ddl:collationSource": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "ddl:collationSource"
+        }},
+        "ddl:padAttribute": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:valueConstraints": [
+            "NO PAD",
+            "PAD SPACE"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "ddl:padAttribute"
+        }}
+      }
+    },
+    "ddl:createTranslationStatement": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "ddl:createTranslationStatement",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "true",
+        "jcr:supertypes": [
+          "ddl:statement",
+          "ddl:creatable",
+          "ddl:translationOperand"
+        ]
+      },
+      "children": {
+        "ddl:sourceCharacterSetName": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "true",
+          "jcr:autoCreated": "false",
+          "jcr:name": "ddl:sourceCharacterSetName"
+        }},
+        "ddl:targetCharacterSetName": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "true",
+          "jcr:autoCreated": "false",
+          "jcr:name": "ddl:targetCharacterSetName"
+        }},
+        "ddl:translationSource": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "ddl:translationSource"
+        }}
+      }
+    },
+    "ddl:alterTableStatement": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "ddl:alterTableStatement",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "true",
+        "jcr:supertypes": [
+          "ddl:statement",
+          "ddl:alterable",
+          "ddl:tableOperand"
+        ]
+      },
+      "children": {
+        "*": {"properties": {
+          "jcr:requiredPrimaryTypes": ["ddl:addColumnDefinition"],
+          "jcr:primaryType": "nt:childNodeDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:defaultPrimaryType": "ddl:addColumnDefinition",
+          "jcr:sameNameSiblings": "true",
+          "jcr:protected": "false",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false"
+        }},
+        "*[2]": {"properties": {
+          "jcr:requiredPrimaryTypes": ["ddl:dropColumnDefinition"],
+          "jcr:primaryType": "nt:childNodeDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:defaultPrimaryType": "ddl:dropColumnDefinition",
+          "jcr:sameNameSiblings": "true",
+          "jcr:protected": "false",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false"
+        }},
+        "*[3]": {"properties": {
+          "jcr:requiredPrimaryTypes": ["ddl:alterColumnDefinition"],
+          "jcr:primaryType": "nt:childNodeDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:defaultPrimaryType": "ddl:alterColumnDefinition",
+          "jcr:sameNameSiblings": "true",
+          "jcr:protected": "false",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false"
+        }},
+        "*[4]": {"properties": {
+          "jcr:requiredPrimaryTypes": ["ddl:addTableConstraintDefinition"],
+          "jcr:primaryType": "nt:childNodeDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:defaultPrimaryType": "ddl:addTableConstraintDefinition",
+          "jcr:sameNameSiblings": "true",
+          "jcr:protected": "false",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false"
+        }},
+        "*[5]": {"properties": {
+          "jcr:requiredPrimaryTypes": ["ddl:dropTableConstraintDefinition"],
+          "jcr:primaryType": "nt:childNodeDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:defaultPrimaryType": "ddl:dropTableConstraintDefinition",
+          "jcr:sameNameSiblings": "true",
+          "jcr:protected": "false",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false"
+        }},
+        "*[6]": {"properties": {
+          "jcr:requiredPrimaryTypes": ["ddl:statementOption"],
+          "jcr:primaryType": "nt:childNodeDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:defaultPrimaryType": "ddl:statementOption",
+          "jcr:sameNameSiblings": "true",
+          "jcr:protected": "false",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false"
+        }}
+      }
+    },
+    "ddl:alterDomainStatement": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "ddl:alterDomainStatement",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "true",
+        "jcr:supertypes": [
+          "ddl:statement",
+          "ddl:alterable",
+          "ddl:domainOperand"
+        ]
+      },
+      "children": {"ddl:alterDomainAction": {"properties": {
+        "jcr:primaryType": "nt:propertyDefinition",
+        "jcr:onParentVersion": "COPY",
+        "jcr:multiple": "false",
+        "jcr:protected": "false",
+        "jcr:availableQueryOperators": [
+          "jcr.operator.equal.to",
+          "jcr.operator.greater.than",
+          "jcr.operator.greater.than.or.equal.to",
+          "jcr.operator.less.than",
+          "jcr.operator.less.than.or.equal.to",
+          "jcr.operator.like",
+          "jcr.operator.not.equal.to"
+        ],
+        "jcr:requiredType": "STRING",
+        "jcr:mandatory": "false",
+        "jcr:autoCreated": "false",
+        "jcr:name": "ddl:alterDomainAction"
+      }}}
+    },
+    "ddl:dropSchemaStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "ddl:dropSchemaStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": [
+        "ddl:statement",
+        "ddl:droppable",
+        "ddl:schemaOperand"
+      ]
+    }},
+    "ddl:dropTableStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "ddl:dropTableStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": [
+        "ddl:statement",
+        "ddl:droppable",
+        "ddl:tableOperand"
+      ]
+    }},
+    "ddl:dropViewStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "ddl:dropViewStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": [
+        "ddl:statement",
+        "ddl:droppable",
+        "ddl:viewOperand"
+      ]
+    }},
+    "ddl:dropDomainStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "ddl:dropDomainStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": [
+        "ddl:statement",
+        "ddl:droppable",
+        "ddl:domainOperand"
+      ]
+    }},
+    "ddl:dropCharacterSetStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "ddl:dropCharacterSetStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": [
+        "ddl:statement",
+        "ddl:droppable",
+        "ddl:characterSetOperand"
+      ]
+    }},
+    "ddl:dropCollationStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "ddl:dropCollationStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": [
+        "ddl:statement",
+        "ddl:droppable",
+        "ddl:collationOperand"
+      ]
+    }},
+    "ddl:dropTranslationStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "ddl:dropTranslationStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": [
+        "ddl:statement",
+        "ddl:droppable",
+        "ddl:translationOperand"
+      ]
+    }},
+    "ddl:dropAssertionStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "ddl:dropAssertionStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": [
+        "ddl:statement",
+        "ddl:droppable",
+        "ddl:assertionOperand"
+      ]
+    }},
+    "ddl:alterColumnDefinition": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "ddl:alterColumnDefinition",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": [
+        "ddl:columnDefinition",
+        "ddl:alterable"
+      ]
+    }},
+    "ddl:addColumnDefinition": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "ddl:addColumnDefinition",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": [
+        "ddl:columnDefinition",
+        "ddl:creatable"
+      ]
+    }},
+    "ddl:dropColumnDefinition": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "ddl:dropColumnDefinition",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": [
+        "ddl:columnDefinition",
+        "ddl:droppable"
+      ]
+    }},
+    "ddl:addTableConstraintDefinition": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "ddl:addTableConstraintDefinition",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": [
+        "ddl:tableConstraint",
+        "ddl:creatable"
+      ]
+    }},
+    "ddl:dropTableConstraintDefinition": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "ddl:dropTableConstraintDefinition",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": [
+        "ddl:tableConstraint",
+        "ddl:droppable"
+      ]
+    }},
+    "ddl:setStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "ddl:setStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": [
+        "ddl:statement",
+        "ddl:settable"
+      ]
+    }},
+    "ddl:insertStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "ddl:insertStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": [
+        "ddl:statement",
+        "ddl:insertable"
+      ]
+    }},
+    "ddl:grantPrivilege": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "ddl:grantPrivilege",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "true",
+        "jcr:supertypes": []
+      },
+      "children": {
+        "ddl:type": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "true",
+          "jcr:autoCreated": "false",
+          "jcr:name": "ddl:type"
+        }},
+        "*": {"properties": {
+          "jcr:requiredPrimaryTypes": ["ddl:columnReference"],
+          "jcr:primaryType": "nt:childNodeDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:defaultPrimaryType": "ddl:columnReference",
+          "jcr:sameNameSiblings": "true",
+          "jcr:protected": "false",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false"
+        }}
+      }
+    },
+    "ddl:grantStatement": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "ddl:grantStatement",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "true",
+        "jcr:supertypes": [
+          "ddl:statement",
+          "ddl:grantable"
+        ]
+      },
+      "children": {
+        "ddl:allPrivileges": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "BOOLEAN",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "ddl:allPrivileges"
+        }},
+        "*": {"properties": {
+          "jcr:requiredPrimaryTypes": ["ddl:grantPrivilege"],
+          "jcr:primaryType": "nt:childNodeDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:defaultPrimaryType": "ddl:grantPrivilege",
+          "jcr:sameNameSiblings": "true",
+          "jcr:protected": "false",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false"
+        }},
+        "*[2]": {"properties": {
+          "jcr:requiredPrimaryTypes": ["ddl:grantee"],
+          "jcr:primaryType": "nt:childNodeDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:defaultPrimaryType": "ddl:grantee",
+          "jcr:sameNameSiblings": "true",
+          "jcr:protected": "false",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false"
+        }}
+      }
+    },
+    "ddl:grantOnTableStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "ddl:grantOnTableStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": [
+        "ddl:grantStatement",
+        "ddl:tableOperand"
+      ]
+    }},
+    "ddl:grantOnDomainStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "ddl:grantOnDomainStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": [
+        "ddl:grantStatement",
+        "ddl:domainOperand"
+      ]
+    }},
+    "ddl:grantOnCollationStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "ddl:grantOnCollationStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": [
+        "ddl:grantStatement",
+        "ddl:collationOperand"
+      ]
+    }},
+    "ddl:grantOnCharacterSetStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "ddl:grantOnCharacterSetStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": [
+        "ddl:grantStatement",
+        "ddl:characterSetOperand"
+      ]
+    }},
+    "ddl:grantOnTranslationStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "ddl:grantOnTranslationStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": [
+        "ddl:grantStatement",
+        "ddl:translationOperand"
+      ]
+    }},
+    "ddl:revokeStatement": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "ddl:revokeStatement",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "true",
+        "jcr:supertypes": [
+          "ddl:statement",
+          "ddl:revokable",
+          "ddl:droppable"
+        ]
+      },
+      "children": {
+        "ddl:allPrivileges": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "BOOLEAN",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "ddl:allPrivileges"
+        }},
+        "*": {"properties": {
+          "jcr:requiredPrimaryTypes": ["ddl:grantPrivilege"],
+          "jcr:primaryType": "nt:childNodeDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:defaultPrimaryType": "ddl:grantPrivilege",
+          "jcr:sameNameSiblings": "true",
+          "jcr:protected": "false",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false"
+        }},
+        "*[2]": {"properties": {
+          "jcr:requiredPrimaryTypes": ["ddl:grantee"],
+          "jcr:primaryType": "nt:childNodeDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:defaultPrimaryType": "ddl:grantee",
+          "jcr:sameNameSiblings": "true",
+          "jcr:protected": "false",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false"
+        }}
+      }
+    },
+    "ddl:revokeOnTableStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "ddl:revokeOnTableStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": [
+        "ddl:revokeStatement",
+        "ddl:tableOperand"
+      ]
+    }},
+    "ddl:revokeOnDomainStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "ddl:revokeOnDomainStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": [
+        "ddl:revokeStatement",
+        "ddl:domainOperand"
+      ]
+    }},
+    "ddl:revokeOnCollationStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "ddl:revokeOnCollationStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": [
+        "ddl:revokeStatement",
+        "ddl:collationOperand"
+      ]
+    }},
+    "ddl:revokeOnCharacterSetStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "ddl:revokeOnCharacterSetStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": [
+        "ddl:revokeStatement",
+        "ddl:characterSetOperand"
+      ]
+    }},
+    "ddl:revokeOnTranslationStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "ddl:revokeOnTranslationStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": [
+        "ddl:revokeStatement",
+        "ddl:translationOperand"
+      ]
+    }},
+    "derbyddl:functionOperand": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "derbyddl:functionOperand",
+      "jcr:isAbstract": "true",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": ["ddl:operand"]
+    }},
+    "derbyddl:indexOperand": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "derbyddl:indexOperand",
+      "jcr:isAbstract": "true",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": ["ddl:operand"]
+    }},
+    "derbyddl:procedureOperand": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "derbyddl:procedureOperand",
+      "jcr:isAbstract": "true",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": ["ddl:operand"]
+    }},
+    "derbyddl:roleOperand": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "derbyddl:roleOperand",
+      "jcr:isAbstract": "true",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": ["ddl:operand"]
+    }},
+    "derbyddl:synonymOperand": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "derbyddl:synonymOperand",
+      "jcr:isAbstract": "true",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": ["ddl:operand"]
+    }},
+    "derbyddl:triggerOperand": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "derbyddl:triggerOperand",
+      "jcr:isAbstract": "true",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": ["ddl:operand"]
+    }},
+    "derbyddl:roleName": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "derbyddl:roleName",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": ["derbyddl:roleOperand"]
+    }},
+    "derbyddl:columnDefinition": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "derbyddl:columnDefinition",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "true",
+        "jcr:supertypes": ["ddl:columnDefinition"]
+      },
+      "children": {"derbyddl:dropDefault": {"properties": {
+        "jcr:primaryType": "nt:propertyDefinition",
+        "jcr:onParentVersion": "COPY",
+        "jcr:multiple": "false",
+        "jcr:protected": "false",
+        "jcr:availableQueryOperators": [
+          "jcr.operator.equal.to",
+          "jcr.operator.greater.than",
+          "jcr.operator.greater.than.or.equal.to",
+          "jcr.operator.less.than",
+          "jcr.operator.less.than.or.equal.to",
+          "jcr.operator.like",
+          "jcr.operator.not.equal.to"
+        ],
+        "jcr:requiredType": "BOOLEAN",
+        "jcr:mandatory": "false",
+        "jcr:autoCreated": "false",
+        "jcr:name": "derbyddl:dropDefault"
+      }}}
+    },
+    "derbyddl:functionParameter": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "derbyddl:functionParameter",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": ["ddl:columnDefinition"]
+    }},
+    "derbyddl:indexColumnReference": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "derbyddl:indexColumnReference",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "true",
+        "jcr:supertypes": ["ddl:columnReference"]
+      },
+      "children": {"derbyddl:order": {"properties": {
+        "jcr:primaryType": "nt:propertyDefinition",
+        "jcr:onParentVersion": "COPY",
+        "jcr:multiple": "false",
+        "jcr:protected": "false",
+        "jcr:availableQueryOperators": [
+          "jcr.operator.equal.to",
+          "jcr.operator.greater.than",
+          "jcr.operator.greater.than.or.equal.to",
+          "jcr.operator.less.than",
+          "jcr.operator.less.than.or.equal.to",
+          "jcr.operator.like",
+          "jcr.operator.not.equal.to"
+        ],
+        "jcr:requiredType": "STRING",
+        "jcr:mandatory": "false",
+        "jcr:autoCreated": "false",
+        "jcr:name": "derbyddl:order"
+      }}}
+    },
+    "derbyddl:createFunctionStatement": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "derbyddl:createFunctionStatement",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "true",
+        "jcr:supertypes": [
+          "ddl:creatable",
+          "ddl:statement",
+          "derbyddl:functionOperand"
+        ]
+      },
+      "children": {
+        "ddl:datatypeName": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "ddl:datatypeName"
+        }},
+        "ddl:datatypeLength": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "LONG",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "ddl:datatypeLength"
+        }},
+        "ddl:datatypePrecision": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "LONG",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "ddl:datatypePrecision"
+        }},
+        "ddl:datatypeScale": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "LONG",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "ddl:datatypeScale"
+        }},
+        "ddl:isTableType": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "BOOLEAN",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "ddl:isTableType"
+        }},
+        "derbyddl:parameterStyle": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "derbyddl:parameterStyle"
+        }},
+        "*": {"properties": {
+          "jcr:requiredPrimaryTypes": ["ddl:createTableStatement"],
+          "jcr:primaryType": "nt:childNodeDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:defaultPrimaryType": "ddl:createTableStatement",
+          "jcr:sameNameSiblings": "true",
+          "jcr:protected": "false",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false"
+        }},
+        "*[2]": {"properties": {
+          "jcr:requiredPrimaryTypes": ["derbyddl:functionParameter"],
+          "jcr:primaryType": "nt:childNodeDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:defaultPrimaryType": "derbyddl:functionParameter",
+          "jcr:sameNameSiblings": "true",
+          "jcr:protected": "false",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false"
+        }},
+        "*[3]": {"properties": {
+          "jcr:requiredPrimaryTypes": ["ddl:statementOption"],
+          "jcr:primaryType": "nt:childNodeDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:defaultPrimaryType": "ddl:statementOption",
+          "jcr:sameNameSiblings": "true",
+          "jcr:protected": "false",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false"
+        }}
+      }
+    },
+    "derbyddl:createIndexStatement": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "derbyddl:createIndexStatement",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "true",
+        "jcr:supertypes": [
+          "ddl:statement",
+          "ddl:creatable",
+          "derbyddl:indexOperand"
+        ]
+      },
+      "children": {
+        "derbyddl:tableName": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "true",
+          "jcr:autoCreated": "false",
+          "jcr:name": "derbyddl:tableName"
+        }},
+        "derbyddl:unique": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "BOOLEAN",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "derbyddl:unique"
+        }},
+        "*": {"properties": {
+          "jcr:requiredPrimaryTypes": ["derbyddl:indexColumnReference"],
+          "jcr:primaryType": "nt:childNodeDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:defaultPrimaryType": "derbyddl:indexColumnReference",
+          "jcr:sameNameSiblings": "true",
+          "jcr:protected": "false",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false"
+        }}
+      }
+    },
+    "derbyddl:createProcedureStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "derbyddl:createProcedureStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": [
+        "ddl:creatable",
+        "ddl:statement",
+        "derbyddl:procedureOperand"
+      ]
+    }},
+    "derbyddl:createRoleStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "derbyddl:createRoleStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": [
+        "ddl:creatable",
+        "ddl:statement",
+        "derbyddl:roleOperand"
+      ]
+    }},
+    "derbyddl:createSynonymStatement": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "derbyddl:createSynonymStatement",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "true",
+        "jcr:supertypes": [
+          "ddl:creatable",
+          "ddl:statement",
+          "derbyddl:synonymOperand"
+        ]
+      },
+      "children": {"derbyddl:tableName": {"properties": {
+        "jcr:primaryType": "nt:propertyDefinition",
+        "jcr:onParentVersion": "COPY",
+        "jcr:multiple": "false",
+        "jcr:protected": "false",
+        "jcr:availableQueryOperators": [
+          "jcr.operator.equal.to",
+          "jcr.operator.greater.than",
+          "jcr.operator.greater.than.or.equal.to",
+          "jcr.operator.less.than",
+          "jcr.operator.less.than.or.equal.to",
+          "jcr.operator.like",
+          "jcr.operator.not.equal.to"
+        ],
+        "jcr:requiredType": "STRING",
+        "jcr:mandatory": "true",
+        "jcr:autoCreated": "false",
+        "jcr:name": "derbyddl:tableName"
+      }}}
+    },
+    "derbyddl:createTriggerStatement": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "derbyddl:createTriggerStatement",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "true",
+        "jcr:supertypes": [
+          "ddl:creatable",
+          "ddl:statement",
+          "derbyddl:triggerOperand"
+        ]
+      },
+      "children": {
+        "derbyddl:tableName": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "true",
+          "jcr:autoCreated": "false",
+          "jcr:name": "derbyddl:tableName"
+        }},
+        "ddl:sql": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "true",
+          "jcr:autoCreated": "false",
+          "jcr:name": "ddl:sql"
+        }},
+        "*": {"properties": {
+          "jcr:requiredPrimaryTypes": ["ddl:columnReference"],
+          "jcr:primaryType": "nt:childNodeDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:defaultPrimaryType": "ddl:columnReference",
+          "jcr:sameNameSiblings": "true",
+          "jcr:protected": "false",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false"
+        }}
+      }
+    },
+    "derbyddl:declareGlobalTemporaryTableStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "derbyddl:declareGlobalTemporaryTableStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": ["ddl:createTableStatement"]
+    }},
+    "derbyddl:dropFunctionStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "derbyddl:dropFunctionStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": [
+        "ddl:droppable",
+        "derbyddl:functionOperand"
+      ]
+    }},
+    "derbyddl:dropIndexStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "derbyddl:dropIndexStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": [
+        "ddl:droppable",
+        "derbyddl:indexOperand"
+      ]
+    }},
+    "derbyddl:dropProcedureStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "derbyddl:dropProcedureStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": [
+        "ddl:droppable",
+        "derbyddl:procedureOperand"
+      ]
+    }},
+    "derbyddl:dropRoleStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "derbyddl:dropRoleStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": [
+        "ddl:droppable",
+        "derbyddl:roleOperand"
+      ]
+    }},
+    "derbyddl:dropSynonymStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "derbyddl:dropSynonymStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": [
+        "ddl:droppable",
+        "derbyddl:synonymOperand"
+      ]
+    }},
+    "derbyddl:dropTriggerStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "derbyddl:dropTriggerStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": [
+        "ddl:droppable",
+        "derbyddl:triggerOperand"
+      ]
+    }},
+    "derbyddl:lockTableStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "derbyddl:lockTableStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": [
+        "ddl:statement",
+        "ddl:tableOperand"
+      ]
+    }},
+    "derbyddl:renameTableStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "derbyddl:renameTableStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": [
+        "ddl:statement",
+        "ddl:renamable",
+        "ddl:tableOperand"
+      ]
+    }},
+    "derbyddl:renameIndexStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "derbyddl:renameIndexStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": [
+        "ddl:statement",
+        "ddl:renamable",
+        "derbyddl:indexOperand"
+      ]
+    }},
+    "derbyddl:grantOnFunctionStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "derbyddl:grantOnFunctionStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": [
+        "ddl:grantStatement",
+        "derbyddl:functionOperand"
+      ]
+    }},
+    "derbyddl:grantOnProcedureStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "derbyddl:grantOnProcedureStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": [
+        "ddl:grantStatement",
+        "derbyddl:procedureOperand"
+      ]
+    }},
+    "derbyddl:grantRolesStatement": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "derbyddl:grantRolesStatement",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "true",
+        "jcr:supertypes": ["ddl:grantStatement"]
+      },
+      "children": {"ddl:name": {"properties": {
+        "jcr:requiredPrimaryTypes": ["derbyddl:roleName"],
+        "jcr:primaryType": "nt:childNodeDefinition",
+        "jcr:onParentVersion": "COPY",
+        "jcr:defaultPrimaryType": "derbyddl:roleName",
+        "jcr:sameNameSiblings": "true",
+        "jcr:protected": "false",
+        "jcr:mandatory": "false",
+        "jcr:autoCreated": "false",
+        "jcr:name": "ddl:name"
+      }}}
+    },
+    "oracleddl:clusterOperand": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "oracleddl:clusterOperand",
+      "jcr:isAbstract": "true",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": ["ddl:operand"]
+    }},
+    "oracleddl:commentOperand": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "oracleddl:commentOperand",
+      "jcr:isAbstract": "true",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": ["ddl:operand"]
+    }},
+    "oracleddl:contextOperand": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "oracleddl:contextOperand",
+      "jcr:isAbstract": "true",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": ["ddl:operand"]
+    }},
+    "oracleddl:controlfileOperand": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "oracleddl:controlfileOperand",
+      "jcr:isAbstract": "true",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": ["ddl:operand"]
+    }},
+    "oracleddl:databaseOperand": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "oracleddl:databaseOperand",
+      "jcr:isAbstract": "true",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": ["ddl:operand"]
+    }},
+    "oracleddl:dimensionOperand": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "oracleddl:dimensionOperand",
+      "jcr:isAbstract": "true",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": ["ddl:operand"]
+    }},
+    "oracleddl:directoryOperand": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "oracleddl:directoryOperand",
+      "jcr:isAbstract": "true",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": ["ddl:operand"]
+    }},
+    "oracleddl:diskgroupOperand": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "oracleddl:diskgroupOperand",
+      "jcr:isAbstract": "true",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": ["ddl:operand"]
+    }},
+    "oracleddl:functionOperand": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "oracleddl:functionOperand",
+      "jcr:isAbstract": "true",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": ["ddl:operand"]
+    }},
+    "oracleddl:indexOperand": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "oracleddl:indexOperand",
+      "jcr:isAbstract": "true",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": ["ddl:operand"]
+    }},
+    "oracleddl:indextypeOperand": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "oracleddl:indextypeOperand",
+      "jcr:isAbstract": "true",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": ["ddl:operand"]
+    }},
+    "oracleddl:javaOperand": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "oracleddl:javaOperand",
+      "jcr:isAbstract": "true",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": ["ddl:operand"]
+    }},
+    "oracleddl:libraryOperand": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "oracleddl:libraryOperand",
+      "jcr:isAbstract": "true",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": ["ddl:operand"]
+    }},
+    "oracleddl:materializedOperand": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "oracleddl:materializedOperand",
+      "jcr:isAbstract": "true",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": ["ddl:operand"]
+    }},
+    "oracleddl:operatorOperand": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "oracleddl:operatorOperand",
+      "jcr:isAbstract": "true",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": ["ddl:operand"]
+    }},
+    "oracleddl:outlineOperand": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "oracleddl:outlineOperand",
+      "jcr:isAbstract": "true",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": ["ddl:operand"]
+    }},
+    "oracleddl:packageOperand": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "oracleddl:packageOperand",
+      "jcr:isAbstract": "true",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": ["ddl:operand"]
+    }},
+    "oracleddl:parameterOperand": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "oracleddl:parameterOperand",
+      "jcr:isAbstract": "true",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": ["ddl:operand"]
+    }},
+    "oracleddl:pfileOperand": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "oracleddl:pfileOperand",
+      "jcr:isAbstract": "true",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": ["ddl:operand"]
+    }},
+    "oracleddl:procedureOperand": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "oracleddl:procedureOperand",
+      "jcr:isAbstract": "true",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": ["ddl:operand"]
+    }},
+    "oracleddl:profileOperand": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "oracleddl:profileOperand",
+      "jcr:isAbstract": "true",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": ["ddl:operand"]
+    }},
+    "oracleddl:resourceOperand": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "oracleddl:resourceOperand",
+      "jcr:isAbstract": "true",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": ["ddl:operand"]
+    }},
+    "oracleddl:roleOperand": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "oracleddl:roleOperand",
+      "jcr:isAbstract": "true",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": ["ddl:operand"]
+    }},
+    "oracleddl:rollbackOperand": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "oracleddl:rollbackOperand",
+      "jcr:isAbstract": "true",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": ["ddl:operand"]
+    }},
+    "oracleddl:sequenceOperand": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "oracleddl:sequenceOperand",
+      "jcr:isAbstract": "true",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": ["ddl:operand"]
+    }},
+    "oracleddl:sessionOperand": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "oracleddl:sessionOperand",
+      "jcr:isAbstract": "true",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": ["ddl:operand"]
+    }},
+    "oracleddl:spfileOperand": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "oracleddl:spfileOperand",
+      "jcr:isAbstract": "true",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": ["ddl:operand"]
+    }},
+    "oracleddl:systemOperand": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "oracleddl:systemOperand",
+      "jcr:isAbstract": "true",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": ["ddl:operand"]
+    }},
+    "oracleddl:synonymOperand": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "oracleddl:synonymOperand",
+      "jcr:isAbstract": "true",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": ["ddl:operand"]
+    }},
+    "oracleddl:tablespaceOperand": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "oracleddl:tablespaceOperand",
+      "jcr:isAbstract": "true",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": ["ddl:operand"]
+    }},
+    "oracleddl:triggerOperand": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "oracleddl:triggerOperand",
+      "jcr:isAbstract": "true",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": ["ddl:operand"]
+    }},
+    "oracleddl:typeOperand": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "oracleddl:typeOperand",
+      "jcr:isAbstract": "true",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": ["ddl:operand"]
+    }},
+    "oracleddl:userOperand": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "oracleddl:userOperand",
+      "jcr:isAbstract": "true",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": ["ddl:operand"]
+    }},
+    "oracleddl:columnDefinition": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "oracleddl:columnDefinition",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "false",
+        "jcr:supertypes": [
+          "nt:base",
+          "ddl:columnDefinition"
+        ]
+      },
+      "children": {"oracleddl:dropDefault": {"properties": {
+        "jcr:primaryType": "nt:propertyDefinition",
+        "jcr:onParentVersion": "COPY",
+        "jcr:multiple": "false",
+        "jcr:protected": "false",
+        "jcr:availableQueryOperators": [
+          "jcr.operator.equal.to",
+          "jcr.operator.greater.than",
+          "jcr.operator.greater.than.or.equal.to",
+          "jcr.operator.less.than",
+          "jcr.operator.less.than.or.equal.to",
+          "jcr.operator.like",
+          "jcr.operator.not.equal.to"
+        ],
+        "jcr:requiredType": "BOOLEAN",
+        "jcr:mandatory": "false",
+        "jcr:autoCreated": "false",
+        "jcr:name": "oracleddl:dropDefault"
+      }}}
+    },
+    "oracleddl:functionParameter": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "oracleddl:functionParameter",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "true",
+        "jcr:supertypes": ["oracleddl:parameterOperand"]
+      },
+      "children": {
+        "ddl:datatypeName": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "true",
+          "jcr:autoCreated": "false",
+          "jcr:name": "ddl:datatypeName"
+        }},
+        "ddl:datatypeLength": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "LONG",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "ddl:datatypeLength"
+        }},
+        "ddl:datatypePrecision": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "LONG",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "ddl:datatypePrecision"
+        }},
+        "ddl:datatypeScale": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "LONG",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "ddl:datatypeScale"
+        }},
+        "oracleddl:default": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "oracleddl:default"
+        }},
+        "oracleddl:defaultExpresssion": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "oracleddl:defaultExpresssion"
+        }},
+        "oracleddl:inOutNoCopy": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "oracleddl:inOutNoCopy"
+        }}
+      }
+    },
+    "oracleddl:alterClusterStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "oracleddl:alterClusterStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": [
+        "ddl:alterable",
+        "ddl:statement",
+        "oracleddl:clusterOperand"
+      ]
+    }},
+    "oracleddl:alterDatabaseStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "oracleddl:alterDatabaseStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": [
+        "ddl:alterable",
+        "ddl:statement",
+        "oracleddl:databaseOperand"
+      ]
+    }},
+    "oracleddl:alterDimensionStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "oracleddl:alterDimensionStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": [
+        "ddl:alterable",
+        "ddl:statement",
+        "oracleddl:dimensionOperand"
+      ]
+    }},
+    "oracleddl:alterDiskgroupStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "oracleddl:alterDiskgroupStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": [
+        "ddl:alterable",
+        "ddl:statement",
+        "oracleddl:diskgroupOperand"
+      ]
+    }},
+    "oracleddl:alterFunctionStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "oracleddl:alterFunctionStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": [
+        "ddl:alterable",
+        "ddl:statement",
+        "oracleddl:functionOperand"
+      ]
+    }},
+    "oracleddl:alterIndexStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "oracleddl:alterIndexStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": [
+        "ddl:alterable",
+        "ddl:statement",
+        "oracleddl:indexOperand"
+      ]
+    }},
+    "oracleddl:alterIndextypeStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "oracleddl:alterIndextypeStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": [
+        "ddl:alterable",
+        "ddl:statement",
+        "oracleddl:indextypeOperand"
+      ]
+    }},
+    "oracleddl:alterJavaStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "oracleddl:alterJavaStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": [
+        "ddl:alterable",
+        "ddl:statement",
+        "oracleddl:javaOperand"
+      ]
+    }},
+    "oracleddl:alterMaterializedStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "oracleddl:alterMaterializedStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": [
+        "ddl:alterable",
+        "ddl:statement",
+        "oracleddl:materializedOperand"
+      ]
+    }},
+    "oracleddl:alterOperatorStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "oracleddl:alterOperatorStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": [
+        "ddl:alterable",
+        "ddl:statement",
+        "oracleddl:operatorOperand"
+      ]
+    }},
+    "oracleddl:alterOutlineStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "oracleddl:alterOutlineStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": [
+        "ddl:alterable",
+        "ddl:statement",
+        "oracleddl:outlineOperand"
+      ]
+    }},
+    "oracleddl:alterPackageStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "oracleddl:alterPackageStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": [
+        "ddl:alterable",
+        "ddl:statement",
+        "oracleddl:packageOperand"
+      ]
+    }},
+    "oracleddl:alterProcedureStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "oracleddl:alterProcedureStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": [
+        "ddl:alterable",
+        "ddl:statement",
+        "oracleddl:procedureOperand"
+      ]
+    }},
+    "oracleddl:alterProfileStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "oracleddl:alterProfileStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": [
+        "ddl:alterable",
+        "ddl:statement",
+        "oracleddl:profileOperand"
+      ]
+    }},
+    "oracleddl:alterResourceStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "oracleddl:alterResourceStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": [
+        "ddl:alterable",
+        "ddl:statement",
+        "oracleddl:resourceOperand"
+      ]
+    }},
+    "oracleddl:alterRoleStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "oracleddl:alterRoleStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": [
+        "ddl:alterable",
+        "ddl:statement",
+        "oracleddl:roleOperand"
+      ]
+    }},
+    "oracleddl:alterRollbackStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "oracleddl:alterRollbackStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": [
+        "ddl:alterable",
+        "ddl:statement",
+        "oracleddl:rollbackOperand"
+      ]
+    }},
+    "oracleddl:alterSequenceStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "oracleddl:alterSequenceStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": [
+        "ddl:alterable",
+        "ddl:statement",
+        "oracleddl:sequenceOperand"
+      ]
+    }},
+    "oracleddl:alterSessionStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "oracleddl:alterSessionStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": [
+        "ddl:alterable",
+        "ddl:statement",
+        "oracleddl:sessionOperand"
+      ]
+    }},
+    "oracleddl:alterSystemStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "oracleddl:alterSystemStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": [
+        "ddl:alterable",
+        "ddl:statement",
+        "oracleddl:systemOperand"
+      ]
+    }},
+    "oracleddl:alterTablespaceStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "oracleddl:alterTablespaceStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": [
+        "ddl:alterable",
+        "ddl:statement",
+        "oracleddl:tablespaceOperand"
+      ]
+    }},
+    "oracleddl:alterTriggerStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "oracleddl:alterTriggerStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": [
+        "ddl:alterable",
+        "ddl:statement",
+        "oracleddl:triggerOperand"
+      ]
+    }},
+    "oracleddl:alterTypeStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "oracleddl:alterTypeStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": [
+        "ddl:alterable",
+        "ddl:statement",
+        "oracleddl:typeOperand"
+      ]
+    }},
+    "oracleddl:alterUserStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "oracleddl:alterUserStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": [
+        "ddl:alterable",
+        "ddl:statement",
+        "oracleddl:userOperand"
+      ]
+    }},
+    "oracleddl:alterViewStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "oracleddl:alterViewStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": [
+        "ddl:alterable",
+        "ddl:statement",
+        "ddl:viewOperand"
+      ]
+    }},
+    "oracleddl:alterTableStatement": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "oracleddl:alterTableStatement",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "true",
+        "jcr:supertypes": ["ddl:alterTableStatement"]
+      },
+      "children": {
+        "oracleddl:newTableName": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "oracleddl:newTableName"
+        }},
+        "oracleddl:renameColumn": {"properties": {
+          "jcr:requiredPrimaryTypes": ["ddl:renamable"],
+          "jcr:primaryType": "nt:childNodeDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:defaultPrimaryType": "ddl:renamable",
+          "jcr:sameNameSiblings": "true",
+          "jcr:protected": "false",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "oracleddl:renameColumn"
+        }},
+        "oracleddl:renameConstraint": {"properties": {
+          "jcr:requiredPrimaryTypes": ["ddl:renamable"],
+          "jcr:primaryType": "nt:childNodeDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:defaultPrimaryType": "ddl:renamable",
+          "jcr:sameNameSiblings": "true",
+          "jcr:protected": "false",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "oracleddl:renameConstraint"
+        }}
+      }
+    },
+    "oracleddl:createClusterStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "oracleddl:createClusterStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": [
+        "ddl:creatable",
+        "ddl:statement",
+        "oracleddl:clusterOperand"
+      ]
+    }},
+    "oracleddl:createContextStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "oracleddl:createContextStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": [
+        "ddl:creatable",
+        "ddl:statement",
+        "oracleddl:contextOperand"
+      ]
+    }},
+    "oracleddl:createControlfileStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "oracleddl:createControlfileStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": [
+        "ddl:creatable",
+        "ddl:statement",
+        "oracleddl:controlfileOperand"
+      ]
+    }},
+    "oracleddl:createDatabaseStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "oracleddl:createDatabaseStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": [
+        "ddl:creatable",
+        "ddl:statement",
+        "oracleddl:databaseOperand"
+      ]
+    }},
+    "oracleddl:createDimensionStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "oracleddl:createDimensionStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": [
+        "ddl:creatable",
+        "ddl:statement",
+        "oracleddl:dimensionOperand"
+      ]
+    }},
+    "oracleddl:createDirectoryStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "oracleddl:createDirectoryStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": [
+        "ddl:creatable",
+        "ddl:statement",
+        "oracleddl:directoryOperand"
+      ]
+    }},
+    "oracleddl:createDiskgroupStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "oracleddl:createDiskgroupStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": [
+        "ddl:creatable",
+        "ddl:statement",
+        "oracleddl:diskgroupOperand"
+      ]
+    }},
+    "oracleddl:createFunctionStatement": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "oracleddl:createFunctionStatement",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "true",
+        "jcr:supertypes": [
+          "ddl:creatable",
+          "ddl:statement",
+          "oracleddl:functionOperand"
+        ]
+      },
+      "children": {
+        "ddl:datatypeName": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "true",
+          "jcr:autoCreated": "false",
+          "jcr:name": "ddl:datatypeName"
+        }},
+        "ddl:datatypeLength": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "LONG",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "ddl:datatypeLength"
+        }},
+        "ddl:datatypePrecision": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "LONG",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "ddl:datatypePrecision"
+        }},
+        "ddl:datatypeScale": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "LONG",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "ddl:datatypeScale"
+        }},
+        "oracleddl:parameter": {"properties": {
+          "jcr:requiredPrimaryTypes": ["oracleddl:functionParameter"],
+          "jcr:primaryType": "nt:childNodeDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:defaultPrimaryType": "oracleddl:functionParameter",
+          "jcr:sameNameSiblings": "true",
+          "jcr:protected": "false",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "oracleddl:parameter"
+        }}
+      }
+    },
+    "oracleddl:indexOrderable": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "oracleddl:indexOrderable",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "true",
+        "jcr:supertypes": []
+      },
+      "children": {"oracleddl:order": {"properties": {
+        "jcr:primaryType": "nt:propertyDefinition",
+        "jcr:onParentVersion": "COPY",
+        "jcr:multiple": "false",
+        "jcr:protected": "false",
+        "jcr:availableQueryOperators": [
+          "jcr.operator.equal.to",
+          "jcr.operator.greater.than",
+          "jcr.operator.greater.than.or.equal.to",
+          "jcr.operator.less.than",
+          "jcr.operator.less.than.or.equal.to",
+          "jcr.operator.like",
+          "jcr.operator.not.equal.to"
+        ],
+        "jcr:valueConstraints": [
+          "ASC",
+          "DESC"
+        ],
+        "jcr:requiredType": "STRING",
+        "jcr:mandatory": "false",
+        "jcr:autoCreated": "false",
+        "jcr:name": "oracleddl:order"
+      }}}
+    },
+    "oracleddl:createIndexStatement": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "oracleddl:createIndexStatement",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "true",
+        "jcr:supertypes": [
+          "ddl:creatable",
+          "ddl:statement",
+          "oracleddl:indexOperand"
+        ]
+      },
+      "children": {
+        "oracleddl:indexType": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:valueConstraints": [
+            "CLUSTER",
+            "TABLE",
+            "BITMAP"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "oracleddl:indexType"
+        }},
+        "oracleddl:unique": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "BOOLEAN",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "oracleddl:unique"
+        }},
+        "oracleddl:bitmap": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "BOOLEAN",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "oracleddl:bitmap"
+        }},
+        "oracleddl:indexAttributes": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "true",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "oracleddl:indexAttributes"
+        }},
+        "oracleddl:unusable": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "BOOLEAN",
+          "jcr:mandatory": "false",
+          "jcr:defaultValues": ["false"],
+          "jcr:autoCreated": "false",
+          "jcr:name": "oracleddl:unusable"
+        }}
+      }
+    },
+    "oracleddl:createClusterIndexStatement": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "oracleddl:createClusterIndexStatement",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "true",
+        "jcr:supertypes": ["oracleddl:createIndexStatement"]
+      },
+      "children": {
+        "oracleddl:indexType": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:valueConstraints": ["CLUSTER"],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "true",
+          "jcr:defaultValues": ["CLUSTER"],
+          "jcr:autoCreated": "true",
+          "jcr:name": "oracleddl:indexType"
+        }},
+        "oracleddl:clustereName": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "true",
+          "jcr:autoCreated": "false",
+          "jcr:name": "oracleddl:clustereName"
+        }}
+      }
+    },
+    "oracleddl:createTableIndexStatement": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "oracleddl:createTableIndexStatement",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "true",
+        "jcr:supertypes": ["oracleddl:createIndexStatement"]
+      },
+      "children": {
+        "oracleddl:indexType": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:valueConstraints": ["TABLE"],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "true",
+          "jcr:defaultValues": ["TABLE"],
+          "jcr:autoCreated": "true",
+          "jcr:name": "oracleddl:indexType"
+        }},
+        "oracleddl:tableName": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "true",
+          "jcr:autoCreated": "false",
+          "jcr:name": "oracleddl:tableName"
+        }},
+        "oracleddl:tableAlias": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "oracleddl:tableAlias"
+        }},
+        "oracleddl:otherRefs": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "true",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "oracleddl:otherRefs"
+        }},
+        "*": {"properties": {
+          "jcr:requiredPrimaryTypes": ["ddl:columnReference"],
+          "jcr:primaryType": "nt:childNodeDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:defaultPrimaryType": "ddl:columnReference",
+          "jcr:sameNameSiblings": "false",
+          "jcr:protected": "false",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false"
+        }}
+      }
+    },
+    "oracleddl:createBitmapIndexStatement": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "oracleddl:createBitmapIndexStatement",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "true",
+        "jcr:supertypes": ["oracleddl:createIndexStatement"]
+      },
+      "children": {
+        "oracleddl:indexType": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:valueConstraints": ["BITMAP"],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "true",
+          "jcr:defaultValues": ["BITMAP"],
+          "jcr:autoCreated": "true",
+          "jcr:name": "oracleddl:indexType"
+        }},
+        "oracleddl:tableName": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "true",
+          "jcr:autoCreated": "false",
+          "jcr:name": "oracleddl:tableName"
+        }},
+        "oracleddl:whereClause": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "true",
+          "jcr:autoCreated": "false",
+          "jcr:name": "oracleddl:whereClause"
+        }},
+        "*": {"properties": {
+          "jcr:requiredPrimaryTypes": ["ddl:columnReference"],
+          "jcr:primaryType": "nt:childNodeDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:defaultPrimaryType": "ddl:columnReference",
+          "jcr:sameNameSiblings": "false",
+          "jcr:protected": "false",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false"
+        }},
+        "*[2]": {"properties": {
+          "jcr:requiredPrimaryTypes": ["ddl:tableReference"],
+          "jcr:primaryType": "nt:childNodeDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:defaultPrimaryType": "ddl:tableReference",
+          "jcr:sameNameSiblings": "false",
+          "jcr:protected": "false",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false"
+        }}
+      }
+    },
+    "oracleddl:createIndexTypeStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "oracleddl:createIndexTypeStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": [
+        "ddl:creatable",
+        "ddl:statement",
+        "oracleddl:indextypeOperand"
+      ]
+    }},
+    "oracleddl:createJavaStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "oracleddl:createJavaStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": [
+        "ddl:creatable",
+        "ddl:statement",
+        "oracleddl:javaOperand"
+      ]
+    }},
+    "oracleddl:createLibraryStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "oracleddl:createLibraryStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": [
+        "ddl:creatable",
+        "ddl:statement",
+        "oracleddl:libraryOperand"
+      ]
+    }},
+    "oracleddl:createMaterializedViewStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "oracleddl:createMaterializedViewStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": [
+        "ddl:creatable",
+        "ddl:statement",
+        "oracleddl:materializedOperand"
+      ]
+    }},
+    "oracleddl:createMaterializedViewLogStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "oracleddl:createMaterializedViewLogStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": [
+        "ddl:creatable",
+        "ddl:statement",
+        "oracleddl:materializedOperand"
+      ]
+    }},
+    "oracleddl:createOperatorStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "oracleddl:createOperatorStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": [
+        "ddl:creatable",
+        "ddl:statement",
+        "oracleddl:operatorOperand"
+      ]
+    }},
+    "oracleddl:createOutlineStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "oracleddl:createOutlineStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": [
+        "ddl:creatable",
+        "ddl:statement",
+        "oracleddl:outlineOperand"
+      ]
+    }},
+    "oracleddl:createPackageStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "oracleddl:createPackageStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": [
+        "ddl:creatable",
+        "ddl:statement",
+        "oracleddl:packageOperand"
+      ]
+    }},
+    "oracleddl:createPfileStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "oracleddl:createPfileStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": [
+        "ddl:creatable",
+        "ddl:statement",
+        "oracleddl:pfileOperand"
+      ]
+    }},
+    "oracleddl:createProcedureStatement": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "oracleddl:createProcedureStatement",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "true",
+        "jcr:supertypes": [
+          "ddl:creatable",
+          "ddl:statement",
+          "oracleddl:procedureOperand"
+        ]
+      },
+      "children": {"oracleddl:parameter": {"properties": {
+        "jcr:requiredPrimaryTypes": ["oracleddl:functionParameter"],
+        "jcr:primaryType": "nt:childNodeDefinition",
+        "jcr:onParentVersion": "COPY",
+        "jcr:defaultPrimaryType": "oracleddl:functionParameter",
+        "jcr:sameNameSiblings": "true",
+        "jcr:protected": "false",
+        "jcr:mandatory": "false",
+        "jcr:autoCreated": "false",
+        "jcr:name": "oracleddl:parameter"
+      }}}
+    },
+    "oracleddl:createRoleStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "oracleddl:createRoleStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": [
+        "ddl:creatable",
+        "ddl:statement",
+        "oracleddl:roleOperand"
+      ]
+    }},
+    "oracleddl:createRollbackStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "oracleddl:createRollbackStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": [
+        "ddl:creatable",
+        "ddl:statement",
+        "oracleddl:rollbackOperand"
+      ]
+    }},
+    "oracleddl:createSequenceStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "oracleddl:createSequenceStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": [
+        "ddl:creatable",
+        "ddl:statement",
+        "oracleddl:sequenceOperand"
+      ]
+    }},
+    "oracleddl:createSpfileStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "oracleddl:createSpfileStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": [
+        "ddl:creatable",
+        "ddl:statement",
+        "oracleddl:spfileOperand"
+      ]
+    }},
+    "oracleddl:createSynonymStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "oracleddl:createSynonymStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": [
+        "ddl:creatable",
+        "ddl:statement",
+        "oracleddl:synonymOperand"
+      ]
+    }},
+    "oracleddl:createTablespaceStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "oracleddl:createTablespaceStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": [
+        "ddl:creatable",
+        "ddl:statement",
+        "oracleddl:tablespaceOperand"
+      ]
+    }},
+    "oracleddl:createTriggerStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "oracleddl:createTriggerStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": [
+        "ddl:creatable",
+        "ddl:statement",
+        "oracleddl:triggerOperand"
+      ]
+    }},
+    "oracleddl:createTypeStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "oracleddl:createTypeStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": [
+        "ddl:creatable",
+        "ddl:statement",
+        "oracleddl:typeOperand"
+      ]
+    }},
+    "oracleddl:createUserStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "oracleddl:createUserStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": [
+        "ddl:creatable",
+        "ddl:statement",
+        "oracleddl:userOperand"
+      ]
+    }},
+    "oracleddl:dropClusterStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "oracleddl:dropClusterStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": [
+        "ddl:droppable",
+        "ddl:statement",
+        "oracleddl:clusterOperand"
+      ]
+    }},
+    "oracleddl:dropContextStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "oracleddl:dropContextStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": [
+        "ddl:droppable",
+        "ddl:statement",
+        "oracleddl:contextOperand"
+      ]
+    }},
+    "oracleddl:dropDatabaseStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "oracleddl:dropDatabaseStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": [
+        "ddl:droppable",
+        "ddl:statement",
+        "oracleddl:databaseOperand"
+      ]
+    }},
+    "oracleddl:dropDimensionStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "oracleddl:dropDimensionStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": [
+        "ddl:droppable",
+        "ddl:statement",
+        "oracleddl:dimensionOperand"
+      ]
+    }},
+    "oracleddl:dropDirectoryStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "oracleddl:dropDirectoryStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": [
+        "ddl:droppable",
+        "ddl:statement",
+        "oracleddl:directoryOperand"
+      ]
+    }},
+    "oracleddl:dropDiskgroupStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "oracleddl:dropDiskgroupStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": [
+        "ddl:droppable",
+        "ddl:statement",
+        "oracleddl:diskgroupOperand"
+      ]
+    }},
+    "oracleddl:dropFunctionStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "oracleddl:dropFunctionStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": [
+        "ddl:droppable",
+        "ddl:statement",
+        "oracleddl:functionOperand"
+      ]
+    }},
+    "oracleddl:dropIndexStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "oracleddl:dropIndexStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": [
+        "ddl:droppable",
+        "ddl:statement",
+        "oracleddl:indexOperand"
+      ]
+    }},
+    "oracleddl:dropIndextypeStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "oracleddl:dropIndextypeStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": [
+        "ddl:droppable",
+        "ddl:statement",
+        "oracleddl:indextypeOperand"
+      ]
+    }},
+    "oracleddl:dropJavaStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "oracleddl:dropJavaStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": [
+        "ddl:droppable",
+        "ddl:statement",
+        "oracleddl:javaOperand"
+      ]
+    }},
+    "oracleddl:dropLibraryStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "oracleddl:dropLibraryStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": [
+        "ddl:droppable",
+        "ddl:statement",
+        "oracleddl:libraryOperand"
+      ]
+    }},
+    "oracleddl:dropMaterializedStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "oracleddl:dropMaterializedStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": [
+        "ddl:droppable",
+        "ddl:statement",
+        "oracleddl:materializedOperand"
+      ]
+    }},
+    "oracleddl:dropOperatorStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "oracleddl:dropOperatorStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": [
+        "ddl:droppable",
+        "ddl:statement",
+        "oracleddl:operatorOperand"
+      ]
+    }},
+    "oracleddl:dropOutlineStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "oracleddl:dropOutlineStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": [
+        "ddl:droppable",
+        "ddl:statement",
+        "oracleddl:outlineOperand"
+      ]
+    }},
+    "oracleddl:dropPackageStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "oracleddl:dropPackageStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": [
+        "ddl:droppable",
+        "ddl:statement",
+        "oracleddl:packageOperand"
+      ]
+    }},
+    "oracleddl:dropProcedureStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "oracleddl:dropProcedureStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": [
+        "ddl:droppable",
+        "ddl:statement",
+        "oracleddl:procedureOperand"
+      ]
+    }},
+    "oracleddl:dropProfileStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "oracleddl:dropProfileStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": [
+        "ddl:droppable",
+        "ddl:statement",
+        "oracleddl:profileOperand"
+      ]
+    }},
+    "oracleddl:dropRoleStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "oracleddl:dropRoleStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": [
+        "ddl:droppable",
+        "ddl:statement",
+        "oracleddl:roleOperand"
+      ]
+    }},
+    "oracleddl:dropRollbackStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "oracleddl:dropRollbackStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": [
+        "ddl:droppable",
+        "ddl:statement",
+        "oracleddl:rollbackOperand"
+      ]
+    }},
+    "oracleddl:dropSequenceStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "oracleddl:dropSequenceStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": [
+        "ddl:droppable",
+        "ddl:statement",
+        "oracleddl:sequenceOperand"
+      ]
+    }},
+    "oracleddl:dropSynonymStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "oracleddl:dropSynonymStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": [
+        "ddl:droppable",
+        "ddl:statement",
+        "oracleddl:synonymOperand"
+      ]
+    }},
+    "oracleddl:dropTablespaceStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "oracleddl:dropTablespaceStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": [
+        "ddl:droppable",
+        "ddl:statement",
+        "oracleddl:tablespaceOperand"
+      ]
+    }},
+    "oracleddl:dropTriggerStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "oracleddl:dropTriggerStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": [
+        "ddl:droppable",
+        "ddl:statement",
+        "oracleddl:triggerOperand"
+      ]
+    }},
+    "oracleddl:dropTypeStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "oracleddl:dropTypeStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": [
+        "ddl:droppable",
+        "ddl:statement",
+        "oracleddl:typeOperand"
+      ]
+    }},
+    "oracleddl:dropUserStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "oracleddl:dropUserStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": [
+        "ddl:droppable",
+        "ddl:statement",
+        "oracleddl:userOperand"
+      ]
+    }},
+    "oracleddl:analyzeStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "oracleddl:analyzeStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": ["ddl:statement"]
+    }},
+    "oracleddl:associateStatisticsStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "oracleddl:associateStatisticsStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": ["ddl:statement"]
+    }},
+    "oracleddl:auditStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "oracleddl:auditStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": ["ddl:statement"]
+    }},
+    "oracleddl:commitStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "oracleddl:commitStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": ["ddl:statement"]
+    }},
+    "oracleddl:commentOnStatement": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "oracleddl:commentOnStatement",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "true",
+        "jcr:supertypes": [
+          "ddl:statement",
+          "oracleddl:commentOperand"
+        ]
+      },
+      "children": {
+        "oracleddl:targetObjectType": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "true",
+          "jcr:autoCreated": "false",
+          "jcr:name": "oracleddl:targetObjectType"
+        }},
+        "oracleddl:targetObjectName": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "oracleddl:targetObjectName"
+        }},
+        "oracleddl:comment": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "true",
+          "jcr:autoCreated": "false",
+          "jcr:name": "oracleddl:comment"
+        }}
+      }
+    },
+    "oracleddl:disassociateStatisticsStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "oracleddl:disassociateStatisticsStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": ["ddl:statement"]
+    }},
+    "oracleddl:explainPlanStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "oracleddl:explainPlanStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": ["ddl:statement"]
+    }},
+    "oracleddl:flashbackStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "oracleddl:flashbackStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": ["ddl:statement"]
+    }},
+    "oracleddl:lockTableStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "oracleddl:lockTableStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": ["ddl:statement"]
+    }},
+    "oracleddl:mergeStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "oracleddl:mergeStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": ["ddl:statement"]
+    }},
+    "oracleddl:nestedTableStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "oracleddl:nestedTableStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": ["ddl:statement"]
+    }},
+    "oracleddl:noauditStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "oracleddl:noauditStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": ["ddl:statement"]
+    }},
+    "oracleddl:purgeStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "oracleddl:purgeStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": ["ddl:statement"]
+    }},
+    "oracleddl:renameStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "oracleddl:renameStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": ["ddl:statement"]
+    }},
+    "oracleddl:revokeStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "oracleddl:revokeStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": ["ddl:statement"]
+    }},
+    "oracleddl:rollbackStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "oracleddl:rollbackStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": ["ddl:statement"]
+    }},
+    "oracleddl:setConstraintsStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "oracleddl:setConstraintsStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": [
+        "ddl:statement",
+        "ddl:settable"
+      ]
+    }},
+    "oracleddl:setRoleStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "oracleddl:setRoleStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": [
+        "ddl:statement",
+        "ddl:settable"
+      ]
+    }},
+    "oracleddl:setTransactionStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "oracleddl:setTransactionStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": [
+        "ddl:statement",
+        "ddl:settable"
+      ]
+    }},
+    "oracleddl:truncateStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "oracleddl:truncateStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": ["ddl:statement"]
+    }},
+    "postgresddl:aggregateOperand": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "postgresddl:aggregateOperand",
+      "jcr:isAbstract": "true",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": ["ddl:operand"]
+    }},
+    "postgresddl:castOperand": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "postgresddl:castOperand",
+      "jcr:isAbstract": "true",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": ["ddl:operand"]
+    }},
+    "postgresddl:commentOperand": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "postgresddl:commentOperand",
+      "jcr:isAbstract": "true",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": ["ddl:operand"]
+    }},
+    "postgresddl:constraintTriggerOperand": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "postgresddl:constraintTriggerOperand",
+      "jcr:isAbstract": "true",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": ["ddl:operand"]
+    }},
+    "postgresddl:conversionOperand": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "postgresddl:conversionOperand",
+      "jcr:isAbstract": "true",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": ["ddl:operand"]
+    }},
+    "postgresddl:databaseOperand": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "postgresddl:databaseOperand",
+      "jcr:isAbstract": "true",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": ["ddl:operand"]
+    }},
+    "postgresddl:foreignDataOperand": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "postgresddl:foreignDataOperand",
+      "jcr:isAbstract": "true",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": ["ddl:operand"]
+    }},
+    "postgresddl:groupOperand": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "postgresddl:groupOperand",
+      "jcr:isAbstract": "true",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": ["ddl:operand"]
+    }},
+    "postgresddl:functionOperand": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "postgresddl:functionOperand",
+      "jcr:isAbstract": "true",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": ["ddl:operand"]
+    }},
+    "postgresddl:indexOperand": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "postgresddl:indexOperand",
+      "jcr:isAbstract": "true",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": ["ddl:operand"]
+    }},
+    "postgresddl:languageOperand": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "postgresddl:languageOperand",
+      "jcr:isAbstract": "true",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": ["ddl:operand"]
+    }},
+    "postgresddl:operatorOperand": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "postgresddl:operatorOperand",
+      "jcr:isAbstract": "true",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": ["ddl:operand"]
+    }},
+    "postgresddl:ownedByOperand": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "postgresddl:ownedByOperand",
+      "jcr:isAbstract": "true",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": ["ddl:operand"]
+    }},
+    "postgresddl:roleOperand": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "postgresddl:roleOperand",
+      "jcr:isAbstract": "true",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": ["ddl:operand"]
+    }},
+    "postgresddl:ruleOperand": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "postgresddl:ruleOperand",
+      "jcr:isAbstract": "true",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": ["ddl:operand"]
+    }},
+    "postgresddl:sequenceOperand": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "postgresddl:sequenceOperand",
+      "jcr:isAbstract": "true",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": ["ddl:operand"]
+    }},
+    "postgresddl:serverOperand": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "postgresddl:serverOperand",
+      "jcr:isAbstract": "true",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": ["ddl:operand"]
+    }},
+    "postgresddl:tablespaceOperand": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "postgresddl:tablespaceOperand",
+      "jcr:isAbstract": "true",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": ["ddl:operand"]
+    }},
+    "postgresddl:textSearchOperand": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "postgresddl:textSearchOperand",
+      "jcr:isAbstract": "true",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": ["ddl:operand"]
+    }},
+    "postgresddl:triggerOperand": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "postgresddl:triggerOperand",
+      "jcr:isAbstract": "true",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": ["ddl:operand"]
+    }},
+    "postgresddl:typeOperand": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "postgresddl:typeOperand",
+      "jcr:isAbstract": "true",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": ["ddl:operand"]
+    }},
+    "postgresddl:userOperand": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "postgresddl:userOperand",
+      "jcr:isAbstract": "true",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": ["ddl:operand"]
+    }},
+    "postgresddl:userMappingOperand": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "postgresddl:userMappingOperand",
+      "jcr:isAbstract": "true",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": ["ddl:operand"]
+    }},
+    "postgresddl:parameterOperand": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "postgresddl:parameterOperand",
+      "jcr:isAbstract": "true",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": ["ddl:operand"]
+    }},
+    "postgresddl:functionParameter": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "postgresddl:functionParameter",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "true",
+        "jcr:supertypes": ["postgresddl:parameterOperand"]
+      },
+      "children": {
+        "ddl:datatypeName": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "true",
+          "jcr:autoCreated": "false",
+          "jcr:name": "ddl:datatypeName"
+        }},
+        "ddl:datatypeLength": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "LONG",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "ddl:datatypeLength"
+        }},
+        "ddl:datatypePrecision": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "LONG",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "ddl:datatypePrecision"
+        }},
+        "ddl:datatypeScale": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "LONG",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "ddl:datatypeScale"
+        }},
+        "ddl:nullable": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "ddl:nullable"
+        }},
+        "ddl:defaultOption": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "ddl:defaultOption"
+        }},
+        "postgresddl:mode": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "postgresddl:mode"
+        }}
+      }
+    },
+    "postgresddl:role": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "postgresddl:role",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": ["postgresddl:roleOperand"]
+    }},
+    "postgresddl:renamedColumn": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "postgresddl:renamedColumn",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": ["ddl:renamable"]
+    }},
+    "postgresddl:alterAggregateStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "postgresddl:alterAggregateStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": [
+        "ddl:alterable",
+        "ddl:statement",
+        "postgresddl:aggregateOperand"
+      ]
+    }},
+    "postgresddl:alterConversionStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "postgresddl:alterConversionStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": [
+        "ddl:alterable",
+        "ddl:statement",
+        "postgresddl:conversionOperand"
+      ]
+    }},
+    "postgresddl:alterDatabaseStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "postgresddl:alterDatabaseStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": [
+        "ddl:alterable",
+        "ddl:statement",
+        "postgresddl:databaseOperand"
+      ]
+    }},
+    "postgresddl:alterForeignDataWrapperStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "postgresddl:alterForeignDataWrapperStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": [
+        "ddl:alterable",
+        "ddl:statement",
+        "postgresddl:foreignDataOperand"
+      ]
+    }},
+    "postgresddl:alterFunctionStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "postgresddl:alterFunctionStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": [
+        "ddl:alterable",
+        "ddl:statement",
+        "postgresddl:functionOperand"
+      ]
+    }},
+    "postgresddl:alterGroupStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "postgresddl:alterGroupStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": [
+        "ddl:alterable",
+        "ddl:statement",
+        "postgresddl:groupOperand"
+      ]
+    }},
+    "postgresddl:alterIndexStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "postgresddl:alterIndexStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": [
+        "ddl:alterable",
+        "ddl:statement",
+        "postgresddl:indexOperand"
+      ]
+    }},
+    "postgresddl:alterLanguageStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "postgresddl:alterLanguageStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": [
+        "ddl:alterable",
+        "ddl:statement",
+        "postgresddl:languageOperand"
+      ]
+    }},
+    "postgresddl:alterOperatorStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "postgresddl:alterOperatorStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": [
+        "ddl:alterable",
+        "ddl:statement",
+        "postgresddl:operatorOperand"
+      ]
+    }},
+    "postgresddl:alterRoleStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "postgresddl:alterRoleStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": [
+        "ddl:alterable",
+        "ddl:statement",
+        "postgresddl:roleOperand"
+      ]
+    }},
+    "postgresddl:alterSchemaStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "postgresddl:alterSchemaStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": [
+        "ddl:alterable",
+        "ddl:statement",
+        "ddl:schemaOperand"
+      ]
+    }},
+    "postgresddl:alterSequenceStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "postgresddl:alterSequenceStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": [
+        "ddl:alterable",
+        "ddl:statement",
+        "postgresddl:sequenceOperand"
+      ]
+    }},
+    "postgresddl:alterServerStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "postgresddl:alterServerStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": [
+        "ddl:alterable",
+        "ddl:statement",
+        "postgresddl:serverOperand"
+      ]
+    }},
+    "postgresddl:alterTablespaceStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "postgresddl:alterTablespaceStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": [
+        "ddl:alterable",
+        "ddl:statement",
+        "postgresddl:tablespaceOperand"
+      ]
+    }},
+    "postgresddl:alterTextSearchStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "postgresddl:alterTextSearchStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": [
+        "ddl:alterable",
+        "ddl:statement",
+        "postgresddl:textSearchOperand"
+      ]
+    }},
+    "postgresddl:alterTriggerStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "postgresddl:alterTriggerStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": [
+        "ddl:alterable",
+        "ddl:statement",
+        "postgresddl:triggerOperand"
+      ]
+    }},
+    "postgresddl:alterTypeStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "postgresddl:alterTypeStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": [
+        "ddl:alterable",
+        "ddl:statement",
+        "postgresddl:typeOperand"
+      ]
+    }},
+    "postgresddl:alterUserStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "postgresddl:alterUserStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": [
+        "ddl:alterable",
+        "ddl:statement",
+        "postgresddl:userOperand"
+      ]
+    }},
+    "postgresddl:alterUserMappingStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "postgresddl:alterUserMappingStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": [
+        "ddl:alterable",
+        "ddl:statement",
+        "postgresddl:userMappingOperand"
+      ]
+    }},
+    "postgresddl:alterViewStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "postgresddl:alterViewStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": [
+        "ddl:alterable",
+        "ddl:statement",
+        "ddl:viewOperand"
+      ]
+    }},
+    "postgresddl:alterTableStatement": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "postgresddl:alterTableStatement",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "true",
+        "jcr:supertypes": ["ddl:alterTableStatement"]
+      },
+      "children": {
+        "postgresddl:newTableName": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "postgresddl:newTableName"
+        }},
+        "postgresddl:schemaName": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "postgresddl:schemaName"
+        }},
+        "postgresddl:renameColumn": {"properties": {
+          "jcr:requiredPrimaryTypes": ["postgresddl:renamedColumn"],
+          "jcr:primaryType": "nt:childNodeDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:defaultPrimaryType": "postgresddl:renamedColumn",
+          "jcr:sameNameSiblings": "true",
+          "jcr:protected": "false",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "postgresddl:renameColumn"
+        }}
+      }
+    },
+    "postgresddl:createAggregateStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "postgresddl:createAggregateStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": [
+        "ddl:creatable",
+        "ddl:statement",
+        "postgresddl:aggregateOperand"
+      ]
+    }},
+    "postgresddl:createCastStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "postgresddl:createCastStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": [
+        "ddl:creatable",
+        "ddl:statement",
+        "postgresddl:castOperand"
+      ]
+    }},
+    "postgresddl:createConstraintTriggerStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "postgresddl:createConstraintTriggerStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": [
+        "ddl:creatable",
+        "ddl:statement",
+        "postgresddl:constraintTriggerOperand"
+      ]
+    }},
+    "postgresddl:createConversionStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "postgresddl:createConversionStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": [
+        "ddl:creatable",
+        "ddl:statement",
+        "postgresddl:conversionOperand"
+      ]
+    }},
+    "postgresddl:createDatabaseStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "postgresddl:createDatabaseStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": [
+        "ddl:creatable",
+        "ddl:statement",
+        "postgresddl:databaseOperand"
+      ]
+    }},
+    "postgresddl:createForeignDataWrapperStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "postgresddl:createForeignDataWrapperStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": [
+        "ddl:creatable",
+        "ddl:statement",
+        "postgresddl:foreignDataOperand"
+      ]
+    }},
+    "postgresddl:createFunctionStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "postgresddl:createFunctionStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": [
+        "ddl:creatable",
+        "ddl:statement",
+        "postgresddl:functionOperand"
+      ]
+    }},
+    "postgresddl:createGroupStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "postgresddl:createGroupStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": [
+        "ddl:creatable",
+        "ddl:statement",
+        "postgresddl:groupOperand"
+      ]
+    }},
+    "postgresddl:createIndexStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "postgresddl:createIndexStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": [
+        "ddl:creatable",
+        "ddl:statement",
+        "postgresddl:indexOperand"
+      ]
+    }},
+    "postgresddl:createLanguageStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "postgresddl:createLanguageStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": [
+        "ddl:creatable",
+        "ddl:statement",
+        "postgresddl:languageOperand"
+      ]
+    }},
+    "postgresddl:createOperatorStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "postgresddl:createOperatorStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": [
+        "ddl:creatable",
+        "ddl:statement",
+        "postgresddl:operatorOperand"
+      ]
+    }},
+    "postgresddl:createRoleStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "postgresddl:createRoleStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": [
+        "ddl:creatable",
+        "ddl:statement",
+        "postgresddl:roleOperand"
+      ]
+    }},
+    "postgresddl:createRuleStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "postgresddl:createRuleStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": [
+        "ddl:creatable",
+        "ddl:statement",
+        "postgresddl:ruleOperand"
+      ]
+    }},
+    "postgresddl:createSequenceStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "postgresddl:createSequenceStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": [
+        "ddl:creatable",
+        "ddl:statement",
+        "postgresddl:sequenceOperand"
+      ]
+    }},
+    "postgresddl:createServerStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "postgresddl:createServerStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": [
+        "ddl:creatable",
+        "ddl:statement",
+        "postgresddl:serverOperand"
+      ]
+    }},
+    "postgresddl:createTablespaceStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "postgresddl:createTablespaceStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": [
+        "ddl:creatable",
+        "ddl:statement",
+        "postgresddl:tablespaceOperand"
+      ]
+    }},
+    "postgresddl:createTextSearchStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "postgresddl:createTextSearchStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": [
+        "ddl:creatable",
+        "ddl:statement",
+        "postgresddl:textSearchOperand"
+      ]
+    }},
+    "postgresddl:createTriggerStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "postgresddl:createTriggerStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": [
+        "ddl:creatable",
+        "ddl:statement",
+        "postgresddl:triggerOperand"
+      ]
+    }},
+    "postgresddl:createTypeStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "postgresddl:createTypeStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": [
+        "ddl:creatable",
+        "ddl:statement",
+        "postgresddl:typeOperand"
+      ]
+    }},
+    "postgresddl:createUserStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "postgresddl:createUserStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": [
+        "ddl:creatable",
+        "ddl:statement",
+        "postgresddl:userOperand"
+      ]
+    }},
+    "postgresddl:createUserMappingStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "postgresddl:createUserMappingStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": [
+        "ddl:creatable",
+        "ddl:statement",
+        "postgresddl:userMappingOperand"
+      ]
+    }},
+    "postgresddl:dropAggregateStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "postgresddl:dropAggregateStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": [
+        "ddl:droppable",
+        "ddl:statement",
+        "postgresddl:aggregateOperand"
+      ]
+    }},
+    "postgresddl:dropCastStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "postgresddl:dropCastStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": [
+        "ddl:droppable",
+        "ddl:statement",
+        "postgresddl:castOperand"
+      ]
+    }},
+    "postgresddl:dropConstraintTriggerStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "postgresddl:dropConstraintTriggerStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": [
+        "ddl:droppable",
+        "ddl:statement",
+        "postgresddl:constraintTriggerOperand"
+      ]
+    }},
+    "postgresddl:dropConversionStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "postgresddl:dropConversionStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": [
+        "ddl:droppable",
+        "ddl:statement",
+        "postgresddl:conversionOperand"
+      ]
+    }},
+    "postgresddl:dropDatabaseStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "postgresddl:dropDatabaseStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": [
+        "ddl:droppable",
+        "ddl:statement",
+        "postgresddl:databaseOperand"
+      ]
+    }},
+    "postgresddl:dropForeignDataWrapperStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "postgresddl:dropForeignDataWrapperStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": [
+        "ddl:droppable",
+        "ddl:statement",
+        "postgresddl:foreignDataOperand"
+      ]
+    }},
+    "postgresddl:dropFunctionStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "postgresddl:dropFunctionStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": [
+        "ddl:droppable",
+        "ddl:statement",
+        "postgresddl:functionOperand"
+      ]
+    }},
+    "postgresddl:dropGroupStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "postgresddl:dropGroupStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": [
+        "ddl:droppable",
+        "ddl:statement",
+        "postgresddl:groupOperand"
+      ]
+    }},
+    "postgresddl:dropIndexStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "postgresddl:dropIndexStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": [
+        "ddl:droppable",
+        "ddl:statement",
+        "postgresddl:indexOperand"
+      ]
+    }},
+    "postgresddl:dropLanguageStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "postgresddl:dropLanguageStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": [
+        "ddl:droppable",
+        "ddl:statement",
+        "postgresddl:languageOperand"
+      ]
+    }},
+    "postgresddl:dropOperatorStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "postgresddl:dropOperatorStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": [
+        "ddl:droppable",
+        "ddl:statement",
+        "postgresddl:operatorOperand"
+      ]
+    }},
+    "postgresddl:dropOwnedByStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "postgresddl:dropOwnedByStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": [
+        "ddl:droppable",
+        "ddl:statement",
+        "postgresddl:ownedByOperand"
+      ]
+    }},
+    "postgresddl:dropRoleStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "postgresddl:dropRoleStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": [
+        "ddl:droppable",
+        "ddl:statement",
+        "postgresddl:roleOperand"
+      ]
+    }},
+    "postgresddl:dropRuleStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "postgresddl:dropRuleStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": [
+        "ddl:droppable",
+        "ddl:statement",
+        "postgresddl:ruleOperand"
+      ]
+    }},
+    "postgresddl:dropSequenceStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "postgresddl:dropSequenceStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": [
+        "ddl:droppable",
+        "ddl:statement",
+        "postgresddl:sequenceOperand"
+      ]
+    }},
+    "postgresddl:dropServerStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "postgresddl:dropServerStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": [
+        "ddl:droppable",
+        "ddl:statement",
+        "postgresddl:serverOperand"
+      ]
+    }},
+    "postgresddl:dropTablespaceStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "postgresddl:dropTablespaceStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": [
+        "ddl:droppable",
+        "ddl:statement",
+        "postgresddl:tablespaceOperand"
+      ]
+    }},
+    "postgresddl:dropTextSearchStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "postgresddl:dropTextSearchStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": [
+        "ddl:droppable",
+        "ddl:statement",
+        "postgresddl:textSearchOperand"
+      ]
+    }},
+    "postgresddl:dropTriggerStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "postgresddl:dropTriggerStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": [
+        "ddl:droppable",
+        "ddl:statement",
+        "postgresddl:triggerOperand"
+      ]
+    }},
+    "postgresddl:dropTypeStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "postgresddl:dropTypeStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": [
+        "ddl:droppable",
+        "ddl:statement",
+        "postgresddl:typeOperand"
+      ]
+    }},
+    "postgresddl:dropUserStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "postgresddl:dropUserStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": [
+        "ddl:droppable",
+        "ddl:statement",
+        "postgresddl:userOperand"
+      ]
+    }},
+    "postgresddl:dropUserMappingStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "postgresddl:dropUserMappingStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": [
+        "ddl:droppable",
+        "ddl:statement",
+        "postgresddl:userMappingOperand"
+      ]
+    }},
+    "postgresddl:abortStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "postgresddl:abortStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": ["ddl:statement"]
+    }},
+    "postgresddl:analyzeStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "postgresddl:analyzeStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": ["ddl:statement"]
+    }},
+    "postgresddl:clusterStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "postgresddl:clusterStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": ["ddl:statement"]
+    }},
+    "postgresddl:commentOnStatement": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "postgresddl:commentOnStatement",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "true",
+        "jcr:supertypes": [
+          "ddl:statement",
+          "postgresddl:commentOperand"
+        ]
+      },
+      "children": {
+        "postgresddl:targetObjectType": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "true",
+          "jcr:autoCreated": "false",
+          "jcr:name": "postgresddl:targetObjectType"
+        }},
+        "postgresddl:targetObjectName": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "postgresddl:targetObjectName"
+        }},
+        "postgresddl:comment": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "true",
+          "jcr:autoCreated": "false",
+          "jcr:name": "postgresddl:comment"
+        }}
+      }
+    },
+    "postgresddl:copyStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "postgresddl:copyStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": ["ddl:statement"]
+    }},
+    "postgresddl:deallocateStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "postgresddl:deallocateStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": ["ddl:statement"]
+    }},
+    "postgresddl:declareStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "postgresddl:declareStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": ["ddl:statement"]
+    }},
+    "postgresddl:explainStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "postgresddl:explainStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": ["ddl:statement"]
+    }},
+    "postgresddl:fetchStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "postgresddl:fetchStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": ["ddl:statement"]
+    }},
+    "postgresddl:listenStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "postgresddl:listenStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": ["ddl:statement"]
+    }},
+    "postgresddl:loadStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "postgresddl:loadStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": ["ddl:statement"]
+    }},
+    "postgresddl:lockTableStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "postgresddl:lockTableStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": ["ddl:statement"]
+    }},
+    "postgresddl:moveStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "postgresddl:moveStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": ["ddl:statement"]
+    }},
+    "postgresddl:notifyStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "postgresddl:notifyStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": ["ddl:statement"]
+    }},
+    "postgresddl:prepareStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "postgresddl:prepareStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": ["ddl:statement"]
+    }},
+    "postgresddl:reassignOwnedStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "postgresddl:reassignOwnedStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": ["ddl:statement"]
+    }},
+    "postgresddl:reindexStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "postgresddl:reindexStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": ["ddl:statement"]
+    }},
+    "postgresddl:releaseSavepointStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "postgresddl:releaseSavepointStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": ["ddl:statement"]
+    }},
+    "postgresddl:rollbackStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "postgresddl:rollbackStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": ["ddl:statement"]
+    }},
+    "postgresddl:selectIntoStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "postgresddl:selectIntoStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": ["ddl:statement"]
+    }},
+    "postgresddl:showStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "postgresddl:showStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": ["ddl:statement"]
+    }},
+    "postgresddl:truncateStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "postgresddl:truncateStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": ["ddl:statement"]
+    }},
+    "postgresddl:unlistenStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "postgresddl:unlistenStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": ["ddl:statement"]
+    }},
+    "postgresddl:vacuumStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "postgresddl:vacuumStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": ["ddl:statement"]
+    }},
+    "postgresddl:commitStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "postgresddl:commitStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": ["ddl:statement"]
+    }},
+    "postgresddl:grantOnTableStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "postgresddl:grantOnTableStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": [
+        "ddl:grantStatement",
+        "ddl:tableOperand"
+      ]
+    }},
+    "postgresddl:grantOnSequenceStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "postgresddl:grantOnSequenceStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": [
+        "ddl:grantStatement",
+        "postgresddl:sequenceOperand"
+      ]
+    }},
+    "postgresddl:grantOnDatabaseStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "postgresddl:grantOnDatabaseStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": [
+        "ddl:grantStatement",
+        "postgresddl:databaseOperand"
+      ]
+    }},
+    "postgresddl:grantOnForeignDataWrapperStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "postgresddl:grantOnForeignDataWrapperStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": [
+        "ddl:grantStatement",
+        "postgresddl:foreignDataOperand"
+      ]
+    }},
+    "postgresddl:grantOnForeignServerStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "postgresddl:grantOnForeignServerStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": [
+        "ddl:grantStatement",
+        "postgresddl:serverOperand"
+      ]
+    }},
+    "postgresddl:grantOnFunctionStatement": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "postgresddl:grantOnFunctionStatement",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "true",
+        "jcr:supertypes": [
+          "ddl:grantStatement",
+          "postgresddl:functionOperand"
+        ]
+      },
+      "children": {"postgresddl:parameter": {"properties": {
+        "jcr:requiredPrimaryTypes": ["postgresddl:functionParameter"],
+        "jcr:primaryType": "nt:childNodeDefinition",
+        "jcr:onParentVersion": "COPY",
+        "jcr:defaultPrimaryType": "postgresddl:functionParameter",
+        "jcr:sameNameSiblings": "true",
+        "jcr:protected": "false",
+        "jcr:mandatory": "false",
+        "jcr:autoCreated": "false",
+        "jcr:name": "postgresddl:parameter"
+      }}}
+    },
+    "postgresddl:grantOnLanguageStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "postgresddl:grantOnLanguageStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": [
+        "ddl:grantStatement",
+        "postgresddl:languageOperand"
+      ]
+    }},
+    "postgresddl:grantOnSchemaStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "postgresddl:grantOnSchemaStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": [
+        "ddl:grantStatement",
+        "ddl:schemaOperand"
+      ]
+    }},
+    "postgresddl:grantOnTablespaceStatement": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "postgresddl:grantOnTablespaceStatement",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": [
+        "ddl:grantStatement",
+        "postgresddl:tablespaceOperand"
+      ]
+    }},
+    "postgresddl:grantRolesStatement": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "postgresddl:grantRolesStatement",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "true",
+        "jcr:supertypes": ["ddl:grantStatement"]
+      },
+      "children": {"postgresddl:grantRole": {"properties": {
+        "jcr:requiredPrimaryTypes": ["postgresddl:role"],
+        "jcr:primaryType": "nt:childNodeDefinition",
+        "jcr:onParentVersion": "COPY",
+        "jcr:defaultPrimaryType": "postgresddl:role",
+        "jcr:sameNameSiblings": "true",
+        "jcr:protected": "false",
+        "jcr:mandatory": "false",
+        "jcr:autoCreated": "false",
+        "jcr:name": "postgresddl:grantRole"
+      }}}
+    },
+    "teiidddl:constraint": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "teiidddl:constraint",
+        "jcr:isAbstract": "true",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "true",
+        "jcr:supertypes": []
+      },
+      "children": {
+        "teiidddl:constraintType": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:valueConstraints": [
+            "PRIMARY KEY",
+            "UNIQUE",
+            "ACCESSPATTERN",
+            "FOREIGN KEY",
+            "INDEX"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "teiidddl:constraintType"
+        }},
+        "teiidddl:tableElementRefs": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "true",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "REFERENCE",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "teiidddl:tableElementRefs"
+        }}
+      }
+    },
+    "teiidddl:tableElementConstraint": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "teiidddl:tableElementConstraint",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "true",
+        "jcr:supertypes": ["teiidddl:constraint"]
+      },
+      "children": {"teiidddl:constraintType": {"properties": {
+        "jcr:primaryType": "nt:propertyDefinition",
+        "jcr:onParentVersion": "COPY",
+        "jcr:multiple": "false",
+        "jcr:protected": "false",
+        "jcr:availableQueryOperators": [
+          "jcr.operator.equal.to",
+          "jcr.operator.greater.than",
+          "jcr.operator.greater.than.or.equal.to",
+          "jcr.operator.less.than",
+          "jcr.operator.less.than.or.equal.to",
+          "jcr.operator.like",
+          "jcr.operator.not.equal.to"
+        ],
+        "jcr:valueConstraints": [
+          "PRIMARY KEY",
+          "UNIQUE",
+          "ACCESSPATTERN"
+        ],
+        "jcr:requiredType": "STRING",
+        "jcr:mandatory": "true",
+        "jcr:autoCreated": "false",
+        "jcr:name": "teiidddl:constraintType"
+      }}}
+    },
+    "teiidddl:foreignKeyConstraint": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "teiidddl:foreignKeyConstraint",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "true",
+        "jcr:supertypes": ["teiidddl:constraint"]
+      },
+      "children": {
+        "teiidddl:constraintType": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:valueConstraints": ["FOREIGN KEY"],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "true",
+          "jcr:defaultValues": ["FOREIGN KEY"],
+          "jcr:autoCreated": "true",
+          "jcr:name": "teiidddl:constraintType"
+        }},
+        "teiidddl:tableRef": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "REFERENCE",
+          "jcr:mandatory": "true",
+          "jcr:autoCreated": "false",
+          "jcr:name": "teiidddl:tableRef"
+        }},
+        "teiidddl:tableRefElementRefs": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "true",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "REFERENCE",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "teiidddl:tableRefElementRefs"
+        }}
+      }
+    },
+    "teiidddl:indexConstraint": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "teiidddl:indexConstraint",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "true",
+        "jcr:supertypes": ["teiidddl:constraint"]
+      },
+      "children": {
+        "teiidddl:constraintType": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:valueConstraints": ["INDEX"],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "true",
+          "jcr:defaultValues": ["INDEX"],
+          "jcr:autoCreated": "true",
+          "jcr:name": "teiidddl:constraintType"
+        }},
+        "teiidddl:expression": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "teiidddl:expression"
+        }}
+      }
+    },
+    "teiidddl:schemaElement": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "teiidddl:schemaElement",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "true",
+        "jcr:supertypes": []
+      },
+      "children": {"teiidddl:schemaElementType": {"properties": {
+        "jcr:primaryType": "nt:propertyDefinition",
+        "jcr:onParentVersion": "COPY",
+        "jcr:multiple": "false",
+        "jcr:protected": "false",
+        "jcr:availableQueryOperators": [
+          "jcr.operator.equal.to",
+          "jcr.operator.greater.than",
+          "jcr.operator.greater.than.or.equal.to",
+          "jcr.operator.less.than",
+          "jcr.operator.less.than.or.equal.to",
+          "jcr.operator.like",
+          "jcr.operator.not.equal.to"
+        ],
+        "jcr:valueConstraints": [
+          "FOREIGN",
+          "VIRTUAL"
+        ],
+        "jcr:requiredType": "STRING",
+        "jcr:mandatory": "true",
+        "jcr:defaultValues": ["FOREIGN"],
+        "jcr:autoCreated": "true",
+        "jcr:name": "teiidddl:schemaElementType"
+      }}}
+    },
+    "teiidddl:tableElement": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "teiidddl:tableElement",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "true",
+        "jcr:supertypes": [
+          "ddl:columnDefinition",
+          "mix:referenceable"
+        ]
+      },
+      "children": {
+        "teiidddl:autoIncrement": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "BOOLEAN",
+          "jcr:mandatory": "false",
+          "jcr:defaultValues": ["false"],
+          "jcr:autoCreated": "false",
+          "jcr:name": "teiidddl:autoIncrement"
+        }},
+        "ddl:nullable": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:valueConstraints": [
+            "NULL",
+            "NOT NULL"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "true",
+          "jcr:defaultValues": ["NULL"],
+          "jcr:autoCreated": "true",
+          "jcr:name": "ddl:nullable"
+        }},
+        "*": {"properties": {
+          "jcr:requiredPrimaryTypes": ["ddl:statementOption"],
+          "jcr:primaryType": "nt:childNodeDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:defaultPrimaryType": "ddl:statementOption",
+          "jcr:sameNameSiblings": "false",
+          "jcr:protected": "false",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false"
+        }}
+      }
+    },
+    "teiidddl:abstractCreateTable": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "teiidddl:abstractCreateTable",
+        "jcr:isAbstract": "true",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "true",
+        "jcr:supertypes": [
+          "ddl:createTableStatement",
+          "teiidddl:schemaElement",
+          "mix:referenceable"
+        ]
+      },
+      "children": {
+        "teiidddl:queryExpression": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "teiidddl:queryExpression"
+        }},
+        "*": {"properties": {
+          "jcr:requiredPrimaryTypes": ["teiidddl:constraint"],
+          "jcr:primaryType": "nt:childNodeDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:defaultPrimaryType": "teiidddl:constraint",
+          "jcr:sameNameSiblings": "true",
+          "jcr:protected": "false",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false"
+        }}
+      }
+    },
+    "teiidddl:createTable": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "teiidddl:createTable",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": ["teiidddl:abstractCreateTable"]
+    }},
+    "teiidddl:createView": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "teiidddl:createView",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": ["teiidddl:abstractCreateTable"]
+    }},
+    "teiidddl:procedureParameter": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "teiidddl:procedureParameter",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "true",
+        "jcr:supertypes": ["mix:referenceable"]
+      },
+      "children": {
+        "teiidddl:parameterType": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:valueConstraints": [
+            "IN",
+            "OUT",
+            "INOUT",
+            "VARIADIC"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "true",
+          "jcr:defaultValues": ["IN"],
+          "jcr:autoCreated": "true",
+          "jcr:name": "teiidddl:parameterType"
+        }},
+        "teiidddl:result": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "BOOLEAN",
+          "jcr:mandatory": "false",
+          "jcr:defaultValues": ["false"],
+          "jcr:autoCreated": "true",
+          "jcr:name": "teiidddl:result"
+        }},
+        "ddl:nullable": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:valueConstraints": [
+            "NULL",
+            "NOT NULL"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "true",
+          "jcr:defaultValues": ["NULL"],
+          "jcr:autoCreated": "true",
+          "jcr:name": "ddl:nullable"
+        }},
+        "ddl:datatypeName": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "ddl:datatypeName"
+        }},
+        "ddl:datatypeLength": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "LONG",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "ddl:datatypeLength"
+        }},
+        "ddl:datatypePrecision": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "LONG",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "ddl:datatypePrecision"
+        }},
+        "ddl:datatypeScale": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "LONG",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "ddl:datatypeScale"
+        }},
+        "ddl:defaultOption": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:valueConstraints": [
+            "LITERAL",
+            "DATETIME",
+            "USER",
+            "CURRENT_USER",
+            "SESSION_USER",
+            "SYSTEM_USER",
+            "NULL"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "ddl:defaultOption"
+        }},
+        "ddl:defaultValue": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "ddl:defaultValue"
+        }},
+        "ddl:defaultPrecision": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "LONG",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "ddl:defaultPrecision"
+        }},
+        "*": {"properties": {
+          "jcr:requiredPrimaryTypes": ["ddl:statementOption"],
+          "jcr:primaryType": "nt:childNodeDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:defaultPrimaryType": "ddl:statementOption",
+          "jcr:sameNameSiblings": "false",
+          "jcr:protected": "false",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false"
+        }}
+      }
+    },
+    "teiidddl:resultColumn": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "teiidddl:resultColumn",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "true",
+        "jcr:supertypes": []
+      },
+      "children": {
+        "ddl:datatypeName": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "ddl:datatypeName"
+        }},
+        "ddl:datatypeLength": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "LONG",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "ddl:datatypeLength"
+        }},
+        "ddl:datatypePrecision": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "LONG",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "ddl:datatypePrecision"
+        }},
+        "ddl:datatypeScale": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "LONG",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "ddl:datatypeScale"
+        }},
+        "ddl:nullable": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:valueConstraints": [
+            "NULL",
+            "NOT NULL"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "true",
+          "jcr:defaultValues": ["NULL"],
+          "jcr:autoCreated": "true",
+          "jcr:name": "ddl:nullable"
+        }},
+        "*": {"properties": {
+          "jcr:requiredPrimaryTypes": ["ddl:statementOption"],
+          "jcr:primaryType": "nt:childNodeDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:defaultPrimaryType": "ddl:statementOption",
+          "jcr:sameNameSiblings": "false",
+          "jcr:protected": "false",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false"
+        }}
+      }
+    },
+    "teiidddl:resultSet": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "teiidddl:resultSet",
+      "jcr:isAbstract": "true",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": []
+    }},
+    "teiidddl:resultDataType": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "teiidddl:resultDataType",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": [
+        "teiidddl:resultSet",
+        "teiidddl:resultColumn"
+      ]
+    }},
+    "teiidddl:resultColumns": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "teiidddl:resultColumns",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "true",
+        "jcr:supertypes": ["teiidddl:resultSet"]
+      },
+      "children": {
+        "teiidddl:table": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "BOOLEAN",
+          "jcr:mandatory": "false",
+          "jcr:defaultValues": ["false"],
+          "jcr:autoCreated": "true",
+          "jcr:name": "teiidddl:table"
+        }},
+        "*": {"properties": {
+          "jcr:requiredPrimaryTypes": ["teiidddl:resultColumn"],
+          "jcr:primaryType": "nt:childNodeDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:defaultPrimaryType": "teiidddl:resultColumn",
+          "jcr:sameNameSiblings": "false",
+          "jcr:protected": "false",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false"
+        }}
+      }
+    },
+    "teiidddl:abstractCreateProcedure": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "teiidddl:abstractCreateProcedure",
+        "jcr:isAbstract": "true",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "true",
+        "jcr:supertypes": [
+          "ddl:creatable",
+          "ddl:statement",
+          "teiidddl:schemaElement"
+        ]
+      },
+      "children": {
+        "*": {"properties": {
+          "jcr:requiredPrimaryTypes": ["teiidddl:procedureParameter"],
+          "jcr:primaryType": "nt:childNodeDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:defaultPrimaryType": "teiidddl:procedureParameter",
+          "jcr:sameNameSiblings": "false",
+          "jcr:protected": "false",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false"
+        }},
+        "resultSet": {"properties": {
+          "jcr:requiredPrimaryTypes": ["teiidddl:resultSet"],
+          "jcr:primaryType": "nt:childNodeDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:sameNameSiblings": "false",
+          "jcr:protected": "false",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "resultSet"
+        }},
+        "*[2]": {"properties": {
+          "jcr:requiredPrimaryTypes": ["ddl:statementOption"],
+          "jcr:primaryType": "nt:childNodeDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:defaultPrimaryType": "ddl:statementOption",
+          "jcr:sameNameSiblings": "false",
+          "jcr:protected": "false",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false"
+        }}
+      }
+    },
+    "teiidddl:createFunction": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "teiidddl:createFunction",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": ["teiidddl:abstractCreateProcedure"]
+    }},
+    "teiidddl:createProcedure": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "teiidddl:createProcedure",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "true",
+        "jcr:supertypes": [
+          "teiidddl:abstractCreateProcedure",
+          "mix:referenceable"
+        ]
+      },
+      "children": {"teiidddl:statement": {"properties": {
+        "jcr:primaryType": "nt:propertyDefinition",
+        "jcr:onParentVersion": "COPY",
+        "jcr:multiple": "false",
+        "jcr:protected": "false",
+        "jcr:availableQueryOperators": [
+          "jcr.operator.equal.to",
+          "jcr.operator.greater.than",
+          "jcr.operator.greater.than.or.equal.to",
+          "jcr.operator.less.than",
+          "jcr.operator.less.than.or.equal.to",
+          "jcr.operator.like",
+          "jcr.operator.not.equal.to"
+        ],
+        "jcr:requiredType": "STRING",
+        "jcr:mandatory": "false",
+        "jcr:autoCreated": "false",
+        "jcr:name": "teiidddl:statement"
+      }}}
+    },
+    "teiidddl:alterOptionsList": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "teiidddl:alterOptionsList",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "true",
+        "jcr:supertypes": []
+      },
+      "children": {
+        "teiidddl:dropped": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "true",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "teiidddl:dropped"
+        }},
+        "*": {"properties": {
+          "jcr:requiredPrimaryTypes": ["ddl:statementOption"],
+          "jcr:primaryType": "nt:childNodeDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:defaultPrimaryType": "ddl:statementOption",
+          "jcr:sameNameSiblings": "false",
+          "jcr:protected": "false",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false"
+        }}
+      }
+    },
+    "teiidddl:alterOptions": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "teiidddl:alterOptions",
+        "jcr:isAbstract": "true",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "true",
+        "jcr:supertypes": [
+          "ddl:creatable",
+          "ddl:statement",
+          "teiidddl:schemaElement"
+        ]
+      },
+      "children": {
+        "teiidddl:reference": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "REFERENCE",
+          "jcr:mandatory": "true",
+          "jcr:autoCreated": "false",
+          "jcr:name": "teiidddl:reference"
+        }},
+        "alters": {"properties": {
+          "jcr:requiredPrimaryTypes": ["teiidddl:alterOptionsList"],
+          "jcr:primaryType": "nt:childNodeDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:sameNameSiblings": "false",
+          "jcr:protected": "false",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "alters"
+        }}
+      }
+    },
+    "teiidddl:alterTable": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "teiidddl:alterTable",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": ["teiidddl:alterOptions"]
+    }},
+    "teiidddl:alterView": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "teiidddl:alterView",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": ["teiidddl:alterOptions"]
+    }},
+    "teiidddl:alterProcedure": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "teiidddl:alterProcedure",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": ["teiidddl:alterOptions"]
+    }},
+    "teiidddl:alterColumn": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "teiidddl:alterColumn",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "true",
+        "jcr:supertypes": [
+          "teiidddl:alterOptionsList",
+          "mix:referenceable"
+        ]
+      },
+      "children": {"teiidddl:reference": {"properties": {
+        "jcr:primaryType": "nt:propertyDefinition",
+        "jcr:onParentVersion": "COPY",
+        "jcr:multiple": "false",
+        "jcr:protected": "false",
+        "jcr:availableQueryOperators": [
+          "jcr.operator.equal.to",
+          "jcr.operator.greater.than",
+          "jcr.operator.greater.than.or.equal.to",
+          "jcr.operator.less.than",
+          "jcr.operator.less.than.or.equal.to",
+          "jcr.operator.like",
+          "jcr.operator.not.equal.to"
+        ],
+        "jcr:requiredType": "REFERENCE",
+        "jcr:mandatory": "true",
+        "jcr:autoCreated": "false",
+        "jcr:name": "teiidddl:reference"
+      }}}
+    },
+    "teiidddl:alterParameter": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "teiidddl:alterParameter",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "true",
+        "jcr:supertypes": [
+          "teiidddl:alterOptionsList",
+          "mix:referenceable"
+        ]
+      },
+      "children": {"teiidddl:reference": {"properties": {
+        "jcr:primaryType": "nt:propertyDefinition",
+        "jcr:onParentVersion": "COPY",
+        "jcr:multiple": "false",
+        "jcr:protected": "false",
+        "jcr:availableQueryOperators": [
+          "jcr.operator.equal.to",
+          "jcr.operator.greater.than",
+          "jcr.operator.greater.than.or.equal.to",
+          "jcr.operator.less.than",
+          "jcr.operator.less.than.or.equal.to",
+          "jcr.operator.like",
+          "jcr.operator.not.equal.to"
+        ],
+        "jcr:requiredType": "REFERENCE",
+        "jcr:mandatory": "true",
+        "jcr:autoCreated": "false",
+        "jcr:name": "teiidddl:reference"
+      }}}
+    },
+    "teiidddl:triggerRowAction": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "teiidddl:triggerRowAction",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "true",
+        "jcr:supertypes": []
+      },
+      "children": {"teiidddl:action": {"properties": {
+        "jcr:primaryType": "nt:propertyDefinition",
+        "jcr:onParentVersion": "COPY",
+        "jcr:multiple": "false",
+        "jcr:protected": "false",
+        "jcr:availableQueryOperators": [
+          "jcr.operator.equal.to",
+          "jcr.operator.greater.than",
+          "jcr.operator.greater.than.or.equal.to",
+          "jcr.operator.less.than",
+          "jcr.operator.less.than.or.equal.to",
+          "jcr.operator.like",
+          "jcr.operator.not.equal.to"
+        ],
+        "jcr:requiredType": "STRING",
+        "jcr:mandatory": "true",
+        "jcr:autoCreated": "false",
+        "jcr:name": "teiidddl:action"
+      }}}
+    },
+    "teiidddl:createTrigger": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "teiidddl:createTrigger",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "true",
+        "jcr:supertypes": [
+          "ddl:creatable",
+          "ddl:statement"
+        ]
+      },
+      "children": {
+        "teiidddl:insteadOf": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:valueConstraints": [
+            "INSERT",
+            "UPDATE",
+            "DELETE"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "true",
+          "jcr:autoCreated": "false",
+          "jcr:name": "teiidddl:insteadOf"
+        }},
+        "teiidddl:tableRef": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "REFERENCE",
+          "jcr:mandatory": "true",
+          "jcr:autoCreated": "false",
+          "jcr:name": "teiidddl:tableRef"
+        }},
+        "teiidddl:atomic": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "BOOLEAN",
+          "jcr:mandatory": "false",
+          "jcr:defaultValues": ["true"],
+          "jcr:autoCreated": "true",
+          "jcr:name": "teiidddl:atomic"
+        }},
+        "rowAction": {"properties": {
+          "jcr:requiredPrimaryTypes": ["teiidddl:triggerRowAction"],
+          "jcr:primaryType": "nt:childNodeDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:defaultPrimaryType": "teiidddl:triggerRowAction",
+          "jcr:sameNameSiblings": "true",
+          "jcr:protected": "false",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "rowAction"
+        }},
+        "*": {"properties": {
+          "jcr:requiredPrimaryTypes": ["ddl:statementOption"],
+          "jcr:primaryType": "nt:childNodeDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:defaultPrimaryType": "ddl:statementOption",
+          "jcr:sameNameSiblings": "false",
+          "jcr:protected": "false",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false"
+        }}
+      }
+    },
+    "teiidddl:optionNamespace": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "teiidddl:optionNamespace",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "true",
+        "jcr:supertypes": ["ddl:statement"]
+      },
+      "children": {"teiidddl:uri": {"properties": {
+        "jcr:primaryType": "nt:propertyDefinition",
+        "jcr:onParentVersion": "COPY",
+        "jcr:multiple": "false",
+        "jcr:protected": "false",
+        "jcr:availableQueryOperators": [
+          "jcr.operator.equal.to",
+          "jcr.operator.greater.than",
+          "jcr.operator.greater.than.or.equal.to",
+          "jcr.operator.less.than",
+          "jcr.operator.less.than.or.equal.to",
+          "jcr.operator.like",
+          "jcr.operator.not.equal.to"
+        ],
+        "jcr:requiredType": "STRING",
+        "jcr:mandatory": "true",
+        "jcr:autoCreated": "false",
+        "jcr:name": "teiidddl:uri"
+      }}}
+    },
+    "text:column": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "text:column",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "true",
+        "jcr:supertypes": []
+      },
+      "children": {"text:data": {"properties": {
+        "jcr:primaryType": "nt:propertyDefinition",
+        "jcr:onParentVersion": "COPY",
+        "jcr:multiple": "false",
+        "jcr:protected": "false",
+        "jcr:availableQueryOperators": [
+          "jcr.operator.equal.to",
+          "jcr.operator.greater.than",
+          "jcr.operator.greater.than.or.equal.to",
+          "jcr.operator.less.than",
+          "jcr.operator.less.than.or.equal.to",
+          "jcr.operator.like",
+          "jcr.operator.not.equal.to"
+        ],
+        "jcr:requiredType": "STRING",
+        "jcr:mandatory": "false",
+        "jcr:autoCreated": "false",
+        "jcr:name": "text:data"
+      }}}
+    },
+    "msoffice:metadata": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "msoffice:metadata",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "false",
+        "jcr:supertypes": [
+          "nt:unstructured",
+          "mix:mimeType"
+        ]
+      },
+      "children": {
+        "msoffice:title": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "msoffice:title"
+        }},
+        "msoffice:subject": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "msoffice:subject"
+        }},
+        "msoffice:author": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "msoffice:author"
+        }},
+        "msoffice:keywords": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "msoffice:keywords"
+        }},
+        "msoffice:comment": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "msoffice:comment"
+        }},
+        "msoffice:template": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "msoffice:template"
+        }},
+        "msoffice:last_saved_by": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "msoffice:last_saved_by"
+        }},
+        "msoffice:revision": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "msoffice:revision"
+        }},
+        "msoffice:total_editing_time": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "LONG",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "msoffice:total_editing_time"
+        }},
+        "msoffice:last_printed": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "DATE",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "msoffice:last_printed"
+        }},
+        "msoffice:created": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "DATE",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "msoffice:created"
+        }},
+        "msoffice:saved": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "DATE",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "msoffice:saved"
+        }},
+        "msoffice:pages": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "LONG",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "msoffice:pages"
+        }},
+        "msoffice:words": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "LONG",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "msoffice:words"
+        }},
+        "msoffice:characters": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "LONG",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "msoffice:characters"
+        }},
+        "msoffice:creating_application": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "msoffice:creating_application"
+        }},
+        "msoffice:thumbnail": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "BINARY",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "msoffice:thumbnail"
+        }},
+        "msoffice:full_content": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "msoffice:full_content"
+        }},
+        "msoffice:heading": {"properties": {
+          "jcr:requiredPrimaryTypes": ["msoffice:heading"],
+          "jcr:primaryType": "nt:childNodeDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:sameNameSiblings": "true",
+          "jcr:protected": "false",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "msoffice:heading"
+        }},
+        "msoffice:slide": {"properties": {
+          "jcr:requiredPrimaryTypes": ["msoffice:pptslide"],
+          "jcr:primaryType": "nt:childNodeDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:sameNameSiblings": "true",
+          "jcr:protected": "false",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "msoffice:slide"
+        }},
+        "msoffice:sheet": {"properties": {
+          "jcr:requiredPrimaryTypes": ["msoffice:xlssheet"],
+          "jcr:primaryType": "nt:childNodeDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:sameNameSiblings": "true",
+          "jcr:protected": "false",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "msoffice:sheet"
+        }}
+      }
+    },
+    "msoffice:pptslide": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "msoffice:pptslide",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "false",
+        "jcr:supertypes": ["nt:base"]
+      },
+      "children": {
+        "msoffice:title": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "msoffice:title"
+        }},
+        "msoffice:text": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "msoffice:text"
+        }},
+        "msoffice:notes": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "msoffice:notes"
+        }},
+        "msoffice:thumbnail": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "BINARY",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "msoffice:thumbnail"
+        }}
+      }
+    },
+    "msoffice:xlssheet": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "msoffice:xlssheet",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "false",
+        "jcr:supertypes": ["nt:base"]
+      },
+      "children": {
+        "msoffice:sheet_name": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "msoffice:sheet_name"
+        }},
+        "msoffice:text": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "msoffice:text"
+        }}
+      }
+    },
+    "msoffice:heading": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "msoffice:heading",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "false",
+        "jcr:supertypes": ["nt:base"]
+      },
+      "children": {
+        "msoffice:heading_name": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "msoffice:heading_name"
+        }},
+        "msoffice:heading_level": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "LONG",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "msoffice:heading_level"
+        }}
+      }
+    },
+    "class:package": {"properties": {
+      "jcr:primaryType": "nt:nodeType",
+      "jcr:nodeTypeName": "class:package",
+      "jcr:isAbstract": "false",
+      "jcr:hasOrderableChildNodes": "false",
+      "jcr:isQueryable": "true",
+      "jcr:isMixin": "true",
+      "jcr:supertypes": []
+    }},
+    "class:annotationMember": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "class:annotationMember",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "false",
+        "jcr:supertypes": ["nt:base"]
+      },
+      "children": {
+        "class:name": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "true",
+          "jcr:autoCreated": "false",
+          "jcr:name": "class:name"
+        }},
+        "class:value": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "class:value"
+        }}
+      }
+    },
+    "class:annotation": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "class:annotation",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "false",
+        "jcr:supertypes": ["nt:base"]
+      },
+      "children": {
+        "class:name": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "true",
+          "jcr:autoCreated": "false",
+          "jcr:name": "class:name"
+        }},
+        "*": {"properties": {
+          "jcr:requiredPrimaryTypes": ["class:annotationMember"],
+          "jcr:primaryType": "nt:childNodeDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:defaultPrimaryType": "class:annotationMember",
+          "jcr:sameNameSiblings": "false",
+          "jcr:protected": "false",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false"
+        }}
+      }
+    },
+    "class:annotations": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "class:annotations",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "false",
+        "jcr:supertypes": ["nt:base"]
+      },
+      "children": {"*": {"properties": {
+        "jcr:requiredPrimaryTypes": ["class:annotation"],
+        "jcr:primaryType": "nt:childNodeDefinition",
+        "jcr:onParentVersion": "COPY",
+        "jcr:defaultPrimaryType": "class:annotation",
+        "jcr:sameNameSiblings": "false",
+        "jcr:protected": "false",
+        "jcr:mandatory": "false",
+        "jcr:autoCreated": "false"
+      }}}
+    },
+    "class:field": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "class:field",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "false",
+        "jcr:supertypes": ["nt:base"]
+      },
+      "children": {
+        "class:name": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "true",
+          "jcr:autoCreated": "false",
+          "jcr:name": "class:name"
+        }},
+        "class:typeClassName": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "true",
+          "jcr:autoCreated": "false",
+          "jcr:name": "class:typeClassName"
+        }},
+        "class:visibility": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:valueConstraints": [
+            "public",
+            "protected",
+            "package",
+            "private"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "true",
+          "jcr:autoCreated": "false",
+          "jcr:name": "class:visibility"
+        }},
+        "class:static": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "BOOLEAN",
+          "jcr:mandatory": "true",
+          "jcr:autoCreated": "false",
+          "jcr:name": "class:static"
+        }},
+        "class:final": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "BOOLEAN",
+          "jcr:mandatory": "true",
+          "jcr:autoCreated": "false",
+          "jcr:name": "class:final"
+        }},
+        "class:transient": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "BOOLEAN",
+          "jcr:mandatory": "true",
+          "jcr:autoCreated": "false",
+          "jcr:name": "class:transient"
+        }},
+        "class:volatile": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "BOOLEAN",
+          "jcr:mandatory": "true",
+          "jcr:autoCreated": "false",
+          "jcr:name": "class:volatile"
+        }},
+        "class:annotations": {"properties": {
+          "jcr:requiredPrimaryTypes": ["class:annotations"],
+          "jcr:primaryType": "nt:childNodeDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:defaultPrimaryType": "class:annotations",
+          "jcr:sameNameSiblings": "false",
+          "jcr:protected": "false",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "class:annotations"
+        }}
+      }
+    },
+    "class:fields": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "class:fields",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "false",
+        "jcr:supertypes": ["nt:base"]
+      },
+      "children": {"*": {"properties": {
+        "jcr:requiredPrimaryTypes": ["class:field"],
+        "jcr:primaryType": "nt:childNodeDefinition",
+        "jcr:onParentVersion": "COPY",
+        "jcr:defaultPrimaryType": "class:field",
+        "jcr:sameNameSiblings": "false",
+        "jcr:protected": "false",
+        "jcr:mandatory": "false",
+        "jcr:autoCreated": "false"
+      }}}
+    },
+    "class:interfaces": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "class:interfaces",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "false",
+        "jcr:supertypes": ["nt:base"]
+      },
+      "children": {"*": {"properties": {
+        "jcr:primaryType": "nt:propertyDefinition",
+        "jcr:onParentVersion": "COPY",
+        "jcr:multiple": "false",
+        "jcr:protected": "false",
+        "jcr:availableQueryOperators": [
+          "jcr.operator.equal.to",
+          "jcr.operator.greater.than",
+          "jcr.operator.greater.than.or.equal.to",
+          "jcr.operator.less.than",
+          "jcr.operator.less.than.or.equal.to",
+          "jcr.operator.like",
+          "jcr.operator.not.equal.to"
+        ],
+        "jcr:requiredType": "STRING",
+        "jcr:mandatory": "false",
+        "jcr:autoCreated": "false"
+      }}}
+    },
+    "class:method": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "class:method",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "false",
+        "jcr:supertypes": ["nt:base"]
+      },
+      "children": {
+        "class:name": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "true",
+          "jcr:autoCreated": "false",
+          "jcr:name": "class:name"
+        }},
+        "class:returnTypeClassName": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "true",
+          "jcr:autoCreated": "false",
+          "jcr:name": "class:returnTypeClassName"
+        }},
+        "class:visibility": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:valueConstraints": [
+            "public",
+            "protected",
+            "package",
+            "private"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "true",
+          "jcr:autoCreated": "false",
+          "jcr:name": "class:visibility"
+        }},
+        "class:static": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "BOOLEAN",
+          "jcr:mandatory": "true",
+          "jcr:autoCreated": "false",
+          "jcr:name": "class:static"
+        }},
+        "class:final": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "BOOLEAN",
+          "jcr:mandatory": "true",
+          "jcr:autoCreated": "false",
+          "jcr:name": "class:final"
+        }},
+        "class:abstract": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "BOOLEAN",
+          "jcr:mandatory": "true",
+          "jcr:autoCreated": "false",
+          "jcr:name": "class:abstract"
+        }},
+        "class:strictFp": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "BOOLEAN",
+          "jcr:mandatory": "true",
+          "jcr:autoCreated": "false",
+          "jcr:name": "class:strictFp"
+        }},
+        "class:native": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "BOOLEAN",
+          "jcr:mandatory": "true",
+          "jcr:autoCreated": "false",
+          "jcr:name": "class:native"
+        }},
+        "class:synchronized": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "BOOLEAN",
+          "jcr:mandatory": "true",
+          "jcr:autoCreated": "false",
+          "jcr:name": "class:synchronized"
+        }},
+        "class:parameters": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "true",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "class:parameters"
+        }},
+        "class:annotations": {"properties": {
+          "jcr:requiredPrimaryTypes": ["class:annotations"],
+          "jcr:primaryType": "nt:childNodeDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:defaultPrimaryType": "class:annotations",
+          "jcr:sameNameSiblings": "false",
+          "jcr:protected": "false",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "class:annotations"
+        }},
+        "class:methodParameters": {"properties": {
+          "jcr:requiredPrimaryTypes": ["class:parameters"],
+          "jcr:primaryType": "nt:childNodeDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:defaultPrimaryType": "class:parameters",
+          "jcr:sameNameSiblings": "false",
+          "jcr:protected": "false",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "class:methodParameters"
+        }}
+      }
+    },
+    "class:methods": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "class:methods",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "false",
+        "jcr:supertypes": ["nt:base"]
+      },
+      "children": {"*": {"properties": {
+        "jcr:requiredPrimaryTypes": ["class:method"],
+        "jcr:primaryType": "nt:childNodeDefinition",
+        "jcr:onParentVersion": "COPY",
+        "jcr:defaultPrimaryType": "class:method",
+        "jcr:sameNameSiblings": "false",
+        "jcr:protected": "false",
+        "jcr:mandatory": "false",
+        "jcr:autoCreated": "false"
+      }}}
+    },
+    "class:constructors": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "class:constructors",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "false",
+        "jcr:supertypes": ["nt:base"]
+      },
+      "children": {"*": {"properties": {
+        "jcr:requiredPrimaryTypes": ["class:method"],
+        "jcr:primaryType": "nt:childNodeDefinition",
+        "jcr:onParentVersion": "COPY",
+        "jcr:defaultPrimaryType": "class:method",
+        "jcr:sameNameSiblings": "false",
+        "jcr:protected": "false",
+        "jcr:mandatory": "false",
+        "jcr:autoCreated": "false"
+      }}}
+    },
+    "class:parameters": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "class:parameters",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "false",
+        "jcr:supertypes": ["nt:base"]
+      },
+      "children": {"*": {"properties": {
+        "jcr:requiredPrimaryTypes": ["class:parameter"],
+        "jcr:primaryType": "nt:childNodeDefinition",
+        "jcr:onParentVersion": "COPY",
+        "jcr:defaultPrimaryType": "class:parameter",
+        "jcr:sameNameSiblings": "false",
+        "jcr:protected": "false",
+        "jcr:mandatory": "false",
+        "jcr:autoCreated": "false"
+      }}}
+    },
+    "class:parameter": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "class:parameter",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "false",
+        "jcr:supertypes": ["nt:base"]
+      },
+      "children": {
+        "class:name": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "true",
+          "jcr:autoCreated": "false",
+          "jcr:name": "class:name"
+        }},
+        "class:typeClassName": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "true",
+          "jcr:autoCreated": "false",
+          "jcr:name": "class:typeClassName"
+        }},
+        "class:final": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "BOOLEAN",
+          "jcr:mandatory": "true",
+          "jcr:autoCreated": "false",
+          "jcr:name": "class:final"
+        }},
+        "class:annotations": {"properties": {
+          "jcr:requiredPrimaryTypes": ["class:annotations"],
+          "jcr:primaryType": "nt:childNodeDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:defaultPrimaryType": "class:annotations",
+          "jcr:sameNameSiblings": "false",
+          "jcr:protected": "false",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "class:annotations"
+        }}
+      }
+    },
+    "class:class": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "class:class",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "false",
+        "jcr:supertypes": ["nt:base"]
+      },
+      "children": {
+        "class:name": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "true",
+          "jcr:autoCreated": "false",
+          "jcr:name": "class:name"
+        }},
+        "class:sequencedDate": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "DATE",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "class:sequencedDate"
+        }},
+        "class:superClassName": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "class:superClassName"
+        }},
+        "class:visibility": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:valueConstraints": [
+            "public",
+            "protected",
+            "package",
+            "private"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "true",
+          "jcr:autoCreated": "false",
+          "jcr:name": "class:visibility"
+        }},
+        "class:abstract": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "BOOLEAN",
+          "jcr:mandatory": "true",
+          "jcr:autoCreated": "false",
+          "jcr:name": "class:abstract"
+        }},
+        "class:interface": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "BOOLEAN",
+          "jcr:mandatory": "true",
+          "jcr:autoCreated": "false",
+          "jcr:name": "class:interface"
+        }},
+        "class:final": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "BOOLEAN",
+          "jcr:mandatory": "true",
+          "jcr:autoCreated": "false",
+          "jcr:name": "class:final"
+        }},
+        "class:strictFp": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "BOOLEAN",
+          "jcr:mandatory": "true",
+          "jcr:autoCreated": "false",
+          "jcr:name": "class:strictFp"
+        }},
+        "class:interfaces": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "true",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "class:interfaces"
+        }},
+        "class:imports": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "true",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "class:imports"
+        }},
+        "class:annotations": {"properties": {
+          "jcr:requiredPrimaryTypes": ["class:annotations"],
+          "jcr:primaryType": "nt:childNodeDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:defaultPrimaryType": "class:annotations",
+          "jcr:sameNameSiblings": "false",
+          "jcr:protected": "false",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "class:annotations"
+        }},
+        "class:constructors": {"properties": {
+          "jcr:requiredPrimaryTypes": ["class:constructors"],
+          "jcr:primaryType": "nt:childNodeDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:defaultPrimaryType": "class:constructors",
+          "jcr:sameNameSiblings": "false",
+          "jcr:protected": "false",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "class:constructors"
+        }},
+        "class:methods": {"properties": {
+          "jcr:requiredPrimaryTypes": ["class:methods"],
+          "jcr:primaryType": "nt:childNodeDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:defaultPrimaryType": "class:methods",
+          "jcr:sameNameSiblings": "false",
+          "jcr:protected": "false",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "class:methods"
+        }},
+        "class:fields": {"properties": {
+          "jcr:requiredPrimaryTypes": ["class:fields"],
+          "jcr:primaryType": "nt:childNodeDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:defaultPrimaryType": "class:fields",
+          "jcr:sameNameSiblings": "false",
+          "jcr:protected": "false",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "class:fields"
+        }}
+      }
+    },
+    "class:enum": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "class:enum",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "false",
+        "jcr:supertypes": ["class:class"]
+      },
+      "children": {"class:enumValues": {"properties": {
+        "jcr:primaryType": "nt:propertyDefinition",
+        "jcr:onParentVersion": "COPY",
+        "jcr:multiple": "true",
+        "jcr:protected": "false",
+        "jcr:availableQueryOperators": [
+          "jcr.operator.equal.to",
+          "jcr.operator.greater.than",
+          "jcr.operator.greater.than.or.equal.to",
+          "jcr.operator.less.than",
+          "jcr.operator.less.than.or.equal.to",
+          "jcr.operator.like",
+          "jcr.operator.not.equal.to"
+        ],
+        "jcr:requiredType": "STRING",
+        "jcr:mandatory": "true",
+        "jcr:autoCreated": "false",
+        "jcr:name": "class:enumValues"
+      }}}
+    },
+    "image:metadata": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "image:metadata",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "false",
+        "jcr:supertypes": [
+          "nt:unstructured",
+          "mix:mimeType"
+        ]
+      },
+      "children": {
+        "image:formatName": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:valueConstraints": [
+            "JPEG",
+            "GIF",
+            "PNG",
+            "BMP",
+            "PCX",
+            "IFF",
+            "RAS",
+            "PBM",
+            "PGM",
+            "PPM",
+            "PSD",
+            "TIFF"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "true",
+          "jcr:autoCreated": "false",
+          "jcr:name": "image:formatName"
+        }},
+        "image:width": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "LONG",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "image:width"
+        }},
+        "image:height": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "LONG",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "image:height"
+        }},
+        "image:bitsPerPixel": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "LONG",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "image:bitsPerPixel"
+        }},
+        "image:progressive": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "BOOLEAN",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "image:progressive"
+        }},
+        "image:numberOfImages": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "LONG",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "image:numberOfImages"
+        }},
+        "image:physicalWidthDpi": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "LONG",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "image:physicalWidthDpi"
+        }},
+        "image:physicalHeightDpi": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "LONG",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "image:physicalHeightDpi"
+        }},
+        "image:physicalWidthInches": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "DOUBLE",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "image:physicalWidthInches"
+        }},
+        "image:physicalHeightInches": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "DOUBLE",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "image:physicalHeightInches"
+        }},
+        "image:exif": {"properties": {
+          "jcr:requiredPrimaryTypes": ["image:exif"],
+          "jcr:primaryType": "nt:childNodeDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:defaultPrimaryType": "image:exif",
+          "jcr:sameNameSiblings": "false",
+          "jcr:protected": "false",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "image:exif"
+        }}
+      }
+    },
+    "image:exif": {
+      "properties": {
+        "jcr:primaryType": "nt:nodeType",
+        "jcr:nodeTypeName": "image:exif",
+        "jcr:isAbstract": "false",
+        "jcr:hasOrderableChildNodes": "false",
+        "jcr:isQueryable": "true",
+        "jcr:isMixin": "false",
+        "jcr:supertypes": ["nt:unstructured"]
+      },
+      "children": {
+        "image:artist": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "image:artist"
+        }},
+        "image:copyright": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "image:copyright"
+        }},
+        "image:datetime": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "image:datetime"
+        }},
+        "image:description": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "image:description"
+        }},
+        "image:make": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "image:make"
+        }},
+        "image:model": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "image:model"
+        }},
+        "image:unit": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "image:unit"
+        }},
+        "image:orientation": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "image:orientation"
+        }},
+        "image:software": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "STRING",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "image:software"
+        }},
+        "image:resolution_x": {"properties": {
+          "jcr:primaryType": "nt:propertyDefinition",
+          "jcr:onParentVersion": "COPY",
+          "jcr:multiple": "false",
+          "jcr:protected": "false",
+          "jcr:availableQueryOperators": [
+            "jcr.operator.equal.to",
+            "jcr.operator.greater.than",
+            "jcr.operator.greater.than.or.equal.to",
+            "jcr.operator.less.than",
+            "jcr.operator.less.than.or.equal.to",
+            "jcr.operator.like",
+            "jcr.operator.not.equal.to"
+          ],
+          "jcr:requiredType": "DOUBLE",
+          "jcr:mandatory": "false",
+          "jcr:autoCreated": "false",
+          "jcr:name": "image:resolution_x"
+        }}
+      }
+    }
+  }
+}


### PR DESCRIPTION
The structure of the node types (under `/jcr:system/jcr:nodeTypes`) changed quite some releases ago (not exactly sure when), and the JDBC Driver (and REST client) could no longer read the node types' property definitions and child node definitions. The REST client's methods that obtain the node type representations from the server were updated to also handle the newer format as well as keep support for the old format.

There are new/updated test cases that verify the REST client can correctly obtain the node types from the old representation and the new representation.

The resulting client JAR was then used in Designer (latest version) to import via JDBC from a ModeShape 3.8.0.Final server and a ModeShape 4.0.0.Alpha3 server. 
