### PR TITLE
MODE-2236: Repository Explorer's "Node Types" button results in error

### DIFF
--- a/web/modeshape-web-explorer/src/main/java/org/modeshape/web/client/NodeTypeView.java
+++ b/web/modeshape-web-explorer/src/main/java/org/modeshape/web/client/NodeTypeView.java
@@ -57,14 +57,7 @@ public class NodeTypeView extends View {
         
         nodeTypes = new NodeTypes();
         
-        HLayout vstrut = new HLayout();
-        vstrut.setHeight(15);
-
-        HLayout bottomStrut = new HLayout();
-        bottomStrut.setHeight(15);
-        
         addMember(text);
-//        addMember(vstrut);
         
         DynamicForm form = new DynamicForm();
         form.setFields(workspaces);
@@ -82,6 +75,7 @@ public class NodeTypeView extends View {
         strut.setHeight(20);
         
         addMember(panel);
+        addMember(strut);
         addMember(nodeTypes);
     }
 
@@ -101,7 +95,6 @@ public class NodeTypeView extends View {
                     workspaces.setValue(result[0]);
                 }
                 showTypes();
-                SC.say("123");
             }
         });
     }
@@ -119,7 +112,6 @@ public class NodeTypeView extends View {
             @Override
             public void onSuccess(Collection<JcrNodeType> result) {
 //                hideLoadingIcon();
-                SC.say("124");
                 try {
                     nodeTypes.show(result);
                 } catch (Exception e) {

--- a/web/modeshape-web-explorer/src/main/java/org/modeshape/web/client/grid/NodeTypes.java
+++ b/web/modeshape-web-explorer/src/main/java/org/modeshape/web/client/grid/NodeTypes.java
@@ -28,7 +28,9 @@ import org.modeshape.web.shared.JcrNodeType;
  * @author kulikov
  */
 public class NodeTypes extends Grid<TypeRecord, JcrNodeType> {
-
+    
+    private final static int RECORDS_PER_PAGE = 500;
+    
     public NodeTypes() {
         super("Node types");
     }
@@ -39,7 +41,7 @@ public class NodeTypes extends Grid<TypeRecord, JcrNodeType> {
 
     @Override
     protected TypeRecord[] records() {
-        TypeRecord[] records = new TypeRecord[300];
+        TypeRecord[] records = new TypeRecord[RECORDS_PER_PAGE];
         for (int i = 0; i < records.length; i++) {
             records[i] = new TypeRecord();
         }


### PR DESCRIPTION
This PR fixes error when "Node Types" button is pressed.
