### PR TITLE
MODE-2259 Fixed the WebApp handlers.

### DIFF
--- a/deploy/jbossas/modeshape-jbossas-subsystem/src/main/java/org/modeshape/jboss/subsystem/AddWebApp.java
+++ b/deploy/jbossas/modeshape-jbossas-subsystem/src/main/java/org/modeshape/jboss/subsystem/AddWebApp.java
@@ -48,12 +48,19 @@ class AddWebApp extends AbstractAddStepHandler {
     protected void populateModel( OperationContext context,
                                   ModelNode operation,
                                   org.jboss.as.controller.registry.Resource resource ) throws OperationFailedException {
+        if (!requiresRuntime(context)) {
+            //we need to skip the execution of this handler if it does not require a "runtime mode". Runtime mode is something
+            //that seems to be required only for "normal" servers, as opposed to domain controllers, admin-mode servers and
+            //the likes. A standalone or a host in a group of servers will be considered "normal".
+            return;
+        }
+
         AddressContext addressContext = AddressContext.forOperation(operation);
         String webappName = addressContext.lastPathElementValue();
 
         Module module = Module.forClass(AddWebApp.class);
         if (module == null) {
-            LOGGER.warnv(
+            LOGGER.debugv(
                     "Skipping the deployment of {0} because the module which contains the {1} class cannot be loaded", webappName,
                     AddWebApp.class.getName());
             return;
@@ -71,9 +78,9 @@ class AddWebApp extends AbstractAddStepHandler {
 
         PathAddress deploymentAddress = PathAddress.pathAddress(PathElement.pathElement(ModelDescriptionConstants.DEPLOYMENT,
                                                                                         webappName));
-        ModelNode op = Util.createOperation(ModelDescriptionConstants.ADD, deploymentAddress);
-        op.get(ModelDescriptionConstants.ENABLED).set(true);
-        op.get(ModelDescriptionConstants.PERSISTENT).set(false); // prevents writing this deployment out to standalone.xml
+        ModelNode deploymentOp = Util.createOperation(ModelDescriptionConstants.ADD, deploymentAddress);
+        deploymentOp.get(ModelDescriptionConstants.ENABLED).set(true);
+        deploymentOp.get(ModelDescriptionConstants.PERSISTENT).set(false); // prevents writing this deployment out to standalone.xml
 
 
         ModelNode contentItem = new ModelNode();
@@ -91,12 +98,12 @@ class AddWebApp extends AbstractAddStepHandler {
             contentItem.get(ModelDescriptionConstants.URL).set(url.toExternalForm());
         }
 
-        op.get(ModelDescriptionConstants.CONTENT).add(contentItem);
+        deploymentOp.get(ModelDescriptionConstants.CONTENT).add(contentItem);
 
         ImmutableManagementResourceRegistration rootResourceRegistration = context.getRootResourceRegistration();
-        OperationStepHandler handler = rootResourceRegistration.getOperationHandler(deploymentAddress,
+        OperationStepHandler addDeploymentHandler = rootResourceRegistration.getOperationHandler(deploymentAddress,
                                                                                     ModelDescriptionConstants.ADD);
-        context.addStep(op, handler, OperationContext.Stage.MODEL);
+        context.addStep(deploymentOp, addDeploymentHandler, OperationContext.Stage.MODEL);
     }
 
     private ModelNode attribute( OperationContext context,

--- a/deploy/jbossas/modeshape-jbossas-subsystem/src/main/java/org/modeshape/jboss/subsystem/RemoveWebApp.java
+++ b/deploy/jbossas/modeshape-jbossas-subsystem/src/main/java/org/modeshape/jboss/subsystem/RemoveWebApp.java
@@ -40,6 +40,14 @@ class RemoveWebApp extends AbstractRemoveStepHandler {
     protected void performRemove( OperationContext context,
                                   ModelNode operation,
                                   ModelNode model ) throws OperationFailedException {
+        if (!requiresRuntime(context)) {
+            //we need to skip the execution of this handler if it does not require a "runtime mode", because its corresponding
+            //AddWebApp handler only deploys the webapp in runtime mode, so there's nothing to clean up.
+            //Runtime mode is something that seems to be required only for "normal" servers, as opposed to domain controllers,
+            //admin-mode servers and the likes. A standalone or a host in a group of servers will be considered "normal".
+            return;
+        }
+
         if (!model.isDefined()) {
             //the model hasn't been defined, which means the Add Step did not succeed
             return;
@@ -48,11 +56,11 @@ class RemoveWebApp extends AbstractRemoveStepHandler {
         String webappName = addressContext.lastPathElementValue();
 
         PathAddress deploymentAddress = PathAddress.pathAddress(PathElement.pathElement(ModelDescriptionConstants.DEPLOYMENT, webappName));
-        ModelNode op = Util.createOperation(ModelDescriptionConstants.DEPLOYMENT, deploymentAddress);
+        ModelNode deploymentOp = Util.createOperation(ModelDescriptionConstants.DEPLOYMENT, deploymentAddress);
 
         ImmutableManagementResourceRegistration rootResourceRegistration = context.getRootResourceRegistration();
-        OperationStepHandler handler = rootResourceRegistration.getOperationHandler(deploymentAddress, ModelDescriptionConstants.REMOVE);
-        context.addStep(op, handler, OperationContext.Stage.MODEL);
+        OperationStepHandler removeDeploymentHandler = rootResourceRegistration.getOperationHandler(deploymentAddress, ModelDescriptionConstants.REMOVE);
+        context.addStep(deploymentOp, removeDeploymentHandler, OperationContext.Stage.MODEL);
 
         super.performRemove(context, operation, model);
     }


### PR DESCRIPTION
Since the requirement is to be able to deploy WARs from within our EAP subsystem, the only way I was able to figure out how to do this is via the `DeploymentAddHandler` which only works in the `MODEL` stage.

The solution was to check in our handlers the `requiresRuntime(context)` and only perform the model change & invoke the handler for a "NORMAL" server.
