### PR TITLE
MODE-2227 Updated the EAP kit to run against EAP 6.3.0.Beta1

### DIFF
--- a/bin/install-eap.bat
+++ b/bin/install-eap.bat
@@ -12,5 +12,5 @@ REM ----------------------------------------------------------------------------
 if "%1" == "" (
     echo "Usage: install-eap.bat <eap_zip_file>"
 ) else (
-    mvn install:install-file -Dfile="%1" -DgroupId=org.jboss.as -DartifactId=jboss-eap -Dversion=6.2.0.GA -Dpackaging=zip
+    mvn install:install-file -Dfile="%1" -DgroupId=org.jboss.as -DartifactId=jboss-eap -Dversion=6.3.0.Beta1 -Dpackaging=zip
 )

--- a/bin/install-eap.sh
+++ b/bin/install-eap.sh
@@ -13,5 +13,5 @@ if [ "$#" -ne 1 ] ; then
 	echo "Usage: install-eap.sh <eap_zip_file>"
 	exit 1
 else
-	 mvn install:install-file -Dfile="$1" -DgroupId=org.jboss.as -DartifactId=jboss-eap -Dversion=6.2.0.GA -Dpackaging=zip
+	 mvn install:install-file -Dfile="$1" -DgroupId=org.jboss.as -DartifactId=jboss-eap -Dversion=6.3.0.Beta1 -Dpackaging=zip
 fi

--- a/boms/modeshape-bom-jbosseap/pom.xml
+++ b/boms/modeshape-bom-jbosseap/pom.xml
@@ -56,7 +56,7 @@
         <jboss.snapshots.repo.url>https://repository.jboss.org/nexus/content/repositories/snapshots/</jboss.snapshots.repo.url>
 
         <jcr.version>2.0</jcr.version>
-        <version.org.jboss.eap.bom>6.2.1.GA</version.org.jboss.eap.bom>
+        <version.org.jboss.eap.bom>6.3.0.Beta1</version.org.jboss.eap.bom>
     </properties>
 
     <!--

--- a/integration/modeshape-jbossas-integration-tests/pom.xml
+++ b/integration/modeshape-jbossas-integration-tests/pom.xml
@@ -186,6 +186,9 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
+                <configuration>
+                    <skip>${skipTests}</skip>
+                </configuration>
                 <executions>
                     <execution>
                         <id>unpack</id>
@@ -224,6 +227,9 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-resources-plugin</artifactId>
+                <configuration>
+                    <skip>${skipTests}</skip>
+                </configuration>
                 <executions>
                     <execution>
                         <id>overwrite-modules</id>

--- a/integration/modeshape-jbossas-kit-tests/pom.xml
+++ b/integration/modeshape-jbossas-kit-tests/pom.xml
@@ -109,6 +109,9 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
+                <configuration>
+                    <skip>${skipTests}</skip>
+                </configuration>
                 <executions>
                     <execution>
                         <id>unpack</id>
@@ -143,35 +146,6 @@
                     </execution>
                 </executions>
             </plugin>
-
-            <!--Copy & overwrite user & roles files (by default they are empty in the kit)
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-resources-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>overwrite-configuration</id>
-                        <phase>process-test-classes</phase>
-                        <goals>
-                            <goal>copy-resources</goal>
-                        </goals>
-                        <configuration>
-                            <outputDirectory>${project.build.directory}/${jboss.eap.root.folder}</outputDirectory>
-                            <overwrite>true</overwrite>
-                            <resources>
-                                <resource>
-                                    <directory>src/main/resources/kit/jboss-eap</directory>
-                                    <filtering>false</filtering>
-                                    <includes>
-                                        <include>standalone/**</include>
-                                    </includes>
-                                </resource>
-                            </resources>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-            -->
         </plugins>
     </build>
 </project>

--- a/modeshape-distribution/pom.xml
+++ b/modeshape-distribution/pom.xml
@@ -401,6 +401,7 @@
                     <groupId>org.jboss.as</groupId>
                     <artifactId>jboss-as-controller</artifactId>
                 </dependency>
+
             </dependencies>
             <build>
                 <plugins>

--- a/modeshape-parent/pom.xml
+++ b/modeshape-parent/pom.xml
@@ -283,14 +283,14 @@
              JBOSS AS/EAP constants
          -->
         <!--Version of the artifacts (API) needed by the EAP subsystem and provided as part of EAP-->
-        <version.org.jboss.eap>7.3.1.Final-redhat-3</version.org.jboss.eap>
-        <version.org.jboss.eap.bom>6.2.1.GA</version.org.jboss.eap.bom>
+        <version.org.jboss.eap>7.4.0.Final-redhat-11</version.org.jboss.eap>
+        <version.org.jboss.eap.bom>6.3.0.Beta1</version.org.jboss.eap.bom>
 
         <!--Properties which must be used when installing locally an EAP ZIP distribution -->
         <jboss.eap.groupId>org.jboss.as</jboss.eap.groupId>
         <jboss.eap.artifactId>jboss-eap</jboss.eap.artifactId>
-        <jboss.eap.version>6.2.0.GA</jboss.eap.version>
-        <jboss.eap.root.folder>jboss-eap-6.2</jboss.eap.root.folder>
+        <jboss.eap.version>6.3.0.Beta1</jboss.eap.version>
+        <jboss.eap.root.folder>jboss-eap-6.3</jboss.eap.root.folder>
 
         <!--The root folder under EAP/AS where the ModeShape & related modules should be placed-->
         <jboss.eap.modules.location>modules</jboss.eap.modules.location>

--- a/settings.xml
+++ b/settings.xml
@@ -61,12 +61,12 @@
             </repositories>
         </profile>
         <profile>
-            <id>redhat-techpreview-repository</id>
+            <id>eap</id>
             <repositories>
                 <repository>
-                    <id>redhat-techpreview-repository</id>
-                    <name>JBoss.org Techpreview Repository</name>
-                    <url>http://maven.repository.redhat.com/techpreview/all/</url>
+                    <id>eap</id>
+                    <name>EAP Repository</name>
+                    <url>http://maven.repository.redhat.com/techpreview/eap6/6.3.0.Beta/maven-repository</url>
                     <layout>default</layout>
                     <releases>
                         <enabled>true</enabled>
@@ -84,7 +84,7 @@
 
     <activeProfiles>
         <activeProfile>jboss-public-repository</activeProfile>
-        <activeProfile>redhat-techpreview-repository</activeProfile>
+        <activeProfile>eap</activeProfile>
         <activeProfile>jboss-thirdpartyuploads-repository</activeProfile>
     </activeProfiles>
 </settings>


### PR DESCRIPTION
## Prerequisites for being able to build this locally
1. Run the `install-eap` script passing the EAP 6.3.0.Beta zip as parameter
2. When building via Maven, either use the `settings.xml` from the root of the project or make sure your local file has the same `EAP repository` as this file.
