### PR TITLE
MODE-2246 Implemented default FTS via strict regex matching.

### DIFF
--- a/extractors/modeshape-extractor-tika/src/test/java/org/modeshape/extractor/tika/TikaTextExtractorRepositoryTest.java
+++ b/extractors/modeshape-extractor-tika/src/test/java/org/modeshape/extractor/tika/TikaTextExtractorRepositoryTest.java
@@ -25,7 +25,6 @@ import javax.jcr.query.Query;
 import javax.jcr.query.QueryManager;
 import javax.jcr.query.QueryResult;
 import org.junit.Assert;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.modeshape.common.FixFor;
 import org.modeshape.jcr.SingleUseAbstractTest;
@@ -39,8 +38,6 @@ import org.modeshape.jcr.query.JcrQuery;
  * 
  * @author Horia Chiorean
  */
-// TODO: MODE-2178
-@Ignore
 public class TikaTextExtractorRepositoryTest extends SingleUseAbstractTest {
 
     private JcrTools jcrTools = new JcrTools();

--- a/extractors/modeshape-extractor-tika/src/test/resources/repo-config-exclusions-inclusions.json
+++ b/extractors/modeshape-extractor-tika/src/test/resources/repo-config-exclusions-inclusions.json
@@ -5,22 +5,13 @@
         "default" : "default",
         "allowCreation" : true
     },
