### PR TITLE
MODE-2242 Added back 'modeshape-security' security domain, though it now uses existing 'ApplicationRealm' to manage users/roles

### DIFF
--- a/deploy/jbossas/kit/jboss-wf8/domain/configuration/domain-modeshape.xml
+++ b/deploy/jbossas/kit/jboss-wf8/domain/configuration/domain-modeshape.xml
@@ -395,6 +395,13 @@
                             <policy-module code="Delegating" flag="required"/>
                         </authorization>
                     </security-domain>
+                    <security-domain name="modeshape-security" cache-type="default">
+                        <authentication>
+                            <login-module code="RealmDirect" flag="required">
+                                <module-option name="password-stacking" value="useFirstPass"/>
+                            </login-module>
+                        </authentication>
+                    </security-domain>
                 </security-domains>
             </subsystem>
             <subsystem xmlns="urn:jboss:domain:threads:1.1"/>
@@ -842,6 +849,13 @@
                         <authorization>
                             <policy-module code="Delegating" flag="required"/>
                         </authorization>
+                    </security-domain>
+                    <security-domain name="modeshape-security" cache-type="default">
+                        <authentication>
+                            <login-module code="RealmDirect" flag="required">
+                                <module-option name="password-stacking" value="useFirstPass"/>
+                            </login-module>
+                        </authentication>
                     </security-domain>
                 </security-domains>
             </subsystem>
@@ -1321,6 +1335,13 @@
                         <authorization>
                             <policy-module code="Delegating" flag="required"/>
                         </authorization>
+                    </security-domain>
+                    <security-domain name="modeshape-security" cache-type="default">
+                        <authentication>
+                            <login-module code="RealmDirect" flag="required">
+                                <module-option name="password-stacking" value="useFirstPass"/>
+                            </login-module>
+                        </authentication>
                     </security-domain>
                 </security-domains>
             </subsystem>
@@ -1889,6 +1910,14 @@
                             <policy-module code="Delegating" flag="required"/>
                         </authorization>
                     </security-domain>
+                    <security-domain name="modeshape-security" cache-type="default">
+                        <authentication>
+                            <login-module code="RealmDirect" flag="required">
+                                <module-option name="password-stacking" value="useFirstPass"/>
+                            </login-module>
+                        </authentication>
+                    </security-domain>
+                </security-domains>
             </subsystem>
             <subsystem xmlns="urn:jboss:domain:threads:1.1"/>
             <subsystem xmlns="urn:jboss:domain:transactions:2.0">

--- a/deploy/jbossas/kit/jboss-wf8/standalone/configuration/standalone-modeshape-ha.xml
+++ b/deploy/jbossas/kit/jboss-wf8/standalone/configuration/standalone-modeshape-ha.xml
@@ -486,6 +486,13 @@
                         <policy-module code="Delegating" flag="required"/>
                     </authorization>
                 </security-domain>
+                <security-domain name="modeshape-security" cache-type="default">
+                    <authentication>
+                        <login-module code="RealmDirect" flag="required">
+                            <module-option name="password-stacking" value="useFirstPass"/>
+                        </login-module>
+                    </authentication>
+                </security-domain>
             </security-domains>
         </subsystem>
         <subsystem xmlns="urn:jboss:domain:threads:1.1"/>

--- a/deploy/jbossas/kit/jboss-wf8/standalone/configuration/standalone-modeshape.xml
+++ b/deploy/jbossas/kit/jboss-wf8/standalone/configuration/standalone-modeshape.xml
@@ -438,6 +438,13 @@
                         <policy-module code="Delegating" flag="required"/>
                     </authorization>
                 </security-domain>
+                <security-domain name="modeshape-security" cache-type="default">
+                    <authentication>
+                        <login-module code="RealmDirect" flag="required">
+                            <module-option name="password-stacking" value="useFirstPass"/>
+                        </login-module>
+                    </authentication>
+                </security-domain>
             </security-domains>
         </subsystem>
         <subsystem xmlns="urn:jboss:domain:threads:1.1"/>

