### PR TITLE
MODE-2225 - Custom AuthorizationProvider is not invoked for each child node when iterating through the child nodes of a parent node

### DIFF
--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/AbstractJcrNode.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/AbstractJcrNode.java
@@ -3524,8 +3524,7 @@ abstract class AbstractJcrNode extends AbstractJcrItem implements Node {
         public ChildNodeResolver( JcrSession session, NodeKey parentKey, boolean checkPermission ) {
             this.session = session;
             this.parentKey = parentKey;
-            // we only need to check permissions if ACLs are enabled
-            this.checkPermission = checkPermission && session.repository().repositoryCache().isAccessControlEnabled();
+            this.checkPermission = checkPermission;
         }
 
         protected ChildNodeResolver( JcrSession session,


### PR DESCRIPTION
Removed the condition that required AccessControl to be enabled when determining if the ChildResolver should check if the client has permission to access the child nodes prior to returning them. This resolves an issue where a custom AuthorizationProvider is not called when retiring child nodes for the parent node.

As per the discussion in https://issues.jboss.org/browse/MODE-2225 additional work is required before merging in order to optimize the code so that it only checks that the client has permission to access the child if either:

a) ACL's are enabled
b) The SecurityContext implements either AuthorizationProvider or AdvancedAuthorizationProvider 

Previously only the ACL check was performed.
