### PR TITLE
MODE-2241 Implemented the ability to specify the type of a property when importing initial content.

### DIFF
--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/InitialContentImporter.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/InitialContentImporter.java
@@ -16,17 +16,26 @@
 
 package org.modeshape.jcr;
 
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.LinkedHashMap;
+import java.util.List;
+import javax.jcr.Node;
 import javax.jcr.RepositoryException;
+import javax.jcr.Value;
+import org.modeshape.common.collection.Multimap;
 import org.modeshape.common.logging.Logger;
 import org.modeshape.common.util.IoUtil;
 import org.modeshape.common.util.StringUtil;
 import org.modeshape.jcr.cache.RepositoryCache;
 import org.modeshape.jcr.cache.document.WorkspaceCache;
 import org.modeshape.jcr.value.Path;
+import org.modeshape.jcr.value.PropertyType;
 import org.modeshape.jcr.xml.NodeImportDestination;
 import org.modeshape.jcr.xml.NodeImportXmlHandler;
 import org.xml.sax.InputSource;
@@ -127,9 +136,11 @@ public final class InitialContentImporter {
             return session.context();
         }
 
-        @SuppressWarnings( "synthetic-access" )
+        @SuppressWarnings( {"synthetic-access", "unchecked"} )
         @Override
         public void submit( LinkedHashMap<Path, NodeImportXmlHandler.ImportElement> parseResults ) throws RepositoryException {
+            List<NodeImportXmlHandler.ImportElement> elementsWithReferences = new ArrayList<>();
+            JcrValueFactory valueFactory = session.getValueFactory();
             for (Path nodePath : parseResults.keySet()) {
                 LOGGER.debug("Importing node at path {0}", nodePath);
                 NodeImportXmlHandler.ImportElement element = parseResults.get(nodePath);
@@ -154,13 +165,130 @@ public final class InitialContentImporter {
 
                 // set the properties
                 for (String propertyName : element.getProperties().keySet()) {
+                    org.modeshape.jcr.value.PropertyType propertyType = element.getPropertyType(propertyName);
+                    if (isReference(propertyType)) {
+                        elementsWithReferences.add(element);
+                        //references will be processed later
+                        continue;
+                    }
                     Collection<String> propertyValues = element.getProperties().get(propertyName);
                     if (propertyValues.size() == 1) {
-                        newNode.setProperty(propertyName, propertyValues.iterator().next());
+                        String stringValue = propertyValues.iterator().next();
+                        if (isBinary(propertyType)) {
+                            //we have a binary prop, try to resolve its stream
+                            InputStream inputStream = readBinaryStream(stringValue);
+                            if (inputStream != null) {
+                                newNode.setProperty(propertyName, inputStream);
+                                continue;
+                            }
+                            //we were unable to read its stream, to we'll set the binary value UTF-8 bytes (default behavior)
+                        }
+                        newNode.setProperty(propertyName, stringValue, propertyType.jcrType());
                     } else {
-                        newNode.setProperty(propertyName, propertyValues.toArray(new String[propertyValues.size()]));
+                        String[] stringValues = propertyValues.toArray(new String[propertyValues.size()]);
+                        if (isBinary(propertyType)) {
+                            //try to parse each individual binary value and read its stream
+                            boolean allValuesRead = true;
+                            Value[] binaryValues = new Value[propertyValues.size()];
+                            for (int i = 0; i < stringValues.length; i++) {
+                                String stringValue = stringValues[i];
+                                InputStream inputStream = readBinaryStream(stringValue);
+                                if (inputStream == null) {
+                                    //we were unable to read the stream, so we abort this approach altogether and we'll
+                                    //set the binary value using the string bytes
+                                    allValuesRead = false;
+                                    break;
+                                }
+                                binaryValues[i] = valueFactory.createValue(inputStream);
+                            }
+                            if (allValuesRead) {
+                                newNode.setProperty(propertyName, binaryValues);
+                                //we managed to set the binary multi value streams, so move onto the next property
+                                continue;
+                            }
+                        }
+                        newNode.setProperty(propertyName, stringValues, propertyType.jcrType());
                     }
                 }
+            }
+
+            if (!elementsWithReferences.isEmpty()) {
+                //after we've processed all the nodes (and created them) set the reference properties
+                setReferenceProperties(elementsWithReferences);
+            }
+        }
+
+        private boolean isReference( org.modeshape.jcr.value.PropertyType propertyType ) {
+            return org.modeshape.jcr.value.PropertyType.REFERENCE == propertyType ||
+                org.modeshape.jcr.value.PropertyType.WEAKREFERENCE == propertyType ||
+                org.modeshape.jcr.value.PropertyType.SIMPLEREFERENCE == propertyType;
+        }
+
+        private boolean isBinary(org.modeshape.jcr.value.PropertyType propertyType) {
+            return  PropertyType.BINARY == propertyType;
+        }
+
+        private InputStream readBinaryStream(String resourcePath) {
+            //attempt to resolve the resource as the path to a file
+            File file = new File(resourcePath);
+            if (file.exists() && file.canRead()) {
+                try {
+                    return new FileInputStream(file);
+                } catch (FileNotFoundException e) {
+                   //we cannot locate/read the file
+                }
+            }
+            //try resolving it via the classpath
+            return InitialContentImporter.class.getClassLoader().getResourceAsStream(resourcePath);
+        }
+
+        private void setReferenceProperties(
+                List<NodeImportXmlHandler.ImportElement> elementsWithReferences ) throws RepositoryException {
+            for (NodeImportXmlHandler.ImportElement element : elementsWithReferences) {
+                Node node = session.node(element.getPath());
+                Multimap<String, String> properties = element.getProperties();
+                for (String propertyName : properties.keySet()) {
+                    org.modeshape.jcr.value.PropertyType propertyType = element.getPropertyType(propertyName);
+                    if (!isReference(propertyType)) {
+                        continue;
+                    }
+                    setReferenceProperty(node, propertyName, properties.get(propertyName), propertyType);
+                }
+            }
+        }
+
+        private void setReferenceProperty( Node node,
+                                           String propertyName,
+                                           Collection<String> values,
+                                           org.modeshape.jcr.value.PropertyType referenceType ) throws RepositoryException {
+            List<Value> referenceValues = new ArrayList<>();
+            for (String absPath : values) {
+                AbstractJcrNode referredNode = session.getNode(absPath);
+
+                Value reference = null;
+                switch (referenceType) {
+                    case REFERENCE: {
+                        reference = session.getValueFactory().createValue(referredNode, false);
+                        break;
+                    }
+                    case WEAKREFERENCE: {
+                        reference = session.getValueFactory().createValue(referredNode, true);
+                        break;
+                    }
+                    case SIMPLEREFERENCE: {
+                        reference = session.getValueFactory().createSimpleReference(referredNode);
+                        break;
+                    }
+                    default: {
+                        throw new IllegalArgumentException("Invalid reference type:" + referenceType);
+                    }
+                }
+                referenceValues.add(reference);
+            }
+            if (referenceValues.size() == 1) {
+                node.setProperty(propertyName, referenceValues.get(0));
+            } else {
+                node.setProperty(propertyName, referenceValues.toArray(new Value[referenceValues.size()]));
             }
         }
     }

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/value/PropertyType.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/value/PropertyType.java
@@ -51,24 +51,25 @@ import org.modeshape.jcr.value.basic.StringReference;
 @Immutable
 public enum PropertyType {
 
-    STRING("String", ValueComparators.STRING_COMPARATOR, new ObjectCanonicalizer(), String.class),
-    BINARY("Binary", ValueComparators.BINARY_COMPARATOR, new ObjectCanonicalizer(), BinaryValue.class),
-    LONG("Long", ValueComparators.LONG_COMPARATOR, new LongCanonicalizer(), Long.class, Integer.class, Short.class),
-    DOUBLE("Double", ValueComparators.DOUBLE_COMPARATOR, new DoubleCanonicalizer(), Double.class, Float.class),
-    DECIMAL("Decimal", ValueComparators.DECIMAL_COMPARATOR, new ObjectCanonicalizer(), BigDecimal.class),
-    DATE("Date", ValueComparators.DATE_TIME_COMPARATOR, new DateCanonicalizer(), DateTime.class, Calendar.class, Date.class),
-    BOOLEAN("Boolean", ValueComparators.BOOLEAN_COMPARATOR, new ObjectCanonicalizer(), Boolean.class),
-    NAME("Name", ValueComparators.NAME_COMPARATOR, new ObjectCanonicalizer(), Name.class, BasicName.class),
-    PATH("Path", ValueComparators.PATH_COMPARATOR, new ObjectCanonicalizer(), Path.class, BasicPath.class, ChildPath.class,
+    STRING("String", ValueComparators.STRING_COMPARATOR, new ObjectCanonicalizer(), String.class, javax.jcr.PropertyType.STRING),
+    BINARY("Binary", ValueComparators.BINARY_COMPARATOR, new ObjectCanonicalizer(), BinaryValue.class, javax.jcr.PropertyType.BINARY),
+    LONG("Long", ValueComparators.LONG_COMPARATOR, new LongCanonicalizer(), Long.class, javax.jcr.PropertyType.LONG, Integer.class, Short.class),
+    DOUBLE("Double", ValueComparators.DOUBLE_COMPARATOR, new DoubleCanonicalizer(), Double.class, javax.jcr.PropertyType.DOUBLE, Float.class),
+    DECIMAL("Decimal", ValueComparators.DECIMAL_COMPARATOR, new ObjectCanonicalizer(), BigDecimal.class, javax.jcr.PropertyType.DECIMAL),
+    DATE("Date", ValueComparators.DATE_TIME_COMPARATOR, new DateCanonicalizer(), DateTime.class, javax.jcr.PropertyType.DATE, Calendar.class, Date.class),
+    BOOLEAN("Boolean", ValueComparators.BOOLEAN_COMPARATOR, new ObjectCanonicalizer(), Boolean.class, javax.jcr.PropertyType.BOOLEAN),
+    NAME("Name", ValueComparators.NAME_COMPARATOR, new ObjectCanonicalizer(), Name.class, javax.jcr.PropertyType.NAME, BasicName.class),
+    PATH("Path", ValueComparators.PATH_COMPARATOR, new ObjectCanonicalizer(), Path.class, javax.jcr.PropertyType.PATH, BasicPath.class, ChildPath.class,
          IdentifierPath.class, RootPath.class),
     REFERENCE("Reference", ValueComparators.REFERENCE_COMPARATOR, new ObjectCanonicalizer(), Reference.class,
-              NodeKeyReference.class, StringReference.class),
+              javax.jcr.PropertyType.REFERENCE, NodeKeyReference.class, StringReference.class),
     WEAKREFERENCE("WeakReference", ValueComparators.REFERENCE_COMPARATOR, new ObjectCanonicalizer(), Reference.class,
-                  NodeKeyReference.class, StringReference.class),
+                  javax.jcr.PropertyType.WEAKREFERENCE, NodeKeyReference.class, StringReference.class),
     SIMPLEREFERENCE(org.modeshape.jcr.api.PropertyType.TYPENAME_SIMPLE_REFERENCE,
-                    ValueComparators.REFERENCE_COMPARATOR, new ObjectCanonicalizer(), Reference.class, NodeKeyReference.class),
-    URI("URI", ValueComparators.URI_COMPARATOR, new ObjectCanonicalizer(), URI.class),
-    OBJECT("Object", ValueComparators.OBJECT_COMPARATOR, new ObjectCanonicalizer(), Object.class);
+                    ValueComparators.REFERENCE_COMPARATOR, new ObjectCanonicalizer(), Reference.class, org.modeshape.jcr.api.PropertyType.SIMPLE_REFERENCE,
+                    NodeKeyReference.class),
+    URI("URI", ValueComparators.URI_COMPARATOR, new ObjectCanonicalizer(), URI.class, javax.jcr.PropertyType.URI),
+    OBJECT("Object", ValueComparators.OBJECT_COMPARATOR, new ObjectCanonicalizer(), Object.class, javax.jcr.PropertyType.UNDEFINED);
 
     private static interface Canonicalizer {
         Object canonicalizeValue( Object value );
@@ -164,13 +165,15 @@ public enum PropertyType {
     private final Class<?> valueClass;
     private final Set<Class<?>> castableValueClasses;
     private final TypeChecker typeChecker;
+    private final int jcrType;
 
     private PropertyType( String name,
                           Comparator<?> comparator,
                           Canonicalizer canonicalizer,
                           Class<?> valueClass,
+                          int jcrType,
                           Class<?>... castableClasses ) {
-        this(name, comparator, canonicalizer, valueClass, null, castableClasses);
+        this(name, comparator, canonicalizer, valueClass, null, jcrType, castableClasses);
     }
 
     private PropertyType( String name,
@@ -178,11 +181,13 @@ public enum PropertyType {
                           Canonicalizer canonicalizer,
                           Class<?> valueClass,
                           TypeChecker typeChecker,
+                          int jcrType,
                           Class<?>... castableClasses ) {
         this.name = name;
         this.comparator = comparator;
         this.canonicalizer = canonicalizer;
         this.valueClass = valueClass;
+        this.jcrType = jcrType;
         if (castableClasses != null && castableClasses.length != 0) {
             castableValueClasses = Collections.unmodifiableSet(new HashSet<Class<?>>(Arrays.asList(castableClasses)));
         } else {
@@ -248,6 +253,16 @@ public enum PropertyType {
             if (!isTypeFor(value)) return false;
         }
         return true;
+    }
+
+    /**
+     * Returns the JCR numeric constant which represents the current type.
+     *
+     * @return an {@code int} value
+     * @see {@link javax.jcr.PropertyType}
+     */
+    public final int jcrType() {
+        return this.jcrType;
     }
 
     public static PropertyType discoverType( Object value ) {

--- a/modeshape-jcr/src/test/java/org/modeshape/jcr/JcrInitialContentTest.java
+++ b/modeshape-jcr/src/test/java/org/modeshape/jcr/JcrInitialContentTest.java
@@ -16,8 +16,12 @@
 
 package org.modeshape.jcr;
 
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import java.io.InputStream;
+import java.math.BigDecimal;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
@@ -34,9 +38,13 @@ import org.junit.Test;
 import org.modeshape.common.FixFor;
 import org.modeshape.common.collection.ArrayListMultimap;
 import org.modeshape.common.collection.ListMultimap;
+import org.modeshape.common.util.IoUtil;
 import org.modeshape.common.util.StringUtil;
 import org.modeshape.jcr.api.JcrConstants;
+import org.modeshape.jcr.api.Property;
+import org.modeshape.jcr.api.PropertyType;
 import org.modeshape.jcr.value.Name;
+import org.modeshape.jcr.value.basic.JodaDateTime;
 
 /**
  * Unit test for the initial content import feature.
@@ -147,6 +155,136 @@ public class JcrInitialContentTest extends SingleUseAbstractTest {
         } finally {
             session.logout();
         }
+    }
+
+    @Test
+    @FixFor( "MODE-2241" )
+    public void shouldSupportReferenceProperties() throws Exception {
+        startRepositoryWithConfiguration(getClass().getClassLoader().getResourceAsStream(
+                "config/repo-config-initial-content-references.json"));
+        JcrSession session = repository.login();
+        AbstractJcrNode node1 = session.getNode("/node1");
+        AbstractJcrNode node2 = session.getNode("/node2");
+        AbstractJcrNode node3 = session.getNode("/node3");
+
+        Property hard_ref11 = node1.getProperty("hard_ref11");
+        assertEquals(javax.jcr.PropertyType.REFERENCE, hard_ref11.getType());
+        assertEquals(node2.getIdentifier(), hard_ref11.getNode().getIdentifier());
+        Property hard_ref12 = node1.getProperty("hard_ref12");
+        assertEquals(javax.jcr.PropertyType.REFERENCE, hard_ref12.getType());
+        assertTrue(hard_ref12.isMultiple());
+        List<String> nodeIdentifiers = new ArrayList<>();
+        for (Value value : hard_ref12.getValues()) {
+            nodeIdentifiers.add(value.getString());
+        }
+        assertTrue(nodeIdentifiers.remove(node2.getIdentifier()));
+        assertTrue(nodeIdentifiers.remove(node3.getIdentifier()));
+
+        Property weak_ref11 = node1.getProperty("weak_ref11");
+        assertEquals(javax.jcr.PropertyType.WEAKREFERENCE, weak_ref11.getType());
+        assertEquals(node2.getIdentifier(), weak_ref11.getNode().getIdentifier());
+        Property weak_ref12 = node1.getProperty("weak_ref12");
+        assertEquals(javax.jcr.PropertyType.WEAKREFERENCE, weak_ref12.getType());
+        assertEquals(node2.getIdentifier(), weak_ref12.getNode().getIdentifier());
+
+        Property simple_ref11 = node1.getProperty("simple_ref11");
+        assertEquals(PropertyType.SIMPLE_REFERENCE, simple_ref11.getType());
+        assertEquals(node2.getIdentifier(), simple_ref11.getNode().getIdentifier());
+        Property simple_ref12 = node1.getProperty("simple_ref12");
+        assertEquals(PropertyType.SIMPLE_REFERENCE, simple_ref12.getType());
+        assertEquals(node2.getIdentifier(), simple_ref12.getNode().getIdentifier());
+
+        Property hard_ref21 = node2.getProperty("hard_ref21");
+        assertEquals(javax.jcr.PropertyType.REFERENCE, hard_ref21.getType());
+        assertEquals(node1.getIdentifier(), hard_ref21.getNode().getIdentifier());
+        Property hard_ref22 = node2.getProperty("hard_ref22");
+        assertEquals(javax.jcr.PropertyType.REFERENCE, hard_ref22.getType());
+        assertTrue(hard_ref22.isMultiple());
+        nodeIdentifiers = new ArrayList<>();
+        for (Value value : hard_ref22.getValues()) {
+            nodeIdentifiers.add(value.getString());
+        }
+        assertTrue(nodeIdentifiers.remove(node1.getIdentifier()));
+        assertTrue(nodeIdentifiers.remove(node3.getIdentifier()));
+
+        Property weak_ref21 = node2.getProperty("weak_ref21");
+        assertEquals(javax.jcr.PropertyType.WEAKREFERENCE, weak_ref21.getType());
+        assertEquals(node1.getIdentifier(), weak_ref21.getNode().getIdentifier());
+        Property weak_ref22 = node2.getProperty("weak_ref22");
+        assertEquals(javax.jcr.PropertyType.WEAKREFERENCE, weak_ref22.getType());
+        assertEquals(node1.getIdentifier(), weak_ref22.getNode().getIdentifier());
+
+        Property simple_ref21 = node2.getProperty("simple_ref21");
+        assertEquals(PropertyType.SIMPLE_REFERENCE, simple_ref21.getType());
+        assertEquals(node1.getIdentifier(), simple_ref21.getNode().getIdentifier());
+        Property simple_ref22 = node2.getProperty("simple_ref22");
+        assertEquals(PropertyType.SIMPLE_REFERENCE, simple_ref22.getType());
+        assertEquals(node1.getIdentifier(), simple_ref22.getNode().getIdentifier());
+    }
+
+    @Test
+    @FixFor( "MODE-2241" )
+    public void shouldSupportVariousPropertyTypes() throws Exception {
+        startRepositoryWithConfiguration(getClass().getClassLoader().getResourceAsStream(
+                "config/repo-config-initial-content-props.json"));
+        JcrSession session = repository.login();
+        AbstractJcrNode node1 = session.getNode("/node1");
+
+        Property stringProp = node1.getProperty("string_prop");
+        assertEquals("string", stringProp.getString());
+        assertEquals(javax.jcr.PropertyType.STRING, stringProp.getType());
+
+        Property booleanProp = node1.getProperty("boolean_prop");
+        assertEquals(true, booleanProp.getBoolean());
+        assertEquals(javax.jcr.PropertyType.BOOLEAN, booleanProp.getType());
+
+        Property longProp = node1.getProperty("long_prop");
+        assertEquals(123456l, longProp.getLong());
+        assertEquals(javax.jcr.PropertyType.LONG, longProp.getType());
+
+        Property decimalProp = node1.getProperty("decimal_prop");
+        assertEquals(BigDecimal.valueOf(12.3), decimalProp.getDecimal());
+        assertEquals(javax.jcr.PropertyType.DECIMAL, decimalProp.getType());
+
+        Property dateProp = node1.getProperty("date_prop");
+        assertEquals(new JodaDateTime("1994-11-05T13:15:30Z").toCalendar(), dateProp.getDate());
+        assertEquals(javax.jcr.PropertyType.DATE, dateProp.getType());
+
+        Property doubleProp = node1.getProperty("double_prop");
+        assertEquals(12.3, doubleProp.getDouble(), 0);
+        assertEquals(javax.jcr.PropertyType.DOUBLE, doubleProp.getType());
+
+        Property nameProp = node1.getProperty("name_prop");
+        assertEquals("nt:undefined", nameProp.getString());
+        assertEquals(javax.jcr.PropertyType.NAME, nameProp.getType());
+
+        Property pathProp = node1.getProperty("path_prop");
+        assertEquals("/a/b/c", pathProp.getString());
+        assertEquals(javax.jcr.PropertyType.PATH, pathProp.getType());
+
+        Property uriProp = node1.getProperty("uri_prop");
+        assertEquals("http://www.google.com", uriProp.getString());
+        assertEquals(javax.jcr.PropertyType.URI, uriProp.getType());
+
+        Property binaryProp = node1.getProperty("binary_prop");
+        assertEquals(javax.jcr.PropertyType.BINARY, binaryProp.getType());
+        try (InputStream is = binaryProp.getBinary().getStream()) {
+            byte[] actualBytes = IoUtil.readBytes(is);
+            byte[] expectedBytes = IoUtil.readBytes(getClass().getClassLoader().getResourceAsStream("io/file1.txt"));
+            assertArrayEquals(expectedBytes, actualBytes);
+        }
+
+        Property referenceProp = node1.getProperty("reference_prop");
+        assertEquals(javax.jcr.PropertyType.REFERENCE, referenceProp.getType());
+        assertEquals(session.getNode("/node2").getIdentifier(), referenceProp.getNode().getIdentifier());
+
+        Property weakReferenceProp = node1.getProperty("weakreference_prop");
+        assertEquals(javax.jcr.PropertyType.WEAKREFERENCE, weakReferenceProp.getType());
+        assertEquals(session.getNode("/node2").getIdentifier(), weakReferenceProp.getNode().getIdentifier());
+
+        Property simpleReferenceProp = node1.getProperty("simplereference_prop");
+        assertEquals(PropertyType.SIMPLE_REFERENCE, simpleReferenceProp.getType());
+        assertEquals(session.getNode("/node2").getIdentifier(), simpleReferenceProp.getNode().getIdentifier());
     }
 
     @Override

--- a/modeshape-jcr/src/test/java/org/modeshape/jcr/xml/NodeImportXmlHandlerTest.java
+++ b/modeshape-jcr/src/test/java/org/modeshape/jcr/xml/NodeImportXmlHandlerTest.java
@@ -284,45 +284,188 @@ public class NodeImportXmlHandlerTest {
     @FixFor("MODE-1788")
     public void shouldParseXmlDocumentWithPropertiesCustomSeparator() throws Exception {
         parse("xmlImport/docWithPropertiesCustomSeparator.xml");
-        assertNodeUsingSeparator("story", ";",
-                                 "title=Story with commas in the text lead and body text",
-                                 "lead=Lead text in attribute, split with a comma.",
-                                 "body=Body text in sub element, split by the comma.",
-                                 "multiBody=Body text in sub element; split by semicolon");
+        assertImportElementWithStrings("story", ";",
+                                       "title=Story with commas in the text lead and body text",
+                                       "lead=Lead text in attribute, split with a comma.",
+                                       "body=Body text in sub element, split by the comma.",
+                                       "multiBody=Body text in sub element; split by semicolon");
+    }
+
+    @Test
+    @FixFor( "MODE-2241" )
+    public void shouldParseXmlDocumentWithReferences() throws Exception {
+        parse("xmlImport/docWithReferences.xml");
+        assertImportElementWithReferences("node1", "hard_ref11=/node2", "hard_ref12=/node2,/node3");
+        assertImportElementWithReferences("node2", "hard_ref21=/node1", "hard_ref22=/node1,/node3");
+
+        assertImportElementWithWeakReferences("node1", "weak_ref11=/node2", "weak_ref12=/node2");
+        assertImportElementWithWeakReferences("node2", "weak_ref21=/node1", "weak_ref22=/node1");
+
+        assertImportElementWithSimpleReferences("node1", "simple_ref11=/node2", "simple_ref12=/node2");
+        assertImportElementWithSimpleReferences("node2", "simple_ref21=/node1", "simple_ref22=/node1");
+    }
+
+    @Test
+    @FixFor( "MODE-2241" )
+    public void shouldParseXmlDocumentWithPropertyTypes() throws Exception {
+        parse("xmlImport/docWithPropertyTypes.xml");
+        assertImportElementWithStrings("node1", "string_prop=string");
+        assertImportElementWithBooleans("node1", "boolean_prop=true");
+        assertImportElementWithDecimals("node1", "decimal_prop=12.3");
+        assertImportElementWithDoubles("node1", "double_prop=12.3");
+        assertImportElementWithLongs("node1", "long_prop=123456");
+        assertImportElementWithDates("node1", "date_prop=1994-11-05T13:15:30Z");
+        assertImportElementWithNames("node1", "name_prop=nt:undefined");
+        assertImportElementWithURIs("node1", "uri_prop=http://www.google.com");
+        assertImportElementWithPaths("node1", "path_prop=/a/b/c");
+        assertImportElementWithBinaries("node1", "binary_prop=io/file1.txt");
+        assertImportElementWithReferences("node1", "reference_prop=/node2");
+        assertImportElementWithWeakReferences("node1", "weakreference_prop=/node2");
+        assertImportElementWithSimpleReferences("node1", "simplereference_prop=/node2");
     }
 
     private void assertNode( String path,
-                             String... properties ) {
-      assertNodeUsingSeparator(path, ",", properties);
+                             String... expectedProperties ) {
+        assertImportElementWithStrings(path, NodeImportXmlHandler.DEFAULT_MULTI_VALUE_SEPARATOR, expectedProperties);
     }
 
-    private void assertNodeUsingSeparator( String path,
-                                           String multiValueSeparator,
-                                           String... properties ) {
-        Path expectedPath = context.getValueFactories().getPathFactory().create("/" + path);
+    private void assertImportElementWithReferences( String path, String... expectedReferences ) {
+        NodeImportXmlHandler.ImportElement element = assertImportElementExists(path);
+        assertImportElementHasProperties(element,
+                                         NodeImportXmlHandler.DEFAULT_MULTI_VALUE_SEPARATOR,
+                                         org.modeshape.jcr.value.PropertyType.REFERENCE,
+                                         expectedReferences);
+    }
 
-        NodeImportXmlHandler.ImportElement element = parseResults.get(expectedPath);
-        assertNotNull(path + " not found among parsed elements", element);
+    private void assertImportElementWithWeakReferences( String path, String... expectedReferences ) {
+        NodeImportXmlHandler.ImportElement element = assertImportElementExists(path);
+        assertImportElementHasProperties(element,
+                                         NodeImportXmlHandler.DEFAULT_MULTI_VALUE_SEPARATOR,
+                                         org.modeshape.jcr.value.PropertyType.WEAKREFERENCE,
+                                         expectedReferences);
+    }
 
-        for (String propertyValueString : properties) {
+    private void assertImportElementWithSimpleReferences( String path, String... expectedReferences ) {
+        NodeImportXmlHandler.ImportElement element = assertImportElementExists(path);
+        assertImportElementHasProperties(element,
+                                         NodeImportXmlHandler.DEFAULT_MULTI_VALUE_SEPARATOR,
+                                         org.modeshape.jcr.value.PropertyType.SIMPLEREFERENCE,
+                                         expectedReferences);
+    }
+
+    private void assertImportElementWithBooleans( String path, String... expectedProperties ) {
+        NodeImportXmlHandler.ImportElement element = assertImportElementExists(path);
+        assertImportElementHasProperties(element,
+                                         NodeImportXmlHandler.DEFAULT_MULTI_VALUE_SEPARATOR,
+                                         org.modeshape.jcr.value.PropertyType.BOOLEAN,
+                                         expectedProperties);
+    }
+
+    private void assertImportElementWithDoubles( String path, String... expectedProperties ) {
+        NodeImportXmlHandler.ImportElement element = assertImportElementExists(path);
+        assertImportElementHasProperties(element,
+                                         NodeImportXmlHandler.DEFAULT_MULTI_VALUE_SEPARATOR,
+                                         org.modeshape.jcr.value.PropertyType.DOUBLE,
+                                         expectedProperties);
+    }
+
+    private void assertImportElementWithDecimals( String path, String... expectedProperties ) {
+        NodeImportXmlHandler.ImportElement element = assertImportElementExists(path);
+        assertImportElementHasProperties(element,
+                                         NodeImportXmlHandler.DEFAULT_MULTI_VALUE_SEPARATOR,
+                                         org.modeshape.jcr.value.PropertyType.DECIMAL,
+                                         expectedProperties);
+    }
+
+    private void assertImportElementWithDates( String path, String... expectedProperties ) {
+        NodeImportXmlHandler.ImportElement element = assertImportElementExists(path);
+        assertImportElementHasProperties(element,
+                                         NodeImportXmlHandler.DEFAULT_MULTI_VALUE_SEPARATOR,
+                                         org.modeshape.jcr.value.PropertyType.DATE,
+                                         expectedProperties);
+    }
+
+    private void assertImportElementWithLongs( String path, String... expectedProperties ) {
+        NodeImportXmlHandler.ImportElement element = assertImportElementExists(path);
+        assertImportElementHasProperties(element,
+                                         NodeImportXmlHandler.DEFAULT_MULTI_VALUE_SEPARATOR,
+                                         org.modeshape.jcr.value.PropertyType.LONG,
+                                         expectedProperties);
+    }
+
+    private void assertImportElementWithURIs( String path, String... expectedProperties ) {
+        NodeImportXmlHandler.ImportElement element = assertImportElementExists(path);
+        assertImportElementHasProperties(element,
+                                         NodeImportXmlHandler.DEFAULT_MULTI_VALUE_SEPARATOR,
+                                         org.modeshape.jcr.value.PropertyType.URI,
+                                         expectedProperties);
+    }
+
+    private void assertImportElementWithNames( String path, String... expectedProperties ) {
+        NodeImportXmlHandler.ImportElement element = assertImportElementExists(path);
+        assertImportElementHasProperties(element,
+                                         NodeImportXmlHandler.DEFAULT_MULTI_VALUE_SEPARATOR,
+                                         org.modeshape.jcr.value.PropertyType.NAME,
+                                         expectedProperties);
+    }
+
+    private void assertImportElementWithPaths( String path, String... expectedProperties ) {
+        NodeImportXmlHandler.ImportElement element = assertImportElementExists(path);
+        assertImportElementHasProperties(element,
+                                         NodeImportXmlHandler.DEFAULT_MULTI_VALUE_SEPARATOR,
+                                         org.modeshape.jcr.value.PropertyType.PATH,
+                                         expectedProperties);
+    }
+
+    private void assertImportElementWithBinaries( String path, String... expectedProperties ) {
+        NodeImportXmlHandler.ImportElement element = assertImportElementExists(path);
+        assertImportElementHasProperties(element,
+                                         NodeImportXmlHandler.DEFAULT_MULTI_VALUE_SEPARATOR,
+                                         org.modeshape.jcr.value.PropertyType.BINARY,
+                                         expectedProperties);
+    }
+
+    private void assertImportElementWithStrings( String path,
+                                                 String multiValueSeparator,
+                                                 String... expectedProperties ) {
+        NodeImportXmlHandler.ImportElement element = assertImportElementExists(path);
+        assertImportElementHasProperties(element, multiValueSeparator, org.modeshape.jcr.value.PropertyType.STRING, expectedProperties);
+    }
+
+    private void assertImportElementHasProperties( NodeImportXmlHandler.ImportElement element,
+                                                   String multiValueSeparator,
+                                                   org.modeshape.jcr.value.PropertyType expectedPropertyType,
+                                                   String... expectedProperties ) {
+        for (String propertyValueString : expectedProperties) {
             String[] parts = propertyValueString.split("=");
             String propertyName = context.getValueFactories()
                                          .getNameFactory()
                                          .create(parts[0])
                                          .getString(NoOpEncoder.getInstance());
             String propertyValue = parts[1];
+            org.modeshape.jcr.value.PropertyType propertyType = element.getPropertyType(propertyName);
+
             if (propertyName.equals(JcrConstants.JCR_PRIMARY_TYPE)) {
                 assertEquals(propertyValue, element.getType());
             } else {
-                Collection<String> actualPropertyValue = propertyName.equalsIgnoreCase(JcrConstants.JCR_MIXIN_TYPES) ? element.getMixins() : element.getProperties()
-                                                                                                                                                    .get(propertyName);
+                Collection<String> actualPropertyValue = propertyName.equalsIgnoreCase(JcrConstants.JCR_MIXIN_TYPES)
+                                                         ? element.getMixins() : element.getProperties().get(propertyName);
                 assertNotNull(actualPropertyValue);
                 String[] values = propertyValue.split(multiValueSeparator);
                 for (String value : values) {
                     assertTrue("Expected property not found: " + value, actualPropertyValue.contains(value));
                 }
+                assertEquals("Invalid property type: " + propertyType, expectedPropertyType, propertyType);
             }
         }
+    }
+
+    private NodeImportXmlHandler.ImportElement assertImportElementExists( String path ) {
+        Path expectedPath = context.getValueFactories().getPathFactory().create("/" + path);
+
+        NodeImportXmlHandler.ImportElement element = parseResults.get(expectedPath);
+        assertNotNull(path + " not found among parsed elements", element);
+        return element;
     }
 
     private void parse( String relativePathToXmlFile ) throws Exception {

--- a/modeshape-jcr/src/test/resources/config/repo-config-initial-content-props.json
+++ b/modeshape-jcr/src/test/resources/config/repo-config-initial-content-props.json
@@ -1,0 +1,10 @@
+{
+    "name" : "Repository with initial content",
+    "workspaces" : {
+        "default" : "default",
+        "allowCreation" : true,
+        "initialContent" : {
+            "default" : "xmlImport/docWithPropertyTypes.xml"
+        }
+    }
+}

--- a/modeshape-jcr/src/test/resources/config/repo-config-initial-content-references.json
+++ b/modeshape-jcr/src/test/resources/config/repo-config-initial-content-references.json
@@ -1,0 +1,10 @@
+{
+    "name" : "Repository with initial content",
+    "workspaces" : {
+        "default" : "default",
+        "allowCreation" : true,
+        "initialContent" : {
+            "default" : "xmlImport/docWithReferences.xml"
+        }
+    }
+}

--- a/modeshape-jcr/src/test/resources/xmlImport/docWithPropertyTypes.xml
+++ b/modeshape-jcr/src/test/resources/xmlImport/docWithPropertyTypes.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:jcr="http://www.jcp.org/jcr/1.0">
+    <node1>
+        <string_prop type="string">string</string_prop>
+        <boolean_prop type="boolean">true</boolean_prop>
+        <long_prop type="long">123456</long_prop>
+        <decimal_prop type="decimal">12.3</decimal_prop>
+        <date_prop type="date">1994-11-05T13:15:30Z</date_prop>
+        <double_prop type="double">12.3</double_prop>
+        <name_prop type="name">nt:undefined</name_prop>
+        <path_prop type="path">/a/b/c</path_prop>
+        <uri_prop type="uri">http://www.google.com</uri_prop>
+        <binary_prop type="binary">io/file1.txt</binary_prop>
+        <reference_prop type="reference">/node2</reference_prop>
+        <weakreference_prop type="weakreference">/node2</weakreference_prop>
+        <simplereference_prop type="simplereference">/node2</simplereference_prop>
+    </node1>
+    <node2 jcr:mixinTypes="mix:referenceable"/>
+</jcr:root>

--- a/modeshape-jcr/src/test/resources/xmlImport/docWithReferences.xml
+++ b/modeshape-jcr/src/test/resources/xmlImport/docWithReferences.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:jcr="http://www.jcp.org/jcr/1.0">
+    <node1 jcr:mixinTypes="mix:referenceable">
+        <hard_ref11 type="Reference">/node2</hard_ref11>
+        <property jcr:name="hard_ref12" type="Reference">/node2, /node3</property>
+
+        <weak_ref11 type="WeakReference">/node2</weak_ref11>
+        <property jcr:name="weak_ref12" type="WeakReference">/node2</property>
+
+        <simple_ref11 type="SimpleReference">/node2</simple_ref11>
+        <property jcr:name="simple_ref12" type="SimpleReference">/node2</property>
+    </node1>
+    <node2 jcr:mixinTypes="mix:referenceable">
+        <hard_ref21 type="Reference">/node1</hard_ref21>
+        <property jcr:name="hard_ref22" type="Reference">/node1, /node3</property>
+
+        <weak_ref21 type="WeakReference">/node1</weak_ref21>
+        <property jcr:name="weak_ref22" type="WeakReference">/node1</property>
+
+        <simple_ref21 type="SimpleReference">/node1</simple_ref21>
+        <property jcr:name="simple_ref22" type="SimpleReference">/node1</property>
+    </node2>
+    <node3 jcr:mixinTypes="mix:referenceable"/>
+</jcr:root>


### PR DESCRIPTION
All standard JCR property types are supported, including references, weakreferences and binaries. Simple references (Modeshape specific) are also supported.
The format for explicitly defining the type of the property is:

```
<?xml version="1.0" encoding="UTF-8"?>
<jcr:root xmlns:jcr="http://www.jcp.org/jcr/1.0">
    <node1>
        <string_prop type="string">string</string_prop>
        <boolean_prop type="boolean">true</boolean_prop>
        <long_prop type="long">123456</long_prop>
        <decimal_prop type="decimal">12.3</decimal_prop>
        <date_prop type="date">1994-11-05T13:15:30Z</date_prop>
        <double_prop type="double">12.3</double_prop>
        <name_prop type="name">nt:undefined</name_prop>
        <path_prop type="path">/a/b/c</path_prop>
        <uri_prop type="uri">http://www.google.com</uri_prop>
        <binary_prop type="binary">io/file1.txt</binary_prop>
        <reference_prop type="reference">/node2</reference_prop>
        <weakreference_prop type="weakreference">/node2</weakreference_prop>
        <simplereference_prop type="simplereference">/node2</simplereference_prop>
    </node1>
    <node2 jcr:mixinTypes="mix:referenceable"/>
</jcr:root>
```