--- a/deploy/jbossas/modeshape-jbossas-cmis-war/src/main/webapp/WEB-INF/jboss-web.xml
+++ b/deploy/jbossas/modeshape-jbossas-cmis-war/src/main/webapp/WEB-INF/jboss-web.xml
@@ -3,5 +3,5 @@
    "http://www.jboss.org/j2ee/dtd/jboss-web_5_0.dtd">
    
 <jboss-web>
-   <security-domain>other</security-domain>
+   <security-domain>modeshape-security</security-domain>
 </jboss-web>

--- a/deploy/jbossas/modeshape-jbossas-explorer-war/src/main/webapp/WEB-INF/jboss-web.xml
+++ b/deploy/jbossas/modeshape-jbossas-explorer-war/src/main/webapp/WEB-INF/jboss-web.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <jboss-web>
     <!-- Servlets -->
-    <security-domain>other</security-domain>
+    <security-domain>modeshape-security</security-domain>
     <context-root>modeshape-explorer </context-root>
 </jboss-web>

--- a/deploy/jbossas/modeshape-jbossas-subsystem/src/main/java/org/modeshape/jboss/subsystem/ModelAttributes.java
+++ b/deploy/jbossas/modeshape-jbossas-subsystem/src/main/java/org/modeshape/jboss/subsystem/ModelAttributes.java
@@ -555,7 +555,7 @@ public class ModelAttributes {
                                                                                                          ModelType.STRING).setXmlName(Attribute.SECURITY_DOMAIN.getLocalName())
                                                                                                                           .setAllowExpression(true)
                                                                                                                           .setAllowNull(true)
