### PR TITLE
MODE-2225 Added the option for custom Authorization Providers to always be invoked when children are iterated, regardless whether ACLs are enabled or not.

### DIFF
--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/AbstractJcrNode.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/AbstractJcrNode.java
@@ -3521,16 +3521,15 @@ abstract class AbstractJcrNode extends AbstractJcrItem implements Node {
         private final NodeKey parentKey;
         private final boolean checkPermission;
 
-        public ChildNodeResolver( JcrSession session, NodeKey parentKey, boolean checkPermission ) {
+        protected ChildNodeResolver( JcrSession session, NodeKey parentKey, boolean checkPermission ) {
             this.session = session;
             this.parentKey = parentKey;
-            // we only need to check permissions if ACLs are enabled
-            this.checkPermission = checkPermission && session.repository().repositoryCache().isAccessControlEnabled();
+            this.checkPermission = checkPermission;
         }
 
         protected ChildNodeResolver( JcrSession session,
                                      NodeKey parentKey ) {
-            this(session, parentKey, true);
+            this(session, parentKey, session.checkPermissionsWhenIteratingChildren());
         }
 
         @Override

--- a/modeshape-jcr/src/test/java/org/modeshape/jcr/AuthenticationAndAuthorizationTest.java
+++ b/modeshape-jcr/src/test/java/org/modeshape/jcr/AuthenticationAndAuthorizationTest.java
@@ -18,8 +18,13 @@ package org.modeshape.jcr;
 import java.security.AccessControlContext;
 import java.security.AccessController;
 import java.security.PrivilegedExceptionAction;
+import java.util.HashMap;
+import java.util.Map;
 import javax.jcr.Credentials;
 import javax.jcr.LoginException;
+import javax.jcr.Node;
+import javax.jcr.NodeIterator;
+import javax.jcr.RepositoryException;
 import javax.jcr.Session;
 import javax.jcr.SimpleCredentials;
 import javax.security.auth.Subject;
@@ -39,10 +44,17 @@ import org.modeshape.common.FixFor;
 import org.modeshape.common.junit.SkipLongRunning;
 import org.modeshape.common.junit.SkipTestRule;
 import org.modeshape.jcr.RepositoryConfiguration.FieldName;
+import org.modeshape.jcr.security.AdvancedAuthorizationProvider;
+import org.modeshape.jcr.security.AuthenticationProvider;
+import org.modeshape.jcr.security.AuthorizationProvider;
 import org.modeshape.jcr.security.JaasSecurityContext.UserPasswordCallbackHandler;
+import org.modeshape.jcr.security.SecurityContext;
+import org.modeshape.jcr.value.Path;
+import org.modeshape.jcr.value.StringFactory;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsNull.notNullValue;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 public class AuthenticationAndAuthorizationTest {
@@ -397,6 +409,92 @@ public class AuthenticationAndAuthorizationTest {
             beforeEach();
             shouldLogInAsAnonymousUserIfNoProviderAuthenticatesCredentials();
             afterEach();
+        }
+    }
+
+    @Test
+    @FixFor( "MODE-2225" )
+    public void shouldInvokeAuthorizationProviderWhenIteratingNodes() throws Exception {
+        //this will import an initial structure of nodes (see xmlImport/docWithChildren.xml)
+        repository = TestingUtil.startRepositoryWithConfig("config/custom-authentication-provider-config-1.json");
+        assertPermissionsCheckedWhenIteratingChildren();
+    }
+
+    @Test
+    @FixFor( "MODE-2225" )
+    public void shouldInvokeAdvancedAuthorizationProviderWhenIteratingNodes() throws Exception {
+        //this will import an initial structure of nodes (see xmlImport/docWithChildren.xml)
+        repository = TestingUtil.startRepositoryWithConfig("config/custom-authentication-provider-config-2.json");
+        assertPermissionsCheckedWhenIteratingChildren();
+    }
+
+    private void assertPermissionsCheckedWhenIteratingChildren() throws RepositoryException {
+        session = repository.login();
+        Node testRoot = session.getNode("/testRoot");
+        NodeIterator children = testRoot.getNodes();
+        while (children.hasNext()) {
+            children.nextNode();
+        }
+        TestSecurityProvider provider = (TestSecurityProvider) session.context().getSecurityContext();
+
+        Map<String, String> actionsByNodePath = provider.getActionsByNodePath();
+        assertTrue("READ permission not checked for node", actionsByNodePath.containsKey("/testRoot"));
+        assertTrue("READ permission not checked for node", actionsByNodePath.containsKey("/testRoot/node3"));
+        assertTrue("READ permission not checked for node", actionsByNodePath.containsKey("/testRoot/node2"));
+        assertTrue("READ permission not checked for node", actionsByNodePath.containsKey("/testRoot/node1"));
+    }
+
+    public static abstract class TestSecurityProvider implements AuthenticationProvider, SecurityContext {
+        protected final Map<String, String> actionsByNodePath = new HashMap<>();
+        private String name;
+        protected StringFactory stringFactory;
+
+        @Override
+        public ExecutionContext authenticate( Credentials credentials, String repositoryName, String workspaceName,
+                                              ExecutionContext repositoryContext, Map<String, Object> sessionAttributes ) {
+            stringFactory = repositoryContext.getValueFactories().getStringFactory();
+            return repositoryContext.with(this);
+        }
+
+        @Override
+        public boolean isAnonymous() {
+            return false;
+        }
+
+        @Override
+        public String getUserName() {
+            return "test user";
+        }
+
+        @Override
+        public boolean hasRole( String roleName ) {
+            return true;
+        }
+
+        @Override
+        public void logout() {
+        }
+
+        public Map<String, String> getActionsByNodePath() {
+            return actionsByNodePath;
+        }
+    }
+
+    public static class SimpleTestSecurityProvider extends TestSecurityProvider implements AuthorizationProvider {
+        @Override
+        public boolean hasPermission( ExecutionContext context, String repositoryName, String repositorySourceName,
+                                      String workspaceName, Path absPath, String... actions ) {
+            actionsByNodePath.put(stringFactory.create(absPath), actions[0]);
+            return true;
+        }
+
+    }
+
+    public static class AdvancedTestSecurityProvider extends TestSecurityProvider implements AdvancedAuthorizationProvider {
+        @Override
+        public boolean hasPermission( Context context, Path absPath, String... actions ) {
+            actionsByNodePath.put(stringFactory.create(absPath), actions[0]);
+            return true;
         }
     }
 }

--- a/modeshape-jcr/src/test/resources/config/custom-authentication-provider-config-1.json
+++ b/modeshape-jcr/src/test/resources/config/custom-authentication-provider-config-1.json
@@ -1,0 +1,19 @@
+{
+    "name" : "Custom Authentication Provider 1",
+    "workspaces" : {
+        "predefined" : ["otherWorkspace"],
+        "default" : "default",
+        "allowCreation" : true,
+        "initialContent" : {
+            "default" : "xmlImport/docWithChildren.xml"
+        }
+    },
+    "security" : {
+        "providers" : [
+            {
+                "name" : "Custom Provider",
+                "classname" : "org.modeshape.jcr.AuthenticationAndAuthorizationTest$SimpleTestSecurityProvider"
+            }
+        ]
+    }
+}

--- a/modeshape-jcr/src/test/resources/config/custom-authentication-provider-config-2.json
+++ b/modeshape-jcr/src/test/resources/config/custom-authentication-provider-config-2.json
@@ -1,0 +1,19 @@
+{
+    "name" : "Custom Authentication Provider 2",
+    "workspaces" : {
+        "predefined" : ["otherWorkspace"],
+        "default" : "default",
+        "allowCreation" : true,
+        "initialContent" : {
+            "default" : "xmlImport/docWithChildren.xml"
+        }
+    },
+    "security" : {
+        "providers" : [
+            {
+                "name" : "Custom Provider",
+                "classname" : "org.modeshape.jcr.AuthenticationAndAuthorizationTest$AdvancedTestSecurityProvider"
+            }
+        ]
+    }
+}


### PR DESCRIPTION
This supersedes https://github.com/ModeShape/modeshape/pull/1145
