### PR TITLE
MODE-2224 Java Source File Sequencer Problems When Sequencing Interfaces, Typed Collections, And Nested Types

### DIFF
--- a/sequencers/modeshape-sequencer-java/src/main/java/org/modeshape/sequencer/classfile/ClassFileSequencerLexicon.java
+++ b/sequencers/modeshape-sequencer-java/src/main/java/org/modeshape/sequencer/classfile/ClassFileSequencerLexicon.java
@@ -61,6 +61,89 @@ public class ClassFileSequencerLexicon {
     public static final String VISIBILITY = PREFIX + ":visibility";
     public static final String VOLATILE = PREFIX + ":volatile";
 
+    public static final String ANNOTATION_TYPE = PREFIX + ":annotationType";
+    public static final String ANNOTATION_TYPE_MEMBER = PREFIX + ":annotationTypeMember";
+    public static final String ANNOTATION_TYPE_MEMBERS = PREFIX + ":annotationTypeMembers";
+    public static final String ARGUMENT = PREFIX + ":argument";
+    public static final String ARGUMENTS = PREFIX + ":arguments";
+    public static final String ARRAY_TYPE = PREFIX + ":arrayType";
+    public static final String BASE_TYPE = PREFIX + ":baseType";
+    public static final String BODY = PREFIX + ":body";
+    public static final String BOUND = PREFIX + ":bound";
+    public static final String BOUNDS = PREFIX + ":bounds";
+    public static final String BOUND_TYPE = PREFIX + ":boundType";
+    public static final String COMMENT = PREFIX + ":comment";
+    public static final String COMMENTS = PREFIX + ":comments";
+    public static final String COMMENT_TYPE = PREFIX + ":commentType";
+    public static final String COMPILATION_UNIT = PREFIX + ":compilationUnit";
+    public static final String COMPONENT_TYPE = PREFIX + ":componentType";
+    public static final String CONTENT = PREFIX + ":content";
+    public static final String DEFAULT = PREFIX + ":default";
+    public static final String DIMENSIONS = PREFIX + ":dimensions";
+    public static final String DOCUMENTED = PREFIX + ":documented";
+    public static final String ENUM_CONSTANT = PREFIX + ":enumConstant";
+    public static final String ENUM_CONSTANTS = PREFIX + ":enumConstants";
+    public static final String EXPRESSION = PREFIX + ":expression";
+    public static final String EXTENDS = PREFIX + ":extends";
+    public static final String IMPLEMENTS = PREFIX + ":implements";
+    public static final String IMPORT = PREFIX + ":import";
+    public static final String INITIALIZER = PREFIX + ":initializer";
+    public static final String JAVADOC = PREFIX + ":javadoc";
+    public static final String LENGTH = PREFIX + ":length";
+    public static final String MESSAGE = PREFIX + ":message";
+    public static final String MESSAGES = PREFIX + ":messages";
+    public static final String NESTED_TYPES = PREFIX + ":nestedTypes";
+    public static final String ON_DEMAND = PREFIX + ":onDemand";
+    public static final String PARAMETERIZED_TYPE = PREFIX + ":parameterizedType";
+    public static final String PRIMITIVE_TYPE = PREFIX + ":primitiveType";
+    public static final String QUALIFIED_TYPE = PREFIX + ":qualifiedType";
+    public static final String QUALIFIER = PREFIX + ":qualifier";
+    public static final String RETURN_TYPE = PREFIX + ":returnType";
+    public static final String SIMPLE_TYPE = PREFIX + ":simpleType";
+    public static final String SOURCE_LOCATION = PREFIX + ":sourceLocation";
+    public static final String START_POSITION = PREFIX + ":startPosition";
+    public static final String STATEMENT = PREFIX + ":statement";
+    public static final String STATEMENTS = PREFIX + ":statements";
+    public static final String THROWN_EXCEPTIONS = PREFIX + ":thrownExceptions";
+    public static final String TYPE = PREFIX + ":type";
+    public static final String TYPES = PREFIX + ":types";
+    public static final String TYPE_PARAMETER = PREFIX + ":typeParameter";
+    public static final String TYPE_PARAMETERS = PREFIX + ":typeParameters";
+    public static final String WILDCARD_TYPE = PREFIX + ":wildcardType";
+    public static final String VARARGS = PREFIX + ":varargs";
+
+    /**
+     * The types of comments.
+     */
+    public enum CommentType {
+
+        BLOCK,
+        JAVADOC,
+        LINE
+
+    }
+
+    /**
+     * The types of annotations.
+     */
+    public enum AnnotationType {
+
+        MARKER,
+        NORMAL,
+        SINGLE_MEMBER
+
+    }
+
+    /**
+     * The kind of wildcard type bounds.
+     */
+    public enum WildcardTypeBound {
+
+        LOWER,
+        UPPER
+
+    }
+
     private ClassFileSequencerLexicon() {
     }
 }

--- a/sequencers/modeshape-sequencer-java/src/main/java/org/modeshape/sequencer/javafile/ClassSourceFileRecorder.java
+++ b/sequencers/modeshape-sequencer-java/src/main/java/org/modeshape/sequencer/javafile/ClassSourceFileRecorder.java
@@ -48,6 +48,7 @@ import static org.modeshape.sequencer.classfile.ClassFileSequencerLexicon.TYPE_C
 import static org.modeshape.sequencer.classfile.ClassFileSequencerLexicon.VALUE;
 import static org.modeshape.sequencer.classfile.ClassFileSequencerLexicon.VISIBILITY;
 import static org.modeshape.sequencer.classfile.ClassFileSequencerLexicon.VOLATILE;
+import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -55,6 +56,7 @@ import javax.jcr.Node;
 import javax.jcr.RepositoryException;
 import org.modeshape.common.util.StringUtil;
 import org.modeshape.jcr.api.sequencer.Sequencer;
+import org.modeshape.jcr.api.sequencer.Sequencer.Context;
 import org.modeshape.sequencer.classfile.metadata.Visibility;
 import org.modeshape.sequencer.javafile.metadata.AbstractMetadata;
 import org.modeshape.sequencer.javafile.metadata.AnnotationMetadata;
