### PR TITLE
MODE-2178 Corrected processing of asymmetric UNION/INTERSECT/EXCEPT expressions

### DIFF
--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/NodeTypes.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/NodeTypes.java
@@ -131,6 +131,9 @@ public class NodeTypes {
     private final Set<Name> nodeTypeNamesThatAllowSameNameSiblings = new HashSet<>();
 
     private final Set<Name> nodeTypeNamesThatAreReferenceable = new HashSet<>();
+
+    private final Set<Name> nodeTypeNamesThatAreShareable = new HashSet<>();
+
     /**
      * The map of mandatory (and perhaps auto-created) property definitions for a node type keyed by the name of the node type.
      * See {@link #hasMandatoryPropertyDefinitions}
@@ -195,6 +198,10 @@ public class NodeTypes {
 
                 if (nodeType.isNodeType(JcrMixLexicon.REFERENCEABLE)) {
                     nodeTypeNamesThatAreReferenceable.add(name);
+                }
+
+                if (nodeType.isNodeType(JcrMixLexicon.SHAREABLE)) {
+                    nodeTypeNamesThatAreShareable.add(name);
                 }
 
                 boolean fullyDefined = true;
@@ -486,6 +493,24 @@ public class NodeTypes {
         if (mixinTypes != null) {
             for (Name mixinType : mixinTypes) {
                 if (nodeTypeNamesThatAreReferenceable.contains(mixinType)) return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Determine if at least one of the named primary node type or mixin types is or subtypes the 'mix:shareable' mixin type.
+     * 
+     * @param primaryType the primary type name; may not be null
+     * @param mixinTypes the mixin type names; may be null or empty
+     * @return true if the primary node type is an 'mix:shareable' node type (or subtype), or false otherwise
+     */
+    public boolean isShareable( Name primaryType,
+                                Set<Name> mixinTypes ) {
+        if (nodeTypeNamesThatAreShareable.contains(primaryType)) return true;
+        if (mixinTypes != null) {
+            for (Name mixinType : mixinTypes) {
+                if (nodeTypeNamesThatAreShareable.contains(mixinType)) return true;
             }
         }
         return false;

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/query/engine/ScanningQueryEngine.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/query/engine/ScanningQueryEngine.java
@@ -756,6 +756,14 @@ public class ScanningQueryEngine implements org.modeshape.jcr.query.QueryEngine 
                 NodeSequence first = createNodeSequence(originalQuery, context, firstPlan, firstColumns, sources);
                 NodeSequence second = createNodeSequence(originalQuery, context, secondPlan, secondColumns, sources);
                 useHeap = 0 >= second.getRowCount() && second.getRowCount() < 100;
+                if (first.width() != second.width()) {
+                    // A set operation requires that the 'first' and 'second' sequences have the same width, but this is
+                    // not necessarily the case (e.g., when one side involves a JOIN but the other does not). The columns
+                    // will dictate which subset of selector indexes in the sequences should be used.
+                    first = NodeSequence.slice(first, firstColumns);
+                    second = NodeSequence.slice(second, secondColumns);
+                    assert first.width() == second.width();
+                }
                 pack = false;
                 switch (operation) {
                     case UNION: {

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/query/engine/process/AbstractNodeKeysSequence.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/query/engine/process/AbstractNodeKeysSequence.java
@@ -37,7 +37,6 @@ public abstract class AbstractNodeKeysSequence extends BufferingSequence {
 
     private boolean initialized = false;
 
-    @SuppressWarnings( { "rawtypes", "unchecked" } )
     protected AbstractNodeKeysSequence( String workspaceName,
                                         NodeSequence leftSequence,
                                         NodeSequence rightSequence,

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/query/engine/process/SecureSequence.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/query/engine/process/SecureSequence.java
@@ -27,7 +27,7 @@ import org.modeshape.jcr.query.NodeSequence;
  */
 public class SecureSequence extends DelegatingSequence {
 
-    private final JcrQueryContext context;
+    protected final JcrQueryContext context;
 
     /**
      * Creates a new secure sequence over an existing sequence.

--- a/modeshape-jcr/src/test/java/org/modeshape/jcr/JcrQueryManagerTest.java
+++ b/modeshape-jcr/src/test/java/org/modeshape/jcr/JcrQueryManagerTest.java
@@ -2058,7 +2058,6 @@ public class JcrQueryManagerTest extends MultiUseAbstractTest {
 
     @FixFor( "MODE-2057" )
     @Test
-    @Ignore("Need to handle sequences of different widths...")
     public void shouldBeAbleToCreateAndExecuteJcrSql2QueryWithUnionAndFullTextSearch() throws RepositoryException {
         String sql = "SELECT category.[jcr:path] AS p FROM [nt:unstructured] AS category WHERE contains(category.*, 'Utility')"
                      + "UNION "
@@ -3849,7 +3848,6 @@ public class JcrQueryManagerTest extends MultiUseAbstractTest {
 
     @Test
     @FixFor( "MODE-2247" )
-    @Ignore("Need to handle sequences of different widths...")
     public void shouldBeAbleToExecuteIntersectOperationWithJoinCriteria() throws RepositoryException {
         String sql = "SELECT category.[jcr:path] AS p FROM [nt:unstructured] AS category "
                      + " INTERSECT  "
@@ -3861,7 +3859,6 @@ public class JcrQueryManagerTest extends MultiUseAbstractTest {
 
     @Test
     @FixFor( "MODE-2247" )
-    @Ignore("Need to handle sequences of different widths...")
     public void shouldBeAbleToExecuteIntersectAllOperation() throws RepositoryException {
         String sql = "SELECT category.[jcr:path] AS p FROM [nt:unstructured] AS category "
                      + " INTERSECT ALL "
@@ -3885,7 +3882,6 @@ public class JcrQueryManagerTest extends MultiUseAbstractTest {
 
     @Test
     @FixFor( "MODE-2247" )
-    @Ignore("Need to handle sequences of different widths...")
     public void shouldBeAbleToExecuteExceptOperationWithJoinCriteria() throws RepositoryException {
         String sql = "SELECT category.[jcr:path] AS p FROM [nt:unstructured] AS category WHERE ISCHILDNODE(category,'/Cars')"
                      + "EXCEPT "
@@ -3905,7 +3901,6 @@ public class JcrQueryManagerTest extends MultiUseAbstractTest {
 
     @Test
     @FixFor( "MODE-2247" )
-    @Ignore("Need to handle sequences of different widths...")
     public void shouldBeAbleToExecuteExceptAllOperation() throws RepositoryException {
         String sql = "SELECT category.[jcr:path] AS p FROM [nt:unstructured] AS category JOIN [car:Car] AS cars ON ISCHILDNODE(cars,category) "
                      +" WHERE cars.[jcr:name] LIKE '%Rover%' "


### PR DESCRIPTION
Set operations like `UNION`, `INTERSECT` and `EXCEPT` require that the result columns projected from each side of the set operation be structurally identical. This was already handled by the query engine. However, when the two sides of the set operation have different numbers of selectors (e.g., one side involves a join while the other does not), then the NodeSequence implementations that result from each side do not have the same widths.

For example, consider a simplistic `UNION` query like this:

```
SELECT a.[jcr:path] FROM a
UNION
SELECT c.[jcr:path] FROM b JOIN c ON ISCHILDNODE(b,c)
```

The NodeSequence on the left side (e.g., for "`a`") would have a width of 1, meaning each row in the sequence contains a single NodeKey (at index 0 in that row). The NodeSequence on the right side would have a width of 2, meaning each row in the sequence contains a NodeKey for `b` (at index 0) and a NodeKey for `c` (at index 1). But note that the result of the right side needs to be the path of the `c` node (again, at index 1).

In symbolic form, this is shown as:

```
[a] UNION [b,c]
```

The node sequence that implements the UNION thus sees asymmetric NodeSequences. What we really want is:

```
[a] UNION [c]
```

This commit corrects the logic by looking for the asymmetric case (where the width of the sequences on each is not the same), and if needed wrapping one or both of the sequences with a new NodeSequence implementation that "slices" the original node sequence to return only the required/desired selectors. This is pretty straightforward, and simply involves mapping the required/desired selector indexes (in the example, 0 for both the left and right sides) to the actually wrapped sequence.

Thus, in our example, the sequence on the left side is `[a]` and of size 1, and it does not need to be wrapped since all of its selectors are used in the results needed by the `UNION`. On the other hand, the sequence on the right side is `[b,c]` (of size 2), but only `c` is needed in the results. Note that `b` is at index 0 and `c` is at index 1, and the UNION needs `c` to be at index 0. Therefore, we wrap this sequence with a new slicing sequence that merely converts the '0' index used by the UNION to obtain the NodeKey into the '1' index that can be passed to the real underlying sequence to obtain the `c` node keys.

The implementation works for any widths.

All test cases @Ignored in previous commits have been re-enabled and all pass.