-    "query" : {
-        "enabled" : true,
-        "enableFullTextSearch" : true,
-        "indexing" : {
-            "rebuildOnStartup": {
-                "when": "if_missing"
-            }
-        },
-        "textExtracting": {
-            "extractors" : {
-                "tikaExtractor":{
-                    "name" : "Tika content-based extractor",
-                    "classname" : "tika",
-                    "excludedMimeTypes" : ["text/plain", "text/html, application/xml"],
-                    "includedMimeTypes" : ["application/xsd"," application/pdf, audio/wav"]
-                }
+    "textExtraction": {
+        "extractors" : {
+            "tikaExtractor":{
+                "name" : "Tika content-based extractor",
+                "classname" : "tika",
+                "excludedMimeTypes" : ["text/plain", "text/html, application/xml"],
+                "includedMimeTypes" : ["application/xsd"," application/pdf, audio/wav"]
             }
         }
     }

--- a/extractors/modeshape-extractor-tika/src/test/resources/repo-config-text-extraction-limit.json
+++ b/extractors/modeshape-extractor-tika/src/test/resources/repo-config-text-extraction-limit.json
@@ -5,24 +5,12 @@
         "default" : "default",
         "allowCreation" : true
     },
-    "query" : {
-        "enabled" : true,
-        "enableFullTextSearch" : true,
-        "indexing" : {
-            "rebuildOnStartup": {
-                "when": "if_missing"
-            }
-        },
-        "indexStorage" : {
-            "type" : "ram"
-        },
-        "textExtracting": {
-            "extractors" : {
-                "tikaExtractor":{
-                    "name" : "Tika content-based extractor",
-                    "classname" : "tika",
-                    "writeLimit" : 100
-                }
+    "textExtraction": {
+        "extractors": {
+            "tikaExtractor": {
+                "name": "Tika content-based extractor",
+                "classname": "tika",
+                "writeLimit": 100
             }
         }
     }

--- a/extractors/modeshape-extractor-tika/src/test/resources/repo-config.json
+++ b/extractors/modeshape-extractor-tika/src/test/resources/repo-config.json
@@ -5,23 +5,11 @@
         "default" : "default",
         "allowCreation" : true
     },
-    "query" : {
-        "enabled" : true,
-        "enableFullTextSearch" : true,
-        "indexing" : {
-            "rebuildOnStartup": {
-                "when": "if_missing"
-            }
-        },
-        "indexStorage" : {
-            "type" : "ram"
-        },
-        "textExtracting": {
-            "extractors" : {
-                "tikaExtractor":{
-                    "name" : "Tika content-based extractor",
-                    "classname" : "tika"
-                }
+    "textExtraction": {
+        "extractors" : {
+            "tikaExtractor":{
+                "name" : "Tika content-based extractor",
+                "classname" : "tika"
             }
         }
     }

--- a/integration/modeshape-jbossas-integration-tests/src/test/java/org/modeshape/test/integration/TikaTextExtractorIntegrationTest.java
+++ b/integration/modeshape-jbossas-integration-tests/src/test/java/org/modeshape/test/integration/TikaTextExtractorIntegrationTest.java
@@ -30,7 +30,6 @@ import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.modeshape.common.FixFor;
@@ -70,24 +69,19 @@ public class TikaTextExtractorIntegrationTest {
         session.logout();
     }
 
-    // TODO MODE-2178
-    @Ignore
     @Test
     public void shouldExtractAndIndexContentFromPlainTextFile() throws Exception {
         String queryString = "select [jcr:path] from [nt:resource] as res where contains(res.*, 'The Quick')";
         uploadFileAndCheckExtraction("text-extractor/text-file.txt", queryString);
     }
 
-    // TODO MODE-2178
-    @Ignore
     @Test
     public void shouldExtractAndIndexContentFromDocFile() throws Exception {
         String queryString = "select [jcr:path] from [nt:resource] as res where contains(res.*, 'ModeShape supports')";
         uploadFileAndCheckExtraction("text-extractor/modeshape.doc", queryString);
     }
 
-    // TODO MODE-2178
-    @Ignore
+
     @Test
     @FixFor( "MODE-1810" )
     public void shouldExtractAndIndexContentFromXlsxFile() throws Exception {

--- a/modeshape-jcr/pom.xml
+++ b/modeshape-jcr/pom.xml
@@ -291,25 +291,13 @@
                                         of the form "package#method". One per line. For example:
                                         org.apache.jackrabbit.test.api.ShareableNodeTest#testModifyDescendantAndSave
                                         -->
-                                        org.apache.jackrabbit.test.api.ShareableNodeTesttestSearch
                                         org.apache.jackrabbit.test.api.query.qom.ChildNodeJoinConditionTest#testLeftOuterJoin
                                         org.apache.jackrabbit.test.api.query.qom.DescendantNodeJoinConditionTest#testLeftOuterJoin
                                         org.apache.jackrabbit.test.api.query.qom.EquiJoinConditionTest#testRightOuterJoin1
                                         org.apache.jackrabbit.test.api.query.qom.EquiJoinConditionTest#testRightOuterJoin2
                                         org.apache.jackrabbit.test.api.query.qom.SameNodeJoinConditionTest#testRightOuterJoin
                                         org.apache.jackrabbit.test.api.query.qom.SameNodeJoinConditionTest#testRightOuterJoinWithPath
-                                        org.apache.jackrabbit.test.api.query.SQLQueryLevel2Test#testFullTextSearch
-                                        org.apache.jackrabbit.test.api.query.SQLQueryLevel2Test#testPathColumn
-                                        org.apache.jackrabbit.test.api.query.SQLQueryLevel2Test#testScoreColumn
-                                        org.apache.jackrabbit.test.api.query.XPathQueryLevel2Test#testFullTextSearch
-                                        org.apache.jackrabbit.test.api.query.XPathQueryLevel2Test#testPathColumn
-                                        org.apache.jackrabbit.test.api.query.XPathQueryLevel2Test#testScoreColumn
-                                        org.apache.jackrabbit.test.api.query.TextNodeTest#testTextNodeTestContains
-                                        org.apache.jackrabbit.test.api.query.qom.FullTextSearchScoreTest#testConstraint
-                                        org.apache.jackrabbit.test.api.query.qom.FullTextSearchScoreTest#testOrdering
                                         org.apache.jackrabbit.test.api.ShareableNodeTest#testSearch
-                                        org.apache.jackrabbit.test.api.version.RestoreTest#testRestoreName
-                                        org.apache.jackrabbit.test.api.version.RestoreTest#testRestoreNameJcr2
                                     </value>
                                 </property>
                             </systemProperties>

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/query/RowExtractors.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/query/RowExtractors.java
@@ -784,7 +784,7 @@ public class RowExtractors {
     public static interface ExtractFromRow {
 
         /**
-         * Get the type of value that this extrator will return from {@link #getValueInRow}.
+         * Get the type of value that this extractor will return from {@link #getValueInRow}.
          * 
          * @return the type; never null
          */

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/query/parse/FullTextSearchParser.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/query/parse/FullTextSearchParser.java
@@ -86,7 +86,7 @@ public class FullTextSearchParser implements QueryParser {
                                                                                                                           SCORE_COLUMN_NAME),
                                                                                                         Order.DESCENDING,
                                                                                                         NullOrder.NULLS_LAST));
-    private static boolean FULL_TEXT_DISTINCT = true;
+    private static boolean FULL_TEXT_DISTINCT = false;
 
     private static FullTextSearchParser PARSER = new FullTextSearchParser();
 

--- a/modeshape-jcr/src/test/java/org/modeshape/jcr/JcrQueryManagerTest.java
+++ b/modeshape-jcr/src/test/java/org/modeshape/jcr/JcrQueryManagerTest.java
@@ -2364,111 +2364,113 @@ public class JcrQueryManagerTest extends MultiUseAbstractTest {
         validateQuery().rowCount(13).hasColumns(columnNames).validate(query, result);
     }
 
-    // @FixFor( "MODE-1418" )
-    // @Test
-    // public void shouldBeAbleToCreateAndExecuteJcrSql2QueryWithFullTextSearchWithSelectorAndOneProperty()
-    // throws RepositoryException {
-    // String sql = "select [jcr:path] from [nt:unstructured] as n where contains(n.something, 'cat wearing')";
-    // Query query = session.getWorkspace().getQueryManager().createQuery(sql, Query.JCR_SQL2);
-    // QueryResult result = query.execute();
-    // validateQuery().rowCount(1).hasColumns("jcr:path").validate(query, result);
-    // }
-    //
-    // @FixFor( "MODE-1418" )
-    // @Test
-    // public void shouldBeAbleToCreateAndExecuteJcrSql2QueryWithFullTextSearchWithSelectorAndAllProperties()
-    // throws RepositoryException {
-    // String sql = "select [jcr:path] from [nt:unstructured] as n where contains(n.*, 'cat wearing')";
-    // Query query = session.getWorkspace().getQueryManager().createQuery(sql, Query.JCR_SQL2);
-    // QueryResult result = query.execute();
-    // validateQuery().rowCount(1).hasColumns("jcr:path").validate(query, result);
-    // }
-    //
-    // @FixFor( "MODE-1418" )
-    // @Test
-    // public void shouldBeAbleToCreateAndExecuteJcrSql2QueryWithFullTextSearchWithNoSelectorAndOneProperty()
-    // throws RepositoryException {
-    // String sql = "select [jcr:path] from [nt:unstructured] as n where contains(something,'cat wearing')";
-    // Query query = session.getWorkspace().getQueryManager().createQuery(sql, Query.JCR_SQL2);
-    // QueryResult result = query.execute();
-    // validateQuery().rowCount(1).hasColumns("jcr:path").hasNodesAtPaths("/Other/NodeA[2]").validate(query, result);
-    // }
-    //
-    // @FixFor( "MODE-1829" )
-    // @Test
-    // public void shouldBeAbleToCreateAndExecuteJcrSql2QueryWithFullTextSearchUsingLeadingWildcard() throws RepositoryException {
-    // String sql = "select [jcr:path] from [nt:unstructured] as n where contains(n.something, '*earing')";
-    // Query query = session.getWorkspace().getQueryManager().createQuery(sql, Query.JCR_SQL2);
-    // QueryResult result = query.execute();
-    // validateQuery().rowCount(1).hasColumns("jcr:path").validate(query, result);
-    //
-    // sql = "select [jcr:path] from [nt:unstructured] as n where contains(n.something, '*earing*')";
-    // query = session.getWorkspace().getQueryManager().createQuery(sql, Query.JCR_SQL2);
-    // result = query.execute();
-    // validateQuery().rowCount(1).hasColumns("jcr:path").validate(query, result);
-    // }
-    //
-    // @FixFor( "MODE-1829" )
-    // @Test
-    // public void shouldBeAbleToCreateAndExecuteJcrSql2QueryWithFullTextSearchUsingTrailingWildcard() throws RepositoryException
-    // {
-    // String sql = "select [jcr:path] from [nt:unstructured] as n where contains(n.something, 'wea*')";
-    // Query query = session.getWorkspace().getQueryManager().createQuery(sql, Query.JCR_SQL2);
-    // QueryResult result = query.execute();
-    // validateQuery().rowCount(1).hasColumns("jcr:path").validate(query, result);
-    // }
-    //
-    // @Test
-    // @FixFor( "MODE-1547" )
-    // public void shouldBeAbleToExecuteFullTextSearchQueriesOnPropertiesWhichIncludeStopWords() throws Exception {
-    // String propertyText = "the quick Brown fox jumps over to the dog in at the gate";
-    // Node ftsNode = session.getRootNode().addNode("FTSNode").setProperty("FTSProp", propertyText).getParent();
-    // try {
-    // session.save();
-    //
-    // executeQueryWithSingleResult("select [jcr:path] from [nt:unstructured] as n where contains([nt:unstructured].*,'"
-    // + propertyText + "')");
-    //
-    // executeQueryWithSingleResult("select [jcr:path] from [nt:unstructured] as n where contains(FTSProp,'" + propertyText
-    // + "')");
-    // executeQueryWithSingleResult("select [jcr:path] from [nt:unstructured] as n where contains(n.*,'" + propertyText
-    // + "')");
-    //
-    // executeQueryWithSingleResult("select [jcr:path] from [nt:unstructured] as n where contains(FTSProp,'"
-    // + propertyText.toUpperCase() + "')");
-    // executeQueryWithSingleResult("select [jcr:path] from [nt:unstructured] as n where contains(n.*,'"
-    // + propertyText.toUpperCase() + "')");
-    //
-    // executeQueryWithSingleResult("select [jcr:path] from [nt:unstructured] as n where contains(FTSProp,'the quick Dog')");
-    // executeQueryWithSingleResult("select [jcr:path] from [nt:unstructured] as n where contains(n.*,'the quick Dog')");
-    //
-    // executeQueryWithSingleResult("select [jcr:path] from [nt:unstructured] as n where contains(FTSProp,'the quick jumps over gate')");
-    // executeQueryWithSingleResult("select [jcr:path] from [nt:unstructured] as n where contains(n.*,'the quick jumps over gate')");
-    //
-    // executeQueryWithSingleResult("select [jcr:path] from [nt:unstructured] as n where contains(FTSProp,'the gate')");
-    // executeQueryWithSingleResult("select [jcr:path] from [nt:unstructured] as n where contains(n.*,'the gate')");
-    // } finally {
-    // // Try to remove the node (which messes up the expected results from subsequent tests) ...
-    // ftsNode.remove();
-    // session.save();
-    // }
-    // }
-    //
-    // private void executeQueryWithSingleResult( String sql ) throws RepositoryException {
-    // Query query = session.getWorkspace().getQueryManager().createQuery(sql, JcrRepository.QueryLanguage.JCR_SQL2);
-    // QueryResult result = query.execute();
-    // validateQuery().rowCount(1).hasColumns("jcr:path").validate(query, result);
-    // }
-    //
-    // @FixFor( "MODE-1840" )
-    // @Test
-    // public void shouldBeAbleToCreateAndExecuteJcrSql2QueryWithBindVariableInsideContains() throws RepositoryException {
-    // String sql = "select [jcr:path] from [nt:unstructured] as n where contains(n.something, $expression)";
-    // Query query = session.getWorkspace().getQueryManager().createQuery(sql, Query.JCR_SQL2);
-    // query.bindValue("expression", session.getValueFactory().createValue("cat wearing"));
-    // QueryResult result = query.execute();
-    // validateQuery().rowCount(1).hasColumns("jcr:path").hasNodesAtPaths("/Other/NodeA[2]").validate(query, result);
-    // }
+    @FixFor( "MODE-1418" )
+    @Test
+    public void shouldBeAbleToCreateAndExecuteJcrSql2QueryWithFullTextSearchWithSelectorAndOneProperty()
+            throws RepositoryException {
+        String sql = "select [jcr:path] from [nt:unstructured] as n where contains(n.something, 'cat wearing')";
+        Query query = session.getWorkspace().getQueryManager().createQuery(sql, Query.JCR_SQL2);
+        QueryResult result = query.execute();
+        validateQuery().rowCount(1).hasColumns("jcr:path").validate(query, result);
+    }
+
+    @FixFor( "MODE-1418" )
+    @Test
+    public void shouldBeAbleToCreateAndExecuteJcrSql2QueryWithFullTextSearchWithSelectorAndAllProperties()
+            throws RepositoryException {
+        String sql = "select [jcr:path] from [nt:unstructured] as n where contains(n.*, 'cat wearing')";
+        Query query = session.getWorkspace().getQueryManager().createQuery(sql, Query.JCR_SQL2);
+        QueryResult result = query.execute();
+        validateQuery().rowCount(1).hasColumns("jcr:path").validate(query, result);
+    }
+
+    @FixFor( "MODE-1418" )
+    @Test
+    public void shouldBeAbleToCreateAndExecuteJcrSql2QueryWithFullTextSearchWithNoSelectorAndOneProperty()
+            throws RepositoryException {
+        String sql = "select [jcr:path] from [nt:unstructured] as n where contains(something,'cat wearing')";
+        Query query = session.getWorkspace().getQueryManager().createQuery(sql, Query.JCR_SQL2);
+        QueryResult result = query.execute();
+        validateQuery().rowCount(1).hasColumns("jcr:path").hasNodesAtPaths("/Other/NodeA[2]").validate(query, result);
+    }
+
+    @FixFor( "MODE-1829" )
+    @Test
+    public void shouldBeAbleToCreateAndExecuteJcrSql2QueryWithFullTextSearchUsingLeadingWildcard() throws RepositoryException {
+        String sql = "select [jcr:path] from [nt:unstructured] as n where contains(n.something, '*earing')";
+        Query query = session.getWorkspace().getQueryManager().createQuery(sql, Query.JCR_SQL2);
+        QueryResult result = query.execute();
+        validateQuery().rowCount(1).hasColumns("jcr:path").validate(query, result);
+
+        sql = "select [jcr:path] from [nt:unstructured] as n where contains(n.something, '*earing*')";
+        query = session.getWorkspace().getQueryManager().createQuery(sql, Query.JCR_SQL2);
+        result = query.execute();
+        validateQuery().rowCount(1).hasColumns("jcr:path").validate(query, result);
+    }
+
+    @FixFor( "MODE-1829" )
+    @Test
+    public void shouldBeAbleToCreateAndExecuteJcrSql2QueryWithFullTextSearchUsingTrailingWildcard() throws RepositoryException {
+        String sql = "select [jcr:path] from [nt:unstructured] as n where contains(n.something, 'wea*')";
+        Query query = session.getWorkspace().getQueryManager().createQuery(sql, Query.JCR_SQL2);
+        QueryResult result = query.execute();
+        validateQuery().rowCount(1).hasColumns("jcr:path").validate(query, result);
+    }
+
+    @Test
+    @FixFor( "MODE-1547" )
+    public void shouldBeAbleToExecuteFullTextSearchQueriesOnPropertiesWhichIncludeStopWords() throws Exception {
+        String propertyText = "the quick Brown fox jumps over to the dog in at the gate";
+        Node ftsNode = session.getRootNode().addNode("FTSNode").setProperty("FTSProp", propertyText).getParent();
+        try {
+            session.save();
+
+            executeQueryWithSingleResult("select [jcr:path] from [nt:unstructured] as n where contains([nt:unstructured].*,'"
+                                         + propertyText + "')");
+
+            executeQueryWithSingleResult("select [jcr:path] from [nt:unstructured] as n where contains(FTSProp,'" + propertyText
+                                         + "')");
+            executeQueryWithSingleResult("select [jcr:path] from [nt:unstructured] as n where contains(n.*,'" + propertyText
+                                         + "')");
+
+            executeQueryWithSingleResult("select [jcr:path] from [nt:unstructured] as n where contains(FTSProp,'"
+                                         + propertyText.toUpperCase() + "')");
+            executeQueryWithSingleResult("select [jcr:path] from [nt:unstructured] as n where contains(n.*,'"
+                                         + propertyText.toUpperCase() + "')");
+
+            executeQueryWithSingleResult(
+                    "select [jcr:path] from [nt:unstructured] as n where contains(FTSProp,'the quick Dog')");
+            executeQueryWithSingleResult("select [jcr:path] from [nt:unstructured] as n where contains(n.*,'the quick Dog')");
+
+            executeQueryWithSingleResult(
+                    "select [jcr:path] from [nt:unstructured] as n where contains(FTSProp,'the quick jumps over gate')");
+            executeQueryWithSingleResult(
+                    "select [jcr:path] from [nt:unstructured] as n where contains(n.*,'the quick jumps over gate')");
+
+            executeQueryWithSingleResult("select [jcr:path] from [nt:unstructured] as n where contains(FTSProp,'the gate')");
+            executeQueryWithSingleResult("select [jcr:path] from [nt:unstructured] as n where contains(n.*,'the gate')");
+        } finally {
+            // Try to remove the node (which messes up the expected results from subsequent tests) ...
+            ftsNode.remove();
+            session.save();
+        }
+    }
+
+    private void executeQueryWithSingleResult( String sql ) throws RepositoryException {
+        Query query = session.getWorkspace().getQueryManager().createQuery(sql, JcrRepository.QueryLanguage.JCR_SQL2);
+        QueryResult result = query.execute();
+        validateQuery().rowCount(1).hasColumns("jcr:path").validate(query, result);
+    }
+
+    @FixFor( "MODE-1840" )
+    @Test
+    public void shouldBeAbleToCreateAndExecuteJcrSql2QueryWithBindVariableInsideContains() throws RepositoryException {
+        String sql = "select [jcr:path] from [nt:unstructured] as n where contains(n.something, $expression)";
+        Query query = session.getWorkspace().getQueryManager().createQuery(sql, Query.JCR_SQL2);
+        query.bindValue("expression", session.getValueFactory().createValue("cat wearing"));
+        QueryResult result = query.execute();
+        validateQuery().rowCount(1).hasColumns("jcr:path").hasNodesAtPaths("/Other/NodeA[2]").validate(query, result);
+    }
 
     @FixFor( "MODE-1840" )
     @Test( expected = InvalidQueryException.class )
@@ -2922,65 +2924,64 @@ public class JcrQueryManagerTest extends MultiUseAbstractTest {
         }
     }
 
-    //
-    // @FixFor( "MODE-2027" )
-    // @Test
-    // public void shouldSearchAllPropertiesUsingDotSelectorJCRSql2FullTextSearch() throws RepositoryException {
-    // String sql = "SELECT cars.[jcr:path] FROM [car:Car] AS cars WHERE contains(., 'Toyota') ";
-    // Query query = session.getWorkspace().getQueryManager().createQuery(sql, Query.JCR_SQL2);
-    // final List<String> actual = new ArrayList<String>();
-    // validateQuery().onEachRow(new Predicate() {
-    // @Override
-    // public void validate( int rowNumber,
-    // Row row ) throws RepositoryException {
-    // actual.add(row.getNode().getIdentifier());
-    // }
-    // }).validate(query, query.execute());
-    //
-    // sql = "SELECT cars.[jcr:path] FROM [car:Car] AS cars WHERE contains(cars.*, 'Toyota')";
-    // query = session.getWorkspace().getQueryManager().createQuery(sql, Query.JCR_SQL2);
-    // final List<String> expected = new ArrayList<String>();
-    // validateQuery().rowCount(actual.size()).onEachRow(new Predicate() {
-    // @Override
-    // public void validate( int rowNumber,
-    // Row row ) throws RepositoryException {
-    // expected.add(row.getNode().getIdentifier());
-    // }
-    // }).validate(query, query.execute());
-    //
-    // assertEquals(expected, actual);
-    // }
-    //
-    // @FixFor( "MODE-2062" )
-    // @Test
-    // public void fullTextShouldWorkWithBindVar() throws Exception {
-    // Node n1 = session.getRootNode().addNode("n1");
-    // n1.setProperty("n1-prop-1", "wow");
-    // n1.setProperty("n1-prop-2", "any");
-    //
-    // Node n2 = session.getRootNode().addNode("n2");
-    // n2.setProperty("n2-prop-1", "test");
-    //
-    // try {
-    // session.save();
-    //
-    // // test with literal
-    // String queryString = "select * from [nt:unstructured] as a where contains(a.*, 'wow')";
-    // assertNodesAreFound(queryString, Query.JCR_SQL2, "/n1");
-    //
-    // // test with bind
-    // String queryStringWithBind = "select * from [nt:unstructured] as a where contains(a.*, $text)";
-    // QueryManager queryManager = session.getWorkspace().getQueryManager();
-    // Query query = queryManager.createQuery(queryStringWithBind, Query.JCR_SQL2);
-    // query.bindValue("text", session.getValueFactory().createValue("wow"));
-    // QueryResult result = query.execute();
-    // validateQuery().rowCount(1).hasNodesAtPaths("/n1").validate(query, result);
-    // } finally {
-    // n1.remove();
-    // n2.remove();
-    // session.save();
-    // }
-    // }
+    @FixFor( "MODE-2027" )
+    @Test
+    public void shouldSearchAllPropertiesUsingDotSelectorJCRSql2FullTextSearch() throws RepositoryException {
+        String sql = "SELECT cars.[jcr:path] FROM [car:Car] AS cars WHERE contains(., 'Toyota') ";
+        Query query = session.getWorkspace().getQueryManager().createQuery(sql, Query.JCR_SQL2);
+        final List<String> actual = new ArrayList<String>();
+        validateQuery().onEachRow(new Predicate() {
+            @Override
+            public void validate( int rowNumber,
+                                  Row row ) throws RepositoryException {
+                actual.add(row.getNode().getIdentifier());
+            }
+        }).validate(query, query.execute());
+
+        sql = "SELECT cars.[jcr:path] FROM [car:Car] AS cars WHERE contains(cars.*, 'Toyota')";
+        query = session.getWorkspace().getQueryManager().createQuery(sql, Query.JCR_SQL2);
+        final List<String> expected = new ArrayList<String>();
+        validateQuery().rowCount(actual.size()).onEachRow(new Predicate() {
+            @Override
+            public void validate( int rowNumber,
+                                  Row row ) throws RepositoryException {
+                expected.add(row.getNode().getIdentifier());
+            }
+        }).validate(query, query.execute());
+
+        assertEquals(expected, actual);
+    }
+
+    @FixFor( "MODE-2062" )
+    @Test
+    public void fullTextShouldWorkWithBindVar() throws Exception {
+        Node n1 = session.getRootNode().addNode("n1");
+        n1.setProperty("n1-prop-1", "wow");
+        n1.setProperty("n1-prop-2", "any");
+
+        Node n2 = session.getRootNode().addNode("n2");
+        n2.setProperty("n2-prop-1", "test");
+
+        try {
+            session.save();
+
+            // test with literal
+            String queryString = "select * from [nt:unstructured] as a where contains(a.*, 'wow')";
+            assertNodesAreFound(queryString, Query.JCR_SQL2, "/n1");
+
+            // test with bind
+            String queryStringWithBind = "select * from [nt:unstructured] as a where contains(a.*, $text)";
+            QueryManager queryManager = session.getWorkspace().getQueryManager();
+            Query query = queryManager.createQuery(queryStringWithBind, Query.JCR_SQL2);
+            query.bindValue("text", session.getValueFactory().createValue("wow"));
+            QueryResult result = query.execute();
+            validateQuery().rowCount(1).hasNodesAtPaths("/n1").validate(query, result);
+        } finally {
+            n1.remove();
+            n2.remove();
+            session.save();
+        }
+    }
 
     @FixFor( "MODE-2095" )
     @Test
@@ -3006,29 +3007,29 @@ public class JcrQueryManagerTest extends MultiUseAbstractTest {
     // // Full-text Search Queries
     // // ----------------------------------------------------------------------------------------------------------------
     //
-    // @FixFor( "MODE-1418" )
-    // @Test
-    // public void shouldBeAbleToCreateAndExecuteFullTextSearchQueryOfPhrase() throws RepositoryException {
-    // Query query = session.getWorkspace().getQueryManager().createQuery("cat wearing", JcrRepository.QueryLanguage.SEARCH);
-    // QueryResult result = query.execute();
-    // validateQuery().rowCount(1).hasColumns(searchColumnNames()).validate(query, result);
-    // }
-    //
-    // @FixFor( "MODE-905" )
-    // @Test
-    // public void shouldBeAbleToCreateAndExecuteFullTextSearchQuery() throws RepositoryException {
-    // Query query = session.getWorkspace().getQueryManager().createQuery("land", JcrRepository.QueryLanguage.SEARCH);
-    // QueryResult result = query.execute();
-    // validateQuery().rowCount(3).hasColumns(searchColumnNames()).validate(query, result);
-    // }
-    //
-    // @FixFor( "MODE-905" )
-    // @Test
-    // public void shouldBeAbleToCreateAndExecuteFullTextSearchQueryWithName() throws RepositoryException {
-    // Query query = session.getWorkspace().getQueryManager().createQuery("highlander", JcrRepository.QueryLanguage.SEARCH);
-    // QueryResult result = query.execute();
-    // validateQuery().rowCount(1).hasColumns(searchColumnNames()).validate(query, result);
-    // }
+    @FixFor( "MODE-1418" )
+    @Test
+    public void shouldBeAbleToCreateAndExecuteFullTextSearchQueryOfPhrase() throws RepositoryException {
+        Query query = session.getWorkspace().getQueryManager().createQuery("cat wearing", JcrRepository.QueryLanguage.SEARCH);
+        QueryResult result = query.execute();
+        validateQuery().rowCount(1).hasColumns(searchColumnNames()).validate(query, result);
+    }
+
+    @FixFor( "MODE-905" )
+    @Test
+    public void shouldBeAbleToCreateAndExecuteFullTextSearchQuery() throws RepositoryException {
+        Query query = session.getWorkspace().getQueryManager().createQuery("land", JcrRepository.QueryLanguage.SEARCH);
+        QueryResult result = query.execute();
+        validateQuery().rowCount(4).hasColumns(searchColumnNames()).validate(query, result);
+    }
+
+    @FixFor( "MODE-905" )
+    @Test
+    public void shouldBeAbleToCreateAndExecuteFullTextSearchQueryWithName() throws RepositoryException {
+        Query query = session.getWorkspace().getQueryManager().createQuery("highlander", JcrRepository.QueryLanguage.SEARCH);
+        QueryResult result = query.execute();
+        validateQuery().rowCount(1).hasColumns(searchColumnNames()).validate(query, result);
+    }
 
     // ----------------------------------------------------------------------------------------------------------------
     // JCR-SQL Queries
@@ -3423,134 +3424,134 @@ public class JcrQueryManagerTest extends MultiUseAbstractTest {
         }
     }
 
-    // @SuppressWarnings( "deprecation" )
-    // @Test
-    // public void shouldBeAbleToExecuteXPathQueryWithContainsCriteria() throws RepositoryException {
-    // String xpath = "/jcr:root//*[jcr:contains(., 'liter')]";
-    // Query query = session.getWorkspace().getQueryManager().createQuery(xpath, Query.XPATH);
-    // assertThat(query, is(notNullValue()));
-    // QueryResult result = query.execute();
-    // validateQuery().rowCount(1).hasColumns("jcr:primaryType", "jcr:path", "jcr:score").validate(query, result);
-    // }
-    //
-    // @SuppressWarnings( "deprecation" )
-    // @Test
-    // public void shouldBeAbleToExecuteXPathQueryWithContainsCriteriaAndPluralWord() throws RepositoryException {
-    // String xpath = "/jcr:root//*[jcr:contains(., 'liters')]";
-    // Query query = session.getWorkspace().getQueryManager().createQuery(xpath, Query.XPATH);
-    // assertThat(query, is(notNullValue()));
-    // QueryResult result = query.execute();
-    // validateQuery().rowCount(1).hasColumns("jcr:primaryType", "jcr:path", "jcr:score").validate(query, result);
-    // }
-    //
-    // @SuppressWarnings( "deprecation" )
-    // @Test
-    // public void shouldBeAbleToExecuteXPathQueryWithComplexContainsCriteria() throws RepositoryException {
-    // String xpath = "/jcr:root//*[jcr:contains(., '\"liters V 12\"')]";
-    // Query query = session.getWorkspace().getQueryManager().createQuery(xpath, Query.XPATH);
-    // assertThat(query, is(notNullValue()));
-    // QueryResult result = query.execute();
-    // validateQuery().rowCount(1).hasColumns("jcr:primaryType", "jcr:path", "jcr:score").validate(query, result);
-    // }
-    //
-    // @SuppressWarnings( "deprecation" )
-    // @Test
-    // public void shouldBeAbleToExecuteXPathQueryWithComplexContainsCriteriaWithHyphen() throws RepositoryException {
-    // String xpath = "/jcr:root//*[jcr:contains(., '\"5-speed\"')]";
-    // Query query = session.getWorkspace().getQueryManager().createQuery(xpath, Query.XPATH);
-    // QueryResult result = query.execute();
-    // validateQuery().rowCount(1).hasColumns("jcr:primaryType", "jcr:path", "jcr:score").validate(query, result);
-    // }
-    //
-    // @SuppressWarnings( "deprecation" )
-    // @Test
-    // public void shouldBeAbleToExecuteXPathQueryWithComplexContainsCriteriaWithHyphenAndNumberAndWildcard()
-    // throws RepositoryException {
-    // String xpath = "/jcr:root//*[jcr:contains(., '\"spee*\"')]";
-    // Query query = session.getWorkspace().getQueryManager().createQuery(xpath, Query.XPATH);
-    // QueryResult result = query.execute();
-    // validateQuery().rowCount(2).hasColumns("jcr:primaryType", "jcr:path", "jcr:score").validate(query, result);
-    // }
-    //
-    // @SuppressWarnings( "deprecation" )
-    // @Test
-    // public void shouldBeAbleToExecuteXPathQueryWithComplexContainsCriteriaWithNoHyphenAndNoWildcard() throws
-    // RepositoryException {
-    // String xpath = "/jcr:root//*[jcr:contains(., '\"heavy duty\"')]";
-    // Query query = session.getWorkspace().getQueryManager().createQuery(xpath, Query.XPATH);
-    // QueryResult result = query.execute();
-    // validateQuery().rowCount(1).hasColumns("jcr:primaryType", "jcr:path", "jcr:score").validate(query, result);
-    // }
-    //
-    // @SuppressWarnings( "deprecation" )
-    // @Test
-    // public void shouldBeAbleToExecuteXPathQueryWithComplexContainsCriteriaWithHyphenAndNoWildcard() throws RepositoryException
-    // {
-    // String xpath = "/jcr:root//*[jcr:contains(., '\"heavy-duty\"')]";
-    // Query query = session.getWorkspace().getQueryManager().createQuery(xpath, Query.XPATH);
-    // QueryResult result = query.execute();
-    // validateQuery().rowCount(1).hasColumns("jcr:primaryType", "jcr:path", "jcr:score").validate(query, result);
-    // }
-    //
-    // @SuppressWarnings( "deprecation" )
-    // @Test
-    // public void shouldBeAbleToExecuteXPathQueryWithComplexContainsCriteriaWithNoHyphenAndWildcard() throws RepositoryException
-    // {
-    // String xpath = "/jcr:root//*[jcr:contains(., '\"heavy du*\"')]";
-    // Query query = session.getWorkspace().getQueryManager().createQuery(xpath, Query.XPATH);
-    // QueryResult result = query.execute();
-    // validateQuery().rowCount(1).hasColumns("jcr:primaryType", "jcr:path", "jcr:score").validate(query, result);
-    // }
-    //
-    // @SuppressWarnings( "deprecation" )
-    // @Test
-    // public void shouldBeAbleToExecuteXPathQueryWithComplexContainsCriteriaWithNoHyphenAndLeadingWildcard()
-    // throws RepositoryException {
-    // String xpath = "/jcr:root//*[jcr:contains(., '\"*avy duty\"')]";
-    // Query query = session.getWorkspace().getQueryManager().createQuery(xpath, Query.XPATH);
-    // QueryResult result = query.execute();
-    // validateQuery().rowCount(1).hasColumns("jcr:primaryType", "jcr:path", "jcr:score").validate(query, result);
-    // }
-    //
-    // @SuppressWarnings( "deprecation" )
-    // @Test
-    // public void shouldBeAbleToExecuteXPathQueryWithComplexContainsCriteriaWithHyphenAndWildcard() throws RepositoryException {
-    // String xpath = "/jcr:root//*[jcr:contains(., '\"heavy-du*\"')]";
-    // Query query = session.getWorkspace().getQueryManager().createQuery(xpath, Query.XPATH);
-    // QueryResult result = query.execute();
-    // validateQuery().rowCount(1).hasColumns("jcr:primaryType", "jcr:path", "jcr:score").validate(query, result);
-    // }
-    //
-    // @Ignore
-    // @SuppressWarnings( "deprecation" )
-    // @Test
-    // public void shouldBeAbleToExecuteXPathQueryWithComplexContainsCriteriaWithHyphenAndLeadingWildcard()
-    // throws RepositoryException {
-    // String xpath = "/jcr:root//*[jcr:contains(., '\"*-speed\"')]";
-    // Query query = session.getWorkspace().getQueryManager().createQuery(xpath, Query.XPATH);
-    // QueryResult result = query.execute();
-    // validateQuery().rowCount(2).hasColumns("jcr:primaryType", "jcr:path", "jcr:score").validate(query, result);
-    // }
-    //
-    // @FixFor( "MODE-790" )
-    // @SuppressWarnings( "deprecation" )
-    // @Test
-    // public void shouldBeAbleToExecuteXPathQueryWithCompoundCriteria() throws Exception {
-    // String xpath = "/jcr:root/Cars//element(*,car:Car)[@car:year='2008' and jcr:contains(., '\"liters V 12\"')]";
-    // Query query = session.getWorkspace().getQueryManager().createQuery(xpath, Query.XPATH);
-    // QueryResult result = query.execute();
-    // String[] columnNames = {"jcr:primaryType", "jcr:mixinTypes", "jcr:path", "jcr:score", "jcr:created",
-    // "jcr:createdBy", "jcr:name", "mode:localName", "mode:depth", "car:mpgCity", "car:userRating",
-    // "car:mpgHighway", "car:engine", "car:model", "car:year", "car:maker", "car:lengthInInches",
-    // "car:valueRating", "car:wheelbaseInInches", "car:msrp", "car:alternateModels"};
-    // validateQuery().rowCount(1).hasColumns(columnNames).validate(query, result);
-    //
-    // // Query again with a different criteria that should return no nodes ...
-    // xpath = "/jcr:root/Cars//element(*,car:Car)[@car:year='2007' and jcr:contains(., '\"liter V 12\"')]";
-    // query = session.getWorkspace().getQueryManager().createQuery(xpath, Query.XPATH);
-    // result = query.execute();
-    // validateQuery().rowCount(0).hasColumns(columnNames).validate(query, result);
-    // }
+    @SuppressWarnings( "deprecation" )
+    @Test
+    public void shouldBeAbleToExecuteXPathQueryWithContainsCriteria() throws RepositoryException {
+        String xpath = "/jcr:root//*[jcr:contains(., 'liter')]";
+        Query query = session.getWorkspace().getQueryManager().createQuery(xpath, Query.XPATH);
+        assertThat(query, is(notNullValue()));
+        QueryResult result = query.execute();
+        validateQuery().rowCount(2).hasColumns("jcr:primaryType", "jcr:path", "jcr:score").validate(query, result);
+    }
+
+    @SuppressWarnings( "deprecation" )
+    @Test
+    public void shouldBeAbleToExecuteXPathQueryWithContainsCriteriaAndPluralWord() throws RepositoryException {
+        String xpath = "/jcr:root//*[jcr:contains(., 'liters')]";
+        Query query = session.getWorkspace().getQueryManager().createQuery(xpath, Query.XPATH);
+        assertThat(query, is(notNullValue()));
+        QueryResult result = query.execute();
+        validateQuery().rowCount(1).hasColumns("jcr:primaryType", "jcr:path", "jcr:score").validate(query, result);
+    }
+
+    @SuppressWarnings( "deprecation" )
+    @Test
+    public void shouldBeAbleToExecuteXPathQueryWithComplexContainsCriteria() throws RepositoryException {
+        String xpath = "/jcr:root//*[jcr:contains(., '\"liters V 12\"')]";
+        Query query = session.getWorkspace().getQueryManager().createQuery(xpath, Query.XPATH);
+        assertThat(query, is(notNullValue()));
+        QueryResult result = query.execute();
+        validateQuery().rowCount(1).hasColumns("jcr:primaryType", "jcr:path", "jcr:score").validate(query, result);
+    }
+
+    @SuppressWarnings( "deprecation" )
+    @Test
+    public void shouldBeAbleToExecuteXPathQueryWithComplexContainsCriteriaWithHyphen() throws RepositoryException {
+        String xpath = "/jcr:root//*[jcr:contains(., '\"5-speed\"')]";
+        Query query = session.getWorkspace().getQueryManager().createQuery(xpath, Query.XPATH);
+        QueryResult result = query.execute();
+        validateQuery().rowCount(1).hasColumns("jcr:primaryType", "jcr:path", "jcr:score").validate(query, result);
+    }
+
+    @SuppressWarnings( "deprecation" )
+    @Test
+    public void shouldBeAbleToExecuteXPathQueryWithComplexContainsCriteriaWithHyphenAndNumberAndWildcard()
+            throws RepositoryException {
+        String xpath = "/jcr:root//*[jcr:contains(., '\"spee*\"')]";
+        Query query = session.getWorkspace().getQueryManager().createQuery(xpath, Query.XPATH);
+        QueryResult result = query.execute();
+        validateQuery().rowCount(2).hasColumns("jcr:primaryType", "jcr:path", "jcr:score").validate(query, result);
+    }
+
+    @SuppressWarnings( "deprecation" )
+    @Test
+    public void shouldBeAbleToExecuteXPathQueryWithComplexContainsCriteriaWithNoHyphenAndNoWildcard() throws
+                                                                                                      RepositoryException {
+        String xpath = "/jcr:root//*[jcr:contains(., '\"heavy duty\"')]";
+        Query query = session.getWorkspace().getQueryManager().createQuery(xpath, Query.XPATH);
+        QueryResult result = query.execute();
+
+        //by default there is no stemming or punctuation replacement
+        assertFalse(result.getRows().hasNext());
+    }
+
+    @SuppressWarnings( "deprecation" )
+    @Test
+    public void shouldBeAbleToExecuteXPathQueryWithComplexContainsCriteriaWithHyphenAndNoWildcard() throws RepositoryException {
+        String xpath = "/jcr:root//*[jcr:contains(., '\"heavy-duty\"')]";
+        Query query = session.getWorkspace().getQueryManager().createQuery(xpath, Query.XPATH);
+        QueryResult result = query.execute();
+        validateQuery().rowCount(1).hasColumns("jcr:primaryType", "jcr:path", "jcr:score").validate(query, result);
+    }
+
+    @SuppressWarnings( "deprecation" )
+    @Test
+    public void shouldBeAbleToExecuteXPathQueryWithComplexContainsCriteriaWithNoHyphenAndWildcard() throws RepositoryException {
+        String xpath = "/jcr:root//*[jcr:contains(., '\"heavy-du*\"')]";
+        Query query = session.getWorkspace().getQueryManager().createQuery(xpath, Query.XPATH);
+        QueryResult result = query.execute();
+        validateQuery().rowCount(1).hasColumns("jcr:primaryType", "jcr:path", "jcr:score").validate(query, result);
+    }
+
+    @SuppressWarnings( "deprecation" )
+    @Test
+    public void shouldBeAbleToExecuteXPathQueryWithComplexContainsCriteriaWithNoHyphenAndLeadingWildcard()
+            throws RepositoryException {
+        String xpath = "/jcr:root//*[jcr:contains(., '\"*avy-duty\"')]";
+        Query query = session.getWorkspace().getQueryManager().createQuery(xpath, Query.XPATH);
+        QueryResult result = query.execute();
+        validateQuery().rowCount(1).hasColumns("jcr:primaryType", "jcr:path", "jcr:score").validate(query, result);
+    }
+
+    @SuppressWarnings( "deprecation" )
+    @Test
+    public void shouldBeAbleToExecuteXPathQueryWithComplexContainsCriteriaWithHyphenAndWildcard() throws RepositoryException {
+        String xpath = "/jcr:root//*[jcr:contains(., '\"heavy-du*\"')]";
+        Query query = session.getWorkspace().getQueryManager().createQuery(xpath, Query.XPATH);
+        QueryResult result = query.execute();
+        validateQuery().rowCount(1).hasColumns("jcr:primaryType", "jcr:path", "jcr:score").validate(query, result);
+    }
+
+    @Ignore
+    @SuppressWarnings( "deprecation" )
+    @Test
+    public void shouldBeAbleToExecuteXPathQueryWithComplexContainsCriteriaWithHyphenAndLeadingWildcard()
+            throws RepositoryException {
+        String xpath = "/jcr:root//*[jcr:contains(., '\"*-speed\"')]";
+        Query query = session.getWorkspace().getQueryManager().createQuery(xpath, Query.XPATH);
+        QueryResult result = query.execute();
+        validateQuery().rowCount(2).hasColumns("jcr:primaryType", "jcr:path", "jcr:score").validate(query, result);
+    }
+
+    @FixFor( "MODE-790" )
+    @SuppressWarnings( "deprecation" )
+    @Test
+    public void shouldBeAbleToExecuteXPathQueryWithCompoundCriteria() throws Exception {
+        String xpath = "/jcr:root/Cars//element(*,car:Car)[@car:year='2008' and jcr:contains(., '\"liters V 12\"')]";
+        Query query = session.getWorkspace().getQueryManager().createQuery(xpath, Query.XPATH);
+        QueryResult result = query.execute();
+        String[] columnNames = { "jcr:primaryType", "jcr:mixinTypes", "jcr:path", "jcr:score", "jcr:created",
+                                 "jcr:createdBy", "jcr:name", "mode:localName", "mode:depth", "car:mpgCity", "car:userRating",
+                                 "car:mpgHighway", "car:engine", "car:model", "car:year", "car:maker", "car:lengthInInches",
+                                 "car:valueRating", "car:wheelbaseInInches", "car:msrp", "car:alternateModels" };
+        validateQuery().rowCount(1).hasColumns(columnNames).validate(query, result);
+
+        // Query again with a different criteria that should return no nodes ...
+        xpath = "/jcr:root/Cars//element(*,car:Car)[@car:year='2007' and jcr:contains(., '\"liter V 12\"')]";
+        query = session.getWorkspace().getQueryManager().createQuery(xpath, Query.XPATH);
+        result = query.execute();
+        validateQuery().rowCount(0).hasColumns(columnNames).validate(query, result);
+    }
 
     @SuppressWarnings( "deprecation" )
     @Test
@@ -3656,21 +3657,16 @@ public class JcrQueryManagerTest extends MultiUseAbstractTest {
         }).validate(query, result);
     }
 
-    // @FixFor( "MODE-1144" )
-    // @SuppressWarnings( "deprecation" )
-    // @Test
-    // public void shouldParseMagnoliaXPathQuery() throws Exception {
-    // String xpath = "//*[@jcr:primaryType='mgnl:content']//*[jcr:contains(., 'paragraph')]";
-    // Query query = session.getWorkspace().getQueryManager().createQuery(xpath, Query.XPATH);
-    // QueryResult result = query.execute();
-    // validateQuery().rowCount(1).hasColumns("jcr:primaryType", "jcr:path", "jcr:score").onEachRow(new Predicate() {
-    // @Override
-    // public void validate( int rowNumber,
-    // Row row ) throws RepositoryException {
-    // assertThat(row.getNode().hasProperty("car:wheelbaseInInches"), is(true));
-    // }
-    // }).validate(query, result);
-    // }
+    @FixFor( "MODE-1144" )
+    @SuppressWarnings( "deprecation" )
+    @Test
+    public void shouldParseMagnoliaXPathQuery() throws Exception {
+        String xpath = "//*[@jcr:primaryType='mgnl:content']//*[jcr:contains(., 'paragraph')]";
+        Query query = session.getWorkspace().getQueryManager().createQuery(xpath, Query.XPATH);
+        QueryResult result = query.execute();
+        assertNotNull(result);
+        assertFalse(result.getRows().hasNext());
+    }
 
     // ----------------------------------------------------------------------------------------------------------------
     // QOM Queries


### PR DESCRIPTION
No stemming or punctuation processing is done by default (unlike what Lucene did in 3.x) which means that some of the tests had to be adapted. Also, enabled back the tests that had been previously disabled for full text search.