@@ -71,8 +73,22 @@ import org.modeshape.sequencer.javafile.metadata.TypeMetadata;
  */
 public class ClassSourceFileRecorder implements SourceFileRecorder {
 
+    /**
+     * {@inheritDoc}
+     *
+     * @see org.modeshape.sequencer.javafile.SourceFileRecorder#record(org.modeshape.jcr.api.sequencer.Sequencer.Context, java.io.InputStream, long, java.lang.String, javax.jcr.Node)
+     */
     @Override
-    public void record( Sequencer.Context context,
+    public void record( final Context context,
+                        final InputStream inputStream,
+                        final long length,
+                        final String encoding,
+                        final Node outputNode ) throws Exception {
+            JavaMetadata javaMetadata = JavaMetadata.instance(inputStream, length, encoding);
+            record(context, outputNode, javaMetadata);
+    }
+
+    private void record( Sequencer.Context context,
                         Node outputNode,
                         JavaMetadata javaMetadata ) throws RepositoryException {
         String packageName = javaMetadata.getPackageMetadata().getName();
@@ -134,8 +150,8 @@ public class ClassSourceFileRecorder implements SourceFileRecorder {
                                          Node typeNode,
                                          TypeMetadata typeMetadata ) throws RepositoryException {
         /*
-        - class:name (string) mandatory 
-        - class:superTypeName (string) 
+        - class:name (string) mandatory
+        - class:superTypeName (string)
         - class:visibility (string) mandatory < 'public', 'protected', 'package', 'private'
         - class:abstract (boolean) mandatory
         - class:interface (boolean) mandatory
@@ -187,12 +203,12 @@ public class ClassSourceFileRecorder implements SourceFileRecorder {
         /*
         [class:annotationMember]
         - class:name (string) mandatory
-        - class:value (string) 
-        
+        - class:value (string)
+
         [class:annotation]
         - class:name (string) mandatory
         + * (class:annotationMember) = class:annotationMember
-        
+
         [class:annotations]
         + * (class:annotation) = class:annotation
          */
@@ -223,15 +239,15 @@ public class ClassSourceFileRecorder implements SourceFileRecorder {
 
         /*
             [class:field]
-            - class:name (string) mandatory 
-            - class:typeClassName (string) mandatory 
+            - class:name (string) mandatory
+            - class:typeClassName (string) mandatory
             - class:visibility (string) mandatory < 'public', 'protected', 'package', 'private'
             - class:static (boolean) mandatory
             - class:final (boolean) mandatory
             - class:transient (boolean) mandatory
             - class:volatile (boolean) mandatory
             + class:annotations (class:annotations) = class:annotations
-            
+
             [class:fields]
             + * (class:field) = class:field
          */
@@ -254,8 +270,8 @@ public class ClassSourceFileRecorder implements SourceFileRecorder {
 
         /*
             [class:method]
-            - class:name (string) mandatory 
-            - class:returnTypeClassName (string) mandatory 
+            - class:name (string) mandatory
+            - class:returnTypeClassName (string) mandatory
             - class:visibility (string) mandatory < 'public', 'protected', 'package', 'private'
             - class:static (boolean) mandatory
             - class:final (boolean) mandatory
@@ -296,8 +312,8 @@ public class ClassSourceFileRecorder implements SourceFileRecorder {
                 + * (class:parameter) = class:parameter
 
                 [class:parameter]
-                - class:name (string) mandatory 
-                - class:typeClassName (string) mandatory 
+                - class:name (string) mandatory
+                - class:typeClassName (string) mandatory
                 - class:final (boolean) mandatory
                 + class:annotations (class:annotations) = class:annotations
              */

--- a/sequencers/modeshape-sequencer-java/src/main/java/org/modeshape/sequencer/javafile/CompilationUnitParser.java
+++ b/sequencers/modeshape-sequencer-java/src/main/java/org/modeshape/sequencer/javafile/CompilationUnitParser.java
@@ -30,7 +30,7 @@ public class CompilationUnitParser {
      * Parses and process the java source code as a compilation unit and the result it abstract syntax tree (AST) representation
      * and this action uses the third edition of java Language Specification, that gets the possibility to support J2SE 5 during
      * the parsing.
-     * 
+     *
      * @param source - the java source to be parsed (i.e. the char[] contains Java source).
      * @param resolveBindings - for resolving bindings to get more informations from the unit.
      * @return Abstract syntax tree representation.
@@ -53,9 +53,9 @@ public class CompilationUnitParser {
     @SuppressWarnings( "unchecked" )
     private static Map<?, ?> createCompilerParameters() {
         Map<Object, Object> options = JavaCore.getOptions();
-        options.put(JavaCore.COMPILER_COMPLIANCE, JavaCore.VERSION_1_5);
-        options.put(JavaCore.COMPILER_CODEGEN_TARGET_PLATFORM, JavaCore.VERSION_1_5);
-        options.put(JavaCore.COMPILER_SOURCE, JavaCore.VERSION_1_5);
+        options.put(JavaCore.COMPILER_COMPLIANCE, JavaCore.VERSION_1_7);
+        options.put(JavaCore.COMPILER_CODEGEN_TARGET_PLATFORM, JavaCore.VERSION_1_7);
+        options.put(JavaCore.COMPILER_SOURCE, JavaCore.VERSION_1_7);
         return options;
     }
 

--- a/sequencers/modeshape-sequencer-java/src/main/java/org/modeshape/sequencer/javafile/JavaFileI18n.java
+++ b/sequencers/modeshape-sequencer-java/src/main/java/org/modeshape/sequencer/javafile/JavaFileI18n.java
@@ -1,0 +1,48 @@
+/*
+ * ModeShape (http://www.modeshape.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.modeshape.sequencer.javafile;
+
+import org.modeshape.common.i18n.I18n;
+
+/**
+ * The internationalized string constants for the <code>org.modeshape.sequencer.javafile</code> packages.
+ */
+public final class JavaFileI18n {
+
+    public static I18n unhandledAnnotationType;
+    public static I18n unhandledAnnotationTypeBodyDeclarationType;
+    public static I18n unhandledBodyDeclarationType;
+    public static I18n unhandledCommentType;
+    public static I18n unhandledTopLevelType;
+    public static I18n unhandledType;
+
+    static {
+        try {
+            I18n.initialize(JavaFileI18n.class);
+        } catch (final Exception e) {
+            // CHECKSTYLE IGNORE check FOR NEXT 1 LINES
+            System.err.println(e);
+        }
+    }
+
+    /**
+     * Don't allow construction outside of this class.
+     */
+    private JavaFileI18n() {
+        // nothing to do
+    }
+
+}

--- a/sequencers/modeshape-sequencer-java/src/main/java/org/modeshape/sequencer/javafile/JavaFileSequencer.java
+++ b/sequencers/modeshape-sequencer-java/src/main/java/org/modeshape/sequencer/javafile/JavaFileSequencer.java
@@ -26,17 +26,19 @@ import org.modeshape.common.util.CheckArg;
 import org.modeshape.jcr.api.nodetype.NodeTypeManager;
 import org.modeshape.jcr.api.sequencer.Sequencer;
 import org.modeshape.sequencer.classfile.ClassFileSequencer;
-import org.modeshape.sequencer.javafile.metadata.JavaMetadata;
 
 /**
  * Sequencer which handles java source files.
- * 
+ *
  * @author ?
  * @author Horia Chiorean
  */
 public class JavaFileSequencer extends Sequencer {
 
-    private static final SourceFileRecorder DEFAULT_SOURCE_FILE_RECORDER = new ClassSourceFileRecorder();
+    @SuppressWarnings( "unused" )
+    private static final SourceFileRecorder OLD_SOURCE_FILE_RECORDER = new ClassSourceFileRecorder();
+    private static final SourceFileRecorder DEFAULT_SOURCE_FILE_RECORDER = new JdtRecorder();
+
     private SourceFileRecorder sourceFileRecorder = DEFAULT_SOURCE_FILE_RECORDER;
 
     @Override
@@ -54,9 +56,9 @@ public class JavaFileSequencer extends Sequencer {
         Binary binaryValue = inputProperty.getBinary();
         CheckArg.isNotNull(binaryValue, "binary");
         InputStream stream = binaryValue.getStream();
+
         try {
-            JavaMetadata javaMetadata = JavaMetadata.instance(stream, binaryValue.getSize(), null);
-            sourceFileRecorder.record(context, outputNode, javaMetadata);
+            sourceFileRecorder.record(context, stream, binaryValue.getSize(), null, outputNode);
             return true;
         } catch (Exception ex) {
             getLogger().error(ex, "Error sequencing file");
@@ -69,7 +71,7 @@ public class JavaFileSequencer extends Sequencer {
     /**
      * Sets the custom {@link SourceFileRecorder} by specifying a class name. This method attempts to instantiate an instance of
      * the custom {@link SourceFileRecorder} class prior to ensure that the new value represents a valid implementation.
-     * 
+     *
      * @param sourceFileRecorderClassName the fully-qualified class name of the new custom class file recorder implementation;
      *        null indicates that {@link org.modeshape.sequencer.javafile.ClassSourceFileRecorder the class file recorder} should
      *        be used.

--- a/sequencers/modeshape-sequencer-java/src/main/java/org/modeshape/sequencer/javafile/JdtRecorder.java
+++ b/sequencers/modeshape-sequencer-java/src/main/java/org/modeshape/sequencer/javafile/JdtRecorder.java
@@ -1,0 +1,1596 @@
+/*
+ * ModeShape (http://www.modeshape.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.modeshape.sequencer.javafile;
+
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
+import javax.jcr.Node;
+import javax.jcr.Value;
+import javax.jcr.ValueFactory;
+import org.eclipse.jdt.core.dom.ASTNode;
+import org.eclipse.jdt.core.dom.AbstractTypeDeclaration;
+import org.eclipse.jdt.core.dom.Annotation;
+import org.eclipse.jdt.core.dom.AnnotationTypeDeclaration;
+import org.eclipse.jdt.core.dom.AnnotationTypeMemberDeclaration;
+import org.eclipse.jdt.core.dom.AnonymousClassDeclaration;
+import org.eclipse.jdt.core.dom.ArrayType;
+import org.eclipse.jdt.core.dom.Block;
+import org.eclipse.jdt.core.dom.BodyDeclaration;
+import org.eclipse.jdt.core.dom.BooleanLiteral;
+import org.eclipse.jdt.core.dom.CharacterLiteral;
+import org.eclipse.jdt.core.dom.Comment;
+import org.eclipse.jdt.core.dom.CompilationUnit;
+import org.eclipse.jdt.core.dom.EnumConstantDeclaration;
+import org.eclipse.jdt.core.dom.EnumDeclaration;
+import org.eclipse.jdt.core.dom.Expression;
+import org.eclipse.jdt.core.dom.FieldDeclaration;
+import org.eclipse.jdt.core.dom.IExtendedModifier;
+import org.eclipse.jdt.core.dom.ImportDeclaration;
+import org.eclipse.jdt.core.dom.Initializer;
+import org.eclipse.jdt.core.dom.Javadoc;
+import org.eclipse.jdt.core.dom.MemberValuePair;
+import org.eclipse.jdt.core.dom.Message;
+import org.eclipse.jdt.core.dom.MethodDeclaration;
+import org.eclipse.jdt.core.dom.Modifier;
+import org.eclipse.jdt.core.dom.Name;
+import org.eclipse.jdt.core.dom.NormalAnnotation;
+import org.eclipse.jdt.core.dom.PackageDeclaration;
+import org.eclipse.jdt.core.dom.ParameterizedType;
+import org.eclipse.jdt.core.dom.PrimitiveType;
+import org.eclipse.jdt.core.dom.QualifiedType;
+import org.eclipse.jdt.core.dom.SimpleType;
+import org.eclipse.jdt.core.dom.SingleMemberAnnotation;
+import org.eclipse.jdt.core.dom.SingleVariableDeclaration;
+import org.eclipse.jdt.core.dom.Statement;
+import org.eclipse.jdt.core.dom.StringLiteral;
+import org.eclipse.jdt.core.dom.Type;
+import org.eclipse.jdt.core.dom.TypeDeclaration;
+import org.eclipse.jdt.core.dom.TypeParameter;
+import org.eclipse.jdt.core.dom.VariableDeclarationFragment;
+import org.eclipse.jdt.core.dom.WildcardType;
+import org.modeshape.common.logging.Logger;
+import org.modeshape.common.util.StringUtil;
+import org.modeshape.jcr.api.sequencer.Sequencer;
+import org.modeshape.jcr.api.sequencer.Sequencer.Context;
+import org.modeshape.sequencer.classfile.ClassFileSequencerLexicon;
+import org.modeshape.sequencer.classfile.metadata.Visibility;
+
+/**
+ * An Eclipse JDT DOM to JCR node recorder.
+ *
+ * <pre>
+ * CompilationUnit:
+ *     [ PackageDeclaration ]
+ *         { ImportDeclaration }
+ *         { TypeDeclaration | EnumDeclaration | AnnotationTypeDeclaration | ; }
+ *
+ * PackageDeclaration:
+ *     [ Javadoc ] { Annotation } package Name ;
+ *
+ * ImportDeclaration:
+ *     import [ static ] Name [ . * ] ;
+ *
+ * TypeDeclaration:
+ *     ClassDeclaration
+ *     InterfaceDeclaration
+ *
+ * ClassDeclaration:
+ *     [ Javadoc ] { ExtendedModifier } class Identifier
+ *         [ < TypeParameter { , TypeParameter } > ]
+ *         [ extends Type ]
+ *         [ implements Type { , Type } ]
+ *         { { ClassBodyDeclaration | ; } }
+ *
+ * InterfaceDeclaration:
+ *     [ Javadoc ] { ExtendedModifier } interface Identifier
+ *         [ < TypeParameter { , TypeParameter } > ]
+ *         [ extends Type { , Type } ]
+ *         { { InterfaceBodyDeclaration | ; } }
+ * </pre>
+ */
+public class JdtRecorder implements SourceFileRecorder {
+
+    private static final Logger LOGGER = Logger.getLogger(JdtRecorder.class);
+
+    private CompilationUnit compilationUnit;
+    private Sequencer.Context context;
+    private String sourceCode;
+
+    protected String getSourceCode( final int startPosition,
+                                    final int length ) {
+        if (StringUtil.isBlank(this.sourceCode)) {
+            return null;
+        }
+
+        return this.sourceCode.substring(startPosition, (startPosition + length));
+    }
+
+    protected String getTypeName( final Type type ) {
+        if (type.isPrimitiveType()) {
+            final PrimitiveType primitiveType = (PrimitiveType)type;
+            return primitiveType.getPrimitiveTypeCode().toString();
+        }
+
+        if (type.isSimpleType()) {
+            final SimpleType simpleType = (SimpleType)type;
+            return simpleType.getName().getFullyQualifiedName();
+        }
+
+        if (type.isQualifiedType()) {
+            final QualifiedType qualifiedType = (QualifiedType)type;
+            return qualifiedType.getName().getFullyQualifiedName();
+        }
+
+        if (type.isParameterizedType()) {
+            final ParameterizedType parameterizedType = (ParameterizedType)type;
+            final StringBuilder result = new StringBuilder(getTypeName(parameterizedType.getType()));
+            result.append('<');
+
+            if (!parameterizedType.typeArguments().isEmpty()) {
+                @SuppressWarnings( "unchecked" )
+                final List<ParameterizedType> paramTypes = parameterizedType.typeArguments();
+                boolean firstTime = true;
+
+                for (final Type paramType : paramTypes) {
+                    if (firstTime) {
+                        firstTime = false;
+                    } else {
+                        result.append(", ");
+                    }
+
+                    result.append(getTypeName(paramType));
+                }
+            }
+
+            result.append('>');
+            return result.toString();
+        }
+
+        if (type.isArrayType()) {
+            final ArrayType arrayType = (ArrayType)type;
+            final Type elementType = arrayType.getElementType(); // the element type is never an array type
+
+            if (elementType.isPrimitiveType()) {
+                return ((PrimitiveType)elementType).getPrimitiveTypeCode().toString();
+
+            }
+
+            // can't be an array type
+            if (elementType.isSimpleType()) {
+                return ((SimpleType)elementType).getName().getFullyQualifiedName();
+            }
+        }
+
+        if (type.isWildcardType()) {
+            return "?";
+        }
+
+        return null;
+    }
+
+    protected String getVisibility( final int modifiers ) {
+        if ((modifiers & Modifier.PUBLIC) != 0) {
+            return Visibility.PUBLIC.getDescription();
+        }
+
+        if ((modifiers & Modifier.PROTECTED) != 0) {
+            return Visibility.PROTECTED.getDescription();
+        }
+
+        if ((modifiers & Modifier.PRIVATE) != 0) {
+            return Visibility.PRIVATE.getDescription();
+        }
+
+        return Visibility.PACKAGE.getDescription();
+    }
+
+    /**
+     * <pre>
+     * Annotation:
+     *     NormalAnnotation
+     *     MarkerAnnotation
+     *     SingleMemberAnnotation
+     *
+     * NormalAnnotation:
+     *     \@ TypeName ( [ MemberValuePair { , MemberValuePair } ] )
+     *
+     * MarkerAnnotation:
+     *     \@ TypeName
+     *
+     * SingleMemberAnnotation:
+     *     \@ TypeName ( Expression  )
+     *
+     * MemberValuePair:
+     *     SimpleName = Expression
+     *
+     * </pre>
+     *
+     * @param annotation the {@link Annotation annotation} being recorded (cannot be <code>null</code>)
+     * @param parentNode the parent {@link Node node} where the annotation will be created (cannot be <code>null</code>)
+     * @throws Exception if there is a problem
+     */
+    protected void record( final Annotation annotation,
+                           final Node parentNode ) throws Exception {
+        final String name = annotation.getTypeName().getFullyQualifiedName();
+
+        final Node annotationNode = parentNode.addNode(name, ClassFileSequencerLexicon.ANNOTATION);
+        annotationNode.setProperty(ClassFileSequencerLexicon.NAME, name);
+
+        if (annotation.isMarkerAnnotation()) {
+            annotationNode.setProperty(ClassFileSequencerLexicon.ANNOTATION_TYPE,
+                                       ClassFileSequencerLexicon.AnnotationType.MARKER.toString());
+            LOGGER.debug("Marker annotation {0} created", name);
+        } else if (annotation.isNormalAnnotation()) {
+            annotationNode.setProperty(ClassFileSequencerLexicon.ANNOTATION_TYPE,
+                                       ClassFileSequencerLexicon.AnnotationType.NORMAL.toString());
+            @SuppressWarnings( "unchecked" )
+            final List<MemberValuePair> entries = ((NormalAnnotation)annotation).values();
+
+            if ((entries != null) && !entries.isEmpty()) {
+                for (final MemberValuePair entry : entries) {
+                    final String memberName = entry.getName().getFullyQualifiedName();
+                    final Expression expression = entry.getValue();
+                    recordAnnotationMember(memberName, expression, annotationNode);
+                }
+            }
+
+            LOGGER.debug("Normal annotation {0} created", name);
+        } else if (annotation.isSingleMemberAnnotation()) {
+            annotationNode.setProperty(ClassFileSequencerLexicon.ANNOTATION_TYPE,
+                                       ClassFileSequencerLexicon.AnnotationType.SINGLE_MEMBER.toString());
+            final Expression expression = ((SingleMemberAnnotation)annotation).getValue();
+            recordAnnotationMember(null, expression, annotationNode);
+            LOGGER.debug("Single member annotation {0} created", name);
+        } else {
+            assert false;
+            LOGGER.error(JavaFileI18n.unhandledAnnotationType, annotation.getClass().getName(), parentNode.getName());
+        }
+
+        recordSourceReference(annotation, annotationNode);
+    }
+
+    /**
+     * <pre>
+     * AnnotationTypeDeclaration:
+     *     [ Javadoc ] { ExtendedModifier } @ interface Identifier
+     *          { { AnnotationTypeBodyDeclaration | ; } }
+     *
+     * AnnotationTypeBodyDeclaration:
+     *      AnnotationTypeMemberDeclaration
+     *      FieldDeclaration
+     *      TypeDeclaration
+     *      EnumDeclaration
+     *      AnnotationTypeDeclaration
+     *
+     * AnnotationTypeMemberDeclaration:
+     *     [ Javadoc ] { ExtendedModifier }
+     *         Type Identifier ( ) [ default Expression ] ;
+     * </pre>
+     *
+     * @param annotationType the {@link AnnotationTypeDeclaration annotation type} being recorded (cannot be <code>null</code>)
+     * @param outputNode the output node where the annotation type should be created (cannot be <code>null</code>)
+     * @return the node representing the annotation type (never <code>null</code>)
+     * @throws Exception if there is a problem
+     */
+    protected Node record( final AnnotationTypeDeclaration annotationType,
+                           final Node outputNode ) throws Exception {
+        final String name = annotationType.getName().getFullyQualifiedName();
+        final Node annotationTypeNode = outputNode.addNode(name, ClassFileSequencerLexicon.ANNOTATION_TYPE);
+        annotationTypeNode.setProperty(ClassFileSequencerLexicon.NAME, name);
+        annotationTypeNode.setProperty(ClassFileSequencerLexicon.VISIBILITY, getVisibility(annotationType.getModifiers()));
+        annotationTypeNode.setProperty(ClassFileSequencerLexicon.SEQUENCED_DATE, this.context.getTimestamp());
+
+        { // javadocs
+            final Javadoc javadoc = annotationType.getJavadoc();
+
+            if (javadoc != null) {
+                record(javadoc, annotationTypeNode);
+            }
+        }
+
+        { // annotations
+            @SuppressWarnings( "unchecked" )
+            final List<IExtendedModifier> modifiers = annotationType.modifiers();
+            recordAnnotations(modifiers, annotationTypeNode);
+        }
+
+        { // body
+            @SuppressWarnings( "unchecked" )
+            final List<BodyDeclaration> body = annotationType.bodyDeclarations();
+
+            if ((body != null) && !body.isEmpty()) {
+                Node fieldsNode = null;
+                Node membersNode = null;
+                Node nestedTypesNode = null;
+
+                for (final BodyDeclaration declaration : body) {
+                    if (declaration instanceof AnnotationTypeMemberDeclaration) {
+                        if (membersNode == null) {
+                            membersNode = annotationTypeNode.addNode(ClassFileSequencerLexicon.ANNOTATION_TYPE_MEMBERS,
+                                                                     ClassFileSequencerLexicon.ANNOTATION_TYPE_MEMBERS);
+                        }
+
+                        record((AnnotationTypeMemberDeclaration)declaration, membersNode);
+                    } else if (declaration instanceof FieldDeclaration) {
+                        if (fieldsNode == null) {
+                            fieldsNode = annotationTypeNode.addNode(ClassFileSequencerLexicon.FIELDS,
+                                                                    ClassFileSequencerLexicon.FIELDS);
+                        }
+
+                        record((FieldDeclaration)declaration, fieldsNode);
+                    } else if (declaration instanceof AbstractTypeDeclaration) {
+                        if (nestedTypesNode == null) {
+                            nestedTypesNode = annotationTypeNode.addNode(ClassFileSequencerLexicon.NESTED_TYPES,
+                                                                         ClassFileSequencerLexicon.NESTED_TYPES);
+                        }
+
+                        if (declaration instanceof TypeDeclaration) {
+                            record((TypeDeclaration)declaration, nestedTypesNode);
+                        } else if (declaration instanceof EnumDeclaration) {
+                            record((EnumDeclaration)declaration, nestedTypesNode);
+                        } else if (declaration instanceof AnnotationTypeDeclaration) {
+                            record((AnnotationTypeDeclaration)declaration, nestedTypesNode);
+                        } else {
+                            assert false;
+                            LOGGER.error(JavaFileI18n.unhandledAnnotationTypeBodyDeclarationType,
+                                         declaration.getClass().getName(),
+                                         annotationType.getName());
+                        }
+                    } else {
+                        assert false;
+                        LOGGER.error(JavaFileI18n.unhandledAnnotationTypeBodyDeclarationType,
+                                     declaration.getClass().getName(),
+                                     annotationType.getName());
+                    }
+                }
+            }
+        }
+
+        recordSourceReference(annotationType, annotationTypeNode);
+        return annotationTypeNode;
+    }
+
+    /**
+     * <pre>
+     * AnnotationTypeMemberDeclaration:
+     *     [ Javadoc ] { ExtendedModifier }
+     *         Type Identifier ( ) [ default Expression ] ;
+     * </pre>
+     *
+     * @param annotationTypeMember the {@link AnnotationTypeMemberDeclaration annotation type member} being recorded (cannot be
+     *        <code>null</code>)
+     * @param parentNode the parent {@link Node node} where the annotation type members will be added (cannot be <code>null</code>
+     *        )
+     * @throws Exception if there is a problem
+     */
+    protected void record( final AnnotationTypeMemberDeclaration annotationTypeMember,
+                           final Node parentNode ) throws Exception {
+        final Node memberNode = parentNode.addNode(ClassFileSequencerLexicon.ANNOTATION_TYPE_MEMBER,
+                                                   ClassFileSequencerLexicon.ANNOTATION_TYPE_MEMBER);
+        memberNode.setProperty(ClassFileSequencerLexicon.NAME, annotationTypeMember.getName().getFullyQualifiedName());
+
+        { // modifiers
+            final int modifiers = annotationTypeMember.getModifiers();
+            memberNode.setProperty(ClassFileSequencerLexicon.ABSTRACT, (modifiers & Modifier.ABSTRACT) != 0);
+            memberNode.setProperty(ClassFileSequencerLexicon.VISIBILITY, getVisibility(modifiers));
+        }
+
+        { // javadocs
+            final Javadoc javadoc = annotationTypeMember.getJavadoc();
+
+            if (javadoc != null) {
+                record(javadoc, memberNode);
+            }
+        }
+
+        { // annotations
+            @SuppressWarnings( "unchecked" )
+            final List<IExtendedModifier> modifiers = annotationTypeMember.modifiers();
+            recordAnnotations(modifiers, memberNode);
+        }
+
+        { // type
+            final Type type = annotationTypeMember.getType();
+            record(type, ClassFileSequencerLexicon.TYPE, memberNode);
+        }
+
+        { // default expression
+            final Expression expression = annotationTypeMember.getDefault();
+
+            if (expression != null) {
+                recordExpression(expression, ClassFileSequencerLexicon.DEFAULT, memberNode);
+            }
+        }
+    }
+
+    /**
+     * <pre>
+     * Block:
+     *     { { Statement } }
+     * </pre>
+     *
+     * @param block the {@link Block block} being recorded (cannot be <code>null</code>)
+     * @param blockNode the parent {@link Node node} where the statements will be added (cannot be <code>null</code>)
+     * @throws Exception if there is a problem
+     */
+    protected void record( final Block block,
+                           final Node blockNode ) throws Exception {
+        if (block != null) {
+            @SuppressWarnings( "unchecked" )
+            final List<Statement> statements = block.statements();
+
+            if ((statements != null) && !statements.isEmpty()) {
+                for (final Statement statement : statements) {
+                    // TODO handle each type of statement
+                    final Node stmtNode = blockNode.addNode(ClassFileSequencerLexicon.STATEMENT,
+                                                            ClassFileSequencerLexicon.STATEMENT);
+                    stmtNode.setProperty(ClassFileSequencerLexicon.CONTENT, statement.toString());
+                    recordSourceReference(statement, stmtNode);
+                }
+            }
+        }
+    }
+
+    /**
+     * <pre>
+     * Comment:
+     *     LineComment
+     *     BlockComment
+     *     Javadoc
+     * </pre>
+     *
+     * @param comment the comment being recorded (cannot be <code>null</code>)
+     * @param parentNode the {@link Node parent node} (cannot be <code>null</code>)
+     * @throws Exception if there is a problem
+     */
+    protected void record( final Comment comment,
+                           final Node parentNode ) throws Exception {
+        Node commentNode = null;
+        String commentType = null;
+
+        if (comment.isDocComment()) {
+            commentNode = parentNode.addNode(ClassFileSequencerLexicon.JAVADOC, ClassFileSequencerLexicon.JAVADOC);
+        } else {
+            commentNode = parentNode.addNode(ClassFileSequencerLexicon.COMMENT, ClassFileSequencerLexicon.COMMENT);
+
+            if (comment.isBlockComment()) {
+                commentType = ClassFileSequencerLexicon.CommentType.BLOCK.toString();
+            } else if (comment.isLineComment()) {
+                commentType = ClassFileSequencerLexicon.CommentType.LINE.toString();
+            } else {
+                assert false;
+                LOGGER.error(JavaFileI18n.unhandledCommentType, comment.getClass().getName());
+            }
+
+            commentNode.setProperty(ClassFileSequencerLexicon.COMMENT_TYPE, commentType);
+        }
+
+        final String code = getSourceCode(comment.getStartPosition(), comment.getLength());
+
+        if (!StringUtil.isBlank(code)) {
+            commentNode.setProperty(ClassFileSequencerLexicon.COMMENT, code);
+        }
+
+        recordSourceReference(comment, commentNode);
+    }
+
+    /**
+     * <pre>
+     * CompilationUnit:
+     *     [ PackageDeclaration ]
+     *          { ImportDeclaration }
+     *          { TypeDeclaration | EnumDeclaration | AnnotationTypeDeclaration | ; }
+     * </pre>
+     *
+     * @param unit the {@link CompilationUnit compilation unit} being recorded (cannot be <code>null</code>)
+     * @param compilationUnitNode the output node associated with the compilation unit (cannot be <code>null</code>)
+     * @throws Exception if there is a problem
+     */
+    protected void record( final CompilationUnit unit,
+                           final Node compilationUnitNode ) throws Exception {
+        LOGGER.debug("recording unit comments");
+        recordComments(unit, compilationUnitNode);
+
+        LOGGER.debug("recording unit import nodes");
+        recordImports(unit, compilationUnitNode);
+
+        LOGGER.debug("recording unit compiler messages");
+        recordCompilerMessages(unit, compilationUnitNode);
+
+        LOGGER.debug("recording unit package nodes");
+        final Node pkgNode = recordPackage(unit, compilationUnitNode);
+
+        LOGGER.debug("recording unit type nodes");
+        recordTypes(unit, compilationUnitNode, pkgNode);
+
+        LOGGER.debug("recording unit source reference");
+        recordSourceReference(unit, compilationUnitNode);
+
+        compilationUnitNode.setProperty(ClassFileSequencerLexicon.SEQUENCED_DATE, this.context.getTimestamp());
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see org.modeshape.sequencer.javafile.SourceFileRecorder#record(org.modeshape.jcr.api.sequencer.Sequencer.Context,
+     *      java.io.InputStream, long, java.lang.String, javax.jcr.Node)
+     */
+    @Override
+    public void record( final Context context,
+                        final InputStream inputStream,
+                        final long length,
+                        final String encoding,
+                        final Node outputNode ) throws Exception {
+        final char[] sourceCode = JavaMetadataUtil.getJavaSourceFromTheInputStream(inputStream, length, encoding);
+        record(context, sourceCode, outputNode);
+    }
+
+    /**
+     * <pre>
+     * EnumConstantDeclaration:
+     *     [ Javadoc ] { ExtendedModifier } Identifier
+     *         [ ( [ Expression { , Expression } ] ) ]
+     *         [ AnonymousClassDeclaration ]
+     * </pre>
+     *
+     * @param enumConstant the enum constant being processed (cannot be <code>null</code>)
+     * @param parentNode the {@link Node node} where the enum constant node will be created (cannot be <code>null</code>)
+     * @throws Exception if there is a problem
+     */
+    protected void record( final EnumConstantDeclaration enumConstant,
+                           final Node parentNode ) throws Exception {
+        final String name = enumConstant.getName().getIdentifier();
+        final Node constantNode = parentNode.addNode(name, ClassFileSequencerLexicon.ENUM_CONSTANT);
+
+        { // javadocs
+            final Javadoc javadoc = enumConstant.getJavadoc();
+
+            if (javadoc != null) {
+                record(javadoc, constantNode);
+            }
+        }
+
+        { // no modifiers but can have annotations
+            @SuppressWarnings( "unchecked" )
+            final List<IExtendedModifier> modifiers = enumConstant.modifiers();
+            recordAnnotations(modifiers, constantNode);
+        }
+
+        { // args
+            @SuppressWarnings( "unchecked" )
+            final List<Expression> args = enumConstant.arguments();
+
+            if ((args != null) && !args.isEmpty()) {
+                final Node containerNode = constantNode.addNode(ClassFileSequencerLexicon.ARGUMENTS,
+                                                                ClassFileSequencerLexicon.ARGUMENTS);
+
+                for (final Expression arg : args) {
+                    recordExpression(arg, ClassFileSequencerLexicon.ARGUMENT, containerNode);
+                }
+            }
+        }
+
+        // anonymous classes
+        final AnonymousClassDeclaration acd = enumConstant.getAnonymousClassDeclaration();
+
+        if (acd != null) {
+            recordBodyDeclarations(acd, constantNode);
+        }
+
+        recordSourceReference(enumConstant, constantNode);
+    }
+
+    /**
+     * <pre>
+     * EnumDeclaration:
+     * [ Javadoc ] { ExtendedModifier } enum Identifier
+     *     [ implements Type { , Type } ]
+     *     {
+     *     [ EnumConstantDeclaration { , EnumConstantDeclaration } ] [ , ]
+     *     [ ; { ClassBodyDeclaration | ; } ]
+     *     }
+     * </pre>
+     *
+     * @param enumType the {@link EnumDeclaration enum} being recorded (cannot be <code>null</code>)
+     * @param parentNode the parent {@link Node node} (cannot be <code>null</code>)
+     * @return the node representing the enum being recorded (never <code>null</code>)
+     * @throws Exception if there is a problem
+     */
+    protected Node record( final EnumDeclaration enumType,
+                           final Node parentNode ) throws Exception {
+        final String name = enumType.getName().getFullyQualifiedName();
+        final Node enumNode = parentNode.addNode(name, ClassFileSequencerLexicon.ENUM);
+        enumNode.setProperty(ClassFileSequencerLexicon.NAME, name);
+        enumNode.setProperty(ClassFileSequencerLexicon.SEQUENCED_DATE, this.context.getTimestamp());
+        enumNode.setProperty(ClassFileSequencerLexicon.INTERFACE, false);
+
+        { // javadocs
+            final Javadoc javadoc = enumType.getJavadoc();
+
+            if (javadoc != null) {
+                record(javadoc, enumNode);
+            }
+        }
+
+        { // modifiers
+            final int modifiers = enumType.getModifiers();
+
+            enumNode.setProperty(ClassFileSequencerLexicon.ABSTRACT, (modifiers & Modifier.ABSTRACT) != 0);
+            enumNode.setProperty(ClassFileSequencerLexicon.FINAL, (modifiers & Modifier.FINAL) != 0);
+            enumNode.setProperty(ClassFileSequencerLexicon.STATIC, (modifiers & Modifier.STATIC) != 0);
+            enumNode.setProperty(ClassFileSequencerLexicon.STRICT_FP, (modifiers & Modifier.STRICTFP) != 0);
+            enumNode.setProperty(ClassFileSequencerLexicon.VISIBILITY, getVisibility(modifiers));
+        }
+
+        { // annotations
+            @SuppressWarnings( "unchecked" )
+            final List<IExtendedModifier> modifiers = enumType.modifiers();
+            recordAnnotations(modifiers, enumNode);
+        }
+
+        { // implements
+            @SuppressWarnings( "unchecked" )
+            final List<Type> interfaces = enumType.superInterfaceTypes();
+
+            if ((interfaces != null) && !interfaces.isEmpty()) {
+                final String[] interfaceNames = new String[interfaces.size()];
+                final Node containerNode = enumNode.addNode(ClassFileSequencerLexicon.IMPLEMENTS, ClassFileSequencerLexicon.TYPES);
+                int i = 0;
+
+                for (final Type superInterfaceType : interfaces) {
+                    interfaceNames[i] = getTypeName(superInterfaceType);
+                    record(superInterfaceType, ClassFileSequencerLexicon.INTERFACE, containerNode);
+                    ++i;
+                }
+
+                enumNode.setProperty(ClassFileSequencerLexicon.INTERFACES, interfaceNames);
+            }
+        }
+
+        { // enum constants
+            @SuppressWarnings( "unchecked" )
+            final List<EnumConstantDeclaration> enumValues = enumType.enumConstants();
+
+            if ((enumValues != null) && !enumValues.isEmpty()) {
+                final String[] values = new String[enumValues.size()];
+                final Node containerNode = enumNode.addNode(ClassFileSequencerLexicon.ENUM_CONSTANTS,
+                                                            ClassFileSequencerLexicon.ENUM_CONSTANTS);
+                int i = 0;
+
+                for (final EnumConstantDeclaration enumConstant : enumValues) {
+                    values[i++] = enumConstant.getName().getFullyQualifiedName();
+                    record(enumConstant, containerNode);
+                }
+
+                enumNode.setProperty(ClassFileSequencerLexicon.ENUM_VALUES, values);
+            }
+        }
+
+        recordBodyDeclarations(enumType, enumNode);
+        recordSourceReference(enumType, enumNode);
+        return enumNode;
+    }
+
+    /**
+     * <pre>
+     * FieldDeclaration:
+     *      [Javadoc] { ExtendedModifier } Type VariableDeclarationFragment
+     *           { , VariableDeclarationFragment } ;
+     *
+     * VariableDeclarationFragment:
+     *     Identifier { [] } [ = Expression ]
+     * </pre>
+     *
+     * A field container node will be created if one does not exist under <code>node</node>.
+     *
+     * @param field the {@link FieldDeclaration field} being recorded {cannot be <code>null</code>
+     * @param parentNode the parent {@link Node node} (cannot be <code>null</code>)
+     * @throws Exception if there is a problem
+     */
+    protected void record( final FieldDeclaration field,
+                           final Node parentNode ) throws Exception {
+        @SuppressWarnings( "unchecked" )
+        final List<VariableDeclarationFragment> frags = field.fragments();
+        final String name = frags.get(0).getName().getFullyQualifiedName();
+
+        final Node fieldNode = parentNode.addNode(name, ClassFileSequencerLexicon.FIELD);
+        fieldNode.setProperty(ClassFileSequencerLexicon.NAME, name);
+
+        { // javadocs
+            final Javadoc javadoc = field.getJavadoc();
+
+            if (javadoc != null) {
+                record(javadoc, fieldNode);
+            }
+        }
+
+        { // type
+            final Type type = field.getType();
+            final String typeName = getTypeName(type);
+            fieldNode.setProperty(ClassFileSequencerLexicon.TYPE_CLASS_NAME, typeName);
+            record(type, ClassFileSequencerLexicon.TYPE, fieldNode);
+        }
+
+        { // modifiers
+            final int modifiers = field.getModifiers();
+
+            fieldNode.setProperty(ClassFileSequencerLexicon.FINAL, (modifiers & Modifier.FINAL) != 0);
+            fieldNode.setProperty(ClassFileSequencerLexicon.STATIC, (modifiers & Modifier.STATIC) != 0);
+            fieldNode.setProperty(ClassFileSequencerLexicon.TRANSIENT, (modifiers & Modifier.TRANSIENT) != 0);
+            fieldNode.setProperty(ClassFileSequencerLexicon.VISIBILITY, getVisibility(modifiers));
+            fieldNode.setProperty(ClassFileSequencerLexicon.VOLATILE, (modifiers & Modifier.VOLATILE) != 0);
+        }
+
+        { // annotations
+            @SuppressWarnings( "unchecked" )
+            final List<IExtendedModifier> modifiers = field.modifiers();
+            recordAnnotations(modifiers, fieldNode);
+        }
+
+        { // fragments
+            @SuppressWarnings( "unchecked" )
+            final List<VariableDeclarationFragment> fragments = field.fragments();
+
+            if ((fragments != null) && !fragments.isEmpty()) {
+                for (final VariableDeclarationFragment var : fragments) {
+                    final Expression initializer = var.getInitializer();
+
+                    if (initializer != null) {
+                        recordExpression(initializer, ClassFileSequencerLexicon.INITIALIZER, fieldNode);
+                    }
+                }
+            }
+        }
+
+        recordSourceReference(field, fieldNode);
+    }
+
+    /**
+     * <pre>
+     * Initializer:
+     *     [ static ] Block
+     *
+     * Block:
+     *     { { Statement } }
+     * </pre>
+     *
+     * @param initializer the {@link Initializer initializer} being recorded (cannot be <code>null</code>)
+     * @param nodeName the name of the node being created that represents the initializer (cannot be <code>null</code> or empty)
+     * @param parentNode the parent {@link Node node} (cannot be <code>null</code>)
+     * @throws Exception if there is a problem
+     */
+    protected void record( final Initializer initializer,
+                           final String nodeName,
+                           final Node parentNode ) throws Exception {
+        final Block block = initializer.getBody();
+
+        if (block != null) {
+            @SuppressWarnings( "unchecked" )
+            final List<Statement> statements = block.statements();
+
+            if ((statements != null) && !statements.isEmpty()) {
+                final Node initializerNode = parentNode.addNode(nodeName, ClassFileSequencerLexicon.STATEMENTS);
+                record(block, initializerNode);
+            }
+        }
+    }
+
+    /**
+     * <pre>
+     * MethodDeclaration:
+     *     [ Javadoc ] { ExtendedModifier }
+     *          [ < TypeParameter { , TypeParameter } > ]
+     *     ( Type | void ) Identifier (
+     *     [ FormalParameter
+     *          { , FormalParameter } ] ) {[ ] }
+     *     [ throws TypeName { , TypeName } ] ( Block | ; )
+     *
+     * ConstructorDeclaration:
+     *     [ Javadoc ] { ExtendedModifier }
+     *          [ < TypeParameter { , TypeParameter } > ]
+     *     Identifier (
+     *         [ FormalParameter
+     *             { , FormalParameter } ] )
+     *     [throws TypeName { , TypeName } ] Block
+     *
+     * </pre>
+     *
+     * @param method the {@link MethodDeclaration method} being recorded (cannot be <code>null</code>)
+     * @param parentNode the parent {@link Node node} (cannot be <code>null</code>)
+     * @throws Exception if there is a problem
+     */
+    protected void record( final MethodDeclaration method,
+                           final Node parentNode ) throws Exception {
+        final String name = method.getName().getFullyQualifiedName();
+        final Node methodNode = parentNode.addNode(name, ClassFileSequencerLexicon.METHOD);
+        methodNode.setProperty(ClassFileSequencerLexicon.NAME, name);
+
+        { // javadocs
+            final Javadoc javadoc = method.getJavadoc();
+
+            if (javadoc != null) {
+                record(javadoc, methodNode);
+            }
+        }
+
+        { // type parameters
+            @SuppressWarnings( "unchecked" )
+            final List<TypeParameter> typeParams = method.typeParameters();
+
+            if ((typeParams != null) && !typeParams.isEmpty()) {
+                final Node containerNode = methodNode.addNode(ClassFileSequencerLexicon.TYPE_PARAMETERS,
+                                                              ClassFileSequencerLexicon.TYPE_PARAMETERS);
+
+                for (final TypeParameter param : typeParams) {
+                    record(param, containerNode);
+                }
+            }
+        }
+
+        { // modifiers
+            final int modifiers = method.getModifiers();
+
+            methodNode.setProperty(ClassFileSequencerLexicon.ABSTRACT, (modifiers & Modifier.ABSTRACT) != 0);
+            methodNode.setProperty(ClassFileSequencerLexicon.FINAL, (modifiers & Modifier.FINAL) != 0);
+            methodNode.setProperty(ClassFileSequencerLexicon.NATIVE, (modifiers & Modifier.NATIVE) != 0);
+            methodNode.setProperty(ClassFileSequencerLexicon.STATIC, (modifiers & Modifier.STATIC) != 0);
+            methodNode.setProperty(ClassFileSequencerLexicon.STRICT_FP, (modifiers & Modifier.STRICTFP) != 0);
+            methodNode.setProperty(ClassFileSequencerLexicon.SYNCHRONIZED, (modifiers & Modifier.SYNCHRONIZED) != 0);
+            methodNode.setProperty(ClassFileSequencerLexicon.VISIBILITY, getVisibility(modifiers));
+        }
+
+        { // annotations
+            @SuppressWarnings( "unchecked" )
+            final List<IExtendedModifier> modifiers = method.modifiers();
+            recordAnnotations(modifiers, methodNode);
+        }
+
+        { // parameters
+            @SuppressWarnings( "unchecked" )
+            final List<SingleVariableDeclaration> params = method.parameters();
+
+            if ((params != null) && !params.isEmpty()) {
+                final Node containerNode = methodNode.addNode(ClassFileSequencerLexicon.METHOD_PARAMETERS,
+                                                              ClassFileSequencerLexicon.PARAMETERS);
+
+                for (final SingleVariableDeclaration param : params) {
+                    record(param, containerNode);
+                }
+            }
+        }
+
+        { // return type
+            if (method.isConstructor()) {
+                methodNode.setProperty(ClassFileSequencerLexicon.RETURN_TYPE_CLASS_NAME, Void.TYPE.getCanonicalName());
+            } else {
+                final Type returnType = method.getReturnType2();
+                methodNode.setProperty(ClassFileSequencerLexicon.RETURN_TYPE_CLASS_NAME, getTypeName(returnType));
+                record(returnType, ClassFileSequencerLexicon.RETURN_TYPE, methodNode);
+            }
+        }
+
+        { // thrown exceptions
+            @SuppressWarnings( "unchecked" )
+            final List<Name> errors = method.thrownExceptions();
+
+            if ((errors != null) && !errors.isEmpty()) {
+                final String[] errorNames = new String[errors.size()];
+                int i = 0;
+
+                for (final Name error : errors) {
+                    errorNames[i++] = error.getFullyQualifiedName();
+                }
+
+                methodNode.setProperty(ClassFileSequencerLexicon.THROWN_EXCEPTIONS, errorNames);
+            }
+        }
+
+        { // body
+            final Block body = method.getBody();
+
+            if ((body != null) && (body.statements() != null) && !body.statements().isEmpty()) {
+                final Node bodyNode = methodNode.addNode(ClassFileSequencerLexicon.BODY, ClassFileSequencerLexicon.STATEMENTS);
+                record(body, bodyNode);
+            }
+        }
+
+        recordSourceReference(method, methodNode);
+    }
+
+    /**
+     * Convert the compilation unit into JCR nodes.
+     *
+     * @param context the sequencer context
+     * @param sourceCode the source code being recorded (can be <code>null</code> if there is no source code)
+     * @param outputNode the {@link Node node} where the output will be saved (cannot be <code>null</code>)
+     * @throws Exception if there is a problem
+     */
+    protected void record( final Sequencer.Context context,
+                           final char[] sourceCode,
+                           final Node outputNode ) throws Exception {
+        if ((sourceCode == null) || (sourceCode.length == 0)) {
+            LOGGER.debug("No source code was found for output node {0}", outputNode.getName());
+            return;
+        }
+
+        this.context = context;
+        this.sourceCode = new String(sourceCode);
+        this.compilationUnit = (CompilationUnit)CompilationUnitParser.runJLS3Conversion(sourceCode, true);
+
+        outputNode.addMixin(ClassFileSequencerLexicon.COMPILATION_UNIT);
+        record(this.compilationUnit, outputNode);
+    }
+
+    /**
+     * <pre>
+     * SingleVariableDeclaration:
+     *     { ExtendedModifier } Type [ ... ] Identifier { [] } [ = Expression ]
+     * </pre>
+     *
+     * @param variable the {@link SingleVariableDeclaration variable} being recorded (cannot be <code>null</code>)
+     * @param parentNode the parent {@link Node node} where the variable is being recorded (cannot be <code>null</code>)
+     * @throws Exception if there is a problem
+     */
+    protected void record( final SingleVariableDeclaration variable,
+                           final Node parentNode ) throws Exception {
+        final String name = variable.getName().getFullyQualifiedName();
+        final Node paramNode = parentNode.addNode(name, ClassFileSequencerLexicon.PARAMETER);
+        paramNode.setProperty(ClassFileSequencerLexicon.NAME, name);
+        paramNode.setProperty(ClassFileSequencerLexicon.FINAL, (variable.getModifiers() & Modifier.FINAL) != 0);
+        paramNode.setProperty(ClassFileSequencerLexicon.VARARGS, variable.isVarargs());
+
+        { // type
+            final Type type = variable.getType();
+            final String typeName = getTypeName(type);
+            paramNode.setProperty(ClassFileSequencerLexicon.TYPE_CLASS_NAME, typeName);
+            record(type, ClassFileSequencerLexicon.TYPE, paramNode);
+        }
+
+        { // initializer
+            final Expression initializer = variable.getInitializer();
+
+            if (initializer != null) {
+                recordExpression(initializer, ClassFileSequencerLexicon.INITIALIZER, paramNode);
+            }
+        }
+
+        { // annotations
+            @SuppressWarnings( "unchecked" )
+            final List<IExtendedModifier> modifiers = variable.modifiers();
+            recordAnnotations(modifiers, paramNode);
+        }
+
+        recordSourceReference(variable, paramNode);
+    }
+
+    /**
+     * <pre>
+     * Type:
+     *     PrimitiveType
+     *     ArrayType
+     *     SimpleType
+     *     QualifiedType
+     *     ParameterizedType
+     *     WildcardType
+     *
+     * PrimitiveType:
+     *     byte
+     *     short
+     *     char
+     *     int
+     *     long
+     *     float
+     *     double
+     *     boolean
+     *     void
+     *
+     * ArrayType:
+     *     Type [ ]
+     *
+     * SimpleType:
+     *     TypeName
+     *
+     * ParameterizedType:
+     *     Type < Type { , Type } >
+     *
+     * QualifiedType:
+     *     Type . SimpleName
+     *
+     * WildcardType:
+     *     ? [ ( extends | super) Type ]
+     * </pre>
+     *
+     * @param type the type {@link Type type} being recorded (cannot be <code>null</code>)
+     * @param typeNodeName the name of the type node being recorded (cannot be <code>null</code> or empty)
+     * @param parentNode the parent {@link Node node} where the type will be recorded (cannot be <code>null</code>)
+     * @throws Exception if there is a problem
+     */
+    protected void record( final Type type,
+                           final String typeNodeName,
+                           final Node parentNode ) throws Exception {
+        if (type.isSimpleType()) {
+            final Node typeNode = parentNode.addNode(typeNodeName, ClassFileSequencerLexicon.SIMPLE_TYPE);
+            typeNode.setProperty(ClassFileSequencerLexicon.TYPE_CLASS_NAME, getTypeName(type));
+            LOGGER.debug("Simple type created at '{0}'", typeNode.getPath());
+        } else if (type.isPrimitiveType()) {
+            final Node typeNode = parentNode.addNode(typeNodeName, ClassFileSequencerLexicon.PRIMITIVE_TYPE);
+            typeNode.setProperty(ClassFileSequencerLexicon.TYPE_CLASS_NAME, getTypeName(type));
+            LOGGER.debug("Primitive type created at '{0}'", typeNode.getPath());
+        } else if (type.isArrayType()) {
+            final Node typeNode = parentNode.addNode(typeNodeName, ClassFileSequencerLexicon.ARRAY_TYPE);
+            typeNode.setProperty(ClassFileSequencerLexicon.TYPE_CLASS_NAME, getTypeName(type));
+
+            final ArrayType arrayType = ((ArrayType)type);
+            typeNode.setProperty(ClassFileSequencerLexicon.DIMENSIONS, arrayType.getDimensions());
+
+            final Type componentType = arrayType.getComponentType();
+            record(componentType, ClassFileSequencerLexicon.COMPONENT_TYPE, typeNode);
+            LOGGER.debug("Array type created at '{0}'", typeNode.getPath());
+        } else if (type.isParameterizedType()) {
+            final Node typeNode = parentNode.addNode(typeNodeName, ClassFileSequencerLexicon.PARAMETERIZED_TYPE);
+            typeNode.setProperty(ClassFileSequencerLexicon.TYPE_CLASS_NAME, getTypeName(type));
+
+            final ParameterizedType paramType = (ParameterizedType)type;
+            final Type baseType = paramType.getType();
+            record(baseType, ClassFileSequencerLexicon.BASE_TYPE, typeNode);
+
+            @SuppressWarnings( "unchecked" )
+            final List<Type> arguments = ((ParameterizedType)type).typeArguments();
+
+            if ((arguments != null) && !arguments.isEmpty()) {
+                final Node containerNode = typeNode.addNode(ClassFileSequencerLexicon.ARGUMENTS, ClassFileSequencerLexicon.TYPES);
+
+                for (final Type arg : arguments) {
+                    record(arg, ClassFileSequencerLexicon.ARGUMENT, containerNode);
+                }
+            }
+
+            LOGGER.debug("Parameterized type created at '{0}'", typeNode.getPath());
+        } else if (type.isQualifiedType()) {
+            final Node typeNode = parentNode.addNode(typeNodeName, ClassFileSequencerLexicon.QUALIFIED_TYPE);
+            typeNode.setProperty(ClassFileSequencerLexicon.TYPE_CLASS_NAME, getTypeName(type));
+
+            final QualifiedType qualifiedType = (QualifiedType)type;
+            record(qualifiedType.getQualifier(), ClassFileSequencerLexicon.QUALIFIER, typeNode);
+            LOGGER.debug("Qualified type created at '{0}'", typeNode.getPath());
+        } else if (type.isWildcardType()) {
+            final Node typeNode = parentNode.addNode("?", ClassFileSequencerLexicon.WILDCARD_TYPE);
+            typeNode.setProperty(ClassFileSequencerLexicon.TYPE_CLASS_NAME, getTypeName(type));
+
+            final WildcardType wildcardType = (WildcardType)type;
+            final String bound = wildcardType.isUpperBound() ? ClassFileSequencerLexicon.WildcardTypeBound.UPPER.toString() : ClassFileSequencerLexicon.WildcardTypeBound.LOWER.toString();
+            typeNode.setProperty(ClassFileSequencerLexicon.BOUND_TYPE, bound);
+
+            if (wildcardType.getBound() != null) {
+                record(wildcardType.getBound(), ClassFileSequencerLexicon.BOUND, typeNode);
+            }
+
+            LOGGER.debug("Wildcard type created at '{0}'", typeNode.getPath());
+        } else {
+            assert false;
+            LOGGER.error(JavaFileI18n.unhandledType, type.getClass().getName(), typeNodeName);
+        }
+    }
+
+    /**
+     * <pre>
+     * TypeDeclaration:
+     *     ClassDeclaration
+     *     InterfaceDeclaration
+     *
+     * ClassDeclaration:
+     *     [ Javadoc ] { ExtendedModifier } class Identifier
+     *     [ < TypeParameter { , TypeParameter } > ]
+     *     [ extends Type ]
+     *     [ implements Type { , Type } ]
+     *     { { ClassBodyDeclaration | ; } }
+     *
+     * InterfaceDeclaration:
+     *     [ Javadoc ] { ExtendedModifier } interface Identifier
+     *     [ < TypeParameter { , TypeParameter } > ]
+     *     [ extends Type { , Type } ]
+     *     { { InterfaceBodyDeclaration | ; } }
+     * </pre>
+     *
+     * @param type the {@link TypeDeclaration type} being recorded (cannot be <code>null</code>)
+     * @param parentNode the parent {@link Node node} where the new type will be created (cannot be <code>null</code>)
+     * @return the node representing the type being recorded (never <code>null</code>)
+     * @throws Exception if there is a problem
+     */
+    protected Node record( final TypeDeclaration type,
+                           final Node parentNode ) throws Exception {
+        final String name = type.getName().getFullyQualifiedName();
+
+        final Node typeNode = parentNode.addNode(name, ClassFileSequencerLexicon.CLASS);
+        typeNode.setProperty(ClassFileSequencerLexicon.NAME, name);
+        typeNode.setProperty(ClassFileSequencerLexicon.SEQUENCED_DATE, this.context.getTimestamp());
+
+        final boolean isInterface = type.isInterface();
+        typeNode.setProperty(ClassFileSequencerLexicon.INTERFACE, isInterface);
+
+        // extends and implements
+        @SuppressWarnings( "unchecked" )
+        final List<Type> interfaces = type.superInterfaceTypes();
+
+        { // extends
+            if (isInterface) {
+                if ((interfaces != null) && !interfaces.isEmpty()) {
+                    final Node extendsNode = typeNode.addNode(ClassFileSequencerLexicon.EXTENDS, ClassFileSequencerLexicon.TYPES);
+
+                    for (final Type interfaceType : interfaces) {
+                        record(interfaceType, ClassFileSequencerLexicon.INTERFACE, extendsNode);
+                    }
+                }
+            } else {
+                final Type superType = type.getSuperclassType();
+                String superTypeName = null;
+
+                if (superType == null) {
+                    superTypeName = Object.class.getCanonicalName();
+                } else {
+                    superTypeName = getTypeName(superType);
+                }
+
+                assert !StringUtil.isBlank(superTypeName);
+                typeNode.setProperty(ClassFileSequencerLexicon.SUPER_CLASS_NAME, superTypeName);
+
+                if (superType != null) {
+                    final Node extendsNode = typeNode.addNode(ClassFileSequencerLexicon.EXTENDS, ClassFileSequencerLexicon.TYPES);
+                    record(superType, getTypeName(superType), extendsNode);
+                }
+            }
+        }
+
+        { // implements
+            if (!isInterface && (interfaces != null) && !interfaces.isEmpty()) {
+                final Node implementsNode = typeNode.addNode(ClassFileSequencerLexicon.IMPLEMENTS,
+                                                             ClassFileSequencerLexicon.TYPES);
+                final String[] interfaceNames = new String[interfaces.size()];
+
+                for (int i = 0, size = interfaces.size(); i < size; ++i) {
+                    final Type interfaceType = interfaces.get(i);
+                    interfaceNames[i] = getTypeName(interfaceType);
+                    record(interfaceType, interfaceNames[i], implementsNode);
+                }
+
+                typeNode.setProperty(ClassFileSequencerLexicon.INTERFACES, interfaceNames);
+            }
+        }
+
+        { // javadocs
+            final Javadoc javadoc = type.getJavadoc();
+
+            if (javadoc != null) {
+                record(javadoc, typeNode);
+            }
+        }
+
+        { // modifiers
+            final int modifiers = type.getModifiers();
+
+            typeNode.setProperty(ClassFileSequencerLexicon.ABSTRACT, (modifiers & Modifier.ABSTRACT) != 0);
+            typeNode.setProperty(ClassFileSequencerLexicon.FINAL, (modifiers & Modifier.FINAL) != 0);
+            typeNode.setProperty(ClassFileSequencerLexicon.STATIC, (modifiers & Modifier.STATIC) != 0);
+            typeNode.setProperty(ClassFileSequencerLexicon.STRICT_FP, (modifiers & Modifier.STRICTFP) != 0);
+            typeNode.setProperty(ClassFileSequencerLexicon.VISIBILITY, getVisibility(modifiers));
+        }
+
+        { // annotations
+            @SuppressWarnings( "unchecked" )
+            final List<IExtendedModifier> modifiers = type.modifiers();
+            recordAnnotations(modifiers, typeNode);
+        }
+
+        { // type parameters
+            @SuppressWarnings( "unchecked" )
+            final List<TypeParameter> typeParams = type.typeParameters();
+
+            if ((typeParams != null) && !typeParams.isEmpty()) {
+                final Node containerNode = typeNode.addNode(ClassFileSequencerLexicon.TYPE_PARAMETERS,
+                                                            ClassFileSequencerLexicon.TYPE_PARAMETERS);
+
+                for (final TypeParameter param : typeParams) {
+                    record(param, containerNode);
+                }
+            }
+        }
+
+        recordBodyDeclarations(type, typeNode);
+        recordSourceReference(type, typeNode);
+        return typeNode;
+    }
+
+    /**
+     * <pre>
+     * TypeParameter:
+     *     TypeVariable [ extends Type { & Type } ]
+     * </pre>
+     *
+     * @param param the {@link TypeParameter type parameter} being recorded (cannot be <code>null</code>)
+     * @param parentNode the parent {@link Node node} where the type parameter will be recorded (cannot be <code>null</code>)
+     * @throws Exception if there is a problem
+     */
+    protected void record( final TypeParameter param,
+                           final Node parentNode ) throws Exception {
+        final String paramName = param.getName().getFullyQualifiedName();
+        final Node paramNode = parentNode.addNode(paramName, ClassFileSequencerLexicon.TYPE_PARAMETER);
+
+        @SuppressWarnings( "unchecked" )
+        final List<Type> bounds = param.typeBounds();
+
+        if ((bounds != null) && !bounds.isEmpty()) {
+            final Node containerNode = paramNode.addNode(ClassFileSequencerLexicon.BOUNDS, ClassFileSequencerLexicon.TYPES);
+
+            for (final Type bound : bounds) {
+                record(bound, getTypeName(bound), containerNode);
+            }
+        }
+
+        recordSourceReference(param, paramNode);
+    }
+
+    protected void recordAnnotationMember( final String memberName,
+                                           final Expression expression,
+                                           final Node parentNode ) throws Exception {
+        final String name = (StringUtil.isBlank(memberName) ? "default" : memberName);
+        final Node node = parentNode.addNode(name, ClassFileSequencerLexicon.ANNOTATION_MEMBER);
+        node.setProperty(ClassFileSequencerLexicon.NAME, name);
+
+        String value = null;
+
+        if (expression instanceof StringLiteral) {
+            value = ((StringLiteral)expression).getLiteralValue();
+        } else if (expression instanceof Name) {
+            value = ((Name)expression).getFullyQualifiedName();
+        } else if (expression instanceof BooleanLiteral) {
+            value = Boolean.toString(((BooleanLiteral)expression).booleanValue());
+        } else if (expression instanceof CharacterLiteral) {
+            value = Character.toString(((CharacterLiteral)expression).charValue());
+        } else {
+            value = expression.toString();
+        }
+
+        node.setProperty(ClassFileSequencerLexicon.VALUE, value);
+        recordExpression(expression, name, node);
+    }
+
+    protected void recordAnnotations( final List<IExtendedModifier> extendedModifiers,
+                                      final Node node ) throws Exception {
+        if ((extendedModifiers != null) && !extendedModifiers.isEmpty()) {
+            Node containerNode = null;
+
+            for (final IExtendedModifier modifier : extendedModifiers) {
+                if (modifier.isAnnotation()) {
+                    if (containerNode == null) {
+                        containerNode = node.addNode(ClassFileSequencerLexicon.ANNOTATIONS, ClassFileSequencerLexicon.ANNOTATIONS);
+                    }
+
+                    record((Annotation)modifier, containerNode);
+                }
+            }
+        }
+    }
+
+    protected void recordBodyDeclarations( final AbstractTypeDeclaration type,
+                                           final Node typeNode ) throws Exception {
+        Node constructorsContainer = null;
+        Node fieldsContainer = null;
+        Node methodsContainer = null;
+        Node nestedTypesContainer = null;
+
+        for (final Object bodyDeclaration : type.bodyDeclarations()) {
+            if (bodyDeclaration instanceof FieldDeclaration) {
+                if (fieldsContainer == null) {
+                    fieldsContainer = typeNode.addNode(ClassFileSequencerLexicon.FIELDS, ClassFileSequencerLexicon.FIELDS);
+                }
+
+                record((FieldDeclaration)bodyDeclaration, fieldsContainer);
+            } else if (bodyDeclaration instanceof MethodDeclaration) {
+                final MethodDeclaration method = (MethodDeclaration)bodyDeclaration;
+
+                if (method.isConstructor()) {
+                    if (constructorsContainer == null) {
+                        constructorsContainer = typeNode.addNode(ClassFileSequencerLexicon.CONSTRUCTORS,
+                                                                 ClassFileSequencerLexicon.CONSTRUCTORS);
+                    }
+
+                    record(method, constructorsContainer);
+                } else {
+                    if (methodsContainer == null) {
+                        methodsContainer = typeNode.addNode(ClassFileSequencerLexicon.METHODS, ClassFileSequencerLexicon.METHODS);
+                    }
+
+                    record(method, methodsContainer);
+                }
+            } else if (bodyDeclaration instanceof TypeDeclaration) {
+                if (nestedTypesContainer == null) {
+                    nestedTypesContainer = typeNode.addNode(ClassFileSequencerLexicon.NESTED_TYPES,
+                                                            ClassFileSequencerLexicon.NESTED_TYPES);
+                }
+
+                record((TypeDeclaration)bodyDeclaration, nestedTypesContainer);
+            } else if (bodyDeclaration instanceof EnumDeclaration) {
+                if (nestedTypesContainer == null) {
+                    nestedTypesContainer = typeNode.addNode(ClassFileSequencerLexicon.NESTED_TYPES,
+                                                            ClassFileSequencerLexicon.NESTED_TYPES);
+                }
+
+                record((EnumDeclaration)bodyDeclaration, nestedTypesContainer);
+            } else if (bodyDeclaration instanceof Initializer) {
+                record(((Initializer)bodyDeclaration), ClassFileSequencerLexicon.INITIALIZER, typeNode);
+            } else {
+                assert false;
+                LOGGER.error(JavaFileI18n.unhandledBodyDeclarationType, bodyDeclaration.getClass().getName());
+            }
+        }
+    }
+
+    protected void recordBodyDeclarations( final AnonymousClassDeclaration anonClass,
+                                           final Node enumConstantNode ) throws Exception {
+        Node fieldsContainer = null;
+        Node methodsContainer = null;
+        Node nestedTypesContainer = null;
+
+        for (final Object bodyDeclaration : anonClass.bodyDeclarations()) {
+            if (bodyDeclaration instanceof FieldDeclaration) {
+                if (fieldsContainer == null) {
+                    fieldsContainer = enumConstantNode.addNode(ClassFileSequencerLexicon.FIELDS, ClassFileSequencerLexicon.FIELDS);
+                }
+
+                record((FieldDeclaration)bodyDeclaration, fieldsContainer);
+            } else if (bodyDeclaration instanceof MethodDeclaration) {
+                if (methodsContainer == null) {
+                    methodsContainer = enumConstantNode.addNode(ClassFileSequencerLexicon.METHODS,
+                                                                ClassFileSequencerLexicon.METHODS);
+                }
+
+                record((MethodDeclaration)bodyDeclaration, methodsContainer);
+            } else if (bodyDeclaration instanceof TypeDeclaration) {
+                if (nestedTypesContainer == null) {
+                    nestedTypesContainer = enumConstantNode.addNode(ClassFileSequencerLexicon.NESTED_TYPES,
+                                                                    ClassFileSequencerLexicon.NESTED_TYPES);
+                }
+
+                record((TypeDeclaration)bodyDeclaration, nestedTypesContainer);
+            } else {
+                assert false;
+                LOGGER.error(JavaFileI18n.unhandledBodyDeclarationType, bodyDeclaration.getClass().getName());
+            }
+        }
+    }
+
+    /**
+     * <pre>
+     * Comment:
+     *     LineComment
+     *     BlockComment
+     *     Javadoc
+     * </pre>
+     *
+     * @param compilationUnit the {@link CompilationUnit compilation unit} being recorded (cannot be <code>null</code>)
+     * @param outputNode the parent {@link Node node} (cannot be <code>null</code>)
+     * @throws Exception if there is a problem
+     */
+    protected void recordComments( final CompilationUnit compilationUnit,
+                                   final Node outputNode ) throws Exception {
+        @SuppressWarnings( "unchecked" )
+        final List<Comment> comments = compilationUnit.getCommentList();
+
+        if ((comments != null) && !comments.isEmpty()) {
+            final Node containerNode = outputNode.addNode(ClassFileSequencerLexicon.COMMENTS, ClassFileSequencerLexicon.COMMENTS);
+
+            for (final Comment comment : comments) {
+                // javadocs are stored with the object they pertain to
+                if (!comment.isDocComment()) {
+                    record(comment, containerNode);
+                }
+            }
+        }
+    }
+
+    protected void recordCompilerMessages( final CompilationUnit unit,
+                                           final Node parentNode ) throws Exception {
+        final Message[] messages = unit.getMessages();
+
+        if ((messages != null) && (messages.length != 0)) {
+            final Node containerNode = parentNode.addNode(ClassFileSequencerLexicon.MESSAGES, ClassFileSequencerLexicon.MESSAGES);
+
+            for (final Message message : messages) {
+                final Node messageNode = containerNode.addNode(ClassFileSequencerLexicon.MESSAGE,
+                                                               ClassFileSequencerLexicon.MESSAGE);
+                messageNode.setProperty(ClassFileSequencerLexicon.MESSAGE, message.getMessage());
+                messageNode.setProperty(ClassFileSequencerLexicon.START_POSITION, message.getStartPosition());
+                messageNode.setProperty(ClassFileSequencerLexicon.LENGTH, message.getLength());
+            }
+        }
+    }
+
+    /**
+     * <pre>
+     * Expression:
+     *
+     * Annotation,
+     * ArrayAccess,
+     * ArrayCreation,
+     * ArrayInitializer,
+     * Assignment,
+     * BooleanLiteral,
+     * CastExpression,
+     * CharacterLiteral,
+     * ClassInstanceCreation,
+     * ConditionalExpression,
+     * FieldAccess,
+     * InfixExpression,
+     * InstanceofExpression,
+     * MethodInvocation,
+     * Name,
+     * NullLiteral,
+     * NumberLiteral,
+     * ParenthesizedExpression,
+     * PostfixExpression,
+     * PrefixExpression,
+     * StringLiteral,
+     * SuperFieldAccess,
+     * SuperMethodInvocation,
+     * ThisExpression,
+     * TypeLiteral,
+     * VariableDeclarationExpression
+     * </pre>
+     *
+     * @param expression the {@link Expression expression} being recorded (cannot be <code>null</code>)
+     * @param nodeName the name of the expression node that is created (cannot be <code>null</code> or empty)
+     * @param parentNode the parent {@link Node node} where the expression is being recorded (cannot be <code>null</code>)
+     * @throws Exception if there is a problem
+     */
+    protected void recordExpression( final Expression expression,
+                                     final String nodeName,
+                                     final Node parentNode ) throws Exception {
+        // TODO handle all the different types of expressions
+        final Node expressionNode = parentNode.addNode(nodeName, ClassFileSequencerLexicon.EXPRESSION);
+        expressionNode.setProperty(ClassFileSequencerLexicon.CONTENT, expression.toString());
+        recordSourceReference(expression, expressionNode);
+    }
+
+    /**
+     * <pre>
+     * ImportDeclaration:
+     *      import [ static ] Name [ . * ] ;
+     * </pre>
+     *
+     * @param compilationUnit the {@link CompilationUnit compilation unit} being recorded (cannot be <code>null</code>)
+     * @param outputNode the parent {@link Node node} (cannot be <code>null</code>)
+     * @throws Exception if there is a problem
+     */
+    protected void recordImports( final CompilationUnit compilationUnit,
+                                  final Node outputNode ) throws Exception {
+        @SuppressWarnings( "unchecked" )
+        final List<ImportDeclaration> imports = compilationUnit.imports();
+
+        if ((imports != null) && !imports.isEmpty()) {
+            final Node containerNode = outputNode.addNode(ClassFileSequencerLexicon.IMPORTS, ClassFileSequencerLexicon.IMPORTS);
+
+            for (final ImportDeclaration mport : imports) {
+                final Node importNode = containerNode.addNode(mport.getName().getFullyQualifiedName(),
+                                                              ClassFileSequencerLexicon.IMPORT);
+                importNode.setProperty(ClassFileSequencerLexicon.STATIC, mport.isStatic());
+                importNode.setProperty(ClassFileSequencerLexicon.ON_DEMAND, mport.isOnDemand());
+
+                recordSourceReference(mport, importNode);
+            }
+        }
+    }
+
+    /**
+     * <pre>
+     * PackageDeclaration:
+     *     [ Javadoc ] { Annotation } package Name ;
+     * </pre>
+     *
+     * @param compilationUnit the {@link CompilationUnit compilation unit} whose package is being recorded (cannot be
+     *        <code>null</code>)
+     * @param outputNode the output node (cannot be <code>null</code>)
+     * @return the package {@link Node node} or the passed in <code>outputNode</code> if a package is not found
+     * @throws Exception if there is a problem
+     */
+    protected Node recordPackage( final CompilationUnit compilationUnit,
+                                  final Node outputNode ) throws Exception {
+        final PackageDeclaration pkg = compilationUnit.getPackage();
+
+        if (pkg == null) {
+            return outputNode;
+        }
+
+        Node pkgNode = outputNode;
+
+        { // create node for each segment of the package name
+            final String pkgName = pkg.getName().getFullyQualifiedName();
+            final String[] packagePath = pkgName.split("\\.");
+
+            if (pkgName.length() > 0) {
+                for (final String segment : packagePath) {
+                    pkgNode = pkgNode.addNode(segment);
+                    pkgNode.addMixin(ClassFileSequencerLexicon.PACKAGE);
+                }
+            }
+        }
+
+        { // Javadocs
+            final Javadoc javadoc = pkg.getJavadoc();
+
+            if (javadoc != null) {
+                record(javadoc, pkgNode);
+            }
+        }
+
+        { // annotations
+            @SuppressWarnings( "unchecked" )
+            final List<Annotation> annotations = pkg.annotations();
+
+            if ((annotations != null) && !annotations.isEmpty()) {
+                for (final Annotation annotation : annotations) {
+                    record(annotation, pkgNode);
+                }
+            }
+        }
+
+        recordSourceReference(pkg, pkgNode);
+        return pkgNode;
+    }
+
+    protected void recordSourceReference( final ASTNode astNode,
+                                          final Node jcrNode ) throws Exception {
+        jcrNode.setProperty(ClassFileSequencerLexicon.START_POSITION, astNode.getStartPosition());
+        jcrNode.setProperty(ClassFileSequencerLexicon.LENGTH, astNode.getLength());
+    }
+
+    protected void recordTypes( final CompilationUnit unit,
+                                final Node compilationUnitNode,
+                                final Node pkgNode ) throws Exception {
+        @SuppressWarnings( "unchecked" )
+        final List<AbstractTypeDeclaration> topLevelTypes = unit.types();
+
+        if ((topLevelTypes != null) && !topLevelTypes.isEmpty()) {
+            final List<Node> types = new ArrayList<>(topLevelTypes.size());
+
+            for (final AbstractTypeDeclaration type : topLevelTypes) {
+                if (type instanceof TypeDeclaration) {
+                    types.add(record((TypeDeclaration)type, pkgNode));
+                } else if (type instanceof EnumDeclaration) {
+                    types.add(record((EnumDeclaration)type, pkgNode));
+                } else if (type instanceof AnnotationTypeDeclaration) {
+                    types.add(record((AnnotationTypeDeclaration)type, pkgNode));
+                } else {
+                    assert false;
+                    LOGGER.error(JavaFileI18n.unhandledTopLevelType, type.getName().getFullyQualifiedName());
+                }
+            }
+
+            final ValueFactory factory = this.context.valueFactory();
+            final Value[] refs = new Value[topLevelTypes.size()];
+            int i = 0;
+
+            for (final Node typeNode : types) {
+                refs[i++] = factory.createValue(typeNode);
+            }
+
+            compilationUnitNode.setProperty(ClassFileSequencerLexicon.TYPES, refs);
+        }
+
+        recordSourceReference(compilationUnit, compilationUnitNode);
+    }
+
+}

--- a/sequencers/modeshape-sequencer-java/src/main/java/org/modeshape/sequencer/javafile/SourceFileRecorder.java
+++ b/sequencers/modeshape-sequencer-java/src/main/java/org/modeshape/sequencer/javafile/SourceFileRecorder.java
@@ -15,11 +15,10 @@
  */
 package org.modeshape.sequencer.javafile;
 
+import java.io.InputStream;
 import javax.jcr.Node;
-import javax.jcr.RepositoryException;
 import org.modeshape.common.annotation.ThreadSafe;
 import org.modeshape.jcr.api.sequencer.Sequencer;
-import org.modeshape.sequencer.javafile.metadata.JavaMetadata;
 
 /**
  * A simple interface that allows an implementer to control how Java source file metadata is mapped to properties (including
@@ -38,13 +37,18 @@ public interface SourceFileRecorder {
 
     /**
      * Records a source file.
-     * 
-     * @param context the sequencer context
-     * @param outputNode the {@link Node} output
-     * @param javaMetadata the metadata for the Java source file
-     * @throws javax.jcr.RepositoryException if anything fails during the sequencing process
+     *
+     * @param context the sequencer context (cannot be <code>null</code>)
+     * @param inputStream the stream being processed (cannot be <code>null</code>)
+     * @param length the length of the java file
+     * @param encoding the encoding to use (can be <code>null</code>)
+     * @param outputNode the {@link Node} output (cannot be <code>null</code>)
+     * @throws Exception if anything fails during the sequencing process
      */
-    void record( Sequencer.Context context,
-                 Node outputNode,
-                 JavaMetadata javaMetadata ) throws RepositoryException;
+    void record( final Sequencer.Context context,
+                 final InputStream inputStream,
+                 final long length,
+                 final String encoding,
+                 final Node outputNode ) throws Exception;
+
 }

--- a/sequencers/modeshape-sequencer-java/src/main/resources/org/modeshape/sequencer/classfile/sequencer-classfile.cnd
+++ b/sequencers/modeshape-sequencer-java/src/main/resources/org/modeshape/sequencer/classfile/sequencer-classfile.cnd
@@ -16,20 +16,66 @@
  
 <class='http://www.modeshape.org/sequencer/javaclass/1.0'>
 
-[class:package] mixin
+[class:sourceLocation] mixin
+- class:startPosition (long) = '-1' autocreated < '[-1,]' // a value equal to or greater than -1
+- class:length (long) = '0' autocreated < '[0,]' // a value equal to or greater than zero
 
-[class:annotationMember]
-- class:name (string) mandatory
-- class:value (string) 
+[class:comment] > class:sourceLocation
+- class:commentType (string) mandatory < 'JAVADOC', 'LINE', 'BLOCK'
+- class:comment (string)
 
-[class:annotation]
+[class:javadoc] > class:comment
+- class:commentType (string) = 'JAVADOC' mandatory autocreated protected < 'JAVADOC'
+
+[class:expression] > class:sourceLocation
+- class:content (string) mandatory
+
+[class:type] > class:sourceLocation abstract
+- class:typeClassName (string) mandatory 
+
+[class:primitiveType] > class:type
+
+[class:arrayType] > class:type
+- class:dimensions (long) mandatory
++ class:componentType (class:type) = class:type
+
+[class:simpleType] > class:type
+
+[class:qualifiedType] > class:type
++ class:qualifier (class:type) = class:type
+
+[class:parameterizedType] > class:type
++ class:baseType (class:type) = class:type
++ class:arguments (class:types) = class:types 
+
+[class:wildcardType] > class:type
+- class:boundType (string) = 'UPPER' autocreated < 'LOWER', 'UPPER' 
++ class:bound (class:type) = class:type
+
+[class:statement] > class:sourceLocation
+- class:content (string) mandatory
+
+[class:statements]
++ class:statement (class:statement) = class:statement sns
+
+[class:package] > class:sourceLocation mixin
++ class:annotations (class:annotations) = class:annotations
++ class:javadoc (class:javadoc) = class:javadoc
+
+[class:annotationMember] > class:sourceLocation
 - class:name (string) mandatory
+- class:value (string)
++ * (class:expression) = class:expression
+
+[class:annotation] > class:sourceLocation
+- class:name (string) mandatory
+- class:annotationType (string) < 'MARKER', 'NORMAL', 'SINGLE_MEMBER' 
 + * (class:annotationMember) = class:annotationMember
 
 [class:annotations]
 + * (class:annotation) = class:annotation
 
-[class:field]
+[class:field] > class:sourceLocation
 - class:name (string) mandatory 
 - class:typeClassName (string) mandatory 
 - class:visibility (string) mandatory < 'public', 'protected', 'package', 'private'
@@ -38,6 +84,9 @@
 - class:transient (boolean) mandatory
 - class:volatile (boolean) mandatory
 + class:annotations (class:annotations) = class:annotations
++ class:type (class:type) = class:type
++ class:initializer (class:expression) = class:expression
++ class:javadoc (class:javadoc) = class:javadoc
 
 [class:fields]
 + * (class:field) = class:field
@@ -45,7 +94,25 @@
 [class:interfaces]
 - * (string)
 
-[class:method]
+[class:typeParameter] > class:sourceLocation
++ class:bounds (class:types) = class:types
+
+[class:typeParameters]
++ * (class:typeParameter) = class:typeParameters
+
+[class:parameter] > class:sourceLocation
+- class:name (string) mandatory 
+- class:typeClassName (string) mandatory 
+- class:final (boolean) mandatory
+- class:varargs (boolean) = 'false' autocreated
++ class:annotations (class:annotations) = class:annotations
++ class:type (class:type) = class:type
++ class:initializer (class:statements) = class:statements
+
+[class:parameters]
++ * (class:parameter) = class:parameter
+
+[class:method] > class:sourceLocation
 - class:name (string) mandatory 
 - class:returnTypeClassName (string) mandatory 
 - class:visibility (string) mandatory < 'public', 'protected', 'package', 'private'
@@ -56,25 +123,27 @@
 - class:native (boolean) mandatory
 - class:synchronized (boolean) mandatory
 - class:parameters (string) multiple
+- class:thrownExceptions (string) multiple
 + class:annotations (class:annotations) = class:annotations
++ class:typeParameters (class:typeParameters) = class:typeParameters
 + class:methodParameters (class:parameters) = class:parameters
++ class:returnType (class:type) = class:type
++ class:javadoc (class:javadoc) = class:javadoc
++ class:body (class:statements) = class:statements
 
 [class:methods]
-+ * (class:method) = class:method
++ * (class:method) = class:method sns
 
 [class:constructors]
-+ * (class:method) = class:method
++ * (class:method) = class:method sns
 
-[class:parameters]
-+ * (class:parameter) = class:parameter
+[class:types]
++ * (class:type) = class:type sns
 
-[class:parameter]
-- class:name (string) mandatory 
-- class:typeClassName (string) mandatory 
-- class:final (boolean) mandatory
-+ class:annotations (class:annotations) = class:annotations
+[class:nestedTypes]
++ * (class:class) = class:class
 
-[class:class]
+[class:class] > class:sourceLocation, mix:referenceable
 - class:name (string) mandatory
 - class:sequencedDate (date) 
 - class:superClassName (string) 
@@ -83,12 +152,82 @@
 - class:interface (boolean) mandatory
 - class:final (boolean) mandatory
 - class:strictFp (boolean) mandatory
+- class:static (boolean)
 - class:interfaces (string) multiple
 - class:imports (string) multiple
 + class:annotations (class:annotations) = class:annotations
 + class:constructors (class:constructors) = class:constructors
 + class:methods (class:methods) = class:methods
 + class:fields (class:fields) = class:fields
++ class:typeParameters (class:typeParameters) = class:typeParameters
++ class:implements (class:types) = class:types
++ class:extends (class:types) = class:types
++ class:javadoc (class:javadoc) = class:javadoc
++ class:nestedTypes (class:nestedTypes) = class:nestedTypes
++ class:initializer (class:statements) = class:statements
+
+[class:arguments]
++ class:argument (class:expression) = class:expression sns
+
+[class:enumConstants]
++ * (class:enumConstant) = class:enumConstant
+
+// node name is the enum value
+[class:enumConstant] > class:sourceLocation
++ class:annotations (class:annotations) = class:annotations
++ class:arguments (class:arguments) = class:arguments
++ class:javadoc (class:javadoc) = class:javadoc
++ class:methods (class:methods) = class:methods
++ class:fields (class:fields) = class:fields
++ class:nestedTypes (class:nestedTypes) = class:nestedTypes
 
 [class:enum] > class:class
 - class:enumValues (string) mandatory multiple
++ class:enumConstants (class:enumConstants) = class:enumConstants
+
+// name is the package or qualified type
+[class:import] > class:sourceLocation
+- class:static (boolean) = 'false' autocreated
+- class:onDemand (boolean) = 'false' autocreated
+
+[class:imports]
++ * (class:import) = class:import
+
+[class:comments]
++ class:comment (class:comment) = class:comment sns
+
+[class:message] > class:sourceLocation
+- class:message (string)
+
+[class:messages]
++ class:message (class:message) = class:messages sns
+
+[class:compilationUnit] > class:sourceLocation mixin
+- class:sequencedDate (date) 
+- class:types (reference) multiple
++ class:imports (class:imports) = class:imports
++ class:comments (class:comments) = class:comments
++ class:messages (class:messages) = class:messages
+
+[class:annotationTypeMember] > class:sourceLocation
+- class:name (string) mandatory
+- class:abstract (boolean) = 'false' mandatory autocreated
+- class:visibility (string) mandatory < 'public', 'protected', 'package', 'private'
++ class:type (class:type) = class:type
++ class:annotations (class:annotations) = class:annotations
++ class:javadoc (class:javadoc) = class:javadoc
++ class:default (class:expression) = class:expression
+
+[class:annotationTypeMembers]
++ class:annotationTypeMember (class:annotationTypeMember) = class:annotationTypeMember sns
+
+// node name is annotation type name
+[class:annotationType] > class:sourceLocation, mix:referenceable
+- class:name (string) mandatory
+- class:sequencedDate (date) 
+- class:visibility (string) mandatory < 'public', 'protected', 'package', 'private'
++ class:annotations (class:annotations) = class:annotations
++ class:javadoc (class:javadoc) = class:javadoc
++ class:fields (class:fields) = class:fields
++ class:nestedTypes (class:nestedTypes) = class:nestedTypes
++ class:annotationTypeMembers (class:annotationTypeMembers) = class:annotationTypeMembers

--- a/sequencers/modeshape-sequencer-java/src/main/resources/org/modeshape/sequencer/javafile/JavaFileI18n.properties
+++ b/sequencers/modeshape-sequencer-java/src/main/resources/org/modeshape/sequencer/javafile/JavaFileI18n.properties
@@ -1,0 +1,6 @@
+unhandledAnnotationType = Annotation type '{0}' with parent node '{1}' was not processed.
+unhandledAnnotationTypeBodyDeclarationType = Body declaration type '{0}' of annotation '{1}' was not processed.
+unhandledBodyDeclarationType = BodyDeclaration of type '{0}' was not processed
+unhandledCommentType = Comment type '{0}' was not processed.
+unhandledTopLevelType = Top-level type '{0}' was not processed.
+unhandledType = Type '{0}' was not processed. Node '{1}' was not created.

--- a/sequencers/modeshape-sequencer-java/src/test/java/org/modeshape/sequencer/javafile/AnnotationTypeSequencerTest.java
+++ b/sequencers/modeshape-sequencer-java/src/test/java/org/modeshape/sequencer/javafile/AnnotationTypeSequencerTest.java
@@ -1,0 +1,176 @@
+/*
+ * ModeShape (http://www.modeshape.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.modeshape.sequencer.javafile;
+
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsNull.notNullValue;
+import static org.junit.Assert.assertThat;
+import javax.jcr.Node;
+import javax.jcr.NodeIterator;
+import org.junit.Test;
+import org.modeshape.jcr.sequencer.AbstractSequencerTest;
+import org.modeshape.sequencer.classfile.ClassFileSequencerLexicon;
+import org.modeshape.sequencer.classfile.metadata.Visibility;
+import org.modeshape.sequencer.testdata.AnnotationType;
+
+public final class AnnotationTypeSequencerTest extends AbstractSequencerTest {
+
+    @Test
+    public void shouldSequenceAnnotationTypeFile() throws Exception {
+        final String packagePath = AnnotationType.class.getName().replaceAll("\\.", "/");
+        createNodeWithContentFromFile("annotationtype.java", packagePath + ".java");
+
+        // expected by sequencer in a different location
+        final String expectedOutputPath = "java/annotationtype.java";
+        final Node compilationUnitNode = getOutputNode(rootNode, expectedOutputPath);
+        assertThat(compilationUnitNode, is(notNullValue()));
+        assertThat(compilationUnitNode.isNodeType(ClassFileSequencerLexicon.COMPILATION_UNIT), is(true));
+        assertThat(compilationUnitNode.hasProperty(ClassFileSequencerLexicon.SEQUENCED_DATE), is(true));
+        assertThat(compilationUnitNode.hasProperty(ClassFileSequencerLexicon.TYPES), is(true));
+        // assertThat(compilationUnitNode.getProperty(ClassFileSequencerLexicon.TYPES).getValues().length, is(2));
+        assertThat(compilationUnitNode.hasNode(ClassFileSequencerLexicon.MESSAGES), is(false));
+
+        { // 2 imports
+            assertThat(compilationUnitNode.hasNode(ClassFileSequencerLexicon.IMPORTS), is(true));
+            assertThat(compilationUnitNode.getNode(ClassFileSequencerLexicon.IMPORTS).getNodes().getSize(), is(2L));
+
+            final NodeIterator itr = compilationUnitNode.getNode(ClassFileSequencerLexicon.IMPORTS).getNodes();
+
+            { // first import
+                final Node firstImport = itr.nextNode();
+                assertThat(firstImport.getName(), is("java.lang.annotation.ElementType"));
+                assertThat(firstImport.hasProperty(ClassFileSequencerLexicon.STATIC), is(true));
+                assertThat(firstImport.getProperty(ClassFileSequencerLexicon.STATIC).getBoolean(), is(false));
+                assertThat(firstImport.hasProperty(ClassFileSequencerLexicon.ON_DEMAND), is(true));
+                assertThat(firstImport.getProperty(ClassFileSequencerLexicon.ON_DEMAND).getBoolean(), is(false));
+            }
+
+            { // second import
+                final Node secondImport = itr.nextNode();
+                assertThat(secondImport.getName(), is("java.lang.annotation.Target"));
+                assertThat(secondImport.hasProperty(ClassFileSequencerLexicon.STATIC), is(true));
+                assertThat(secondImport.getProperty(ClassFileSequencerLexicon.STATIC).getBoolean(), is(false));
+                assertThat(secondImport.hasProperty(ClassFileSequencerLexicon.ON_DEMAND), is(true));
+                assertThat(secondImport.getProperty(ClassFileSequencerLexicon.ON_DEMAND).getBoolean(), is(false));
+            }
+        }
+
+        { // comments
+            assertThat(compilationUnitNode.hasNode(ClassFileSequencerLexicon.COMMENTS), is(true));
+            assertThat(compilationUnitNode.getNode(ClassFileSequencerLexicon.COMMENTS).getNodes().getSize(), is(2L));
+
+            final NodeIterator itr = compilationUnitNode.getNode(ClassFileSequencerLexicon.COMMENTS).getNodes();
+
+            { // file header
+                final Node firstComment = itr.nextNode();
+                assertThat(firstComment.getName(), is(ClassFileSequencerLexicon.COMMENT));
+                assertThat(firstComment.hasProperty(ClassFileSequencerLexicon.COMMENT_TYPE), is(true));
+                assertThat(firstComment.getProperty(ClassFileSequencerLexicon.COMMENT_TYPE).getString(),
+                           is(ClassFileSequencerLexicon.CommentType.BLOCK.toString()));
+                assertThat(firstComment.hasProperty(ClassFileSequencerLexicon.COMMENT), is(true));
+                assertThat(firstComment.getProperty(ClassFileSequencerLexicon.COMMENT).getString().startsWith("/*\n * ModeShape"),
+                           is(true));
+            }
+
+            { // line comment
+                final Node lineComment = itr.nextNode();
+                assertThat(lineComment.getName(), is(ClassFileSequencerLexicon.COMMENT));
+                assertThat(lineComment.hasProperty(ClassFileSequencerLexicon.COMMENT_TYPE), is(true));
+                assertThat(lineComment.getProperty(ClassFileSequencerLexicon.COMMENT_TYPE).getString(),
+                           is(ClassFileSequencerLexicon.CommentType.LINE.toString()));
+                assertThat(lineComment.hasProperty(ClassFileSequencerLexicon.COMMENT), is(true));
+                assertThat(lineComment.getProperty(ClassFileSequencerLexicon.COMMENT).getString(), is("// an annotation type"));
+            }
+        }
+
+        { // annotation type
+            final Node annotationTypeNode = compilationUnitNode.getNode(packagePath);
+            assertThat(annotationTypeNode.getName(), is("AnnotationType"));
+            assertThat(annotationTypeNode.getProperty(ClassFileSequencerLexicon.NAME).getString(),
+                       is(annotationTypeNode.getName()));
+            assertThat(annotationTypeNode.hasProperty(ClassFileSequencerLexicon.SEQUENCED_DATE), is(true));
+            assertThat(annotationTypeNode.getProperty(ClassFileSequencerLexicon.VISIBILITY).getString(),
+                       is(Visibility.PUBLIC.getDescription()));
+
+            assertThat(annotationTypeNode.hasNode(ClassFileSequencerLexicon.ANNOTATIONS), is(true));
+            assertThat(annotationTypeNode.getNode(ClassFileSequencerLexicon.ANNOTATIONS).getNodes().getSize(), is(1L));
+            annotationTypeNode.getNode(ClassFileSequencerLexicon.ANNOTATIONS).getNode("Target"); // throws exception if not found
+
+            assertThat(annotationTypeNode.hasNode(ClassFileSequencerLexicon.JAVADOC), is(true));
+            final Node javadocNode = annotationTypeNode.getNode(ClassFileSequencerLexicon.JAVADOC);
+            final String comment = "This is an annotation type test class.";
+            assertThat(javadocNode.getProperty(ClassFileSequencerLexicon.COMMENT).getString().contains(comment), is(true));
+
+            assertThat(annotationTypeNode.hasNode(ClassFileSequencerLexicon.FIELDS), is(true));
+            assertThat(annotationTypeNode.getNode(ClassFileSequencerLexicon.FIELDS).getNodes().getSize(), is(1L));
+            annotationTypeNode.getNode(ClassFileSequencerLexicon.FIELDS).getNode("choice"); // throws exception if not found
+
+            assertThat(annotationTypeNode.hasNode(ClassFileSequencerLexicon.NESTED_TYPES), is(true));
+            assertThat(annotationTypeNode.getNode(ClassFileSequencerLexicon.NESTED_TYPES).getNodes().getSize(), is(2L));
+            annotationTypeNode.getNode(ClassFileSequencerLexicon.NESTED_TYPES).getNode("Decision");
+            annotationTypeNode.getNode(ClassFileSequencerLexicon.NESTED_TYPES).getNode("Status"); // throws exception if not found
+
+            { // annotation type members
+                assertThat(annotationTypeNode.hasNode(ClassFileSequencerLexicon.ANNOTATION_TYPE_MEMBERS), is(true));
+                assertThat(annotationTypeNode.getNode(ClassFileSequencerLexicon.ANNOTATION_TYPE_MEMBERS).getNodes().getSize(),
+                           is(3L));
+                final NodeIterator itr = annotationTypeNode.getNode(ClassFileSequencerLexicon.ANNOTATION_TYPE_MEMBERS).getNodes();
+
+                { // showStopper
+                    final Node memberNode = itr.nextNode();
+                    assertThat(memberNode.getPrimaryNodeType().getName(), is(ClassFileSequencerLexicon.ANNOTATION_TYPE_MEMBER));
+                    assertThat(memberNode.getProperty(ClassFileSequencerLexicon.NAME).getString(), is("showStopper"));
+                    assertThat(memberNode.getProperty(ClassFileSequencerLexicon.ABSTRACT).getBoolean(), is(true));
+                    assertThat(memberNode.getProperty(ClassFileSequencerLexicon.VISIBILITY).getString(), is("package"));
+                    assertThat(memberNode.hasNode(ClassFileSequencerLexicon.ANNOTATIONS), is(true));
+                    assertThat(memberNode.hasNode(ClassFileSequencerLexicon.JAVADOC), is(false));
+                    assertThat(memberNode.hasNode(ClassFileSequencerLexicon.DEFAULT), is(false));
+                }
+
+                { // status
+                    final Node memberNode = itr.nextNode();
+                    assertThat(memberNode.getPrimaryNodeType().getName(), is(ClassFileSequencerLexicon.ANNOTATION_TYPE_MEMBER));
+                    assertThat(memberNode.getProperty(ClassFileSequencerLexicon.NAME).getString(), is("status"));
+                    assertThat(memberNode.getProperty(ClassFileSequencerLexicon.ABSTRACT).getBoolean(), is(false));
+                    assertThat(memberNode.getProperty(ClassFileSequencerLexicon.VISIBILITY).getString(), is("public"));
+                    assertThat(memberNode.hasNode(ClassFileSequencerLexicon.ANNOTATIONS), is(false));
+                    assertThat(memberNode.hasNode(ClassFileSequencerLexicon.JAVADOC), is(true));
+
+                    assertThat(memberNode.hasNode(ClassFileSequencerLexicon.DEFAULT), is(true));
+                    final Node defaultNode = memberNode.getNode(ClassFileSequencerLexicon.DEFAULT);
+                    assertThat(defaultNode.getPrimaryNodeType().getName(), is(ClassFileSequencerLexicon.EXPRESSION));
+                    assertThat(defaultNode.getProperty(ClassFileSequencerLexicon.CONTENT).getString(), is("Status.UNCONFIRMED"));
+                }
+
+                { // ref
+                    final Node memberNode = itr.nextNode();
+                    assertThat(memberNode.getPrimaryNodeType().getName(), is(ClassFileSequencerLexicon.ANNOTATION_TYPE_MEMBER));
+                    assertThat(memberNode.getProperty(ClassFileSequencerLexicon.NAME).getString(), is("ref"));
+                    assertThat(memberNode.getProperty(ClassFileSequencerLexicon.ABSTRACT).getBoolean(), is(false));
+                    assertThat(memberNode.getProperty(ClassFileSequencerLexicon.VISIBILITY).getString(), is("package"));
+                    assertThat(memberNode.hasNode(ClassFileSequencerLexicon.ANNOTATIONS), is(false));
+                    assertThat(memberNode.hasNode(ClassFileSequencerLexicon.JAVADOC), is(false));
+
+                    assertThat(memberNode.hasNode(ClassFileSequencerLexicon.DEFAULT), is(true));
+                    final Node defaultNode = memberNode.getNode(ClassFileSequencerLexicon.DEFAULT);
+                    assertThat(defaultNode.getPrimaryNodeType().getName(), is(ClassFileSequencerLexicon.EXPRESSION));
+                    assertThat(defaultNode.getProperty(ClassFileSequencerLexicon.CONTENT).getString(), is("@Reference"));
+                }
+            }
+        }
+    }
+
+}

--- a/sequencers/modeshape-sequencer-java/src/test/java/org/modeshape/sequencer/javafile/ClassTypeSequencerTest.java
+++ b/sequencers/modeshape-sequencer-java/src/test/java/org/modeshape/sequencer/javafile/ClassTypeSequencerTest.java
@@ -1,0 +1,542 @@
+/*
+ * ModeShape (http://www.modeshape.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.modeshape.sequencer.javafile;
+
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsNull.notNullValue;
+import static org.junit.Assert.assertThat;
+import javax.jcr.Node;
+import javax.jcr.NodeIterator;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.modeshape.jcr.sequencer.AbstractSequencerTest;
+import org.modeshape.sequencer.classfile.ClassFileSequencerLexicon;
+import org.modeshape.sequencer.classfile.metadata.Visibility;
+import org.modeshape.sequencer.testdata.ClassType;
+
+public final class ClassTypeSequencerTest extends AbstractSequencerTest {
+
+    @Test
+    public void shouldSequenceClassTypeFile() throws Exception {
+        final String packagePath = ClassType.class.getName().replaceAll("\\.", "/");
+        createNodeWithContentFromFile("classtype.java", packagePath + ".java");
+
+        // expected by sequencer in a different location
+        final String expectedOutputPath = "java/classtype.java";
+        final Node compilationUnitNode = getOutputNode(rootNode, expectedOutputPath);
+        assertThat(compilationUnitNode, is(notNullValue()));
+        assertThat(compilationUnitNode.isNodeType(ClassFileSequencerLexicon.COMPILATION_UNIT), is(true));
+        assertThat(compilationUnitNode.hasProperty(ClassFileSequencerLexicon.SEQUENCED_DATE), is(true));
+        assertThat(compilationUnitNode.hasProperty(ClassFileSequencerLexicon.TYPES), is(true));
+        assertThat(compilationUnitNode.getProperty(ClassFileSequencerLexicon.TYPES).getValues().length, is(1));
+        assertThat(compilationUnitNode.hasNode(ClassFileSequencerLexicon.MESSAGES), is(false));
+
+        { // 2 imports
+            assertThat(compilationUnitNode.hasNode(ClassFileSequencerLexicon.IMPORTS), is(true));
+            assertThat(compilationUnitNode.getNode(ClassFileSequencerLexicon.IMPORTS).getNodes().getSize(), is(3L));
+
+            final NodeIterator itr = compilationUnitNode.getNode(ClassFileSequencerLexicon.IMPORTS).getNodes();
+
+            { // first import
+                final Node firstImport = itr.nextNode();
+                assertThat(firstImport.getName(), is("java.io.Serializable"));
+                assertThat(firstImport.hasProperty(ClassFileSequencerLexicon.STATIC), is(true));
+                assertThat(firstImport.getProperty(ClassFileSequencerLexicon.STATIC).getBoolean(), is(false));
+                assertThat(firstImport.hasProperty(ClassFileSequencerLexicon.ON_DEMAND), is(true));
+                assertThat(firstImport.getProperty(ClassFileSequencerLexicon.ON_DEMAND).getBoolean(), is(false));
+            }
+
+            { // second import
+                final Node secondImport = itr.nextNode();
+                assertThat(secondImport.getName(), is("java.util.ArrayList"));
+                assertThat(secondImport.hasProperty(ClassFileSequencerLexicon.STATIC), is(true));
+                assertThat(secondImport.getProperty(ClassFileSequencerLexicon.STATIC).getBoolean(), is(false));
+                assertThat(secondImport.hasProperty(ClassFileSequencerLexicon.ON_DEMAND), is(true));
+                assertThat(secondImport.getProperty(ClassFileSequencerLexicon.ON_DEMAND).getBoolean(), is(false));
+            }
+
+            { // third import
+                final Node thirdImport = itr.nextNode();
+                assertThat(thirdImport.getName(), is("java.util.HashMap"));
+                assertThat(thirdImport.hasProperty(ClassFileSequencerLexicon.STATIC), is(true));
+                assertThat(thirdImport.getProperty(ClassFileSequencerLexicon.STATIC).getBoolean(), is(false));
+                assertThat(thirdImport.hasProperty(ClassFileSequencerLexicon.ON_DEMAND), is(true));
+                assertThat(thirdImport.getProperty(ClassFileSequencerLexicon.ON_DEMAND).getBoolean(), is(false));
+            }
+        }
+
+        { // comments
+            assertThat(compilationUnitNode.hasNode(ClassFileSequencerLexicon.COMMENTS), is(true));
+            assertThat(compilationUnitNode.getNode(ClassFileSequencerLexicon.COMMENTS).getNodes().getSize(), is(2L));
+
+            final NodeIterator itr = compilationUnitNode.getNode(ClassFileSequencerLexicon.COMMENTS).getNodes();
+
+            { // file block header
+                final Node firstComment = itr.nextNode();
+                assertThat(firstComment.getName(), is(ClassFileSequencerLexicon.COMMENT));
+                assertThat(firstComment.hasProperty(ClassFileSequencerLexicon.COMMENT_TYPE), is(true));
+                assertThat(firstComment.getProperty(ClassFileSequencerLexicon.COMMENT_TYPE).getString(),
+                           is(ClassFileSequencerLexicon.CommentType.BLOCK.toString()));
+                assertThat(firstComment.hasProperty(ClassFileSequencerLexicon.COMMENT), is(true));
+                assertThat(firstComment.getProperty(ClassFileSequencerLexicon.COMMENT).getString().startsWith("/*\n * ModeShape"),
+                           is(true));
+            }
+
+            { // line comment for field CONSTANT
+                final Node secondComment = itr.nextNode();
+                assertThat(secondComment.getName(), is(ClassFileSequencerLexicon.COMMENT));
+                assertThat(secondComment.hasProperty(ClassFileSequencerLexicon.COMMENT_TYPE), is(true));
+                assertThat(secondComment.getProperty(ClassFileSequencerLexicon.COMMENT_TYPE).getString(),
+                           is(ClassFileSequencerLexicon.CommentType.LINE.toString()));
+                assertThat(secondComment.hasProperty(ClassFileSequencerLexicon.COMMENT), is(true));
+                assertThat(secondComment.getProperty(ClassFileSequencerLexicon.COMMENT).getString(), is("// a line comment"));
+            }
+        }
+
+        { // class type
+            final Node classNode = compilationUnitNode.getNode(packagePath);
+            assertThat(classNode.getName(), is("ClassType"));
+            assertThat(classNode.getProperty(ClassFileSequencerLexicon.NAME).getString(), is(classNode.getName()));
+            assertThat(classNode.hasProperty(ClassFileSequencerLexicon.SEQUENCED_DATE), is(true));
+            assertThat(classNode.getProperty(ClassFileSequencerLexicon.SUPER_CLASS_NAME).getString(), is("ArrayList<T>"));
+            assertThat(classNode.getProperty(ClassFileSequencerLexicon.VISIBILITY).getString(),
+                       is(Visibility.PUBLIC.getDescription()));
+            assertThat(classNode.getProperty(ClassFileSequencerLexicon.ABSTRACT).getBoolean(), is(true));
+            assertThat(classNode.getProperty(ClassFileSequencerLexicon.INTERFACE).getBoolean(), is(false));
+            assertThat(classNode.getProperty(ClassFileSequencerLexicon.FINAL).getBoolean(), is(false));
+            assertThat(classNode.getProperty(ClassFileSequencerLexicon.STRICT_FP).getBoolean(), is(false));
+            assertThat(classNode.getProperty(ClassFileSequencerLexicon.STATIC).getBoolean(), is(false));
+            assertThat(classNode.hasProperty(ClassFileSequencerLexicon.IMPORTS), is(false));
+            assertThat(classNode.hasProperty(ClassFileSequencerLexicon.INTERFACES), is(true));
+            assertThat(classNode.getProperty(ClassFileSequencerLexicon.INTERFACES).getValues().length, is(1));
+            assertThat(classNode.getProperty(ClassFileSequencerLexicon.INTERFACES).getValues()[0].getString(), is("Serializable"));
+            assertThat(classNode.hasNode(ClassFileSequencerLexicon.CONSTRUCTORS), is(false));
+
+            { // initializer
+                assertThat(classNode.hasNode(ClassFileSequencerLexicon.INITIALIZER), is(true));
+
+                final Node initializerNode = classNode.getNode(ClassFileSequencerLexicon.INITIALIZER);
+                assertThat(initializerNode.getNodes().getSize(), is(1L));
+
+                final Node statementNode = initializerNode.getNodes().nextNode();
+                assertThat(statementNode.getProperty(ClassFileSequencerLexicon.CONTENT).getString(),
+                           is("System.out.println(System.currentTimeMillis());\n"));
+            }
+
+            { // annotations
+                assertThat(classNode.hasNode(ClassFileSequencerLexicon.ANNOTATIONS), is(true));
+                assertThat(classNode.getNode(ClassFileSequencerLexicon.ANNOTATIONS).getNodes().getSize(), is(1l));
+
+                final Node annotationNode = classNode.getNode(ClassFileSequencerLexicon.ANNOTATIONS).getNodes().nextNode();
+                assertThat(annotationNode.getName(), is("SuppressWarnings"));
+                assertThat(annotationNode.hasProperty(ClassFileSequencerLexicon.ANNOTATION_TYPE), is(true));
+                assertThat(annotationNode.getProperty(ClassFileSequencerLexicon.ANNOTATION_TYPE).getString(),
+                           is(ClassFileSequencerLexicon.AnnotationType.SINGLE_MEMBER.toString()));
+                assertThat(annotationNode.getNodes().getSize(), is(1L));
+
+                final String memberName = "default";
+                assertThat(annotationNode.hasNode(memberName), is(true));
+                final Node memberNode = annotationNode.getNode(memberName);
+                assertThat(memberNode.getProperty(ClassFileSequencerLexicon.NAME).getString(), is(memberName));
+                assertThat(memberNode.hasProperty(ClassFileSequencerLexicon.VALUE), is(true));
+                assertThat(memberNode.getProperty(ClassFileSequencerLexicon.VALUE).getString(), is("{\"serial\",\"unused\"}"));
+            }
+
+            { // fields
+                assertThat(classNode.hasNode(ClassFileSequencerLexicon.FIELDS), is(true));
+                assertThat(classNode.getNode(ClassFileSequencerLexicon.FIELDS).getNodes().getSize(), is(4L));
+
+                final Node fieldsNode = classNode.getNode(ClassFileSequencerLexicon.FIELDS);
+
+                { // CONSTANT field
+                    final Node fieldNode = fieldsNode.getNode("CONSTANT");
+                    assertThat(fieldNode.getProperty(ClassFileSequencerLexicon.NAME).getString(), is(fieldNode.getName()));
+                    assertThat(fieldNode.getProperty(ClassFileSequencerLexicon.TYPE_CLASS_NAME).getString(), is("String"));
+                    assertThat(fieldNode.getProperty(ClassFileSequencerLexicon.VISIBILITY).getString(),
+                               is(Visibility.PUBLIC.getDescription()));
+                    assertThat(fieldNode.getProperty(ClassFileSequencerLexicon.STATIC).getBoolean(), is(true));
+                    assertThat(fieldNode.getProperty(ClassFileSequencerLexicon.FINAL).getBoolean(), is(true));
+                    assertThat(fieldNode.getProperty(ClassFileSequencerLexicon.TRANSIENT).getBoolean(), is(false));
+                    assertThat(fieldNode.getProperty(ClassFileSequencerLexicon.VOLATILE).getBoolean(), is(false));
+                    assertThat(fieldNode.hasNode(ClassFileSequencerLexicon.ANNOTATIONS), is(false));
+
+                    assertThat(fieldNode.hasNode(ClassFileSequencerLexicon.INITIALIZER), is(true));
+                    final Node initializerNode = fieldNode.getNode(ClassFileSequencerLexicon.INITIALIZER);
+                    assertThat(initializerNode.getProperty(ClassFileSequencerLexicon.CONTENT).getString(), is("\"constant\""));
+
+                    assertThat(fieldNode.hasNode(ClassFileSequencerLexicon.TYPE), is(true));
+                    final Node fieldTypeNode = fieldNode.getNode(ClassFileSequencerLexicon.TYPE);
+                    assertThat(fieldTypeNode.isNodeType(ClassFileSequencerLexicon.SIMPLE_TYPE), is(true));
+                    assertThat(fieldTypeNode.getProperty(ClassFileSequencerLexicon.TYPE_CLASS_NAME).getString(), is("String"));
+
+                    assertThat(fieldNode.hasNode(ClassFileSequencerLexicon.JAVADOC), is(true));
+                    final Node javadocNode = fieldNode.getNode(ClassFileSequencerLexicon.JAVADOC);
+                    final String comment = "A constant";
+                    assertThat(javadocNode.getProperty(ClassFileSequencerLexicon.COMMENT).getString().contains(comment), is(true));
+                }
+
+                { // twoString field
+                    final Node fieldNode = fieldsNode.getNode("twoString");
+                    assertThat(fieldNode.getProperty(ClassFileSequencerLexicon.NAME).getString(), is(fieldNode.getName()));
+                    assertThat(fieldNode.getProperty(ClassFileSequencerLexicon.TYPE_CLASS_NAME).getString(), is("Object"));
+                    assertThat(fieldNode.getProperty(ClassFileSequencerLexicon.VISIBILITY).getString(),
+                               is(Visibility.PUBLIC.getDescription()));
+                    assertThat(fieldNode.getProperty(ClassFileSequencerLexicon.STATIC).getBoolean(), is(false));
+                    assertThat(fieldNode.getProperty(ClassFileSequencerLexicon.FINAL).getBoolean(), is(false));
+                    assertThat(fieldNode.getProperty(ClassFileSequencerLexicon.TRANSIENT).getBoolean(), is(false));
+                    assertThat(fieldNode.getProperty(ClassFileSequencerLexicon.VOLATILE).getBoolean(), is(false));
+                    assertThat(fieldNode.hasNode(ClassFileSequencerLexicon.ANNOTATIONS), is(false));
+                    assertThat(fieldNode.hasNode(ClassFileSequencerLexicon.JAVADOC), is(false));
+
+                    assertThat(fieldNode.hasNode(ClassFileSequencerLexicon.TYPE), is(true));
+                    final Node fieldTypeNode = fieldNode.getNode(ClassFileSequencerLexicon.TYPE);
+                    assertThat(fieldTypeNode.isNodeType(ClassFileSequencerLexicon.SIMPLE_TYPE), is(true));
+                    assertThat(fieldTypeNode.getProperty(ClassFileSequencerLexicon.TYPE_CLASS_NAME).getString(), is("Object"));
+
+                    assertThat(fieldNode.hasNode(ClassFileSequencerLexicon.INITIALIZER), is(true));
+                    final Node initializerNode = fieldNode.getNode(ClassFileSequencerLexicon.INITIALIZER);
+                    assertThat(initializerNode.getProperty(ClassFileSequencerLexicon.CONTENT).getString().contains("toString"),
+                               is(true));
+                }
+
+                { // number field
+                    final Node fieldNode = fieldsNode.getNode("number");
+                    assertThat(fieldNode.getProperty(ClassFileSequencerLexicon.NAME).getString(), is(fieldNode.getName()));
+                    assertThat(fieldNode.getProperty(ClassFileSequencerLexicon.TYPE_CLASS_NAME).getString(), is("Number"));
+                    assertThat(fieldNode.getProperty(ClassFileSequencerLexicon.VISIBILITY).getString(), is("package"));
+                    assertThat(fieldNode.getProperty(ClassFileSequencerLexicon.STATIC).getBoolean(), is(false));
+                    assertThat(fieldNode.getProperty(ClassFileSequencerLexicon.FINAL).getBoolean(), is(false));
+                    assertThat(fieldNode.getProperty(ClassFileSequencerLexicon.TRANSIENT).getBoolean(), is(false));
+                    assertThat(fieldNode.getProperty(ClassFileSequencerLexicon.VOLATILE).getBoolean(), is(false));
+                    assertThat(fieldNode.hasNode(ClassFileSequencerLexicon.ANNOTATIONS), is(false));
+                    assertThat(fieldNode.hasNode(ClassFileSequencerLexicon.JAVADOC), is(false));
+
+                    assertThat(fieldNode.hasNode(ClassFileSequencerLexicon.TYPE), is(true));
+                    final Node fieldTypeNode = fieldNode.getNode(ClassFileSequencerLexicon.TYPE);
+                    assertThat(fieldTypeNode.isNodeType(ClassFileSequencerLexicon.SIMPLE_TYPE), is(true));
+                    assertThat(fieldTypeNode.getProperty(ClassFileSequencerLexicon.TYPE_CLASS_NAME).getString(), is("Number"));
+
+                    assertThat(fieldNode.hasNode(ClassFileSequencerLexicon.INITIALIZER), is(true));
+                    final Node initializerNode = fieldNode.getNode(ClassFileSequencerLexicon.INITIALIZER);
+                    assertThat(initializerNode.getProperty(ClassFileSequencerLexicon.CONTENT).getLong(), is(1L));
+                }
+
+                { // t field
+                    final Node fieldNode = fieldsNode.getNode("t");
+                    assertThat(fieldNode.getProperty(ClassFileSequencerLexicon.NAME).getString(), is(fieldNode.getName()));
+                    assertThat(fieldNode.getProperty(ClassFileSequencerLexicon.TYPE_CLASS_NAME).getString(), is("T"));
+                    assertThat(fieldNode.getProperty(ClassFileSequencerLexicon.VISIBILITY).getString(),
+                               is(Visibility.PRIVATE.getDescription()));
+                    assertThat(fieldNode.getProperty(ClassFileSequencerLexicon.STATIC).getBoolean(), is(false));
+                    assertThat(fieldNode.getProperty(ClassFileSequencerLexicon.FINAL).getBoolean(), is(false));
+                    assertThat(fieldNode.getProperty(ClassFileSequencerLexicon.TRANSIENT).getBoolean(), is(false));
+                    assertThat(fieldNode.getProperty(ClassFileSequencerLexicon.VOLATILE).getBoolean(), is(false));
+                    assertThat(fieldNode.hasNode(ClassFileSequencerLexicon.ANNOTATIONS), is(false));
+                    assertThat(fieldNode.hasNode(ClassFileSequencerLexicon.JAVADOC), is(false));
+                    assertThat(fieldNode.hasNode(ClassFileSequencerLexicon.INITIALIZER), is(false));
+
+                    assertThat(fieldNode.hasNode(ClassFileSequencerLexicon.TYPE), is(true));
+                    final Node fieldTypeNode = fieldNode.getNode(ClassFileSequencerLexicon.TYPE);
+                    assertThat(fieldTypeNode.isNodeType(ClassFileSequencerLexicon.ARRAY_TYPE), is(true));
+                    assertThat(fieldTypeNode.getProperty(ClassFileSequencerLexicon.TYPE_CLASS_NAME).getString(), is("T"));
+                    assertThat(fieldTypeNode.getProperty(ClassFileSequencerLexicon.DIMENSIONS).getLong(), is(1L));
+                    assertThat(fieldTypeNode.hasNode(ClassFileSequencerLexicon.COMPONENT_TYPE), is(true));
+                    final Node componentTypeNode = fieldTypeNode.getNode(ClassFileSequencerLexicon.COMPONENT_TYPE);
+                    assertThat(componentTypeNode.getProperty(ClassFileSequencerLexicon.TYPE_CLASS_NAME).getString(), is("T"));
+                }
+            }
+
+            { // methods
+                assertThat(classNode.hasNode(ClassFileSequencerLexicon.METHODS), is(true));
+                assertThat(classNode.getNode(ClassFileSequencerLexicon.METHODS).getNodes().getSize(), is(4L));
+
+                final Node methodsNode = classNode.getNode(ClassFileSequencerLexicon.METHODS);
+
+                { // getId method
+                    final Node methodNode = methodsNode.getNode("getId");
+                    assertThat(methodNode.getProperty(ClassFileSequencerLexicon.NAME).getString(), is(methodNode.getName()));
+                    assertThat(methodNode.getProperty(ClassFileSequencerLexicon.RETURN_TYPE_CLASS_NAME).getString(), is("String"));
+                    assertThat(methodNode.getProperty(ClassFileSequencerLexicon.VISIBILITY).getString(), is("package"));
+                    assertThat(methodNode.getProperty(ClassFileSequencerLexicon.STATIC).getBoolean(), is(false));
+                    assertThat(methodNode.getProperty(ClassFileSequencerLexicon.FINAL).getBoolean(), is(false));
+                    assertThat(methodNode.getProperty(ClassFileSequencerLexicon.ABSTRACT).getBoolean(), is(true));
+                    assertThat(methodNode.getProperty(ClassFileSequencerLexicon.STRICT_FP).getBoolean(), is(false));
+                    assertThat(methodNode.getProperty(ClassFileSequencerLexicon.NATIVE).getBoolean(), is(false));
+                    assertThat(methodNode.getProperty(ClassFileSequencerLexicon.SYNCHRONIZED).getBoolean(), is(false));
+                    assertThat(methodNode.hasProperty(ClassFileSequencerLexicon.THROWN_EXCEPTIONS), is(false));
+                    assertThat(methodNode.hasNode(ClassFileSequencerLexicon.ANNOTATIONS), is(false));
+                    assertThat(methodNode.hasNode(ClassFileSequencerLexicon.TYPE_PARAMETERS), is(false));
+                    assertThat(methodNode.hasNode(ClassFileSequencerLexicon.METHOD_PARAMETERS), is(false));
+                    assertThat(methodNode.hasNode(ClassFileSequencerLexicon.BODY), is(false));
+
+                    assertThat(methodNode.hasNode(ClassFileSequencerLexicon.JAVADOC), is(true));
+                    final Node javadocNode = methodNode.getNode(ClassFileSequencerLexicon.JAVADOC);
+                    final String comment = "@return the identifier (never <code>null</code>)";
+                    assertThat(javadocNode.getProperty(ClassFileSequencerLexicon.COMMENT).getString().contains(comment), is(true));
+
+                    assertThat(methodNode.hasNode(ClassFileSequencerLexicon.RETURN_TYPE), is(true));
+                    final Node returnTypeNode = methodNode.getNode(ClassFileSequencerLexicon.RETURN_TYPE);
+                    assertThat(returnTypeNode.isNodeType(ClassFileSequencerLexicon.SIMPLE_TYPE), is(true));
+                    assertThat(returnTypeNode.getProperty(ClassFileSequencerLexicon.TYPE_CLASS_NAME).getString(), is("String"));
+                }
+
+                { // set method
+                    final Node methodNode = methodsNode.getNode("set");
+                    assertThat(methodNode.getProperty(ClassFileSequencerLexicon.NAME).getString(), is(methodNode.getName()));
+                    assertThat(methodNode.getProperty(ClassFileSequencerLexicon.VISIBILITY).getString(), is("public"));
+                    assertThat(methodNode.getProperty(ClassFileSequencerLexicon.STATIC).getBoolean(), is(false));
+                    assertThat(methodNode.getProperty(ClassFileSequencerLexicon.FINAL).getBoolean(), is(true));
+                    assertThat(methodNode.getProperty(ClassFileSequencerLexicon.ABSTRACT).getBoolean(), is(false));
+                    assertThat(methodNode.getProperty(ClassFileSequencerLexicon.STRICT_FP).getBoolean(), is(false));
+                    assertThat(methodNode.getProperty(ClassFileSequencerLexicon.NATIVE).getBoolean(), is(false));
+                    assertThat(methodNode.getProperty(ClassFileSequencerLexicon.SYNCHRONIZED).getBoolean(), is(false));
+                    assertThat(methodNode.hasNode(ClassFileSequencerLexicon.ANNOTATIONS), is(false));
+                    assertThat(methodNode.hasNode(ClassFileSequencerLexicon.TYPE_PARAMETERS), is(false));
+                    assertThat(methodNode.hasNode(ClassFileSequencerLexicon.JAVADOC), is(false));
+                    assertThat(methodNode.hasNode(ClassFileSequencerLexicon.BODY), is(true));
+
+                    { // parameters
+                        assertThat(methodNode.hasNode(ClassFileSequencerLexicon.METHOD_PARAMETERS), is(true));
+                        assertThat(methodNode.getNode(ClassFileSequencerLexicon.METHOD_PARAMETERS).getNodes().getSize(), is(1L));
+                        final Node paramNode = methodNode.getNode(ClassFileSequencerLexicon.METHOD_PARAMETERS).getNodes().nextNode();
+                        assertThat(paramNode.getName(), is("t"));
+                        assertThat(paramNode.getPrimaryNodeType().getName(), is(ClassFileSequencerLexicon.PARAMETER));
+                        assertThat(paramNode.getProperty(ClassFileSequencerLexicon.TYPE_CLASS_NAME).getString(), is("T"));
+                        assertThat(paramNode.getProperty(ClassFileSequencerLexicon.FINAL).getBoolean(), is(false));
+                        assertThat(paramNode.getProperty(ClassFileSequencerLexicon.VARARGS).getBoolean(), is(true));
+                        assertThat(paramNode.hasNode(ClassFileSequencerLexicon.INITIALIZER), is(false));
+
+                        assertThat(paramNode.hasNode(ClassFileSequencerLexicon.ANNOTATIONS), is(true));
+                        assertThat(paramNode.getNode(ClassFileSequencerLexicon.ANNOTATIONS).getNodes().getSize(), is(1L));
+                        final Node annotationNode = paramNode.getNode(ClassFileSequencerLexicon.ANNOTATIONS).getNodes().nextNode();
+                        assertThat(annotationNode.getName(), is("SuppressWarnings"));
+                        assertThat(annotationNode.hasProperty(ClassFileSequencerLexicon.ANNOTATION_TYPE), is(true));
+                        assertThat(annotationNode.getProperty(ClassFileSequencerLexicon.ANNOTATION_TYPE).getString(),
+                                   is(ClassFileSequencerLexicon.AnnotationType.SINGLE_MEMBER.toString()));
+                        assertThat(annotationNode.getNodes().getSize(), is(1L));
+
+                        final String memberName = "default";
+                        assertThat(annotationNode.hasNode(memberName), is(true));
+                        final Node memberNode = annotationNode.getNode(memberName);
+                        assertThat(memberNode.getProperty(ClassFileSequencerLexicon.NAME).getString(), is(memberName));
+                        assertThat(memberNode.hasProperty(ClassFileSequencerLexicon.VALUE), is(true));
+                        assertThat(memberNode.getProperty(ClassFileSequencerLexicon.VALUE).getString(), is("unchecked"));
+                    }
+
+                    { // thrown exceptions
+                        assertThat(methodNode.hasProperty(ClassFileSequencerLexicon.THROWN_EXCEPTIONS), is(true));
+                        assertThat(methodNode.getProperty(ClassFileSequencerLexicon.THROWN_EXCEPTIONS).getValues().length, is(1));
+                        assertThat(methodNode.getProperty(ClassFileSequencerLexicon.THROWN_EXCEPTIONS).getValues()[0].getString(),
+                                   is("Exception"));
+                    }
+
+                    { // return type
+                        assertThat(methodNode.getProperty(ClassFileSequencerLexicon.RETURN_TYPE_CLASS_NAME).getString(),
+                                   is("void"));
+                        assertThat(methodNode.hasNode(ClassFileSequencerLexicon.RETURN_TYPE), is(true));
+                        final Node returnTypeNode = methodNode.getNode(ClassFileSequencerLexicon.RETURN_TYPE);
+                        assertThat(returnTypeNode.isNodeType(ClassFileSequencerLexicon.PRIMITIVE_TYPE), is(true));
+                        assertThat(returnTypeNode.getProperty(ClassFileSequencerLexicon.TYPE_CLASS_NAME).getString(), is("void"));
+                    }
+                }
+
+                { // get method
+                    final Node methodNode = methodsNode.getNode("get");
+                    assertThat(methodNode.getProperty(ClassFileSequencerLexicon.NAME).getString(), is(methodNode.getName()));
+                    assertThat(methodNode.getProperty(ClassFileSequencerLexicon.RETURN_TYPE_CLASS_NAME).getString(), is("T"));
+                    assertThat(methodNode.getProperty(ClassFileSequencerLexicon.VISIBILITY).getString(), is("public"));
+                    assertThat(methodNode.getProperty(ClassFileSequencerLexicon.STATIC).getBoolean(), is(false));
+                    assertThat(methodNode.getProperty(ClassFileSequencerLexicon.FINAL).getBoolean(), is(false));
+                    assertThat(methodNode.getProperty(ClassFileSequencerLexicon.ABSTRACT).getBoolean(), is(false));
+                    assertThat(methodNode.getProperty(ClassFileSequencerLexicon.STRICT_FP).getBoolean(), is(false));
+                    assertThat(methodNode.getProperty(ClassFileSequencerLexicon.NATIVE).getBoolean(), is(false));
+                    assertThat(methodNode.getProperty(ClassFileSequencerLexicon.SYNCHRONIZED).getBoolean(), is(true));
+                    assertThat(methodNode.hasProperty(ClassFileSequencerLexicon.THROWN_EXCEPTIONS), is(false));
+                    assertThat(methodNode.hasNode(ClassFileSequencerLexicon.ANNOTATIONS), is(false));
+                    assertThat(methodNode.hasNode(ClassFileSequencerLexicon.TYPE_PARAMETERS), is(false));
+                    assertThat(methodNode.hasNode(ClassFileSequencerLexicon.METHOD_PARAMETERS), is(false));
+                    assertThat(methodNode.hasNode(ClassFileSequencerLexicon.JAVADOC), is(false));
+
+                    assertThat(methodNode.hasNode(ClassFileSequencerLexicon.RETURN_TYPE), is(true));
+                    final Node returnTypeNode = methodNode.getNode(ClassFileSequencerLexicon.RETURN_TYPE);
+                    assertThat(returnTypeNode.isNodeType(ClassFileSequencerLexicon.ARRAY_TYPE), is(true));
+                    assertThat(returnTypeNode.getProperty(ClassFileSequencerLexicon.TYPE_CLASS_NAME).getString(), is("T"));
+                    assertThat(returnTypeNode.getProperty(ClassFileSequencerLexicon.DIMENSIONS).getLong(), is(1L));
+                    assertThat(returnTypeNode.hasNode(ClassFileSequencerLexicon.COMPONENT_TYPE), is(true));
+                    final Node componentTypeNode = returnTypeNode.getNode(ClassFileSequencerLexicon.COMPONENT_TYPE);
+                    assertThat(componentTypeNode.isNodeType(ClassFileSequencerLexicon.TYPE), is(true));
+                    assertThat(componentTypeNode.getProperty(ClassFileSequencerLexicon.TYPE_CLASS_NAME).getString(), is("T"));
+
+                    assertThat(methodNode.hasNode(ClassFileSequencerLexicon.BODY), is(true));
+                    assertThat(methodNode.getNode(ClassFileSequencerLexicon.BODY).getNodes().getSize(), is(1L));
+
+                    final Node statementNode = methodNode.getNode(ClassFileSequencerLexicon.BODY).getNodes().nextNode();
+                    assertThat(statementNode.getName(), is(ClassFileSequencerLexicon.STATEMENT));
+                    assertThat(statementNode.getProperty(ClassFileSequencerLexicon.CONTENT).getString(), is("return this.t;\n"));
+                }
+
+                { // shutdown method
+                    final Node methodNode = methodsNode.getNode("shutdown");
+                    assertThat(methodNode.getProperty(ClassFileSequencerLexicon.NAME).getString(), is(methodNode.getName()));
+                    assertThat(methodNode.getProperty(ClassFileSequencerLexicon.VISIBILITY).getString(), is("public"));
+                    assertThat(methodNode.getProperty(ClassFileSequencerLexicon.STATIC).getBoolean(), is(false));
+                    assertThat(methodNode.getProperty(ClassFileSequencerLexicon.FINAL).getBoolean(), is(false));
+                    assertThat(methodNode.getProperty(ClassFileSequencerLexicon.ABSTRACT).getBoolean(), is(false));
+                    assertThat(methodNode.getProperty(ClassFileSequencerLexicon.STRICT_FP).getBoolean(), is(false));
+                    assertThat(methodNode.getProperty(ClassFileSequencerLexicon.NATIVE).getBoolean(), is(false));
+                    assertThat(methodNode.getProperty(ClassFileSequencerLexicon.SYNCHRONIZED).getBoolean(), is(false));
+                    assertThat(methodNode.hasProperty(ClassFileSequencerLexicon.THROWN_EXCEPTIONS), is(false));
+                    assertThat(methodNode.hasNode(ClassFileSequencerLexicon.BODY), is(true));
+
+                    assertThat(methodNode.hasNode(ClassFileSequencerLexicon.ANNOTATIONS), is(true));
+                    assertThat(methodNode.getNode(ClassFileSequencerLexicon.ANNOTATIONS).getNodes().getSize(), is(1l));
+                    final Node annotationNode = methodNode.getNode(ClassFileSequencerLexicon.ANNOTATIONS).getNodes().nextNode();
+                    assertThat(annotationNode.getName(), is("Deprecated"));
+                    assertThat(annotationNode.hasProperty(ClassFileSequencerLexicon.ANNOTATION_TYPE), is(true));
+                    assertThat(annotationNode.getProperty(ClassFileSequencerLexicon.ANNOTATION_TYPE).getString(),
+                               is(ClassFileSequencerLexicon.AnnotationType.MARKER.toString()));
+                    assertThat(annotationNode.getNodes().getSize(), is(0L));
+
+                    assertThat(methodNode.hasNode(ClassFileSequencerLexicon.TYPE_PARAMETERS), is(true));
+                    assertThat(methodNode.getNode(ClassFileSequencerLexicon.TYPE_PARAMETERS).getNodes().getSize(), is(1L));
+                    final Node typeParamNode = methodNode.getNode(ClassFileSequencerLexicon.TYPE_PARAMETERS).getNodes().nextNode();
+                    assertThat(typeParamNode.getName(), is("U"));
+                    assertThat(typeParamNode.hasNode(ClassFileSequencerLexicon.BOUNDS), is(true));
+                    assertThat(typeParamNode.getNode(ClassFileSequencerLexicon.BOUNDS).getNodes().getSize(), is(1L));
+                    final Node boundNode = typeParamNode.getNode(ClassFileSequencerLexicon.BOUNDS).getNodes().nextNode();
+                    assertThat(boundNode.getName(), is("Number"));
+
+                    assertThat(methodNode.hasNode(ClassFileSequencerLexicon.JAVADOC), is(true));
+                    final Node javadocNode = methodNode.getNode(ClassFileSequencerLexicon.JAVADOC);
+                    final String comment = "Performs a shutdown";
+                    assertThat(javadocNode.getProperty(ClassFileSequencerLexicon.COMMENT).getString().contains(comment), is(true));
+
+                    { // parameters
+                        assertThat(methodNode.hasNode(ClassFileSequencerLexicon.METHOD_PARAMETERS), is(true));
+                        assertThat(methodNode.getNode(ClassFileSequencerLexicon.METHOD_PARAMETERS).getNodes().getSize(), is(1L));
+                        final Node paramNode = methodNode.getNode(ClassFileSequencerLexicon.METHOD_PARAMETERS).getNodes().nextNode();
+                        assertThat(paramNode.getName(), is("waitTime"));
+                        assertThat(paramNode.getPrimaryNodeType().getName(), is(ClassFileSequencerLexicon.PARAMETER));
+                        assertThat(paramNode.getProperty(ClassFileSequencerLexicon.TYPE_CLASS_NAME).getString(), is("U"));
+                        assertThat(paramNode.getProperty(ClassFileSequencerLexicon.FINAL).getBoolean(), is(true));
+                        assertThat(paramNode.getProperty(ClassFileSequencerLexicon.VARARGS).getBoolean(), is(false));
+                        assertThat(paramNode.hasNode(ClassFileSequencerLexicon.ANNOTATIONS), is(false));
+                        assertThat(paramNode.hasNode(ClassFileSequencerLexicon.INITIALIZER), is(false));
+                    }
+
+                    { // return type
+                        assertThat(methodNode.getProperty(ClassFileSequencerLexicon.RETURN_TYPE_CLASS_NAME).getString(),
+                                   is("void"));
+                        assertThat(methodNode.hasNode(ClassFileSequencerLexicon.RETURN_TYPE), is(true));
+                        final Node returnTypeNode = methodNode.getNode(ClassFileSequencerLexicon.RETURN_TYPE);
+                        assertThat(returnTypeNode.isNodeType(ClassFileSequencerLexicon.PRIMITIVE_TYPE), is(true));
+                        assertThat(returnTypeNode.getProperty(ClassFileSequencerLexicon.TYPE_CLASS_NAME).getString(), is("void"));
+                    }
+                }
+            }
+
+            { // typeParameters
+                assertThat(classNode.hasNode(ClassFileSequencerLexicon.TYPE_PARAMETERS), is(true));
+                assertThat(classNode.getNode(ClassFileSequencerLexicon.TYPE_PARAMETERS).getNodes().getSize(), is(1L));
+                assertThat(classNode.getNode(ClassFileSequencerLexicon.TYPE_PARAMETERS).getPrimaryNodeType().getName(),
+                           is(ClassFileSequencerLexicon.TYPE_PARAMETERS));
+
+                final Node typeParamNode = classNode.getNode(ClassFileSequencerLexicon.TYPE_PARAMETERS).getNode("T");
+                assertThat(typeParamNode.getPrimaryNodeType().getName(), is(ClassFileSequencerLexicon.TYPE_PARAMETER));
+                assertThat(typeParamNode.hasNode(ClassFileSequencerLexicon.BOUNDS), is(true));
+
+                final Node boundsNode = typeParamNode.getNode(ClassFileSequencerLexicon.BOUNDS);
+                assertThat(boundsNode.getNodes().getSize(), is(1L));
+                assertThat(boundsNode.getNodes().nextNode().getName(), is("HashMap<String, ?>"));
+            }
+
+            { // implements
+                assertThat(classNode.hasNode(ClassFileSequencerLexicon.IMPLEMENTS), is(true));
+                assertThat(classNode.getNode(ClassFileSequencerLexicon.IMPLEMENTS).getNodes().getSize(), is(1L));
+
+                final Node interfaceNode = classNode.getNode(ClassFileSequencerLexicon.IMPLEMENTS).getNode("Serializable");
+                assertThat(interfaceNode.getPrimaryNodeType().getName(), is(ClassFileSequencerLexicon.SIMPLE_TYPE));
+            }
+
+            { // extends
+                assertThat(classNode.hasNode(ClassFileSequencerLexicon.EXTENDS), is(true));
+                assertThat(classNode.getNode(ClassFileSequencerLexicon.EXTENDS).getNodes().getSize(), is(1L));
+
+                final Node superTypeNode = classNode.getNode(ClassFileSequencerLexicon.EXTENDS).getNode("ArrayList<T>");
+                assertThat(superTypeNode.getPrimaryNodeType().getName(), is(ClassFileSequencerLexicon.PARAMETERIZED_TYPE));
+            }
+
+            { // javadoc
+                assertThat(classNode.hasNode(ClassFileSequencerLexicon.JAVADOC), is(true));
+
+                final Node javadocNode = classNode.getNode(ClassFileSequencerLexicon.JAVADOC);
+                final String comment = "This is a class type test class";
+                assertThat(javadocNode.getProperty(ClassFileSequencerLexicon.COMMENT).getString().contains(comment), is(true));
+            }
+
+            { // nested types
+                assertThat(classNode.hasNode(ClassFileSequencerLexicon.NESTED_TYPES), is(true));
+                assertThat(classNode.getNode(ClassFileSequencerLexicon.NESTED_TYPES).getNodes().getSize(), is(1L));
+
+                final Node nestedTypeNode = classNode.getNode(ClassFileSequencerLexicon.NESTED_TYPES).getNodes().nextNode();
+                assertThat(nestedTypeNode.getName(), is("Blah"));
+                assertThat(nestedTypeNode.getProperty(ClassFileSequencerLexicon.NAME).getString(), is(nestedTypeNode.getName()));
+                assertThat(nestedTypeNode.hasProperty(ClassFileSequencerLexicon.SEQUENCED_DATE), is(true));
+                assertThat(nestedTypeNode.getProperty(ClassFileSequencerLexicon.SUPER_CLASS_NAME).getString(),
+                           is("java.lang.Object"));
+                assertThat(nestedTypeNode.getProperty(ClassFileSequencerLexicon.VISIBILITY).getString(), is("package"));
+                assertThat(nestedTypeNode.getProperty(ClassFileSequencerLexicon.ABSTRACT).getBoolean(), is(false));
+                assertThat(nestedTypeNode.getProperty(ClassFileSequencerLexicon.INTERFACE).getBoolean(), is(false));
+                assertThat(nestedTypeNode.getProperty(ClassFileSequencerLexicon.FINAL).getBoolean(), is(false));
+                assertThat(nestedTypeNode.getProperty(ClassFileSequencerLexicon.STRICT_FP).getBoolean(), is(false));
+                assertThat(nestedTypeNode.getProperty(ClassFileSequencerLexicon.STATIC).getBoolean(), is(false));
+                assertThat(nestedTypeNode.hasProperty(ClassFileSequencerLexicon.IMPORTS), is(false));
+
+                assertThat(nestedTypeNode.hasProperty(ClassFileSequencerLexicon.INTERFACES), is(true));
+                assertThat(nestedTypeNode.getProperty(ClassFileSequencerLexicon.INTERFACES).getValues().length, is(1));
+                assertThat(nestedTypeNode.getProperty(ClassFileSequencerLexicon.INTERFACES).getValues()[0].getString(),
+                           is("Comparable<T>"));
+
+                assertThat(nestedTypeNode.hasNode(ClassFileSequencerLexicon.FIELDS), is(true));
+                assertThat(nestedTypeNode.getNode(ClassFileSequencerLexicon.FIELDS).getNodes().getSize(), is(1L));
+
+                assertThat(nestedTypeNode.hasNode(ClassFileSequencerLexicon.CONSTRUCTORS), is(true));
+                assertThat(nestedTypeNode.getNode(ClassFileSequencerLexicon.CONSTRUCTORS).getNodes().getSize(), is(1L));
+
+                assertThat(nestedTypeNode.hasNode(ClassFileSequencerLexicon.METHODS), is(true));
+                assertThat(nestedTypeNode.getNode(ClassFileSequencerLexicon.METHODS).getNodes().getSize(), is(2L));
+            }
+        }
+    }
+
+    @Ignore
+    @Test
+    public void shouldSequenceTwoClassesFile() throws Exception {
+        final String packagePath = ClassType.class.getName().replaceAll("\\.", "/");
+        createNodeWithContentFromFile("twoouterclasses.java", packagePath + ".java");
+
+        // expected by sequencer in a different location
+        final String expectedOutputPath = "java/twoouterclasses.java";
+        final Node compilationUnitNode = getOutputNode(rootNode, expectedOutputPath);
+        assertThat(compilationUnitNode, is(notNullValue()));
+        assertThat(compilationUnitNode.isNodeType(ClassFileSequencerLexicon.COMPILATION_UNIT), is(true));
+        assertThat(compilationUnitNode.hasProperty(ClassFileSequencerLexicon.SEQUENCED_DATE), is(true));
+        assertThat(compilationUnitNode.hasNode(ClassFileSequencerLexicon.MESSAGES), is(false));
+        assertThat(compilationUnitNode.hasProperty(ClassFileSequencerLexicon.TYPES), is(true));
+        assertThat(compilationUnitNode.getProperty(ClassFileSequencerLexicon.TYPES).getValues().length, is(2));
+    }
+
+}

--- a/sequencers/modeshape-sequencer-java/src/test/java/org/modeshape/sequencer/javafile/EnumTypeSequencerTest.java
+++ b/sequencers/modeshape-sequencer-java/src/test/java/org/modeshape/sequencer/javafile/EnumTypeSequencerTest.java
@@ -1,0 +1,474 @@
+/*
+ * ModeShape (http://www.modeshape.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.modeshape.sequencer.javafile;
+
+import java.util.ArrayList;
+import java.util.List;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsNull.notNullValue;
+import static org.hamcrest.CoreMatchers.hasItems;
+import static org.junit.Assert.assertThat;
+import javax.jcr.Node;
+import javax.jcr.NodeIterator;
+import javax.jcr.Value;
+import org.junit.Test;
+import org.modeshape.jcr.sequencer.AbstractSequencerTest;
+import org.modeshape.sequencer.classfile.ClassFileSequencerLexicon;
+import org.modeshape.sequencer.classfile.metadata.Visibility;
+import org.modeshape.sequencer.testdata.EnumType;
+
+public final class EnumTypeSequencerTest extends AbstractSequencerTest {
+
+    @Test
+    public void shouldSequenceEnumTypeFile() throws Exception {
+        final String packagePath = EnumType.class.getName().replaceAll("\\.", "/");
+        createNodeWithContentFromFile("enumtype.java", packagePath + ".java");
+
+        // expected by sequencer in a different location
+        final String expectedOutputPath = "java/enumtype.java";
+        final Node compilationUnitNode = getOutputNode(rootNode, expectedOutputPath);
+        assertThat(compilationUnitNode, is(notNullValue()));
+        assertThat(compilationUnitNode.isNodeType(ClassFileSequencerLexicon.COMPILATION_UNIT), is(true));
+        assertThat(compilationUnitNode.hasProperty(ClassFileSequencerLexicon.SEQUENCED_DATE), is(true));
+        assertThat(compilationUnitNode.hasProperty(ClassFileSequencerLexicon.TYPES), is(true));
+        assertThat(compilationUnitNode.getProperty(ClassFileSequencerLexicon.TYPES).getValues().length, is(1));
+        assertThat(compilationUnitNode.hasNode(ClassFileSequencerLexicon.MESSAGES), is(false));
+
+        { // 2 imports
+            assertThat(compilationUnitNode.hasNode(ClassFileSequencerLexicon.IMPORTS), is(true));
+            assertThat(compilationUnitNode.getNode(ClassFileSequencerLexicon.IMPORTS).getNodes().getSize(), is(2L));
+
+            final NodeIterator itr = compilationUnitNode.getNode(ClassFileSequencerLexicon.IMPORTS).getNodes();
+
+            { // first import
+                final Node firstImport = itr.nextNode();
+                assertThat(firstImport.getName(), is("java.util.EnumSet"));
+                assertThat(firstImport.hasProperty(ClassFileSequencerLexicon.STATIC), is(true));
+                assertThat(firstImport.getProperty(ClassFileSequencerLexicon.STATIC).getBoolean(), is(false));
+                assertThat(firstImport.hasProperty(ClassFileSequencerLexicon.ON_DEMAND), is(true));
+                assertThat(firstImport.getProperty(ClassFileSequencerLexicon.ON_DEMAND).getBoolean(), is(false));
+            }
+
+            { // second import
+                final Node secondImport = itr.nextNode();
+                assertThat(secondImport.getName(), is("java.util"));
+                assertThat(secondImport.hasProperty(ClassFileSequencerLexicon.STATIC), is(true));
+                assertThat(secondImport.getProperty(ClassFileSequencerLexicon.STATIC).getBoolean(), is(false));
+                assertThat(secondImport.hasProperty(ClassFileSequencerLexicon.ON_DEMAND), is(true));
+                assertThat(secondImport.getProperty(ClassFileSequencerLexicon.ON_DEMAND).getBoolean(), is(true));
+            }
+        }
+
+        { // comments
+            assertThat(compilationUnitNode.hasNode(ClassFileSequencerLexicon.COMMENTS), is(true));
+            assertThat(compilationUnitNode.getNode(ClassFileSequencerLexicon.COMMENTS).getNodes().getSize(), is(3L));
+
+            final NodeIterator itr = compilationUnitNode.getNode(ClassFileSequencerLexicon.COMMENTS).getNodes();
+
+            {
+                final Node comment = itr.nextNode();
+                assertThat(comment.getName(), is(ClassFileSequencerLexicon.COMMENT));
+                assertThat(comment.hasProperty(ClassFileSequencerLexicon.COMMENT_TYPE), is(true));
+                assertThat(comment.getProperty(ClassFileSequencerLexicon.COMMENT_TYPE).getString(),
+                           is(ClassFileSequencerLexicon.CommentType.BLOCK.toString()));
+                assertThat(comment.hasProperty(ClassFileSequencerLexicon.COMMENT), is(true));
+                assertThat(comment.getProperty(ClassFileSequencerLexicon.COMMENT).getString().startsWith("/*\n * ModeShape"),
+                           is(true));
+            }
+
+            {
+                final Node comment = itr.nextNode();
+                assertThat(comment.getName(), is(ClassFileSequencerLexicon.COMMENT));
+                assertThat(comment.hasProperty(ClassFileSequencerLexicon.COMMENT_TYPE), is(true));
+                assertThat(comment.getProperty(ClassFileSequencerLexicon.COMMENT_TYPE).getString(),
+                           is(ClassFileSequencerLexicon.CommentType.LINE.toString()));
+                assertThat(comment.hasProperty(ClassFileSequencerLexicon.COMMENT), is(true));
+                assertThat(comment.getProperty(ClassFileSequencerLexicon.COMMENT).getString(), is("//CHECKSTYLE:OFF"));
+            }
+
+            {
+                final Node comment = itr.nextNode();
+                assertThat(comment.getName(), is(ClassFileSequencerLexicon.COMMENT));
+                assertThat(comment.hasProperty(ClassFileSequencerLexicon.COMMENT_TYPE), is(true));
+                assertThat(comment.getProperty(ClassFileSequencerLexicon.COMMENT_TYPE).getString(),
+                           is(ClassFileSequencerLexicon.CommentType.LINE.toString()));
+                assertThat(comment.hasProperty(ClassFileSequencerLexicon.COMMENT), is(true));
+                assertThat(comment.getProperty(ClassFileSequencerLexicon.COMMENT).getString(), is("//CHECKSTYLE:ON"));
+            }
+        }
+
+        { // enum type
+            final Node enumNode = compilationUnitNode.getNode(packagePath);
+            assertThat(enumNode.getName(), is("EnumType"));
+            assertThat(enumNode.getProperty(ClassFileSequencerLexicon.NAME).getString(), is(enumNode.getName()));
+            assertThat(enumNode.hasProperty(ClassFileSequencerLexicon.SEQUENCED_DATE), is(true));
+            assertThat(enumNode.hasProperty(ClassFileSequencerLexicon.SUPER_CLASS_NAME), is(false));
+            assertThat(enumNode.getProperty(ClassFileSequencerLexicon.VISIBILITY).getString(),
+                       is(Visibility.PUBLIC.getDescription()));
+            assertThat(enumNode.getProperty(ClassFileSequencerLexicon.ABSTRACT).getBoolean(), is(false));
+            assertThat(enumNode.getProperty(ClassFileSequencerLexicon.INTERFACE).getBoolean(), is(false));
+            assertThat(enumNode.getProperty(ClassFileSequencerLexicon.FINAL).getBoolean(), is(false));
+            assertThat(enumNode.getProperty(ClassFileSequencerLexicon.STRICT_FP).getBoolean(), is(false));
+            assertThat(enumNode.getProperty(ClassFileSequencerLexicon.STATIC).getBoolean(), is(false));
+            assertThat(enumNode.hasProperty(ClassFileSequencerLexicon.IMPORTS), is(false));
+            assertThat(enumNode.hasProperty(ClassFileSequencerLexicon.INTERFACES), is(true));
+            assertThat(enumNode.getProperty(ClassFileSequencerLexicon.INTERFACES).getValues().length, is(1));
+            assertThat(enumNode.getProperty(ClassFileSequencerLexicon.INTERFACES).getValues()[0].getString(), is("Cloneable"));
+
+            assertThat(enumNode.hasNode(ClassFileSequencerLexicon.FIELDS), is(true));
+            assertThat(enumNode.getNode(ClassFileSequencerLexicon.FIELDS).getNodes().getSize(), is(3L));
+
+            final Node fieldsNode = enumNode.getNode(ClassFileSequencerLexicon.FIELDS);
+
+            { // _lookup field
+                final Node fieldNode = fieldsNode.getNode("_lookup");
+                assertThat(fieldNode.getProperty(ClassFileSequencerLexicon.NAME).getString(), is(fieldNode.getName()));
+                assertThat(fieldNode.getProperty(ClassFileSequencerLexicon.TYPE_CLASS_NAME).getString(),
+                           is("Map<Integer, EnumType>"));
+                assertThat(fieldNode.getProperty(ClassFileSequencerLexicon.VISIBILITY).getString(),
+                           is(Visibility.PRIVATE.getDescription()));
+                assertThat(fieldNode.getProperty(ClassFileSequencerLexicon.STATIC).getBoolean(), is(true));
+                assertThat(fieldNode.getProperty(ClassFileSequencerLexicon.FINAL).getBoolean(), is(true));
+                assertThat(fieldNode.getProperty(ClassFileSequencerLexicon.TRANSIENT).getBoolean(), is(false));
+                assertThat(fieldNode.getProperty(ClassFileSequencerLexicon.VOLATILE).getBoolean(), is(false));
+                assertThat(fieldNode.hasNode(ClassFileSequencerLexicon.ANNOTATIONS), is(false));
+                assertThat(fieldNode.hasNode(ClassFileSequencerLexicon.INITIALIZER), is(false));
+                assertThat(fieldNode.hasNode(ClassFileSequencerLexicon.JAVADOC), is(false));
+
+                assertThat(fieldNode.hasNode(ClassFileSequencerLexicon.TYPE), is(true));
+                final Node fieldTypeNode = fieldNode.getNode(ClassFileSequencerLexicon.TYPE);
+                assertThat(fieldTypeNode.isNodeType(ClassFileSequencerLexicon.PARAMETERIZED_TYPE), is(true));
+                assertThat(fieldTypeNode.getProperty(ClassFileSequencerLexicon.TYPE_CLASS_NAME).getString(),
+                           is("Map<Integer, EnumType>"));
+            }
+
+            { // code field
+                final Node fieldNode = fieldsNode.getNode("code");
+                assertThat(fieldNode.getProperty(ClassFileSequencerLexicon.NAME).getString(), is(fieldNode.getName()));
+                assertThat(fieldNode.getProperty(ClassFileSequencerLexicon.TYPE_CLASS_NAME).getString(), is("int"));
+                assertThat(fieldNode.getProperty(ClassFileSequencerLexicon.VISIBILITY).getString(),
+                           is(Visibility.PRIVATE.getDescription()));
+                assertThat(fieldNode.getProperty(ClassFileSequencerLexicon.STATIC).getBoolean(), is(false));
+                assertThat(fieldNode.getProperty(ClassFileSequencerLexicon.FINAL).getBoolean(), is(false));
+                assertThat(fieldNode.getProperty(ClassFileSequencerLexicon.TRANSIENT).getBoolean(), is(false));
+                assertThat(fieldNode.getProperty(ClassFileSequencerLexicon.VOLATILE).getBoolean(), is(false));
+                assertThat(fieldNode.hasNode(ClassFileSequencerLexicon.ANNOTATIONS), is(false));
+                assertThat(fieldNode.hasNode(ClassFileSequencerLexicon.INITIALIZER), is(false));
+                assertThat(fieldNode.hasNode(ClassFileSequencerLexicon.JAVADOC), is(false));
+
+                assertThat(fieldNode.hasNode(ClassFileSequencerLexicon.TYPE), is(true));
+                final Node fieldTypeNode = fieldNode.getNode(ClassFileSequencerLexicon.TYPE);
+                assertThat(fieldTypeNode.isNodeType(ClassFileSequencerLexicon.PRIMITIVE_TYPE), is(true));
+                assertThat(fieldTypeNode.getProperty(ClassFileSequencerLexicon.TYPE_CLASS_NAME).getString(), is("int"));
+            }
+
+            { // executor field
+                final Node fieldNode = fieldsNode.getNode("executor");
+                assertThat(fieldNode.getProperty(ClassFileSequencerLexicon.NAME).getString(), is(fieldNode.getName()));
+                assertThat(fieldNode.getProperty(ClassFileSequencerLexicon.TYPE_CLASS_NAME).getString(), is("Executor"));
+                assertThat(fieldNode.getProperty(ClassFileSequencerLexicon.VISIBILITY).getString(),
+                           is(Visibility.PACKAGE.getDescription()));
+                assertThat(fieldNode.getProperty(ClassFileSequencerLexicon.STATIC).getBoolean(), is(false));
+                assertThat(fieldNode.getProperty(ClassFileSequencerLexicon.FINAL).getBoolean(), is(false));
+                assertThat(fieldNode.getProperty(ClassFileSequencerLexicon.TRANSIENT).getBoolean(), is(false));
+                assertThat(fieldNode.getProperty(ClassFileSequencerLexicon.VOLATILE).getBoolean(), is(false));
+                assertThat(fieldNode.hasNode(ClassFileSequencerLexicon.ANNOTATIONS), is(false));
+                assertThat(fieldNode.hasNode(ClassFileSequencerLexicon.INITIALIZER), is(false));
+                assertThat(fieldNode.hasNode(ClassFileSequencerLexicon.JAVADOC), is(false));
+
+                assertThat(fieldNode.hasNode(ClassFileSequencerLexicon.TYPE), is(true));
+                final Node fieldTypeNode = fieldNode.getNode(ClassFileSequencerLexicon.TYPE);
+                assertThat(fieldTypeNode.isNodeType(ClassFileSequencerLexicon.SIMPLE_TYPE), is(true));
+                assertThat(fieldTypeNode.getProperty(ClassFileSequencerLexicon.TYPE_CLASS_NAME).getString(), is("Executor"));
+            }
+
+            assertThat(enumNode.hasNode(ClassFileSequencerLexicon.CONSTRUCTORS), is(true));
+            assertThat(enumNode.getNode(ClassFileSequencerLexicon.CONSTRUCTORS).getNodes().getSize(), is(1L));
+
+            { // constructor
+                final Node constructorNode = enumNode.getNode(ClassFileSequencerLexicon.CONSTRUCTORS).getNodes().nextNode();
+                assertThat(constructorNode.getName(), is("EnumType"));
+                assertThat(constructorNode.getProperty(ClassFileSequencerLexicon.RETURN_TYPE_CLASS_NAME).getString(), is("void"));
+                assertThat(constructorNode.getProperty(ClassFileSequencerLexicon.VISIBILITY).getString(), is("private"));
+                assertThat(constructorNode.getProperty(ClassFileSequencerLexicon.STATIC).getBoolean(), is(false));
+                assertThat(constructorNode.getProperty(ClassFileSequencerLexicon.FINAL).getBoolean(), is(false));
+                assertThat(constructorNode.getProperty(ClassFileSequencerLexicon.ABSTRACT).getBoolean(), is(false));
+                assertThat(constructorNode.getProperty(ClassFileSequencerLexicon.STRICT_FP).getBoolean(), is(false));
+                assertThat(constructorNode.getProperty(ClassFileSequencerLexicon.NATIVE).getBoolean(), is(false));
+                assertThat(constructorNode.getProperty(ClassFileSequencerLexicon.SYNCHRONIZED).getBoolean(), is(false));
+                assertThat(constructorNode.hasProperty(ClassFileSequencerLexicon.THROWN_EXCEPTIONS), is(false));
+                assertThat(constructorNode.hasNode(ClassFileSequencerLexicon.ANNOTATIONS), is(false));
+                assertThat(constructorNode.hasNode(ClassFileSequencerLexicon.TYPE_PARAMETERS), is(false));
+                assertThat(constructorNode.hasNode(ClassFileSequencerLexicon.JAVADOC), is(false));
+                assertThat(constructorNode.hasNode(ClassFileSequencerLexicon.METHOD_PARAMETERS), is(true));
+                assertThat(constructorNode.getNode(ClassFileSequencerLexicon.METHOD_PARAMETERS).getNodes().getSize(), is(1L));
+
+                { // code parameter
+                    final Node paramNode = constructorNode.getNode(ClassFileSequencerLexicon.METHOD_PARAMETERS).getNodes().nextNode();
+                    assertThat(paramNode.getName(), is("code"));
+                    assertThat(paramNode.getProperty(ClassFileSequencerLexicon.FINAL).getBoolean(), is(false));
+                    assertThat(paramNode.getProperty(ClassFileSequencerLexicon.VARARGS).getBoolean(), is(false));
+                    assertThat(paramNode.getProperty(ClassFileSequencerLexicon.TYPE_CLASS_NAME).getString(), is("int"));
+                    assertThat(paramNode.hasNode(ClassFileSequencerLexicon.ANNOTATIONS), is(false));
+                    assertThat(paramNode.hasNode(ClassFileSequencerLexicon.INITIALIZER), is(false));
+                    assertThat(paramNode.hasNode(ClassFileSequencerLexicon.TYPE), is(true));
+                }
+
+                { // constructor body statements
+                    assertThat(constructorNode.hasNode(ClassFileSequencerLexicon.BODY), is(true));
+                    assertThat(constructorNode.getNode(ClassFileSequencerLexicon.BODY).getNodes().getSize(), is(2L));
+
+                    final NodeIterator itr = constructorNode.getNode(ClassFileSequencerLexicon.BODY).getNodes();
+
+                    { // first statement
+                        final Node statementNode = itr.nextNode();
+                        assertThat(statementNode.getProperty(ClassFileSequencerLexicon.CONTENT).getString(),
+                                   is("this.code=code;\n"));
+                    }
+
+                    { // second statement
+                        final Node statementNode = itr.nextNode();
+                        assertThat(statementNode.getProperty(ClassFileSequencerLexicon.CONTENT).getString(),
+                                   is("this.executor=new Executor();\n"));
+                    }
+                }
+            }
+
+            assertThat(enumNode.hasNode(ClassFileSequencerLexicon.METHODS), is(true));
+            assertThat(enumNode.getNode(ClassFileSequencerLexicon.METHODS).getNodes().getSize(), is(3L));
+
+            final Node methodsNode = enumNode.getNode(ClassFileSequencerLexicon.METHODS);
+
+            { // getId method
+                final Node methodNode = methodsNode.getNode("getCode");
+                assertThat(methodNode.getProperty(ClassFileSequencerLexicon.NAME).getString(), is(methodNode.getName()));
+                assertThat(methodNode.getProperty(ClassFileSequencerLexicon.RETURN_TYPE_CLASS_NAME).getString(), is("int"));
+                assertThat(methodNode.getProperty(ClassFileSequencerLexicon.VISIBILITY).getString(),
+                           is(Visibility.PUBLIC.getDescription()));
+                assertThat(methodNode.getProperty(ClassFileSequencerLexicon.STATIC).getBoolean(), is(false));
+                assertThat(methodNode.getProperty(ClassFileSequencerLexicon.FINAL).getBoolean(), is(false));
+                assertThat(methodNode.getProperty(ClassFileSequencerLexicon.ABSTRACT).getBoolean(), is(false));
+                assertThat(methodNode.getProperty(ClassFileSequencerLexicon.STRICT_FP).getBoolean(), is(false));
+                assertThat(methodNode.getProperty(ClassFileSequencerLexicon.NATIVE).getBoolean(), is(false));
+                assertThat(methodNode.getProperty(ClassFileSequencerLexicon.SYNCHRONIZED).getBoolean(), is(false));
+                assertThat(methodNode.hasProperty(ClassFileSequencerLexicon.THROWN_EXCEPTIONS), is(false));
+                assertThat(methodNode.hasNode(ClassFileSequencerLexicon.ANNOTATIONS), is(false));
+                assertThat(methodNode.hasNode(ClassFileSequencerLexicon.TYPE_PARAMETERS), is(false));
+                assertThat(methodNode.hasNode(ClassFileSequencerLexicon.METHOD_PARAMETERS), is(false));
+                assertThat(methodNode.hasNode(ClassFileSequencerLexicon.JAVADOC), is(false));
+
+                assertThat(methodNode.hasNode(ClassFileSequencerLexicon.RETURN_TYPE), is(true));
+                final Node returnTypeNode = methodNode.getNode(ClassFileSequencerLexicon.RETURN_TYPE);
+                assertThat(returnTypeNode.isNodeType(ClassFileSequencerLexicon.PRIMITIVE_TYPE), is(true));
+                assertThat(returnTypeNode.getProperty(ClassFileSequencerLexicon.TYPE_CLASS_NAME).getString(), is("int"));
+
+                assertThat(methodNode.hasNode(ClassFileSequencerLexicon.BODY), is(true));
+                assertThat(methodNode.getNode(ClassFileSequencerLexicon.BODY).getNodes().getSize(), is(1L));
+                final Node statementNode = methodNode.getNode(ClassFileSequencerLexicon.BODY).getNodes().nextNode();
+                assertThat(statementNode.getProperty(ClassFileSequencerLexicon.CONTENT).getString(), is("return this.code;\n"));
+            }
+
+            { // execute method
+                final Node methodNode = methodsNode.getNode("execute");
+                assertThat(methodNode.getProperty(ClassFileSequencerLexicon.NAME).getString(), is(methodNode.getName()));
+                assertThat(methodNode.getProperty(ClassFileSequencerLexicon.RETURN_TYPE_CLASS_NAME).getString(), is("void"));
+                assertThat(methodNode.getProperty(ClassFileSequencerLexicon.VISIBILITY).getString(),
+                           is(Visibility.PUBLIC.getDescription()));
+                assertThat(methodNode.getProperty(ClassFileSequencerLexicon.STATIC).getBoolean(), is(false));
+                assertThat(methodNode.getProperty(ClassFileSequencerLexicon.FINAL).getBoolean(), is(false));
+                assertThat(methodNode.getProperty(ClassFileSequencerLexicon.ABSTRACT).getBoolean(), is(true));
+                assertThat(methodNode.getProperty(ClassFileSequencerLexicon.STRICT_FP).getBoolean(), is(false));
+                assertThat(methodNode.getProperty(ClassFileSequencerLexicon.NATIVE).getBoolean(), is(false));
+                assertThat(methodNode.getProperty(ClassFileSequencerLexicon.SYNCHRONIZED).getBoolean(), is(false));
+                assertThat(methodNode.hasProperty(ClassFileSequencerLexicon.THROWN_EXCEPTIONS), is(false));
+                assertThat(methodNode.hasNode(ClassFileSequencerLexicon.ANNOTATIONS), is(false));
+                assertThat(methodNode.hasNode(ClassFileSequencerLexicon.TYPE_PARAMETERS), is(false));
+                assertThat(methodNode.hasNode(ClassFileSequencerLexicon.METHOD_PARAMETERS), is(false));
+                assertThat(methodNode.hasNode(ClassFileSequencerLexicon.BODY), is(false));
+                assertThat(methodNode.hasNode(ClassFileSequencerLexicon.JAVADOC), is(false));
+
+                assertThat(methodNode.hasNode(ClassFileSequencerLexicon.RETURN_TYPE), is(true));
+                final Node returnTypeNode = methodNode.getNode(ClassFileSequencerLexicon.RETURN_TYPE);
+                assertThat(returnTypeNode.isNodeType(ClassFileSequencerLexicon.PRIMITIVE_TYPE), is(true));
+                assertThat(returnTypeNode.getProperty(ClassFileSequencerLexicon.TYPE_CLASS_NAME).getString(), is("void"));
+            }
+
+            { // get method
+                final Node methodNode = methodsNode.getNode("get");
+                assertThat(methodNode.getProperty(ClassFileSequencerLexicon.NAME).getString(), is(methodNode.getName()));
+                assertThat(methodNode.getProperty(ClassFileSequencerLexicon.RETURN_TYPE_CLASS_NAME).getString(), is("EnumType"));
+                assertThat(methodNode.getProperty(ClassFileSequencerLexicon.VISIBILITY).getString(),
+                           is(Visibility.PUBLIC.getDescription()));
+                assertThat(methodNode.getProperty(ClassFileSequencerLexicon.STATIC).getBoolean(), is(true));
+                assertThat(methodNode.getProperty(ClassFileSequencerLexicon.FINAL).getBoolean(), is(false));
+                assertThat(methodNode.getProperty(ClassFileSequencerLexicon.ABSTRACT).getBoolean(), is(false));
+                assertThat(methodNode.getProperty(ClassFileSequencerLexicon.STRICT_FP).getBoolean(), is(false));
+                assertThat(methodNode.getProperty(ClassFileSequencerLexicon.NATIVE).getBoolean(), is(false));
+                assertThat(methodNode.getProperty(ClassFileSequencerLexicon.SYNCHRONIZED).getBoolean(), is(false));
+                assertThat(methodNode.hasProperty(ClassFileSequencerLexicon.THROWN_EXCEPTIONS), is(false));
+                assertThat(methodNode.hasNode(ClassFileSequencerLexicon.ANNOTATIONS), is(false));
+                assertThat(methodNode.hasNode(ClassFileSequencerLexicon.TYPE_PARAMETERS), is(false));
+                assertThat(methodNode.hasNode(ClassFileSequencerLexicon.JAVADOC), is(false));
+
+                assertThat(methodNode.hasNode(ClassFileSequencerLexicon.METHOD_PARAMETERS), is(true));
+                assertThat(methodNode.getNode(ClassFileSequencerLexicon.METHOD_PARAMETERS).getNodes().getSize(), is(1L));
+
+                { // code parameter
+                    final Node paramNode = methodNode.getNode(ClassFileSequencerLexicon.METHOD_PARAMETERS).getNodes().nextNode();
+                    assertThat(paramNode.getName(), is("code"));
+                    assertThat(paramNode.getProperty(ClassFileSequencerLexicon.FINAL).getBoolean(), is(false));
+                    assertThat(paramNode.getProperty(ClassFileSequencerLexicon.VARARGS).getBoolean(), is(false));
+                    assertThat(paramNode.getProperty(ClassFileSequencerLexicon.TYPE_CLASS_NAME).getString(), is("int"));
+                    assertThat(paramNode.hasNode(ClassFileSequencerLexicon.ANNOTATIONS), is(false));
+                    assertThat(paramNode.hasNode(ClassFileSequencerLexicon.INITIALIZER), is(false));
+                    assertThat(paramNode.hasNode(ClassFileSequencerLexicon.TYPE), is(true));
+                }
+
+                { // body
+                    assertThat(methodNode.hasNode(ClassFileSequencerLexicon.BODY), is(true));
+                    assertThat(methodNode.getNode(ClassFileSequencerLexicon.BODY).getNodes().getSize(), is(1L));
+                    final Node statementNode = methodNode.getNode(ClassFileSequencerLexicon.BODY).getNodes().nextNode();
+                    assertThat(statementNode.getProperty(ClassFileSequencerLexicon.CONTENT).getString(),
+                               is("return _lookup.get(code);\n"));
+                }
+
+                assertThat(methodNode.hasNode(ClassFileSequencerLexicon.RETURN_TYPE), is(true));
+                final Node returnTypeNode = methodNode.getNode(ClassFileSequencerLexicon.RETURN_TYPE);
+                assertThat(returnTypeNode.isNodeType(ClassFileSequencerLexicon.SIMPLE_TYPE), is(true));
+                assertThat(returnTypeNode.getProperty(ClassFileSequencerLexicon.TYPE_CLASS_NAME).getString(), is("EnumType"));
+            }
+
+            { // initializer
+                assertThat(enumNode.hasNode(ClassFileSequencerLexicon.INITIALIZER), is(true));
+
+                final Node initializerNode = enumNode.getNode(ClassFileSequencerLexicon.INITIALIZER);
+                assertThat(initializerNode.getNodes().getSize(), is(2L));
+
+                final NodeIterator itr = initializerNode.getNodes();
+
+                { // first statement
+                    final Node statementNode = itr.nextNode();
+                    assertThat(statementNode.getProperty(ClassFileSequencerLexicon.CONTENT).getString(),
+                               is("_lookup=new HashMap<Integer,EnumType>();\n"));
+                }
+
+                { // second statement
+                    final Node statementNode = itr.nextNode();
+                    assertThat(statementNode.getProperty(ClassFileSequencerLexicon.CONTENT).getString().startsWith("for (EnumType"),
+                               is(true));
+                }
+            }
+
+            { // nested types
+                assertThat(enumNode.hasNode(ClassFileSequencerLexicon.NESTED_TYPES), is(true));
+                assertThat(enumNode.getNode(ClassFileSequencerLexicon.NESTED_TYPES).getNodes().getSize(), is(1L));
+
+                final Node nestedTypeNode = enumNode.getNode(ClassFileSequencerLexicon.NESTED_TYPES).getNodes().nextNode();
+                assertThat(nestedTypeNode.getName(), is("Executor"));
+                assertThat(nestedTypeNode.getProperty(ClassFileSequencerLexicon.NAME).getString(), is(nestedTypeNode.getName()));
+                assertThat(nestedTypeNode.hasProperty(ClassFileSequencerLexicon.SEQUENCED_DATE), is(true));
+                assertThat(nestedTypeNode.getProperty(ClassFileSequencerLexicon.SUPER_CLASS_NAME).getString(),
+                           is("java.lang.Object"));
+                assertThat(nestedTypeNode.getProperty(ClassFileSequencerLexicon.VISIBILITY).getString(), is("package"));
+                assertThat(nestedTypeNode.getProperty(ClassFileSequencerLexicon.ABSTRACT).getBoolean(), is(false));
+                assertThat(nestedTypeNode.getProperty(ClassFileSequencerLexicon.INTERFACE).getBoolean(), is(false));
+                assertThat(nestedTypeNode.getProperty(ClassFileSequencerLexicon.FINAL).getBoolean(), is(false));
+                assertThat(nestedTypeNode.getProperty(ClassFileSequencerLexicon.STRICT_FP).getBoolean(), is(false));
+                assertThat(nestedTypeNode.getProperty(ClassFileSequencerLexicon.STATIC).getBoolean(), is(false));
+                assertThat(nestedTypeNode.hasProperty(ClassFileSequencerLexicon.IMPORTS), is(false));
+                assertThat(nestedTypeNode.hasProperty(ClassFileSequencerLexicon.INTERFACES), is(false));
+                assertThat(nestedTypeNode.hasNode(ClassFileSequencerLexicon.FIELDS), is(false));
+                assertThat(nestedTypeNode.hasNode(ClassFileSequencerLexicon.CONSTRUCTORS), is(false));
+                assertThat(nestedTypeNode.hasNode(ClassFileSequencerLexicon.METHODS), is(true));
+                assertThat(nestedTypeNode.getNode(ClassFileSequencerLexicon.METHODS).getNodes().getSize(), is(1L));
+            }
+
+            // enum constants
+            final Value[] jcrValues = enumNode.getProperty(ClassFileSequencerLexicon.ENUM_VALUES).getValues();
+            final List<String> values = new ArrayList<>(jcrValues.length);
+            for (final Value value : jcrValues)
+                values.add(value.getString());
+            assertThat(values, hasItems("DONE", "READY", "SKIPPED", "WAITING"));
+            assertThat(enumNode.hasNode(ClassFileSequencerLexicon.ENUM_CONSTANTS), is(true));
+
+            final Node constantsNode = enumNode.getNode(ClassFileSequencerLexicon.ENUM_CONSTANTS);
+
+            { // DONE
+                assertThat(constantsNode.hasNode("DONE"), is(true));
+                final Node doneNode = constantsNode.getNode("DONE");
+                assertThat(doneNode.hasNode(ClassFileSequencerLexicon.ANNOTATIONS), is(false));
+                assertThat(doneNode.hasNode(ClassFileSequencerLexicon.JAVADOC), is(true));
+                assertThat(doneNode.hasNode(ClassFileSequencerLexicon.FIELDS), is(false));
+                assertThat(doneNode.hasNode(ClassFileSequencerLexicon.METHODS), is(true));
+                assertThat(doneNode.hasNode(ClassFileSequencerLexicon.NESTED_TYPES), is(false));
+
+                assertThat(doneNode.hasNode(ClassFileSequencerLexicon.ARGUMENTS), is(true));
+                assertThat(doneNode.getNode(ClassFileSequencerLexicon.ARGUMENTS).getNodes().getSize(), is(1L));
+                final Node argNode = doneNode.getNode(ClassFileSequencerLexicon.ARGUMENTS).getNodes().nextNode();
+                assertThat(argNode.getName(), is(ClassFileSequencerLexicon.ARGUMENT));
+                assertThat(argNode.getProperty(ClassFileSequencerLexicon.CONTENT).getLong(), is(3L));
+            }
+
+            { // READY
+                assertThat(constantsNode.hasNode("READY"), is(true));
+                final Node doneNode = constantsNode.getNode("READY");
+                assertThat(doneNode.hasNode(ClassFileSequencerLexicon.ANNOTATIONS), is(false));
+                assertThat(doneNode.hasNode(ClassFileSequencerLexicon.JAVADOC), is(true));
+                assertThat(doneNode.hasNode(ClassFileSequencerLexicon.FIELDS), is(true));
+                assertThat(doneNode.hasNode(ClassFileSequencerLexicon.METHODS), is(true));
+                assertThat(doneNode.hasNode(ClassFileSequencerLexicon.NESTED_TYPES), is(false));
+
+                assertThat(doneNode.hasNode(ClassFileSequencerLexicon.ARGUMENTS), is(true));
+                assertThat(doneNode.getNode(ClassFileSequencerLexicon.ARGUMENTS).getNodes().getSize(), is(1L));
+                final Node argNode = doneNode.getNode(ClassFileSequencerLexicon.ARGUMENTS).getNodes().nextNode();
+                assertThat(argNode.getName(), is(ClassFileSequencerLexicon.ARGUMENT));
+                assertThat(argNode.getProperty(ClassFileSequencerLexicon.CONTENT).getLong(), is(1L));
+            }
+
+            { // SKIPPED
+                assertThat(constantsNode.hasNode("SKIPPED"), is(true));
+                final Node doneNode = constantsNode.getNode("SKIPPED");
+                assertThat(doneNode.hasNode(ClassFileSequencerLexicon.ANNOTATIONS), is(false));
+                assertThat(doneNode.hasNode(ClassFileSequencerLexicon.JAVADOC), is(true));
+                assertThat(doneNode.hasNode(ClassFileSequencerLexicon.FIELDS), is(false));
+                assertThat(doneNode.hasNode(ClassFileSequencerLexicon.METHODS), is(true));
+                assertThat(doneNode.hasNode(ClassFileSequencerLexicon.NESTED_TYPES), is(false));
+
+                assertThat(doneNode.hasNode(ClassFileSequencerLexicon.ARGUMENTS), is(true));
+                assertThat(doneNode.getNode(ClassFileSequencerLexicon.ARGUMENTS).getNodes().getSize(), is(1L));
+                final Node argNode = doneNode.getNode(ClassFileSequencerLexicon.ARGUMENTS).getNodes().nextNode();
+                assertThat(argNode.getName(), is(ClassFileSequencerLexicon.ARGUMENT));
+                assertThat(argNode.getProperty(ClassFileSequencerLexicon.CONTENT).getLong(), is(2L));
+            }
+
+            { // WAITING
+                assertThat(constantsNode.hasNode("WAITING"), is(true));
+                final Node doneNode = constantsNode.getNode("WAITING");
+                assertThat(doneNode.hasNode(ClassFileSequencerLexicon.ANNOTATIONS), is(false));
+                assertThat(doneNode.hasNode(ClassFileSequencerLexicon.JAVADOC), is(true));
+                assertThat(doneNode.hasNode(ClassFileSequencerLexicon.FIELDS), is(false));
+                assertThat(doneNode.hasNode(ClassFileSequencerLexicon.METHODS), is(true));
+                assertThat(doneNode.hasNode(ClassFileSequencerLexicon.NESTED_TYPES), is(true));
+
+                assertThat(doneNode.hasNode(ClassFileSequencerLexicon.ARGUMENTS), is(true));
+                assertThat(doneNode.getNode(ClassFileSequencerLexicon.ARGUMENTS).getNodes().getSize(), is(1L));
+                final Node argNode = doneNode.getNode(ClassFileSequencerLexicon.ARGUMENTS).getNodes().nextNode();
+                assertThat(argNode.getName(), is(ClassFileSequencerLexicon.ARGUMENT));
+                assertThat(argNode.getProperty(ClassFileSequencerLexicon.CONTENT).getLong(), is(0L));
+            }
+        }
+    }
+}

--- a/sequencers/modeshape-sequencer-java/src/test/java/org/modeshape/sequencer/javafile/InterfaceTypeSequencerTest.java
+++ b/sequencers/modeshape-sequencer-java/src/test/java/org/modeshape/sequencer/javafile/InterfaceTypeSequencerTest.java
@@ -1,0 +1,108 @@
+/*
+ * ModeShape (http://www.modeshape.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.modeshape.sequencer.javafile;
+
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsNull.notNullValue;
+import static org.junit.Assert.assertThat;
+import javax.jcr.Node;
+import javax.jcr.NodeIterator;
+import org.junit.Test;
+import org.modeshape.jcr.sequencer.AbstractSequencerTest;
+import org.modeshape.sequencer.classfile.ClassFileSequencerLexicon;
+import org.modeshape.sequencer.testdata.ClassType;
+
+public final class InterfaceTypeSequencerTest extends AbstractSequencerTest {
+
+    @Test
+    public void shouldSequenceClassTypeFile() throws Exception {
+        final String packagePath = ClassType.class.getName().replaceAll("\\.", "/");
+        createNodeWithContentFromFile("classtype.java", packagePath + ".java");
+
+        // expected by sequencer in a different location
+        final String expectedOutputPath = "java/classtype.java";
+        final Node compilationUnitNode = getOutputNode(rootNode, expectedOutputPath);
+        assertThat(compilationUnitNode, is(notNullValue()));
+        assertThat(compilationUnitNode.isNodeType(ClassFileSequencerLexicon.COMPILATION_UNIT), is(true));
+        assertThat(compilationUnitNode.hasProperty(ClassFileSequencerLexicon.SEQUENCED_DATE), is(true));
+        assertThat(compilationUnitNode.hasProperty(ClassFileSequencerLexicon.TYPES), is(true));
+        assertThat(compilationUnitNode.getProperty(ClassFileSequencerLexicon.TYPES).getValues().length, is(1));
+        assertThat(compilationUnitNode.hasNode(ClassFileSequencerLexicon.MESSAGES), is(false));
+
+        { // 2 imports
+            assertThat(compilationUnitNode.hasNode(ClassFileSequencerLexicon.IMPORTS), is(true));
+            assertThat(compilationUnitNode.getNode(ClassFileSequencerLexicon.IMPORTS).getNodes().getSize(), is(3L));
+
+            final NodeIterator itr = compilationUnitNode.getNode(ClassFileSequencerLexicon.IMPORTS).getNodes();
+
+            { // first import
+                final Node firstImport = itr.nextNode();
+                assertThat(firstImport.getName(), is("java.io.Serializable"));
+                assertThat(firstImport.hasProperty(ClassFileSequencerLexicon.STATIC), is(true));
+                assertThat(firstImport.getProperty(ClassFileSequencerLexicon.STATIC).getBoolean(), is(false));
+                assertThat(firstImport.hasProperty(ClassFileSequencerLexicon.ON_DEMAND), is(true));
+                assertThat(firstImport.getProperty(ClassFileSequencerLexicon.ON_DEMAND).getBoolean(), is(false));
+            }
+
+            { // second import
+                final Node secondImport = itr.nextNode();
+                assertThat(secondImport.getName(), is("java.util.ArrayList"));
+                assertThat(secondImport.hasProperty(ClassFileSequencerLexicon.STATIC), is(true));
+                assertThat(secondImport.getProperty(ClassFileSequencerLexicon.STATIC).getBoolean(), is(false));
+                assertThat(secondImport.hasProperty(ClassFileSequencerLexicon.ON_DEMAND), is(true));
+                assertThat(secondImport.getProperty(ClassFileSequencerLexicon.ON_DEMAND).getBoolean(), is(false));
+            }
+
+            { // third import
+                final Node thirdImport = itr.nextNode();
+                assertThat(thirdImport.getName(), is("java.util.HashMap"));
+                assertThat(thirdImport.hasProperty(ClassFileSequencerLexicon.STATIC), is(true));
+                assertThat(thirdImport.getProperty(ClassFileSequencerLexicon.STATIC).getBoolean(), is(false));
+                assertThat(thirdImport.hasProperty(ClassFileSequencerLexicon.ON_DEMAND), is(true));
+                assertThat(thirdImport.getProperty(ClassFileSequencerLexicon.ON_DEMAND).getBoolean(), is(false));
+            }
+        }
+
+        { // comments
+            assertThat(compilationUnitNode.hasNode(ClassFileSequencerLexicon.COMMENTS), is(true));
+            assertThat(compilationUnitNode.getNode(ClassFileSequencerLexicon.COMMENTS).getNodes().getSize(), is(2L));
+
+            final NodeIterator itr = compilationUnitNode.getNode(ClassFileSequencerLexicon.COMMENTS).getNodes();
+
+            { // file block header
+                final Node firstComment = itr.nextNode();
+                assertThat(firstComment.getName(), is(ClassFileSequencerLexicon.COMMENT));
+                assertThat(firstComment.hasProperty(ClassFileSequencerLexicon.COMMENT_TYPE), is(true));
+                assertThat(firstComment.getProperty(ClassFileSequencerLexicon.COMMENT_TYPE).getString(),
+                           is(ClassFileSequencerLexicon.CommentType.BLOCK.toString()));
+                assertThat(firstComment.hasProperty(ClassFileSequencerLexicon.COMMENT), is(true));
+                assertThat(firstComment.getProperty(ClassFileSequencerLexicon.COMMENT).getString().startsWith("/*\n * ModeShape"),
+                           is(true));
+            }
+
+            { // line comment for field CONSTANT
+                final Node secondComment = itr.nextNode();
+                assertThat(secondComment.getName(), is(ClassFileSequencerLexicon.COMMENT));
+                assertThat(secondComment.hasProperty(ClassFileSequencerLexicon.COMMENT_TYPE), is(true));
+                assertThat(secondComment.getProperty(ClassFileSequencerLexicon.COMMENT_TYPE).getString(),
+                           is(ClassFileSequencerLexicon.CommentType.LINE.toString()));
+                assertThat(secondComment.hasProperty(ClassFileSequencerLexicon.COMMENT), is(true));
+                assertThat(secondComment.getProperty(ClassFileSequencerLexicon.COMMENT).getString(), is("// a line comment"));
+            }
+        }
+    }
+
+}

--- a/sequencers/modeshape-sequencer-java/src/test/java/org/modeshape/sequencer/javafile/JavaFileSequencerTest.java
+++ b/sequencers/modeshape-sequencer-java/src/test/java/org/modeshape/sequencer/javafile/JavaFileSequencerTest.java
@@ -16,50 +16,51 @@
 package org.modeshape.sequencer.javafile;
 
 import static org.hamcrest.core.Is.is;
-import static org.hamcrest.core.IsCollectionContaining.hasItems;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 import static org.modeshape.sequencer.JavaSequencerHelper.JAVA_FILE_HELPER;
 import static org.modeshape.sequencer.classfile.ClassFileSequencerLexicon.IMPORTS;
-import java.util.ArrayList;
-import java.util.List;
 import javax.jcr.Node;
-import javax.jcr.Value;
 import org.junit.Test;
 import org.modeshape.jcr.sequencer.AbstractSequencerTest;
+import org.modeshape.sequencer.classfile.ClassFileSequencerLexicon;
 import org.modeshape.sequencer.testdata.MockClass;
 import org.modeshape.sequencer.testdata.MockEnum;
 
 /**
  * Unit test for {@link JavaFileSequencer}
- * 
+ *
  * @author Horia Chiorean
  */
 public class JavaFileSequencerTest extends AbstractSequencerTest {
 
-    private void assertClassImports( final Node classNode ) throws Exception {
-        assertThat(classNode.hasProperty(IMPORTS), is(true));
+    private void assertClassImports( final Node compilationUnitNode ) throws Exception {
+        assertThat(compilationUnitNode.hasNode(IMPORTS), is(true));
 
-        final Value[] values = classNode.getProperty(IMPORTS).getValues();
-        assertThat(values.length, is(3));
+        final Node importsNode = compilationUnitNode.getNode(IMPORTS);
+        assertThat(importsNode.getNodes().getSize(), is(3L));
 
-        final List<String> items = new ArrayList<String>(3);
-        items.add(values[0].getString());
-        items.add(values[1].getString());
-        items.add(values[2].getString());
-        assertThat(items, hasItems("java.io.Serializable", "java.util.ArrayList", "java.util.List"));
+        final Node serializableImport = importsNode.getNode("java.io.Serializable");
+        assertThat(serializableImport.getPrimaryNodeType().getName(), is(ClassFileSequencerLexicon.IMPORT));
+
+        final Node arrayListImport = importsNode.getNode("java.util.ArrayList");
+        assertThat(arrayListImport.getPrimaryNodeType().getName(), is(ClassFileSequencerLexicon.IMPORT));
+
+        final Node listImport = importsNode.getNode("java.util.List");
+        assertThat(listImport.getPrimaryNodeType().getName(), is(ClassFileSequencerLexicon.IMPORT));
     }
 
-    private void assertEnumImports( final Node classNode ) throws Exception {
-        assertThat(classNode.hasProperty(IMPORTS), is(true));
+    private void assertEnumImports( final Node compilationUnitNode ) throws Exception {
+        assertThat(compilationUnitNode.hasNode(IMPORTS), is(true));
 
-        final Value[] values = classNode.getProperty(IMPORTS).getValues();
-        assertThat(values.length, is(2));
+        final Node importsNode = compilationUnitNode.getNode(IMPORTS);
+        assertThat(importsNode.getNodes().getSize(), is(2L));
 
-        final List<String> items = new ArrayList<String>(2);
-        items.add(values[0].getString());
-        items.add(values[1].getString());
-        assertThat(items, hasItems("java.util.Random", "java.text.DateFormat"));
+        final Node randomImport = importsNode.getNode("java.util.Random");
+        assertThat(randomImport.getPrimaryNodeType().getName(), is(ClassFileSequencerLexicon.IMPORT));
+
+        final Node dateFormatImport = importsNode.getNode("java.text.DateFormat");
+        assertThat(dateFormatImport.getPrimaryNodeType().getName(), is(ClassFileSequencerLexicon.IMPORT));
     }
 
     @Test
@@ -73,7 +74,8 @@ public class JavaFileSequencerTest extends AbstractSequencerTest {
         assertNotNull(outputNode);
         Node enumNode = outputNode.getNode(packagePath);
         JAVA_FILE_HELPER.assertSequencedMockEnum(enumNode);
-        assertEnumImports(enumNode);
+
+        assertEnumImports(outputNode);
     }
 
     @Test
@@ -87,7 +89,8 @@ public class JavaFileSequencerTest extends AbstractSequencerTest {
         assertNotNull(outputNode);
         Node javaNode = outputNode.getNode(packagePath);
         JAVA_FILE_HELPER.assertSequencedMockClass(javaNode);
-        assertClassImports(javaNode);
+
+        assertClassImports(outputNode);
     }
 
 }

--- a/sequencers/modeshape-sequencer-java/src/test/java/org/modeshape/sequencer/testdata/AnnotationType.java
+++ b/sequencers/modeshape-sequencer-java/src/test/java/org/modeshape/sequencer/testdata/AnnotationType.java
@@ -1,0 +1,61 @@
+/*
+ * ModeShape (http://www.modeshape.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.modeshape.sequencer.testdata;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Target;
+
+/**
+ * This is an annotation type test class.
+ */
+@Target( ElementType.TYPE )
+public @interface AnnotationType {
+
+    class Decision {
+        enum Choice {
+            YES,
+            NO
+        }
+    }
+
+    Decision.Choice choice = Decision.Choice.YES;
+
+    enum Status {
+        UNCONFIRMED,
+        CONFIRMED,
+        FIXED,
+        NOTABUG
+    }
+
+    @Deprecated
+    abstract boolean showStopper();
+
+    /**
+     * Obtain the status.
+     *
+     * @return a status
+     */
+    public Status status() default Status.UNCONFIRMED;
+
+    Reference ref() default @Reference; // an annotation type
+
+}
+
+@interface Reference {
+
+    String id() default "[unassigned]";
+
+}

--- a/sequencers/modeshape-sequencer-java/src/test/java/org/modeshape/sequencer/testdata/ClassType.java
+++ b/sequencers/modeshape-sequencer-java/src/test/java/org/modeshape/sequencer/testdata/ClassType.java
@@ -1,0 +1,114 @@
+/*
+ * ModeShape (http://www.modeshape.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.modeshape.sequencer.testdata;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.HashMap;
+
+/**
+ * This is a class type test class.
+ *
+ * @author Schting Schtang
+ * @param <T> a map
+ * @since 2.0
+ */
+@SuppressWarnings( {"serial", "unused"} )
+public abstract class ClassType<T extends HashMap<String, ?>> extends ArrayList<T> implements Serializable {
+
+    /**
+     * A constant.
+     */
+    public static final String CONSTANT = "constant"; // a line comment
+
+    static {
+        System.out.println(System.currentTimeMillis());
+    }
+
+    public Object twoString = new Object() {
+        @Override
+        public String toString() {
+            return (super.toString() + super.toString());
+        }
+    };
+
+    Number number = 1;
+
+    private T[] t;
+
+    /**
+     * @return the identifier (never <code>null</code>)
+     */
+    abstract String getId();
+
+    public final void set(@SuppressWarnings( "unchecked" ) T... t) throws Exception {
+        if (this.t == t) {
+            throw new Exception("Blah blah blah");
+        }
+
+        this.t = t;
+    }
+
+    public synchronized T[] get() {
+        return this.t;
+    }
+
+    /**
+     * Performs a shutdown.
+     *
+     * @param waitTime the time to wait in milliseconds before shutdown
+     */
+    @Deprecated
+    public <U extends Number> void shutdown( final U waitTime ) {
+        this.number = waitTime;
+    }
+
+    /**
+     * The nested class.
+     */
+    class Blah implements Comparable<T> {
+
+        private final T stuff;
+
+        /**
+         * Constructs a blah.
+         *
+         * @param stuff the stuff
+         */
+        public Blah( T stuff ) {
+            this.stuff = stuff;
+        }
+
+        /**
+         * {@inheritDoc}
+         *
+         * @see java.lang.Comparable#compareTo(java.lang.Object)
+         */
+        @Override
+        public int compareTo( T that ) {
+            return 0;
+        }
+
+        /**
+         * @return stuff
+         */
+        public T getStuff() {
+            return stuff;
+        }
+
+    }
+
+}

--- a/sequencers/modeshape-sequencer-java/src/test/java/org/modeshape/sequencer/testdata/EnumType.java
+++ b/sequencers/modeshape-sequencer-java/src/test/java/org/modeshape/sequencer/testdata/EnumType.java
@@ -1,0 +1,134 @@
+/*
+ * ModeShape (http://www.modeshape.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.modeshape.sequencer.testdata;
+
+import java.util.EnumSet;
+//CHECKSTYLE:OFF
+import java.util.*;
+//CHECKSTYLE:ON
+
+/**
+ * This is a enum type test class.
+ */
+public enum EnumType implements Cloneable {
+
+    /**
+     * Indicates a waiting state.
+     */
+    WAITING(0) {
+
+        class TextProvider {
+            public String get() {
+                return "I'm waiting.";
+            }
+        }
+
+        /**
+         * {@inheritDoc}
+         *
+         * @see org.modeshape.sequencer.testdata.EnumType#execute()
+         */
+        @Override
+        public void execute() {
+            this.executor.execute(new TextProvider().get());
+        }
+    },
+
+    /**
+     * Indicates a ready state.
+     */
+    READY(1) {
+
+        private String text = "I'm ready.";
+
+        /**
+         * {@inheritDoc}
+         *
+         * @see org.modeshape.sequencer.testdata.EnumType#execute()
+         */
+        @Override
+        public void execute() {
+            this.executor.execute(text);
+        }
+    },
+
+    /**
+     * Indicates a skipped state.
+     */
+    SKIPPED(2) {
+
+        /**
+         * {@inheritDoc}
+         *
+         * @see org.modeshape.sequencer.testdata.EnumType#execute()
+         */
+        @Override
+        public void execute() {
+            this.executor.execute("I've been skipped.");
+        }
+    },
+
+    /**
+     * Indicates a done state.
+     */
+    DONE(3) {
+
+        /**
+         * {@inheritDoc}
+         *
+         * @see org.modeshape.sequencer.testdata.EnumType#execute()
+         */
+        @Override
+        public void execute() {
+            this.executor.execute("I'm done.");
+        }
+    };
+
+    class Executor {
+        void execute(String text) {
+            System.out.println(text);
+        }
+    }
+
+    private static final Map<Integer, EnumType> _lookup;
+
+    static {
+        _lookup = new HashMap<Integer, EnumType>();
+
+        for (EnumType enumType : EnumSet.allOf(EnumType.class)) {
+            _lookup.put(enumType.getCode(), enumType);
+        }
+    }
+
+    public static EnumType get( int code ) {
+        return _lookup.get(code);
+    }
+
+    private int code;
+    Executor executor;
+
+    private EnumType( int code ) {
+        this.code = code;
+        this.executor = new Executor();
+    }
+
+    public abstract void execute();
+
+    public int getCode() {
+        return this.code;
+    }
+
+}

--- a/sequencers/modeshape-sequencer-java/src/test/java/org/modeshape/sequencer/testdata/TwoOuterClasses.java
+++ b/sequencers/modeshape-sequencer-java/src/test/java/org/modeshape/sequencer/testdata/TwoOuterClasses.java
@@ -1,0 +1,27 @@
+/*
+ * ModeShape (http://www.modeshape.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.modeshape.sequencer.testdata;
+
+public class TwoOuterClasses {
+
+    @SuppressWarnings( "unused" )
+    private AnotherClass another;
+
+}
+
+class AnotherClass {
+
+}


### PR DESCRIPTION
I created a new source file recorder that eliminates the "metadata" layer of classes that existed in the old source recorder between the JDT and the JCR nodes. Since a java file can contain more than one top-level class, I have created a "compilationUnit" mixin that I add to the output node that gets passed to the sequencer. This output node is where the compilation unit's non-javadoc comments, imports, and compiler messages are being stored. I've tried to make the CND changes backward compatible by adding new nodes for the information that was not being persisted. A couple complex JDT/Java constructs, expressions and statements, have not been broken down in the design (just a toString representation is being persisted). New tests that test various forms of class, enum, interface, and annotation type definitions have been added.
