### PR TITLE
MODE-2221 Made sure SelfClosingInputStream always closes the underlying InputStream.

### DIFF
--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrI18n.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrI18n.java
@@ -523,6 +523,8 @@ public final class JcrI18n {
     public static I18n cannotRegisterMBean;
     public static I18n cannotUnRegisterMBean;
 
+    public static I18n errorClosingBinaryStream;
+
     public static I18n upgrade3_6_0Running;
     public static I18n upgrade3_6_0CannotUpdateNodeTypes;
     public static I18n upgrade3_6_0CannotUpdateLocks;

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/value/binary/StoredBinaryValue.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/value/binary/StoredBinaryValue.java
@@ -27,6 +27,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import javax.jcr.RepositoryException;
 import org.modeshape.common.annotation.Immutable;
+import org.modeshape.jcr.SelfClosingInputStream;
 import org.modeshape.jcr.value.BinaryValue;
 import org.modeshape.jcr.value.BinaryKey;
 
@@ -59,8 +60,8 @@ public class StoredBinaryValue extends AbstractBinary {
 
     @Override
     public InputStream getStream() throws BinaryStoreException {
-        // Delegate to the store ...
-        return store.getInputStream(getKey());
+        // Delegate to the store and then wrap the stream to make sure it's always closed
+        return new SelfClosingInputStream(this, store.getInputStream(getKey()));
     }
 
     @Override

--- a/modeshape-jcr/src/main/resources/org/modeshape/jcr/JcrI18n.properties
+++ b/modeshape-jcr/src/main/resources/org/modeshape/jcr/JcrI18n.properties
@@ -504,7 +504,9 @@ errorDuringChildrenOptimization = Error during background optimization of childr
 
 mBeanAlreadyRegistered = JMX bean "{0}" has already been registered
 cannotRegisterMBean = Cannot register MBean "{0}"
-cannotUnRegisterMBean = Cannot un-register MBean "{0}"
+cannotUnRegisterMBean = Cannot un-register MBean "{0}"      '
+
+errorClosingBinaryStream = Error while attempting to close the input stream of a binary value
 
 upgrade3_6_0Running = Running ModeShape 3.6.0 upgrade function...
 upgrade3_6_0CannotUpdateNodeTypes = ModeShape 3.6.0 upgrade error: cannot update the internal node types. Reason: "{0}"


### PR DESCRIPTION
Also, made sure this type of stream is returned when calling `property.getBinary().getStream()`. Up until now, this type of stream would only be created when calling `property.getStream()`.