-                                                                                                                          .setDefaultValue(new ModelNode().set("other"))
+                                                                                                                          .setDefaultValue(new ModelNode().set("modeshape-security"))
                                                                                                                           .setFlags(AttributeAccess.Flag.RESTART_NONE)
                                                                                                                           .setAccessConstraints(SensitiveTargetAccessConstraintDefinition.SECURITY_DOMAIN_REF)
                                                                                                                           .setFieldPathInRepositoryConfiguration(FieldName.SECURITY,

--- a/deploy/jbossas/modeshape-jbossas-subsystem/src/main/resources/schema/modeshape_2_0.xsd
+++ b/deploy/jbossas/modeshape-jbossas-subsystem/src/main/resources/schema/modeshape_2_0.xsd
@@ -181,10 +181,10 @@
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="security-domain" type="xs:string" default="other">
+        <xs:attribute name="security-domain" type="xs:string" default="modeshape-security">
             <xs:annotation>
                 <xs:documentation>The name of the security domain that should be used for JAAS authentication.
-                    The default is the 'other' security domain which uses the default ApplicationRealm security realm.
+                    The default is the 'modeshape-security' security domain which uses the default ApplicationRealm security realm.
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>

--- a/deploy/jbossas/modeshape-jbossas-subsystem/src/test/resources/org/modeshape/jboss/subsystem/modeshape-cache-binary-storage.xml
+++ b/deploy/jbossas/modeshape-jbossas-subsystem/src/test/resources/org/modeshape/jboss/subsystem/modeshape-cache-binary-storage.xml
@@ -3,7 +3,7 @@
                 cache-name="sample" cache-container="modeshape"
                 jndi-name="jcr/local/sample"
                 enable-monitoring="true"
-                security-domain="other"
+                security-domain="modeshape-security"
                 anonymous-roles="readonly readwrite admin connect"
                 anonymous-username="&lt;anonymous&gt;"
                 use-anonymous-upon-failed-authentication="false">

--- a/deploy/jbossas/modeshape-jbossas-subsystem/src/test/resources/org/modeshape/jboss/subsystem/modeshape-custom-authenticators-config.xml
+++ b/deploy/jbossas/modeshape-jbossas-subsystem/src/test/resources/org/modeshape/jboss/subsystem/modeshape-custom-authenticators-config.xml
@@ -3,7 +3,7 @@
               cache-name="sample" cache-container="modeshape"
               jndi-name="jcr/local/sample"
               enable-monitoring="true"
-              security-domain="other"
+              security-domain="modeshape-security"
               anonymous-roles="readonly readwrite admin connect" 
               anonymous-username="&lt;anonymous&gt;" 
               use-anonymous-upon-failed-authentication="false">

--- a/deploy/jbossas/modeshape-jbossas-subsystem/src/test/resources/org/modeshape/jboss/subsystem/modeshape-federation-config.xml
+++ b/deploy/jbossas/modeshape-jbossas-subsystem/src/test/resources/org/modeshape/jboss/subsystem/modeshape-federation-config.xml
@@ -3,7 +3,7 @@
               cache-name="sample" cache-container="modeshape"
               jndi-name="jcr/local/sample"
               enable-monitoring="true"
-              security-domain="other"
+              security-domain="modeshape-security"
               anonymous-roles="readonly readwrite admin connect" 
               anonymous-username="&lt;anonymous&gt;" 
               use-anonymous-upon-failed-authentication="false">

--- a/deploy/jbossas/modeshape-jbossas-subsystem/src/test/resources/org/modeshape/jboss/subsystem/modeshape-file-binary-storage.xml
+++ b/deploy/jbossas/modeshape-jbossas-subsystem/src/test/resources/org/modeshape/jboss/subsystem/modeshape-file-binary-storage.xml
@@ -3,7 +3,7 @@
               cache-name="sample" cache-container="modeshape"
               jndi-name="jcr/local/sample"
               enable-monitoring="true"
-              security-domain="other"
+              security-domain="modeshape-security"
               anonymous-roles="readonly readwrite admin connect" 
               anonymous-username="&lt;anonymous&gt;" 
               use-anonymous-upon-failed-authentication="false">

--- a/deploy/jbossas/modeshape-jbossas-subsystem/src/test/resources/org/modeshape/jboss/subsystem/modeshape-garbage-collection.xml
+++ b/deploy/jbossas/modeshape-jbossas-subsystem/src/test/resources/org/modeshape/jboss/subsystem/modeshape-garbage-collection.xml
@@ -3,7 +3,7 @@
               cache-name="sample" cache-container="modeshape"
               jndi-name="jcr/local/sample"
               enable-monitoring="true"
-              security-domain="other"
+              security-domain="modeshape-security"
               anonymous-roles="readonly readwrite admin connect" 
               anonymous-username="&lt;anonymous&gt;" 
               use-anonymous-upon-failed-authentication="false"

--- a/deploy/jbossas/modeshape-jbossas-subsystem/src/test/resources/org/modeshape/jboss/subsystem/modeshape-initial-content-config.xml
+++ b/deploy/jbossas/modeshape-jbossas-subsystem/src/test/resources/org/modeshape/jboss/subsystem/modeshape-initial-content-config.xml
@@ -3,7 +3,7 @@
               cache-name="sample" cache-container="modeshape"
               jndi-name="jcr/local/sample"
               enable-monitoring="true"
-              security-domain="other"
+              security-domain="modeshape-security"
               anonymous-roles="readonly readwrite admin connect" 
               anonymous-username="&lt;anonymous&gt;" 
               use-anonymous-upon-failed-authentication="false">

--- a/deploy/jbossas/modeshape-jbossas-subsystem/src/test/resources/org/modeshape/jboss/subsystem/modeshape-journaling.xml
+++ b/deploy/jbossas/modeshape-jbossas-subsystem/src/test/resources/org/modeshape/jboss/subsystem/modeshape-journaling.xml
@@ -3,7 +3,7 @@
               cache-name="sample" cache-container="modeshape"
               jndi-name="jcr/local/sample"
               enable-monitoring="true"
-              security-domain="other"
+              security-domain="modeshape-security"
               anonymous-roles="readonly readwrite admin connect" 
               anonymous-username="&lt;anonymous&gt;" 
               use-anonymous-upon-failed-authentication="false"

--- a/deploy/jbossas/modeshape-jbossas-subsystem/src/test/resources/org/modeshape/jboss/subsystem/modeshape-local-file-index-storage.xml
+++ b/deploy/jbossas/modeshape-jbossas-subsystem/src/test/resources/org/modeshape/jboss/subsystem/modeshape-local-file-index-storage.xml
@@ -3,7 +3,7 @@
               cache-name="sample" cache-container="modeshape"
               jndi-name="jcr/local/sample"
               enable-monitoring="true"
-              security-domain="other"
+              security-domain="modeshape-security"
               anonymous-roles="readonly readwrite admin connect" 
               anonymous-username="&lt;anonymous&gt;" 
               use-anonymous-upon-failed-authentication="false">

--- a/deploy/jbossas/modeshape-jbossas-subsystem/src/test/resources/org/modeshape/jboss/subsystem/modeshape-node-types-config.xml
+++ b/deploy/jbossas/modeshape-jbossas-subsystem/src/test/resources/org/modeshape/jboss/subsystem/modeshape-node-types-config.xml
@@ -3,7 +3,7 @@
               cache-name="sample" cache-container="modeshape"
               jndi-name="jcr/local/sample"
               enable-monitoring="true"
-              security-domain="other"
+              security-domain="modeshape-security"
               anonymous-roles="readonly readwrite admin connect" 
               anonymous-username="&lt;anonymous&gt;" 
               use-anonymous-upon-failed-authentication="false">

--- a/deploy/jbossas/modeshape-jbossas-subsystem/src/test/resources/org/modeshape/jboss/subsystem/modeshape-workspaces-cache-config.xml
+++ b/deploy/jbossas/modeshape-jbossas-subsystem/src/test/resources/org/modeshape/jboss/subsystem/modeshape-workspaces-cache-config.xml
@@ -3,7 +3,7 @@
               cache-name="sample" cache-container="modeshape"
               jndi-name="jcr/local/sample"
               enable-monitoring="true"
-              security-domain="other"
+              security-domain="modeshape-security"
               anonymous-roles="readonly readwrite admin connect" 
               anonymous-username="&lt;anonymous&gt;" 
               use-anonymous-upon-failed-authentication="false">

--- a/deploy/jbossas/modeshape-jbossas-web-rest-war/src/main/webapp/WEB-INF/jboss-web.xml
+++ b/deploy/jbossas/modeshape-jbossas-web-rest-war/src/main/webapp/WEB-INF/jboss-web.xml
@@ -3,5 +3,5 @@
    "http://www.jboss.org/j2ee/dtd/jboss-web_5_0.dtd">
    
 <jboss-web>
-   <security-domain>other</security-domain>
+   <security-domain>modeshape-security</security-domain>
 </jboss-web>

--- a/deploy/jbossas/modeshape-jbossas-web-webdav-war/src/main/webapp/WEB-INF/jboss-web.xml
+++ b/deploy/jbossas/modeshape-jbossas-web-webdav-war/src/main/webapp/WEB-INF/jboss-web.xml
@@ -2,5 +2,5 @@
    "-//JBoss//DTD Web Application 5.0//EN"
    "http://www.jboss.org/j2ee/dtd/jboss-web_5_0.dtd">
 <jboss-web>
-    <security-domain>other</security-domain>
+    <security-domain>modeshape-security</security-domain>
 </jboss-web>

--- a/integration/modeshape-jbossas-integration-tests/src/main/resources/kit/jboss-wf8/standalone/configuration/standalone-modeshape.xml
+++ b/integration/modeshape-jbossas-integration-tests/src/main/resources/kit/jboss-wf8/standalone/configuration/standalone-modeshape.xml
@@ -775,15 +775,10 @@
             <security-domains>
                 <security-domain name="other" cache-type="default">
                     <authentication>
-                        <!--Overwrite the security domain to allow testing via simple users and password-->
-                        <login-module code="UsersRoles" flag="required">
-                            <module-option name="usersProperties" value="${jboss.server.config.dir}/modeshape-users.properties"/>
-                            <module-option name="rolesProperties" value="${jboss.server.config.dir}/modeshape-roles.properties"/>
-                        </login-module>
                         <login-module code="Remoting" flag="optional">
                             <module-option name="password-stacking" value="useFirstPass"/>
                         </login-module>
-                        <login-module code="RealmDirect" flag="optional">
+                        <login-module code="RealmDirect" flag="required">
                             <module-option name="password-stacking" value="useFirstPass"/>
                         </login-module>
                     </authentication>
@@ -797,6 +792,18 @@
                     <authorization>
                         <policy-module code="Delegating" flag="required"/>
                     </authorization>
+                </security-domain>
+                <security-domain name="modeshape-security" cache-type="default">
+                    <authentication>
+                        <!--Overwrite the security domain to allow testing via simple users and password-->
+                        <login-module code="UsersRoles" flag="required">
+                            <module-option name="usersProperties" value="${jboss.server.config.dir}/modeshape-users.properties"/>
+                            <module-option name="rolesProperties" value="${jboss.server.config.dir}/modeshape-roles.properties"/>
+                        </login-module>
+                        <login-module code="RealmDirect" flag="optional">
+                            <module-option name="password-stacking" value="useFirstPass"/>
+                        </login-module>
+                    </authentication>
                 </security-domain>
             </security-domains>
         </subsystem>

--- a/integration/modeshape-jbossas-kit-tests/src/main/resources/kit/jboss-wf8/standalone/configuration/standalone-modeshape.xml
+++ b/integration/modeshape-jbossas-kit-tests/src/main/resources/kit/jboss-wf8/standalone/configuration/standalone-modeshape.xml
@@ -420,15 +420,10 @@
             <security-domains>
                 <security-domain name="other" cache-type="default">
                     <authentication>
-                        <!--Overwrite the security domain to allow testing via simple users and password-->
-                        <login-module code="UsersRoles" flag="required">
-                            <module-option name="usersProperties" value="${jboss.server.config.dir}/modeshape-users.properties"/>
-                            <module-option name="rolesProperties" value="${jboss.server.config.dir}/modeshape-roles.properties"/>
-                        </login-module>
                         <login-module code="Remoting" flag="optional">
                             <module-option name="password-stacking" value="useFirstPass"/>
                         </login-module>
-                        <login-module code="RealmDirect" flag="optional">
+                        <login-module code="RealmDirect" flag="required">
                             <module-option name="password-stacking" value="useFirstPass"/>
                         </login-module>
                     </authentication>
@@ -441,6 +436,18 @@
                 <security-domain name="jboss-ejb-policy" cache-type="default">
                     <authorization>
                         <policy-module code="Delegating" flag="required"/>
+                    </authorization>
+                </security-domain>
+                <security-domain name="modeshape-security" cache-type="default">
+                    <authentication>
+                        <!--Overwrite the security domain to allow testing via simple users and password-->
+                        <login-module code="UsersRoles" flag="required">
+                            <module-option name="usersProperties" value="${jboss.server.config.dir}/modeshape-users.properties"/>
+                            <module-option name="rolesProperties" value="${jboss.server.config.dir}/modeshape-roles.properties"/>
+                        </login-module>
+                        <login-module code="RealmDirect" flag="optional">
+                            <module-option name="password-stacking" value="useFirstPass"/>
+                        </login-module>
                     </authorization>
                 </security-domain>
             </security-domains>

--- a/web/modeshape-web-explorer/src/main/webapp/WEB-INF/jboss-web.xml
+++ b/web/modeshape-web-explorer/src/main/webapp/WEB-INF/jboss-web.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <jboss-web>
     <!-- Servlets -->
-    <security-domain>other</security-domain>
+    <security-domain>modeshape-security</security-domain>
     <context-root>modeshape-explorer </context-root>
 </jboss-web>


### PR DESCRIPTION
Changed back to a "`modeshape-security`" security domain that reuses the  existing "`ApplicationRealm`" security realm for authentication. So users with ModeShape roles are still added via the Wildfly (and EAP) `add-user.sh` script (resulting in encrypted passwords).
