### PR TITLE
MODE-1671 Added 'mode:id' pseudocolumn for JCR-SQL2 queries

### DIFF
--- a/modeshape-jcr-api/src/main/java/org/modeshape/jcr/api/query/qom/NodeId.java
+++ b/modeshape-jcr-api/src/main/java/org/modeshape/jcr/api/query/qom/NodeId.java
@@ -1,0 +1,33 @@
+/*
+ * ModeShape (http://www.modeshape.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.modeshape.jcr.api.query.qom;
+
+import javax.jcr.Node;
+import javax.jcr.query.qom.Comparison;
+
+/**
+ * A dynamic operand that evaluates to the {@link Node#getIdentifier() identifier} of a node given by a selector, used in a
+ * {@link Comparison} constraint.
+ */
+public interface NodeId extends javax.jcr.query.qom.DynamicOperand {
+
+    /**
+     * Get the selector symbol upon which this operand applies.
+     * 
+     * @return the one selector names used by this operand; never null
+     */
+    public String getSelectorName();
+}

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrI18n.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrI18n.java
@@ -280,6 +280,7 @@ public final class JcrI18n {
     public static I18n multipleSelectorsAppearInQueryUnableToCallMethod;
     public static I18n multipleCallsToGetRowsOrNodesIsNotAllowed;
     public static I18n equiJoinWithOneJcrPathPseudoColumnIsInvalid;
+    public static I18n equiJoinWithOneNodeIdPseudoColumnIsInvalid;
     public static I18n noSuchVariableInQuery;
 
     // Type registration messages

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrQueryManager.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrQueryManager.java
@@ -292,8 +292,8 @@ class JcrQueryManager implements QueryManager {
             if (node == null) {
                 return null;
             }
-            //this *does not* check permissions because it is expected that the correct sequence already wraps the results and
-            //therefore it should not be possible to return a Node/Row from a batch on which there aren't any read permissions
+            // this *does not* check permissions because it is expected that the correct sequence already wraps the results and
+            // therefore it should not be possible to return a Node/Row from a batch on which there aren't any read permissions
             return session.node(node, (AbstractJcrNode.Type)null);
         }
 
@@ -342,6 +342,12 @@ class JcrQueryManager implements QueryManager {
         public long getDepth( CachedNode node ) {
             assert node != null;
             return node.getDepth(session.cache());
+        }
+
+        @Override
+        public String getIdentifier( CachedNode node ) {
+            // the identifier format varies depending upon the node ...
+            return session.nodeIdentifier(node.getKey());
         }
 
         @Override

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/ModeShapeLexicon.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/ModeShapeLexicon.java
@@ -66,6 +66,7 @@ public class ModeShapeLexicon {
     public static final Name SHARED_UUID = new BasicName(Namespace.URI, "sharedUuid");
 
     public static final Name DEPTH = new BasicName(Namespace.URI, "depth");
+    public static final Name ID = new BasicName(Namespace.URI, "id");
     public static final Name LOCALNAME = new BasicName(Namespace.URI, "localName");
 
     /**

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/NodeTypeSchemata.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/NodeTypeSchemata.java
@@ -114,6 +114,7 @@ public class NodeTypeSchemata implements Schemata {
         pseudoProperties.add(pseudoProperty(context, JcrLexicon.SCORE, PropertyType.DOUBLE));
         pseudoProperties.add(pseudoProperty(context, ModeShapeLexicon.LOCALNAME, PropertyType.STRING));
         pseudoProperties.add(pseudoProperty(context, ModeShapeLexicon.DEPTH, PropertyType.LONG));
+        pseudoProperties.add(pseudoProperty(context, ModeShapeLexicon.ID, PropertyType.STRING));
 
         // Create the "ALLNODES" table, which will contain all possible properties ...
         addAllNodesTable(builder, context, pseudoProperties);

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/query/JcrQueryContext.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/query/JcrQueryContext.java
@@ -99,14 +99,13 @@ public interface JcrQueryContext {
      */
     Node getNode( CachedNode node );
 
-
     /**
      * Checks if there is a {@link org.modeshape.jcr.ModeShapePermissions#READ} permission for the given node in this context.
-     *
+     * 
      * @param node a {@link org.modeshape.jcr.cache.CachedNode}, never {@code null}
      * @return {@code true} if the current context can read the given node, {@code false} otherwise
      */
-    boolean canRead(CachedNode node);
+    boolean canRead( CachedNode node );
 
     /**
      * Create a JCR {@link Value} instance given the supplied value and property type.
@@ -146,6 +145,14 @@ public interface JcrQueryContext {
      * @return the node name; never null
      */
     Name getName( CachedNode node );
+
+    /**
+     * Get the internal {@link Node#getIdentifier() public JCR identifier} of the supplied cached node.
+     * 
+     * @param node the cached node; may not be null
+     * @return the JCR identifier; never null
+     */
+    String getIdentifier( CachedNode node );
 
     /**
      * Get the depth of the supplied cached node.

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/query/JcrQueryResult.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/query/JcrQueryResult.java
@@ -59,10 +59,11 @@ public class JcrQueryResult implements org.modeshape.jcr.api.query.QueryResult {
     public static final String JCR_UUID_COLUMN_NAME = "jcr:uuid";
     public static final String MODE_LOCALNAME_COLUMN_NAME = "mode:localName";
     public static final String MODE_DEPTH_COLUMN_NAME = "mode:depth";
+    public static final String MODE_ID_COLUMN_NAME = "mode:id";
     protected static final Set<String> PSEUDO_COLUMNS = Collections.unmodifiableSet(JCR_SCORE_COLUMN_NAME, JCR_PATH_COLUMN_NAME,
                                                                                     JCR_NAME_COLUMN_NAME, JCR_UUID_COLUMN_NAME,
                                                                                     MODE_LOCALNAME_COLUMN_NAME,
-                                                                                    MODE_DEPTH_COLUMN_NAME);
+                                                                                    MODE_DEPTH_COLUMN_NAME, MODE_ID_COLUMN_NAME);
 
     protected final JcrQueryContext context;
     protected final QueryResults results;
@@ -388,6 +389,12 @@ public class JcrQueryResult implements org.modeshape.jcr.api.query.QueryResult {
             return context.createValue(PropertyType.LONG, context.getDepth(node));
         }
 
+        protected Value jcrId( CachedNode node ) {
+            assert node != null;
+            // Every node has an identifier, but we need to figure out the correct version that's exposed
+            return context.createValue(PropertyType.STRING, context.getIdentifier(node));
+        }
+
         protected Value jcrPath( String path ) {
             return context.createValue(PropertyType.PATH, path);
         }
@@ -485,6 +492,9 @@ public class JcrQueryResult implements org.modeshape.jcr.api.query.QueryResult {
                 }
                 if (MODE_DEPTH_COLUMN_NAME.equals(propertyName)) {
                     return iterator.jcrDepth(cachedNode);
+                }
+                if (MODE_ID_COLUMN_NAME.equals(propertyName)) {
+                    return iterator.jcrId(cachedNode);
                 }
                 if (JCR_SCORE_COLUMN_NAME.equals(propertyName)) {
                     float score = batchAtRow.getScore(nodeIndex);

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/query/model/NodeId.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/query/model/NodeId.java
@@ -1,0 +1,86 @@
+/*
+ * ModeShape (http://www.modeshape.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.modeshape.jcr.query.model;
+
+import java.util.Set;
+import javax.jcr.Node;
+import org.modeshape.common.annotation.Immutable;
+
+/**
+ * A dynamic operand that evaluates to the {@link Node#getIdentifier() identifier} of a node given by a selector, used in a
+ * {@link Comparison} constraint.
+ */
+@Immutable
+public class NodeId implements DynamicOperand, org.modeshape.jcr.api.query.qom.NodeId {
+    private static final long serialVersionUID = 1L;
+
+    private final Set<SelectorName> selectorNames;
+
+    /**
+     * Create a dynamic operand that evaluates to the {@link Node#getIdentifier() identifier} of the node described by the
+     * selector.
+     * 
+     * @param selectorName the name of the selector
+     * @throws IllegalArgumentException if the selector name or property name are null
+     */
+    public NodeId( SelectorName selectorName ) {
+        this.selectorNames = SelectorName.nameSetFrom(selectorName);
+    }
+
+    /**
+     * Get the selector symbol upon which this operand applies.
+     * 
+     * @return the one selector names used by this operand; never null
+     */
+    public SelectorName selectorName() {
+        return selectorNames.iterator().next();
+    }
+
+    @Override
+    public Set<SelectorName> selectorNames() {
+        return selectorNames;
+    }
+
+    @Override
+    public String getSelectorName() {
+        return selectorName().getString();
+    }
+
+    @Override
+    public String toString() {
+        return Visitors.readable(this);
+    }
+
+    @Override
+    public int hashCode() {
+        return selectorNames().hashCode();
+    }
+
+    @Override
+    public boolean equals( Object obj ) {
+        if (obj == this) return true;
+        if (obj instanceof NodeId) {
+            NodeId that = (NodeId)obj;
+            return this.selectorNames().equals(that.selectorNames());
+        }
+        return false;
+    }
+
+    @Override
+    public void accept( Visitor visitor ) {
+        visitor.visit(this);
+    }
+}

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/query/model/Visitor.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/query/model/Visitor.java
@@ -20,8 +20,8 @@ package org.modeshape.jcr.query.model;
  */
 public interface Visitor {
 
-    void visit(Relike obj);
-    
+    void visit( Relike obj );
+
     void visit( AllNodes obj );
 
     void visit( And obj );
@@ -65,6 +65,8 @@ public interface Visitor {
     void visit( NodePath obj );
 
     void visit( NodeDepth obj );
+
+    void visit( NodeId obj );
 
     void visit( NamedSelector obj );
 

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/query/model/Visitors.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/query/model/Visitors.java
@@ -460,6 +460,10 @@ public class Visitors {
         }
 
         @Override
+        public void visit( NodeId obj ) {
+        }
+
+        @Override
         public void visit( NodeDepth obj ) {
         }
 
@@ -736,6 +740,12 @@ public class Visitors {
         @Override
         public void visit( NodeDepth depth ) {
             strategy.visit(depth);
+            visitNext();
+        }
+
+        @Override
+        public void visit( NodeId id ) {
+            strategy.visit(id);
             visitNext();
         }
 
@@ -1219,6 +1229,11 @@ public class Visitors {
         @Override
         public void visit( NodeDepth depth ) {
             append("DEPTH(").append(depth.selectorName()).append(')');
+        }
+
+        @Override
+        public void visit( NodeId id ) {
+            append("ID(").append(id.selectorName()).append(')');
         }
 
         @Override

--- a/modeshape-jcr/src/main/resources/org/modeshape/jcr/JcrI18n.properties
+++ b/modeshape-jcr/src/main/resources/org/modeshape/jcr/JcrI18n.properties
@@ -267,6 +267,7 @@ multipleSelectorsAppearInQueryRequireSpecifyingSelectorName = Selector name must
 multipleSelectorsAppearInQueryUnableToCallMethod = As stipulated by the JCR API, it is not possible to return an iterator over the nodes in the results for a query with multiple selectors, since each result row may contain multiple nodes: {0}
 multipleCallsToGetRowsOrNodesIsNotAllowed = The JCR API specifies that 'getRows()' or 'getNodes()' may only be called once per QueryResult object, but one of these has already been called for the query: {0}
 equiJoinWithOneJcrPathPseudoColumnIsInvalid = Equi-join condition using one 'jcr:path' column is not valid: expected "... [{0}].[jcr:path] = [{1}].[jcr:path] ..."
+equiJoinWithOneNodeIdPseudoColumnIsInvalid = Equi-join condition using one 'mode:id' column is not valid: expected "... [{0}].[mode:id] = [{1}].[mode:id] ..."
 noSuchVariableInQuery = The variable '{0}' is not used in the query: {1}
 
 invalidNodeTypeName=Node types cannot have a null or empty name

--- a/modeshape-jdbc-local/src/main/java/org/modeshape/jdbc/JcrMetaData.java
+++ b/modeshape-jdbc-local/src/main/java/org/modeshape/jdbc/JcrMetaData.java
@@ -73,6 +73,8 @@ public class JcrMetaData implements DatabaseMetaData {
         defnNames.add("mode:localName");
         defns.add(new PseudoPropertyDefinition(null, "mode:depth", PropertyType.LONG, auto, mand, prot, mult, search, order));
         defnNames.add("mode:depth");
+        defns.add(new PseudoPropertyDefinition(null, "mode:id", PropertyType.STRING, auto, mand, prot, mult, search, order));
+        defnNames.add("mode:id");
 
         PSEUDO_COLUMN_DEFNS = Collections.unmodifiableList(defns);
         PSEUDO_COLUMN_NAMES = Collections.unmodifiableList(defnNames);
@@ -289,12 +291,9 @@ public class JcrMetaData implements DatabaseMetaData {
 
         Map<?, Object>[] metadataList = new Map[1];
 
-        metadataList[0] = MetadataProvider.getColumnMetadata(catalogName,
-                                                             null,
-                                                             JDBCColumnNames.CATALOGS.TABLE_CAT,
+        metadataList[0] = MetadataProvider.getColumnMetadata(catalogName, null, JDBCColumnNames.CATALOGS.TABLE_CAT,
                                                              JcrType.DefaultDataTypes.STRING,
-                                                             ResultsMetadataConstants.NULL_TYPES.NULLABLE,
-                                                             this.connection);
+                                                             ResultsMetadataConstants.NULL_TYPES.NULLABLE, this.connection);
 
         MetadataProvider provider = new MetadataProvider(metadataList);
 
@@ -333,140 +332,74 @@ public class JcrMetaData implements DatabaseMetaData {
 
         Map<?, Object>[] metadataList = new Map[JDBCColumnPositions.COLUMNS.MAX_COLUMNS];
 
-        metadataList[0] = MetadataProvider.getColumnMetadata(catalogName,
-                                                             null,
-                                                             JDBCColumnNames.COLUMNS.TABLE_CAT,
+        metadataList[0] = MetadataProvider.getColumnMetadata(catalogName, null, JDBCColumnNames.COLUMNS.TABLE_CAT,
                                                              JcrType.DefaultDataTypes.STRING,
-                                                             ResultsMetadataConstants.NULL_TYPES.NULLABLE,
-                                                             this.connection);
-        metadataList[1] = MetadataProvider.getColumnMetadata(catalogName,
-                                                             null,
-                                                             JDBCColumnNames.COLUMNS.TABLE_SCHEM,
+                                                             ResultsMetadataConstants.NULL_TYPES.NULLABLE, this.connection);
+        metadataList[1] = MetadataProvider.getColumnMetadata(catalogName, null, JDBCColumnNames.COLUMNS.TABLE_SCHEM,
                                                              JcrType.DefaultDataTypes.STRING,
-                                                             ResultsMetadataConstants.NULL_TYPES.NULLABLE,
-                                                             this.connection);
-        metadataList[2] = MetadataProvider.getColumnMetadata(catalogName,
-                                                             null,
-                                                             JDBCColumnNames.COLUMNS.TABLE_NAME,
+                                                             ResultsMetadataConstants.NULL_TYPES.NULLABLE, this.connection);
+        metadataList[2] = MetadataProvider.getColumnMetadata(catalogName, null, JDBCColumnNames.COLUMNS.TABLE_NAME,
                                                              JcrType.DefaultDataTypes.STRING,
-                                                             ResultsMetadataConstants.NULL_TYPES.NOT_NULL,
-                                                             this.connection);
-        metadataList[3] = MetadataProvider.getColumnMetadata(catalogName,
-                                                             null,
-                                                             JDBCColumnNames.COLUMNS.COLUMN_NAME,
+                                                             ResultsMetadataConstants.NULL_TYPES.NOT_NULL, this.connection);
+        metadataList[3] = MetadataProvider.getColumnMetadata(catalogName, null, JDBCColumnNames.COLUMNS.COLUMN_NAME,
                                                              JcrType.DefaultDataTypes.STRING,
-                                                             ResultsMetadataConstants.NULL_TYPES.NOT_NULL,
-                                                             this.connection);
-        metadataList[4] = MetadataProvider.getColumnMetadata(catalogName,
-                                                             null,
-                                                             JDBCColumnNames.COLUMNS.DATA_TYPE,
+                                                             ResultsMetadataConstants.NULL_TYPES.NOT_NULL, this.connection);
+        metadataList[4] = MetadataProvider.getColumnMetadata(catalogName, null, JDBCColumnNames.COLUMNS.DATA_TYPE,
                                                              JcrType.DefaultDataTypes.LONG,
-                                                             ResultsMetadataConstants.NULL_TYPES.NOT_NULL,
-                                                             this.connection);
-        metadataList[5] = MetadataProvider.getColumnMetadata(catalogName,
-                                                             null,
-                                                             JDBCColumnNames.COLUMNS.TYPE_NAME,
+                                                             ResultsMetadataConstants.NULL_TYPES.NOT_NULL, this.connection);
+        metadataList[5] = MetadataProvider.getColumnMetadata(catalogName, null, JDBCColumnNames.COLUMNS.TYPE_NAME,
                                                              JcrType.DefaultDataTypes.STRING,
-                                                             ResultsMetadataConstants.NULL_TYPES.NOT_NULL,
-                                                             this.connection);
-        metadataList[6] = MetadataProvider.getColumnMetadata(catalogName,
-                                                             null,
-                                                             JDBCColumnNames.COLUMNS.COLUMN_SIZE,
+                                                             ResultsMetadataConstants.NULL_TYPES.NOT_NULL, this.connection);
+        metadataList[6] = MetadataProvider.getColumnMetadata(catalogName, null, JDBCColumnNames.COLUMNS.COLUMN_SIZE,
                                                              JcrType.DefaultDataTypes.LONG,
-                                                             ResultsMetadataConstants.NULL_TYPES.NOT_NULL,
-                                                             this.connection);
-        metadataList[7] = MetadataProvider.getColumnMetadata(catalogName,
-                                                             null,
-                                                             JDBCColumnNames.COLUMNS.BUFFER_LENGTH,
+                                                             ResultsMetadataConstants.NULL_TYPES.NOT_NULL, this.connection);
+        metadataList[7] = MetadataProvider.getColumnMetadata(catalogName, null, JDBCColumnNames.COLUMNS.BUFFER_LENGTH,
                                                              JcrType.DefaultDataTypes.LONG,
-                                                             ResultsMetadataConstants.NULL_TYPES.NULLABLE,
-                                                             this.connection);
-        metadataList[8] = MetadataProvider.getColumnMetadata(catalogName,
-                                                             null,
-                                                             JDBCColumnNames.COLUMNS.DECIMAL_DIGITS,
+                                                             ResultsMetadataConstants.NULL_TYPES.NULLABLE, this.connection);
+        metadataList[8] = MetadataProvider.getColumnMetadata(catalogName, null, JDBCColumnNames.COLUMNS.DECIMAL_DIGITS,
                                                              JcrType.DefaultDataTypes.LONG,
-                                                             ResultsMetadataConstants.NULL_TYPES.NOT_NULL,
-                                                             this.connection);
-        metadataList[9] = MetadataProvider.getColumnMetadata(catalogName,
-                                                             null,
-                                                             JDBCColumnNames.COLUMNS.NUM_PREC_RADIX,
+                                                             ResultsMetadataConstants.NULL_TYPES.NOT_NULL, this.connection);
+        metadataList[9] = MetadataProvider.getColumnMetadata(catalogName, null, JDBCColumnNames.COLUMNS.NUM_PREC_RADIX,
                                                              JcrType.DefaultDataTypes.LONG,
-                                                             ResultsMetadataConstants.NULL_TYPES.NOT_NULL,
-                                                             this.connection);
+                                                             ResultsMetadataConstants.NULL_TYPES.NOT_NULL, this.connection);
 
-        metadataList[10] = MetadataProvider.getColumnMetadata(catalogName,
-                                                              null,
-                                                              JDBCColumnNames.COLUMNS.NULLABLE,
+        metadataList[10] = MetadataProvider.getColumnMetadata(catalogName, null, JDBCColumnNames.COLUMNS.NULLABLE,
                                                               JcrType.DefaultDataTypes.LONG,
-                                                              ResultsMetadataConstants.NULL_TYPES.NOT_NULL,
-                                                              this.connection);
-        metadataList[11] = MetadataProvider.getColumnMetadata(catalogName,
-                                                              null,
-                                                              JDBCColumnNames.COLUMNS.REMARKS,
+                                                              ResultsMetadataConstants.NULL_TYPES.NOT_NULL, this.connection);
+        metadataList[11] = MetadataProvider.getColumnMetadata(catalogName, null, JDBCColumnNames.COLUMNS.REMARKS,
                                                               JcrType.DefaultDataTypes.STRING,
-                                                              ResultsMetadataConstants.NULL_TYPES.NULLABLE,
-                                                              this.connection);
-        metadataList[12] = MetadataProvider.getColumnMetadata(catalogName,
-                                                              null,
-                                                              JDBCColumnNames.COLUMNS.COLUMN_DEF,
+                                                              ResultsMetadataConstants.NULL_TYPES.NULLABLE, this.connection);
+        metadataList[12] = MetadataProvider.getColumnMetadata(catalogName, null, JDBCColumnNames.COLUMNS.COLUMN_DEF,
                                                               JcrType.DefaultDataTypes.STRING,
-                                                              ResultsMetadataConstants.NULL_TYPES.NULLABLE,
-                                                              this.connection);
-        metadataList[13] = MetadataProvider.getColumnMetadata(catalogName,
-                                                              null,
-                                                              JDBCColumnNames.COLUMNS.SQL_DATA_TYPE,
+                                                              ResultsMetadataConstants.NULL_TYPES.NULLABLE, this.connection);
+        metadataList[13] = MetadataProvider.getColumnMetadata(catalogName, null, JDBCColumnNames.COLUMNS.SQL_DATA_TYPE,
                                                               JcrType.DefaultDataTypes.LONG,
-                                                              ResultsMetadataConstants.NULL_TYPES.NOT_NULL,
-                                                              this.connection);
-        metadataList[14] = MetadataProvider.getColumnMetadata(catalogName,
-                                                              null,
-                                                              JDBCColumnNames.COLUMNS.SQL_DATETIME_SUB,
+                                                              ResultsMetadataConstants.NULL_TYPES.NOT_NULL, this.connection);
+        metadataList[14] = MetadataProvider.getColumnMetadata(catalogName, null, JDBCColumnNames.COLUMNS.SQL_DATETIME_SUB,
                                                               JcrType.DefaultDataTypes.LONG,
-                                                              ResultsMetadataConstants.NULL_TYPES.NOT_NULL,
-                                                              this.connection);
-        metadataList[15] = MetadataProvider.getColumnMetadata(catalogName,
-                                                              null,
-                                                              JDBCColumnNames.COLUMNS.CHAR_OCTET_LENGTH,
+                                                              ResultsMetadataConstants.NULL_TYPES.NOT_NULL, this.connection);
+        metadataList[15] = MetadataProvider.getColumnMetadata(catalogName, null, JDBCColumnNames.COLUMNS.CHAR_OCTET_LENGTH,
                                                               JcrType.DefaultDataTypes.LONG,
-                                                              ResultsMetadataConstants.NULL_TYPES.NOT_NULL,
-                                                              this.connection);
-        metadataList[16] = MetadataProvider.getColumnMetadata(catalogName,
-                                                              null,
-                                                              JDBCColumnNames.COLUMNS.ORDINAL_POSITION,
+                                                              ResultsMetadataConstants.NULL_TYPES.NOT_NULL, this.connection);
+        metadataList[16] = MetadataProvider.getColumnMetadata(catalogName, null, JDBCColumnNames.COLUMNS.ORDINAL_POSITION,
                                                               JcrType.DefaultDataTypes.LONG,
-                                                              ResultsMetadataConstants.NULL_TYPES.NOT_NULL,
-                                                              this.connection);
-        metadataList[17] = MetadataProvider.getColumnMetadata(catalogName,
-                                                              null,
-                                                              JDBCColumnNames.COLUMNS.IS_NULLABLE,
+                                                              ResultsMetadataConstants.NULL_TYPES.NOT_NULL, this.connection);
+        metadataList[17] = MetadataProvider.getColumnMetadata(catalogName, null, JDBCColumnNames.COLUMNS.IS_NULLABLE,
                                                               JcrType.DefaultDataTypes.STRING,
-                                                              ResultsMetadataConstants.NULL_TYPES.NULLABLE,
-                                                              this.connection);
-        metadataList[18] = MetadataProvider.getColumnMetadata(catalogName,
-                                                              null,
-                                                              JDBCColumnNames.COLUMNS.SCOPE_CATLOG,
+                                                              ResultsMetadataConstants.NULL_TYPES.NULLABLE, this.connection);
+        metadataList[18] = MetadataProvider.getColumnMetadata(catalogName, null, JDBCColumnNames.COLUMNS.SCOPE_CATLOG,
                                                               JcrType.DefaultDataTypes.STRING,
-                                                              ResultsMetadataConstants.NULL_TYPES.NULLABLE,
-                                                              this.connection);
-        metadataList[19] = MetadataProvider.getColumnMetadata(catalogName,
-                                                              null,
-                                                              JDBCColumnNames.COLUMNS.SCOPE_SCHEMA,
+                                                              ResultsMetadataConstants.NULL_TYPES.NULLABLE, this.connection);
+        metadataList[19] = MetadataProvider.getColumnMetadata(catalogName, null, JDBCColumnNames.COLUMNS.SCOPE_SCHEMA,
                                                               JcrType.DefaultDataTypes.STRING,
-                                                              ResultsMetadataConstants.NULL_TYPES.NULLABLE,
-                                                              this.connection);
+                                                              ResultsMetadataConstants.NULL_TYPES.NULLABLE, this.connection);
 
-        metadataList[20] = MetadataProvider.getColumnMetadata(catalogName,
-                                                              null,
-                                                              JDBCColumnNames.COLUMNS.SCOPE_TABLE,
+        metadataList[20] = MetadataProvider.getColumnMetadata(catalogName, null, JDBCColumnNames.COLUMNS.SCOPE_TABLE,
                                                               JcrType.DefaultDataTypes.STRING,
-                                                              ResultsMetadataConstants.NULL_TYPES.NULLABLE,
-                                                              this.connection);
-        metadataList[21] = MetadataProvider.getColumnMetadata(catalogName,
-                                                              null,
-                                                              JDBCColumnNames.COLUMNS.SOURCE_DATA_TYPE,
+                                                              ResultsMetadataConstants.NULL_TYPES.NULLABLE, this.connection);
+        metadataList[21] = MetadataProvider.getColumnMetadata(catalogName, null, JDBCColumnNames.COLUMNS.SOURCE_DATA_TYPE,
                                                               JcrType.DefaultDataTypes.LONG,
-                                                              ResultsMetadataConstants.NULL_TYPES.NOT_NULL,
-                                                              this.connection);
+                                                              ResultsMetadataConstants.NULL_TYPES.NOT_NULL, this.connection);
 
         MetadataProvider provider = new MetadataProvider(metadataList);
 
@@ -495,12 +428,8 @@ public class JcrMetaData implements DatabaseMetaData {
 
                     Integer nullable = propDefn.isMandatory() ? ResultsMetadataConstants.NULL_TYPES.NOT_NULL : ResultsMetadataConstants.NULL_TYPES.NULLABLE;
 
-                    List<Object> currentRow = loadCurrentRow(type.getName(),
-                                                             propDefn.getName(),
-                                                             jcrtype,
-                                                             nullable,
-                                                             propDefn.isMandatory(),
-                                                             ordinal);
+                    List<Object> currentRow = loadCurrentRow(type.getName(), propDefn.getName(), jcrtype, nullable,
+                                                             propDefn.isMandatory(), ordinal);
 
                     // add the current row to the list of records.
                     records.add(currentRow);
@@ -510,12 +439,9 @@ public class JcrMetaData implements DatabaseMetaData {
                 // if columns where added and if Teiid Support is requested, then add the mode:properties to the list of columns
                 if (ordinal > 0 && this.connection.getRepositoryDelegate().getConnectionInfo().isTeiidSupport()) {
                     if (this.connection.getRepositoryDelegate().getConnectionInfo().isTeiidSupport()) {
-                        List<Object> currentRow = loadCurrentRow(type.getName(),
-                                                                 "mode:properties",
+                        List<Object> currentRow = loadCurrentRow(type.getName(), "mode:properties",
                                                                  JcrType.typeInfo(PropertyType.STRING),
-                                                                 ResultsMetadataConstants.NULL_TYPES.NULLABLE,
-                                                                 false,
-                                                                 ordinal);
+                                                                 ResultsMetadataConstants.NULL_TYPES.NULLABLE, false, ordinal);
 
                         records.add(currentRow);
                     }
@@ -650,90 +576,55 @@ public class JcrMetaData implements DatabaseMetaData {
                                       String table ) throws SQLException {
         @SuppressWarnings( "unchecked" )
         Map<?, Object>[] metadataList = new Map[JDBCColumnPositions.REFERENCE_KEYS.MAX_COLUMNS];
-        metadataList[0] = MetadataProvider.getColumnMetadata(catalogName,
-                                                             null,
-                                                             JDBCColumnNames.REFERENCE_KEYS_INFO.PK_TABLE_CAT,
+        metadataList[0] = MetadataProvider.getColumnMetadata(catalogName, null, JDBCColumnNames.REFERENCE_KEYS_INFO.PK_TABLE_CAT,
                                                              JcrType.DefaultDataTypes.STRING,
-                                                             ResultsMetadataConstants.NULL_TYPES.NULLABLE,
-                                                             this.connection);
-        metadataList[1] = MetadataProvider.getColumnMetadata(catalogName,
-                                                             null,
+                                                             ResultsMetadataConstants.NULL_TYPES.NULLABLE, this.connection);
+        metadataList[1] = MetadataProvider.getColumnMetadata(catalogName, null,
                                                              JDBCColumnNames.REFERENCE_KEYS_INFO.PK_TABLE_SCHEM,
                                                              JcrType.DefaultDataTypes.STRING,
-                                                             ResultsMetadataConstants.NULL_TYPES.NULLABLE,
-                                                             this.connection);
-        metadataList[2] = MetadataProvider.getColumnMetadata(catalogName,
-                                                             null,
+                                                             ResultsMetadataConstants.NULL_TYPES.NULLABLE, this.connection);
+        metadataList[2] = MetadataProvider.getColumnMetadata(catalogName, null,
                                                              JDBCColumnNames.REFERENCE_KEYS_INFO.PK_TABLE_NAME,
                                                              JcrType.DefaultDataTypes.STRING,
-                                                             ResultsMetadataConstants.NULL_TYPES.NOT_NULL,
-                                                             this.connection);
-        metadataList[3] = MetadataProvider.getColumnMetadata(catalogName,
-                                                             null,
+                                                             ResultsMetadataConstants.NULL_TYPES.NOT_NULL, this.connection);
+        metadataList[3] = MetadataProvider.getColumnMetadata(catalogName, null,
                                                              JDBCColumnNames.REFERENCE_KEYS_INFO.PK_COLUMN_NAME,
                                                              JcrType.DefaultDataTypes.STRING,
-                                                             ResultsMetadataConstants.NULL_TYPES.NOT_NULL,
-                                                             this.connection);
-        metadataList[4] = MetadataProvider.getColumnMetadata(catalogName,
-                                                             null,
-                                                             JDBCColumnNames.REFERENCE_KEYS_INFO.FK_TABLE_CAT,
+                                                             ResultsMetadataConstants.NULL_TYPES.NOT_NULL, this.connection);
+        metadataList[4] = MetadataProvider.getColumnMetadata(catalogName, null, JDBCColumnNames.REFERENCE_KEYS_INFO.FK_TABLE_CAT,
                                                              JcrType.DefaultDataTypes.STRING,
-                                                             ResultsMetadataConstants.NULL_TYPES.NULLABLE,
-                                                             this.connection);
-        metadataList[5] = MetadataProvider.getColumnMetadata(catalogName,
-                                                             null,
+                                                             ResultsMetadataConstants.NULL_TYPES.NULLABLE, this.connection);
+        metadataList[5] = MetadataProvider.getColumnMetadata(catalogName, null,
                                                              JDBCColumnNames.REFERENCE_KEYS_INFO.FK_TABLE_SCHEM,
                                                              JcrType.DefaultDataTypes.STRING,
-                                                             ResultsMetadataConstants.NULL_TYPES.NULLABLE,
-                                                             this.connection);
-        metadataList[6] = MetadataProvider.getColumnMetadata(catalogName,
-                                                             null,
+                                                             ResultsMetadataConstants.NULL_TYPES.NULLABLE, this.connection);
+        metadataList[6] = MetadataProvider.getColumnMetadata(catalogName, null,
                                                              JDBCColumnNames.REFERENCE_KEYS_INFO.FK_TABLE_NAME,
                                                              JcrType.DefaultDataTypes.STRING,
-                                                             ResultsMetadataConstants.NULL_TYPES.NOT_NULL,
-                                                             this.connection);
-        metadataList[7] = MetadataProvider.getColumnMetadata(catalogName,
-                                                             null,
+                                                             ResultsMetadataConstants.NULL_TYPES.NOT_NULL, this.connection);
+        metadataList[7] = MetadataProvider.getColumnMetadata(catalogName, null,
                                                              JDBCColumnNames.REFERENCE_KEYS_INFO.FK_COLUMN_NAME,
                                                              JcrType.DefaultDataTypes.STRING,
-                                                             ResultsMetadataConstants.NULL_TYPES.NOT_NULL,
-                                                             this.connection);
-        metadataList[8] = MetadataProvider.getColumnMetadata(catalogName,
-                                                             null,
-                                                             JDBCColumnNames.REFERENCE_KEYS_INFO.KEY_SEQ,
+                                                             ResultsMetadataConstants.NULL_TYPES.NOT_NULL, this.connection);
+        metadataList[8] = MetadataProvider.getColumnMetadata(catalogName, null, JDBCColumnNames.REFERENCE_KEYS_INFO.KEY_SEQ,
                                                              JcrType.DefaultDataTypes.LONG,
-                                                             ResultsMetadataConstants.NULL_TYPES.NOT_NULL,
-                                                             this.connection);
-        metadataList[9] = MetadataProvider.getColumnMetadata(catalogName,
-                                                             null,
-                                                             JDBCColumnNames.REFERENCE_KEYS_INFO.UPDATE_RULE,
+                                                             ResultsMetadataConstants.NULL_TYPES.NOT_NULL, this.connection);
+        metadataList[9] = MetadataProvider.getColumnMetadata(catalogName, null, JDBCColumnNames.REFERENCE_KEYS_INFO.UPDATE_RULE,
                                                              JcrType.DefaultDataTypes.LONG,
-                                                             ResultsMetadataConstants.NULL_TYPES.NOT_NULL,
-                                                             this.connection);
-        metadataList[10] = MetadataProvider.getColumnMetadata(catalogName,
-                                                              null,
-                                                              JDBCColumnNames.REFERENCE_KEYS_INFO.DELETE_RULE,
+                                                             ResultsMetadataConstants.NULL_TYPES.NOT_NULL, this.connection);
+        metadataList[10] = MetadataProvider.getColumnMetadata(catalogName, null, JDBCColumnNames.REFERENCE_KEYS_INFO.DELETE_RULE,
                                                               JcrType.DefaultDataTypes.LONG,
-                                                              ResultsMetadataConstants.NULL_TYPES.NOT_NULL,
-                                                              this.connection);
-        metadataList[11] = MetadataProvider.getColumnMetadata(catalogName,
-                                                              null,
-                                                              JDBCColumnNames.REFERENCE_KEYS_INFO.FK_NAME,
+                                                              ResultsMetadataConstants.NULL_TYPES.NOT_NULL, this.connection);
+        metadataList[11] = MetadataProvider.getColumnMetadata(catalogName, null, JDBCColumnNames.REFERENCE_KEYS_INFO.FK_NAME,
                                                               JcrType.DefaultDataTypes.STRING,
-                                                              ResultsMetadataConstants.NULL_TYPES.NULLABLE,
-                                                              this.connection);
-        metadataList[12] = MetadataProvider.getColumnMetadata(catalogName,
-                                                              null,
-                                                              JDBCColumnNames.REFERENCE_KEYS_INFO.PK_NAME,
+                                                              ResultsMetadataConstants.NULL_TYPES.NULLABLE, this.connection);
+        metadataList[12] = MetadataProvider.getColumnMetadata(catalogName, null, JDBCColumnNames.REFERENCE_KEYS_INFO.PK_NAME,
                                                               JcrType.DefaultDataTypes.STRING,
-                                                              ResultsMetadataConstants.NULL_TYPES.NULLABLE,
-                                                              this.connection);
-        metadataList[13] = MetadataProvider.getColumnMetadata(catalogName,
-                                                              null,
+                                                              ResultsMetadataConstants.NULL_TYPES.NULLABLE, this.connection);
+        metadataList[13] = MetadataProvider.getColumnMetadata(catalogName, null,
                                                               JDBCColumnNames.REFERENCE_KEYS_INFO.DEFERRABILITY,
                                                               JcrType.DefaultDataTypes.LONG,
-                                                              ResultsMetadataConstants.NULL_TYPES.NOT_NULL,
-                                                              this.connection);
+                                                              ResultsMetadataConstants.NULL_TYPES.NOT_NULL, this.connection);
         JcrStatement jcrstmt = new JcrStatement(this.connection);
         MetadataProvider provider = new MetadataProvider(metadataList);
         ResultSetMetaDataImpl resultSetMetaData = new ResultSetMetaDataImpl(provider);
@@ -754,85 +645,46 @@ public class JcrMetaData implements DatabaseMetaData {
         if (tableNamePattern == null) tableNamePattern = WILDCARD;
 
         Map<?, Object>[] metadataList = new Map[JDBCColumnPositions.INDEX_INFO.MAX_COLUMNS];
-        metadataList[0] = MetadataProvider.getColumnMetadata(catalogName,
-                                                             null,
-                                                             JDBCColumnNames.INDEX_INFO.TABLE_CAT,
+        metadataList[0] = MetadataProvider.getColumnMetadata(catalogName, null, JDBCColumnNames.INDEX_INFO.TABLE_CAT,
                                                              JcrType.DefaultDataTypes.STRING,
-                                                             ResultsMetadataConstants.NULL_TYPES.NULLABLE,
-                                                             this.connection);
-        metadataList[1] = MetadataProvider.getColumnMetadata(catalogName,
-                                                             null,
-                                                             JDBCColumnNames.INDEX_INFO.TABLE_SCHEM,
+                                                             ResultsMetadataConstants.NULL_TYPES.NULLABLE, this.connection);
+        metadataList[1] = MetadataProvider.getColumnMetadata(catalogName, null, JDBCColumnNames.INDEX_INFO.TABLE_SCHEM,
                                                              JcrType.DefaultDataTypes.STRING,
-                                                             ResultsMetadataConstants.NULL_TYPES.NULLABLE,
-                                                             this.connection);
-        metadataList[2] = MetadataProvider.getColumnMetadata(catalogName,
-                                                             null,
-                                                             JDBCColumnNames.INDEX_INFO.TABLE_NAME,
+                                                             ResultsMetadataConstants.NULL_TYPES.NULLABLE, this.connection);
+        metadataList[2] = MetadataProvider.getColumnMetadata(catalogName, null, JDBCColumnNames.INDEX_INFO.TABLE_NAME,
                                                              JcrType.DefaultDataTypes.STRING,
-                                                             ResultsMetadataConstants.NULL_TYPES.NOT_NULL,
-                                                             this.connection);
-        metadataList[3] = MetadataProvider.getColumnMetadata(catalogName,
-                                                             null,
-                                                             JDBCColumnNames.INDEX_INFO.NON_UNIQUE,
+                                                             ResultsMetadataConstants.NULL_TYPES.NOT_NULL, this.connection);
+        metadataList[3] = MetadataProvider.getColumnMetadata(catalogName, null, JDBCColumnNames.INDEX_INFO.NON_UNIQUE,
                                                              JcrType.DefaultDataTypes.BOOLEAN,
-                                                             ResultsMetadataConstants.NULL_TYPES.NOT_NULL,
-                                                             this.connection);
-        metadataList[4] = MetadataProvider.getColumnMetadata(catalogName,
-                                                             null,
-                                                             JDBCColumnNames.INDEX_INFO.INDEX_QUALIFIER,
+                                                             ResultsMetadataConstants.NULL_TYPES.NOT_NULL, this.connection);
+        metadataList[4] = MetadataProvider.getColumnMetadata(catalogName, null, JDBCColumnNames.INDEX_INFO.INDEX_QUALIFIER,
                                                              JcrType.DefaultDataTypes.STRING,
-                                                             ResultsMetadataConstants.NULL_TYPES.NULLABLE,
-                                                             this.connection);
-        metadataList[5] = MetadataProvider.getColumnMetadata(catalogName,
-                                                             null,
-                                                             JDBCColumnNames.INDEX_INFO.INDEX_NAME,
+                                                             ResultsMetadataConstants.NULL_TYPES.NULLABLE, this.connection);
+        metadataList[5] = MetadataProvider.getColumnMetadata(catalogName, null, JDBCColumnNames.INDEX_INFO.INDEX_NAME,
                                                              JcrType.DefaultDataTypes.STRING,
-                                                             ResultsMetadataConstants.NULL_TYPES.NULLABLE,
-                                                             this.connection);
-        metadataList[6] = MetadataProvider.getColumnMetadata(catalogName,
-                                                             null,
-                                                             JDBCColumnNames.INDEX_INFO.TYPE,
+                                                             ResultsMetadataConstants.NULL_TYPES.NULLABLE, this.connection);
+        metadataList[6] = MetadataProvider.getColumnMetadata(catalogName, null, JDBCColumnNames.INDEX_INFO.TYPE,
                                                              JcrType.DefaultDataTypes.LONG,
-                                                             ResultsMetadataConstants.NULL_TYPES.NOT_NULL,
-                                                             this.connection);
-        metadataList[7] = MetadataProvider.getColumnMetadata(catalogName,
-                                                             null,
-                                                             JDBCColumnNames.INDEX_INFO.ORDINAL_POSITION,
+                                                             ResultsMetadataConstants.NULL_TYPES.NOT_NULL, this.connection);
+        metadataList[7] = MetadataProvider.getColumnMetadata(catalogName, null, JDBCColumnNames.INDEX_INFO.ORDINAL_POSITION,
                                                              JcrType.DefaultDataTypes.LONG,
-                                                             ResultsMetadataConstants.NULL_TYPES.NULLABLE,
-                                                             this.connection);
-        metadataList[8] = MetadataProvider.getColumnMetadata(catalogName,
-                                                             null,
-                                                             JDBCColumnNames.INDEX_INFO.COLUMN_NAME,
+                                                             ResultsMetadataConstants.NULL_TYPES.NULLABLE, this.connection);
+        metadataList[8] = MetadataProvider.getColumnMetadata(catalogName, null, JDBCColumnNames.INDEX_INFO.COLUMN_NAME,
                                                              JcrType.DefaultDataTypes.LONG,
-                                                             ResultsMetadataConstants.NULL_TYPES.NULLABLE,
-                                                             this.connection);
-        metadataList[9] = MetadataProvider.getColumnMetadata(catalogName,
-                                                             null,
-                                                             JDBCColumnNames.INDEX_INFO.ASC_OR_DESC,
+                                                             ResultsMetadataConstants.NULL_TYPES.NULLABLE, this.connection);
+        metadataList[9] = MetadataProvider.getColumnMetadata(catalogName, null, JDBCColumnNames.INDEX_INFO.ASC_OR_DESC,
                                                              JcrType.DefaultDataTypes.STRING,
-                                                             ResultsMetadataConstants.NULL_TYPES.NULLABLE,
-                                                             this.connection);
+                                                             ResultsMetadataConstants.NULL_TYPES.NULLABLE, this.connection);
 
-        metadataList[10] = MetadataProvider.getColumnMetadata(catalogName,
-                                                              null,
-                                                              JDBCColumnNames.INDEX_INFO.CARDINALITY,
+        metadataList[10] = MetadataProvider.getColumnMetadata(catalogName, null, JDBCColumnNames.INDEX_INFO.CARDINALITY,
                                                               JcrType.DefaultDataTypes.LONG,
-                                                              ResultsMetadataConstants.NULL_TYPES.NOT_NULL,
-                                                              this.connection);
-        metadataList[11] = MetadataProvider.getColumnMetadata(catalogName,
-                                                              null,
-                                                              JDBCColumnNames.INDEX_INFO.PAGES,
+                                                              ResultsMetadataConstants.NULL_TYPES.NOT_NULL, this.connection);
+        metadataList[11] = MetadataProvider.getColumnMetadata(catalogName, null, JDBCColumnNames.INDEX_INFO.PAGES,
                                                               JcrType.DefaultDataTypes.LONG,
-                                                              ResultsMetadataConstants.NULL_TYPES.NOT_NULL,
-                                                              this.connection);
-        metadataList[12] = MetadataProvider.getColumnMetadata(catalogName,
-                                                              null,
-                                                              JDBCColumnNames.INDEX_INFO.FILTER_CONDITION,
+                                                              ResultsMetadataConstants.NULL_TYPES.NOT_NULL, this.connection);
+        metadataList[12] = MetadataProvider.getColumnMetadata(catalogName, null, JDBCColumnNames.INDEX_INFO.FILTER_CONDITION,
                                                               JcrType.DefaultDataTypes.STRING,
-                                                              ResultsMetadataConstants.NULL_TYPES.NULLABLE,
-                                                              this.connection);
+                                                              ResultsMetadataConstants.NULL_TYPES.NULLABLE, this.connection);
 
         try {
             Boolean nonUnique = Boolean.FALSE;
@@ -1108,42 +960,24 @@ public class JcrMetaData implements DatabaseMetaData {
         if (tableNamePattern == null) tableNamePattern = WILDCARD;
 
         Map<?, Object>[] metadataList = new Map[JDBCColumnPositions.PRIMARY_KEYS.MAX_COLUMNS];
-        metadataList[0] = MetadataProvider.getColumnMetadata(catalogName,
-                                                             null,
-                                                             JDBCColumnNames.PRIMARY_KEYS.TABLE_CAT,
+        metadataList[0] = MetadataProvider.getColumnMetadata(catalogName, null, JDBCColumnNames.PRIMARY_KEYS.TABLE_CAT,
                                                              JcrType.DefaultDataTypes.STRING,
-                                                             ResultsMetadataConstants.NULL_TYPES.NULLABLE,
-                                                             this.connection);
-        metadataList[1] = MetadataProvider.getColumnMetadata(catalogName,
-                                                             null,
-                                                             JDBCColumnNames.PRIMARY_KEYS.TABLE_SCHEM,
+                                                             ResultsMetadataConstants.NULL_TYPES.NULLABLE, this.connection);
+        metadataList[1] = MetadataProvider.getColumnMetadata(catalogName, null, JDBCColumnNames.PRIMARY_KEYS.TABLE_SCHEM,
                                                              JcrType.DefaultDataTypes.STRING,
-                                                             ResultsMetadataConstants.NULL_TYPES.NULLABLE,
-                                                             this.connection);
-        metadataList[2] = MetadataProvider.getColumnMetadata(catalogName,
-                                                             null,
-                                                             JDBCColumnNames.PRIMARY_KEYS.TABLE_NAME,
+                                                             ResultsMetadataConstants.NULL_TYPES.NULLABLE, this.connection);
+        metadataList[2] = MetadataProvider.getColumnMetadata(catalogName, null, JDBCColumnNames.PRIMARY_KEYS.TABLE_NAME,
                                                              JcrType.DefaultDataTypes.STRING,
-                                                             ResultsMetadataConstants.NULL_TYPES.NOT_NULL,
-                                                             this.connection);
-        metadataList[3] = MetadataProvider.getColumnMetadata(catalogName,
-                                                             null,
-                                                             JDBCColumnNames.PRIMARY_KEYS.COLUMN_NAME,
+                                                             ResultsMetadataConstants.NULL_TYPES.NOT_NULL, this.connection);
+        metadataList[3] = MetadataProvider.getColumnMetadata(catalogName, null, JDBCColumnNames.PRIMARY_KEYS.COLUMN_NAME,
                                                              JcrType.DefaultDataTypes.STRING,
-                                                             ResultsMetadataConstants.NULL_TYPES.NOT_NULL,
-                                                             this.connection);
-        metadataList[4] = MetadataProvider.getColumnMetadata(catalogName,
-                                                             null,
-                                                             JDBCColumnNames.PRIMARY_KEYS.KEY_SEQ,
+                                                             ResultsMetadataConstants.NULL_TYPES.NOT_NULL, this.connection);
+        metadataList[4] = MetadataProvider.getColumnMetadata(catalogName, null, JDBCColumnNames.PRIMARY_KEYS.KEY_SEQ,
                                                              JcrType.DefaultDataTypes.LONG,
-                                                             ResultsMetadataConstants.NULL_TYPES.NOT_NULL,
-                                                             this.connection);
-        metadataList[5] = MetadataProvider.getColumnMetadata(catalogName,
-                                                             null,
-                                                             JDBCColumnNames.PRIMARY_KEYS.PK_NAME,
+                                                             ResultsMetadataConstants.NULL_TYPES.NOT_NULL, this.connection);
+        metadataList[5] = MetadataProvider.getColumnMetadata(catalogName, null, JDBCColumnNames.PRIMARY_KEYS.PK_NAME,
                                                              JcrType.DefaultDataTypes.STRING,
-                                                             ResultsMetadataConstants.NULL_TYPES.NULLABLE,
-                                                             this.connection);
+                                                             ResultsMetadataConstants.NULL_TYPES.NULLABLE, this.connection);
 
         try {
             List<List<?>> records = new ArrayList<List<?>>();
@@ -1190,60 +1024,33 @@ public class JcrMetaData implements DatabaseMetaData {
                                     String procedureNamePattern ) throws SQLException {
         @SuppressWarnings( "unchecked" )
         Map<?, Object>[] metadataList = new Map[JDBCColumnPositions.PROCEDURES.MAX_COLUMNS];
-        metadataList[0] = MetadataProvider.getColumnMetadata(catalogName,
-                                                             null,
-                                                             JDBCColumnNames.PROCEDURES.PROCEDURE_CAT,
+        metadataList[0] = MetadataProvider.getColumnMetadata(catalogName, null, JDBCColumnNames.PROCEDURES.PROCEDURE_CAT,
                                                              JcrType.DefaultDataTypes.STRING,
-                                                             ResultsMetadataConstants.NULL_TYPES.NULLABLE,
-                                                             this.connection);
-        metadataList[1] = MetadataProvider.getColumnMetadata(catalogName,
-                                                             null,
-                                                             JDBCColumnNames.PROCEDURES.PROCEDURE_SCHEM,
+                                                             ResultsMetadataConstants.NULL_TYPES.NULLABLE, this.connection);
+        metadataList[1] = MetadataProvider.getColumnMetadata(catalogName, null, JDBCColumnNames.PROCEDURES.PROCEDURE_SCHEM,
                                                              JcrType.DefaultDataTypes.STRING,
-                                                             ResultsMetadataConstants.NULL_TYPES.NULLABLE,
-                                                             this.connection);
-        metadataList[2] = MetadataProvider.getColumnMetadata(catalogName,
-                                                             null,
-                                                             JDBCColumnNames.PROCEDURES.PROCEDURE_NAME,
+                                                             ResultsMetadataConstants.NULL_TYPES.NULLABLE, this.connection);
+        metadataList[2] = MetadataProvider.getColumnMetadata(catalogName, null, JDBCColumnNames.PROCEDURES.PROCEDURE_NAME,
                                                              JcrType.DefaultDataTypes.STRING,
-                                                             ResultsMetadataConstants.NULL_TYPES.NOT_NULL,
-                                                             this.connection);
-        metadataList[3] = MetadataProvider.getColumnMetadata(catalogName,
-                                                             null,
-                                                             JDBCColumnNames.PROCEDURES.RESERVED1,
+                                                             ResultsMetadataConstants.NULL_TYPES.NOT_NULL, this.connection);
+        metadataList[3] = MetadataProvider.getColumnMetadata(catalogName, null, JDBCColumnNames.PROCEDURES.RESERVED1,
                                                              JcrType.DefaultDataTypes.STRING,
-                                                             ResultsMetadataConstants.NULL_TYPES.NULLABLE,
-                                                             this.connection);
-        metadataList[4] = MetadataProvider.getColumnMetadata(catalogName,
-                                                             null,
-                                                             JDBCColumnNames.PROCEDURES.RESERVED2,
+                                                             ResultsMetadataConstants.NULL_TYPES.NULLABLE, this.connection);
+        metadataList[4] = MetadataProvider.getColumnMetadata(catalogName, null, JDBCColumnNames.PROCEDURES.RESERVED2,
                                                              JcrType.DefaultDataTypes.STRING,
-                                                             ResultsMetadataConstants.NULL_TYPES.NULLABLE,
-                                                             this.connection);
-        metadataList[5] = MetadataProvider.getColumnMetadata(catalogName,
-                                                             null,
-                                                             JDBCColumnNames.PROCEDURES.RESERVED3,
+                                                             ResultsMetadataConstants.NULL_TYPES.NULLABLE, this.connection);
+        metadataList[5] = MetadataProvider.getColumnMetadata(catalogName, null, JDBCColumnNames.PROCEDURES.RESERVED3,
                                                              JcrType.DefaultDataTypes.STRING,
-                                                             ResultsMetadataConstants.NULL_TYPES.NULLABLE,
-                                                             this.connection);
-        metadataList[6] = MetadataProvider.getColumnMetadata(catalogName,
-                                                             null,
-                                                             JDBCColumnNames.PROCEDURES.REMARKS,
+                                                             ResultsMetadataConstants.NULL_TYPES.NULLABLE, this.connection);
+        metadataList[6] = MetadataProvider.getColumnMetadata(catalogName, null, JDBCColumnNames.PROCEDURES.REMARKS,
                                                              JcrType.DefaultDataTypes.STRING,
-                                                             ResultsMetadataConstants.NULL_TYPES.NOT_NULL,
-                                                             this.connection);
-        metadataList[7] = MetadataProvider.getColumnMetadata(catalogName,
-                                                             null,
-                                                             JDBCColumnNames.PROCEDURES.PROCEDURE_TYPE,
+                                                             ResultsMetadataConstants.NULL_TYPES.NOT_NULL, this.connection);
+        metadataList[7] = MetadataProvider.getColumnMetadata(catalogName, null, JDBCColumnNames.PROCEDURES.PROCEDURE_TYPE,
                                                              JcrType.DefaultDataTypes.LONG,
-                                                             ResultsMetadataConstants.NULL_TYPES.NULLABLE,
-                                                             this.connection);
-        metadataList[8] = MetadataProvider.getColumnMetadata(catalogName,
-                                                             null,
-                                                             JDBCColumnNames.PROCEDURES.SPECIFIC_NAME,
+                                                             ResultsMetadataConstants.NULL_TYPES.NULLABLE, this.connection);
+        metadataList[8] = MetadataProvider.getColumnMetadata(catalogName, null, JDBCColumnNames.PROCEDURES.SPECIFIC_NAME,
                                                              JcrType.DefaultDataTypes.STRING,
-                                                             ResultsMetadataConstants.NULL_TYPES.NOT_NULL,
-                                                             this.connection);
+                                                             ResultsMetadataConstants.NULL_TYPES.NOT_NULL, this.connection);
 
         JcrStatement jcrstmt = new JcrStatement(this.connection);
         MetadataProvider provider = new MetadataProvider(metadataList);
@@ -1289,12 +1096,9 @@ public class JcrMetaData implements DatabaseMetaData {
 
         Map<?, Object>[] metadataList = new Map[1];
 
-        metadataList[0] = MetadataProvider.getColumnMetadata(catalogName,
-                                                             null,
-                                                             JDBCColumnNames.COLUMNS.TABLE_SCHEM,
+        metadataList[0] = MetadataProvider.getColumnMetadata(catalogName, null, JDBCColumnNames.COLUMNS.TABLE_SCHEM,
                                                              JcrType.DefaultDataTypes.STRING,
-                                                             ResultsMetadataConstants.NULL_TYPES.NULLABLE,
-                                                             this.connection);
+                                                             ResultsMetadataConstants.NULL_TYPES.NULLABLE, this.connection);
 
         MetadataProvider provider = new MetadataProvider(metadataList);
 
@@ -1363,12 +1167,9 @@ public class JcrMetaData implements DatabaseMetaData {
 
         Map<?, Object>[] metadataList = new Map[1];
 
-        metadataList[0] = MetadataProvider.getColumnMetadata(catalogName,
-                                                             null,
-                                                             JDBCColumnNames.TABLE_TYPES.TABLE_TYPE,
+        metadataList[0] = MetadataProvider.getColumnMetadata(catalogName, null, JDBCColumnNames.TABLE_TYPES.TABLE_TYPE,
                                                              JcrType.DefaultDataTypes.STRING,
-                                                             ResultsMetadataConstants.NULL_TYPES.NULLABLE,
-                                                             this.connection);
+                                                             ResultsMetadataConstants.NULL_TYPES.NULLABLE, this.connection);
 
         MetadataProvider provider = new MetadataProvider(metadataList);
 
@@ -1395,66 +1196,36 @@ public class JcrMetaData implements DatabaseMetaData {
 
         Map<?, Object>[] metadataList = new Map[JDBCColumnPositions.TABLES.MAX_COLUMNS];
 
-        metadataList[0] = MetadataProvider.getColumnMetadata(catalogName,
-                                                             null,
-                                                             JDBCColumnNames.TABLES.TABLE_CAT,
+        metadataList[0] = MetadataProvider.getColumnMetadata(catalogName, null, JDBCColumnNames.TABLES.TABLE_CAT,
                                                              JcrType.DefaultDataTypes.STRING,
-                                                             ResultsMetadataConstants.NULL_TYPES.NULLABLE,
-                                                             this.connection);
-        metadataList[1] = MetadataProvider.getColumnMetadata(catalogName,
-                                                             null,
-                                                             JDBCColumnNames.TABLES.TABLE_SCHEM,
+                                                             ResultsMetadataConstants.NULL_TYPES.NULLABLE, this.connection);
+        metadataList[1] = MetadataProvider.getColumnMetadata(catalogName, null, JDBCColumnNames.TABLES.TABLE_SCHEM,
                                                              JcrType.DefaultDataTypes.STRING,
-                                                             ResultsMetadataConstants.NULL_TYPES.NULLABLE,
-                                                             this.connection);
-        metadataList[2] = MetadataProvider.getColumnMetadata(catalogName,
-                                                             null,
-                                                             JDBCColumnNames.TABLES.TABLE_NAME,
+                                                             ResultsMetadataConstants.NULL_TYPES.NULLABLE, this.connection);
+        metadataList[2] = MetadataProvider.getColumnMetadata(catalogName, null, JDBCColumnNames.TABLES.TABLE_NAME,
                                                              JcrType.DefaultDataTypes.STRING,
-                                                             ResultsMetadataConstants.NULL_TYPES.NOT_NULL,
-                                                             this.connection);
-        metadataList[3] = MetadataProvider.getColumnMetadata(catalogName,
-                                                             null,
-                                                             JDBCColumnNames.TABLES.TABLE_TYPE,
+                                                             ResultsMetadataConstants.NULL_TYPES.NOT_NULL, this.connection);
+        metadataList[3] = MetadataProvider.getColumnMetadata(catalogName, null, JDBCColumnNames.TABLES.TABLE_TYPE,
                                                              JcrType.DefaultDataTypes.STRING,
-                                                             ResultsMetadataConstants.NULL_TYPES.NOT_NULL,
-                                                             this.connection);
-        metadataList[4] = MetadataProvider.getColumnMetadata(catalogName,
-                                                             null,
-                                                             JDBCColumnNames.TABLES.REMARKS,
+                                                             ResultsMetadataConstants.NULL_TYPES.NOT_NULL, this.connection);
+        metadataList[4] = MetadataProvider.getColumnMetadata(catalogName, null, JDBCColumnNames.TABLES.REMARKS,
                                                              JcrType.DefaultDataTypes.STRING,
-                                                             ResultsMetadataConstants.NULL_TYPES.NULLABLE,
-                                                             this.connection);
-        metadataList[5] = MetadataProvider.getColumnMetadata(catalogName,
-                                                             null,
-                                                             JDBCColumnNames.TABLES.TYPE_CAT,
+                                                             ResultsMetadataConstants.NULL_TYPES.NULLABLE, this.connection);
+        metadataList[5] = MetadataProvider.getColumnMetadata(catalogName, null, JDBCColumnNames.TABLES.TYPE_CAT,
                                                              JcrType.DefaultDataTypes.STRING,
-                                                             ResultsMetadataConstants.NULL_TYPES.NULLABLE,
-                                                             this.connection);
-        metadataList[6] = MetadataProvider.getColumnMetadata(catalogName,
-                                                             null,
-                                                             JDBCColumnNames.TABLES.TYPE_SCHEM,
+                                                             ResultsMetadataConstants.NULL_TYPES.NULLABLE, this.connection);
+        metadataList[6] = MetadataProvider.getColumnMetadata(catalogName, null, JDBCColumnNames.TABLES.TYPE_SCHEM,
                                                              JcrType.DefaultDataTypes.STRING,
-                                                             ResultsMetadataConstants.NULL_TYPES.NULLABLE,
-                                                             this.connection);
-        metadataList[7] = MetadataProvider.getColumnMetadata(catalogName,
-                                                             null,
-                                                             JDBCColumnNames.TABLES.TYPE_NAME,
+                                                             ResultsMetadataConstants.NULL_TYPES.NULLABLE, this.connection);
+        metadataList[7] = MetadataProvider.getColumnMetadata(catalogName, null, JDBCColumnNames.TABLES.TYPE_NAME,
                                                              JcrType.DefaultDataTypes.STRING,
-                                                             ResultsMetadataConstants.NULL_TYPES.NULLABLE,
-                                                             this.connection);
-        metadataList[8] = MetadataProvider.getColumnMetadata(catalogName,
-                                                             null,
-                                                             JDBCColumnNames.TABLES.SELF_REFERENCING_COL_NAME,
+                                                             ResultsMetadataConstants.NULL_TYPES.NULLABLE, this.connection);
+        metadataList[8] = MetadataProvider.getColumnMetadata(catalogName, null, JDBCColumnNames.TABLES.SELF_REFERENCING_COL_NAME,
                                                              JcrType.DefaultDataTypes.STRING,
-                                                             ResultsMetadataConstants.NULL_TYPES.NULLABLE,
-                                                             this.connection);
-        metadataList[9] = MetadataProvider.getColumnMetadata(catalogName,
-                                                             null,
-                                                             JDBCColumnNames.TABLES.REF_GENERATION,
+                                                             ResultsMetadataConstants.NULL_TYPES.NULLABLE, this.connection);
+        metadataList[9] = MetadataProvider.getColumnMetadata(catalogName, null, JDBCColumnNames.TABLES.REF_GENERATION,
                                                              JcrType.DefaultDataTypes.STRING,
-                                                             ResultsMetadataConstants.NULL_TYPES.NULLABLE,
-                                                             this.connection);
+                                                             ResultsMetadataConstants.NULL_TYPES.NULLABLE, this.connection);
 
         MetadataProvider provider = new MetadataProvider(metadataList);
 
@@ -1509,126 +1280,30 @@ public class JcrMetaData implements DatabaseMetaData {
 
     private static List<List<?>> typeInfoRows() {
         List<List<?>> rows = new ArrayList<List<?>>();
-        rows.add(typeInfoRow(JcrType.DefaultDataTypes.STRING,
-                             Types.VARCHAR,
-                             Integer.MAX_VALUE,
-                             NULL_TYPES.NULLABLE,
-                             true,
-                             ResultsMetadataConstants.SEARCH_TYPES.SEARCHABLE,
-                             false,
-                             false,
-                             0,
-                             0));
-        rows.add(typeInfoRow(JcrType.DefaultDataTypes.BINARY,
-                             Types.BLOB,
-                             Integer.MAX_VALUE,
-                             NULL_TYPES.NULLABLE,
-                             true,
-                             ResultsMetadataConstants.SEARCH_TYPES.SEARCHABLE,
-                             false,
-                             false,
-                             0,
-                             0));
-        rows.add(typeInfoRow(JcrType.DefaultDataTypes.BOOLEAN,
-                             Types.BOOLEAN,
-                             1,
-                             NULL_TYPES.NULLABLE,
-                             true,
-                             ResultsMetadataConstants.SEARCH_TYPES.SEARCHABLE,
-                             false,
-                             false,
-                             0,
-                             0));
-        rows.add(typeInfoRow(JcrType.DefaultDataTypes.DATE,
-                             Types.TIMESTAMP,
-                             Integer.MAX_VALUE,
-                             NULL_TYPES.NULLABLE,
-                             true,
-                             ResultsMetadataConstants.SEARCH_TYPES.SEARCHABLE,
-                             false,
-                             false,
-                             0,
-                             0));
-        rows.add(typeInfoRow(JcrType.DefaultDataTypes.DECIMAL,
-                             Types.DECIMAL,
-                             Integer.MAX_VALUE,
-                             NULL_TYPES.NULLABLE,
-                             true,
-                             ResultsMetadataConstants.SEARCH_TYPES.SEARCHABLE,
-                             false,
-                             false,
-                             0,
-                             0));
-        rows.add(typeInfoRow(JcrType.DefaultDataTypes.DOUBLE,
-                             Types.DOUBLE,
-                             18,
-                             NULL_TYPES.NULLABLE,
-                             true,
-                             ResultsMetadataConstants.SEARCH_TYPES.SEARCHABLE,
-                             false,
-                             false,
-                             0,
-                             0));
-        rows.add(typeInfoRow(JcrType.DefaultDataTypes.LONG,
-                             Types.BIGINT,
-                             18,
-                             NULL_TYPES.NULLABLE,
-                             true,
-                             ResultsMetadataConstants.SEARCH_TYPES.SEARCHABLE,
-                             false,
-                             false,
-                             0,
-                             0));
-        rows.add(typeInfoRow(JcrType.DefaultDataTypes.NAME,
-                             Types.VARCHAR,
-                             Integer.MAX_VALUE,
-                             NULL_TYPES.NULLABLE,
-                             true,
-                             ResultsMetadataConstants.SEARCH_TYPES.SEARCHABLE,
-                             false,
-                             false,
-                             0,
-                             0));
-        rows.add(typeInfoRow(JcrType.DefaultDataTypes.PATH,
-                             Types.VARCHAR,
-                             Integer.MAX_VALUE,
-                             NULL_TYPES.NULLABLE,
-                             true,
-                             ResultsMetadataConstants.SEARCH_TYPES.SEARCHABLE,
-                             false,
-                             false,
-                             0,
-                             0));
-        rows.add(typeInfoRow(JcrType.DefaultDataTypes.REFERENCE,
-                             Types.VARCHAR,
-                             Integer.MAX_VALUE,
-                             NULL_TYPES.NULLABLE,
-                             true,
-                             ResultsMetadataConstants.SEARCH_TYPES.SEARCHABLE,
-                             false,
-                             false,
-                             0,
-                             0));
-        rows.add(typeInfoRow(JcrType.DefaultDataTypes.WEAK_REF,
-                             Types.VARCHAR,
-                             Integer.MAX_VALUE,
-                             NULL_TYPES.NULLABLE,
-                             true,
-                             ResultsMetadataConstants.SEARCH_TYPES.SEARCHABLE,
-                             false,
-                             false,
-                             0,
-                             0));
-        rows.add(typeInfoRow(JcrType.DefaultDataTypes.URI,
-                             Types.VARCHAR,
-                             Integer.MAX_VALUE,
-                             NULL_TYPES.NULLABLE,
-                             true,
-                             ResultsMetadataConstants.SEARCH_TYPES.SEARCHABLE,
-                             false,
-                             false,
-                             0,
-                             0));
+        rows.add(typeInfoRow(JcrType.DefaultDataTypes.STRING, Types.VARCHAR, Integer.MAX_VALUE, NULL_TYPES.NULLABLE, true,
+                             ResultsMetadataConstants.SEARCH_TYPES.SEARCHABLE, false, false, 0, 0));
+        rows.add(typeInfoRow(JcrType.DefaultDataTypes.BINARY, Types.BLOB, Integer.MAX_VALUE, NULL_TYPES.NULLABLE, true,
+                             ResultsMetadataConstants.SEARCH_TYPES.SEARCHABLE, false, false, 0, 0));
+        rows.add(typeInfoRow(JcrType.DefaultDataTypes.BOOLEAN, Types.BOOLEAN, 1, NULL_TYPES.NULLABLE, true,
+                             ResultsMetadataConstants.SEARCH_TYPES.SEARCHABLE, false, false, 0, 0));
+        rows.add(typeInfoRow(JcrType.DefaultDataTypes.DATE, Types.TIMESTAMP, Integer.MAX_VALUE, NULL_TYPES.NULLABLE, true,
+                             ResultsMetadataConstants.SEARCH_TYPES.SEARCHABLE, false, false, 0, 0));
+        rows.add(typeInfoRow(JcrType.DefaultDataTypes.DECIMAL, Types.DECIMAL, Integer.MAX_VALUE, NULL_TYPES.NULLABLE, true,
+                             ResultsMetadataConstants.SEARCH_TYPES.SEARCHABLE, false, false, 0, 0));
+        rows.add(typeInfoRow(JcrType.DefaultDataTypes.DOUBLE, Types.DOUBLE, 18, NULL_TYPES.NULLABLE, true,
+                             ResultsMetadataConstants.SEARCH_TYPES.SEARCHABLE, false, false, 0, 0));
+        rows.add(typeInfoRow(JcrType.DefaultDataTypes.LONG, Types.BIGINT, 18, NULL_TYPES.NULLABLE, true,
+                             ResultsMetadataConstants.SEARCH_TYPES.SEARCHABLE, false, false, 0, 0));
+        rows.add(typeInfoRow(JcrType.DefaultDataTypes.NAME, Types.VARCHAR, Integer.MAX_VALUE, NULL_TYPES.NULLABLE, true,
+                             ResultsMetadataConstants.SEARCH_TYPES.SEARCHABLE, false, false, 0, 0));
+        rows.add(typeInfoRow(JcrType.DefaultDataTypes.PATH, Types.VARCHAR, Integer.MAX_VALUE, NULL_TYPES.NULLABLE, true,
+                             ResultsMetadataConstants.SEARCH_TYPES.SEARCHABLE, false, false, 0, 0));
+        rows.add(typeInfoRow(JcrType.DefaultDataTypes.REFERENCE, Types.VARCHAR, Integer.MAX_VALUE, NULL_TYPES.NULLABLE, true,
+                             ResultsMetadataConstants.SEARCH_TYPES.SEARCHABLE, false, false, 0, 0));
+        rows.add(typeInfoRow(JcrType.DefaultDataTypes.WEAK_REF, Types.VARCHAR, Integer.MAX_VALUE, NULL_TYPES.NULLABLE, true,
+                             ResultsMetadataConstants.SEARCH_TYPES.SEARCHABLE, false, false, 0, 0));
+        rows.add(typeInfoRow(JcrType.DefaultDataTypes.URI, Types.VARCHAR, Integer.MAX_VALUE, NULL_TYPES.NULLABLE, true,
+                             ResultsMetadataConstants.SEARCH_TYPES.SEARCHABLE, false, false, 0, 0));
         return rows;
     }
 
@@ -1669,114 +1344,60 @@ public class JcrMetaData implements DatabaseMetaData {
         @SuppressWarnings( "unchecked" )
         Map<?, Object>[] metadataList = new Map[JDBCColumnPositions.TYPE_INFO.MAX_COLUMNS];
 
-        metadataList[0] = MetadataProvider.getColumnMetadata(catalogName,
-                                                             null,
-                                                             JDBCColumnNames.TYPE_INFO.TYPE_NAME,
+        metadataList[0] = MetadataProvider.getColumnMetadata(catalogName, null, JDBCColumnNames.TYPE_INFO.TYPE_NAME,
                                                              JcrType.DefaultDataTypes.STRING,
-                                                             ResultsMetadataConstants.NULL_TYPES.NOT_NULL,
-                                                             this.connection);
-        metadataList[1] = MetadataProvider.getColumnMetadata(catalogName,
-                                                             null,
-                                                             JDBCColumnNames.TYPE_INFO.DATA_TYPE,
+                                                             ResultsMetadataConstants.NULL_TYPES.NOT_NULL, this.connection);
+        metadataList[1] = MetadataProvider.getColumnMetadata(catalogName, null, JDBCColumnNames.TYPE_INFO.DATA_TYPE,
                                                              JcrType.DefaultDataTypes.LONG,
-                                                             ResultsMetadataConstants.NULL_TYPES.NOT_NULL,
-                                                             this.connection);
-        metadataList[2] = MetadataProvider.getColumnMetadata(catalogName,
-                                                             null,
-                                                             JDBCColumnNames.TYPE_INFO.PRECISION,
+                                                             ResultsMetadataConstants.NULL_TYPES.NOT_NULL, this.connection);
+        metadataList[2] = MetadataProvider.getColumnMetadata(catalogName, null, JDBCColumnNames.TYPE_INFO.PRECISION,
                                                              JcrType.DefaultDataTypes.LONG,
-                                                             ResultsMetadataConstants.NULL_TYPES.NOT_NULL,
-                                                             this.connection);
-        metadataList[3] = MetadataProvider.getColumnMetadata(catalogName,
-                                                             null,
-                                                             JDBCColumnNames.TYPE_INFO.LITERAL_PREFIX,
+                                                             ResultsMetadataConstants.NULL_TYPES.NOT_NULL, this.connection);
+        metadataList[3] = MetadataProvider.getColumnMetadata(catalogName, null, JDBCColumnNames.TYPE_INFO.LITERAL_PREFIX,
                                                              JcrType.DefaultDataTypes.STRING,
-                                                             ResultsMetadataConstants.NULL_TYPES.NULLABLE,
-                                                             this.connection);
-        metadataList[4] = MetadataProvider.getColumnMetadata(catalogName,
-                                                             null,
-                                                             JDBCColumnNames.TYPE_INFO.LITERAL_SUFFIX,
+                                                             ResultsMetadataConstants.NULL_TYPES.NULLABLE, this.connection);
+        metadataList[4] = MetadataProvider.getColumnMetadata(catalogName, null, JDBCColumnNames.TYPE_INFO.LITERAL_SUFFIX,
                                                              JcrType.DefaultDataTypes.STRING,
-                                                             ResultsMetadataConstants.NULL_TYPES.NULLABLE,
-                                                             this.connection);
-        metadataList[5] = MetadataProvider.getColumnMetadata(catalogName,
-                                                             null,
-                                                             JDBCColumnNames.TYPE_INFO.CREATE_PARAMS,
+                                                             ResultsMetadataConstants.NULL_TYPES.NULLABLE, this.connection);
+        metadataList[5] = MetadataProvider.getColumnMetadata(catalogName, null, JDBCColumnNames.TYPE_INFO.CREATE_PARAMS,
                                                              JcrType.DefaultDataTypes.STRING,
-                                                             ResultsMetadataConstants.NULL_TYPES.NULLABLE,
-                                                             this.connection);
-        metadataList[6] = MetadataProvider.getColumnMetadata(catalogName,
-                                                             null,
-                                                             JDBCColumnNames.TYPE_INFO.NULLABLE,
+                                                             ResultsMetadataConstants.NULL_TYPES.NULLABLE, this.connection);
+        metadataList[6] = MetadataProvider.getColumnMetadata(catalogName, null, JDBCColumnNames.TYPE_INFO.NULLABLE,
                                                              JcrType.DefaultDataTypes.LONG,
-                                                             ResultsMetadataConstants.NULL_TYPES.NOT_NULL,
-                                                             this.connection);
-        metadataList[7] = MetadataProvider.getColumnMetadata(catalogName,
-                                                             null,
-                                                             JDBCColumnNames.TYPE_INFO.CASE_SENSITIVE,
+                                                             ResultsMetadataConstants.NULL_TYPES.NOT_NULL, this.connection);
+        metadataList[7] = MetadataProvider.getColumnMetadata(catalogName, null, JDBCColumnNames.TYPE_INFO.CASE_SENSITIVE,
                                                              JcrType.DefaultDataTypes.BOOLEAN,
-                                                             ResultsMetadataConstants.NULL_TYPES.NOT_NULL,
-                                                             this.connection);
-        metadataList[8] = MetadataProvider.getColumnMetadata(catalogName,
-                                                             null,
-                                                             JDBCColumnNames.TYPE_INFO.SEARCHABLE,
+                                                             ResultsMetadataConstants.NULL_TYPES.NOT_NULL, this.connection);
+        metadataList[8] = MetadataProvider.getColumnMetadata(catalogName, null, JDBCColumnNames.TYPE_INFO.SEARCHABLE,
                                                              JcrType.DefaultDataTypes.LONG,
-                                                             ResultsMetadataConstants.NULL_TYPES.NOT_NULL,
-                                                             this.connection);
-        metadataList[9] = MetadataProvider.getColumnMetadata(catalogName,
-                                                             null,
-                                                             JDBCColumnNames.TYPE_INFO.UNSIGNED_ATTRIBUTE,
+                                                             ResultsMetadataConstants.NULL_TYPES.NOT_NULL, this.connection);
+        metadataList[9] = MetadataProvider.getColumnMetadata(catalogName, null, JDBCColumnNames.TYPE_INFO.UNSIGNED_ATTRIBUTE,
                                                              JcrType.DefaultDataTypes.BOOLEAN,
-                                                             ResultsMetadataConstants.NULL_TYPES.NOT_NULL,
-                                                             this.connection);
-        metadataList[10] = MetadataProvider.getColumnMetadata(catalogName,
-                                                              null,
-                                                              JDBCColumnNames.TYPE_INFO.FIXED_PREC_SCALE,
+                                                             ResultsMetadataConstants.NULL_TYPES.NOT_NULL, this.connection);
+        metadataList[10] = MetadataProvider.getColumnMetadata(catalogName, null, JDBCColumnNames.TYPE_INFO.FIXED_PREC_SCALE,
                                                               JcrType.DefaultDataTypes.BOOLEAN,
-                                                              ResultsMetadataConstants.NULL_TYPES.NOT_NULL,
-                                                              this.connection);
-        metadataList[11] = MetadataProvider.getColumnMetadata(catalogName,
-                                                              null,
-                                                              JDBCColumnNames.TYPE_INFO.AUTOINCREMENT,
+                                                              ResultsMetadataConstants.NULL_TYPES.NOT_NULL, this.connection);
+        metadataList[11] = MetadataProvider.getColumnMetadata(catalogName, null, JDBCColumnNames.TYPE_INFO.AUTOINCREMENT,
                                                               JcrType.DefaultDataTypes.BOOLEAN,
-                                                              ResultsMetadataConstants.NULL_TYPES.NOT_NULL,
-                                                              this.connection);
-        metadataList[12] = MetadataProvider.getColumnMetadata(catalogName,
-                                                              null,
-                                                              JDBCColumnNames.TYPE_INFO.LOCAL_TYPE_NAME,
+                                                              ResultsMetadataConstants.NULL_TYPES.NOT_NULL, this.connection);
+        metadataList[12] = MetadataProvider.getColumnMetadata(catalogName, null, JDBCColumnNames.TYPE_INFO.LOCAL_TYPE_NAME,
                                                               JcrType.DefaultDataTypes.STRING,
-                                                              ResultsMetadataConstants.NULL_TYPES.NULLABLE,
-                                                              this.connection);
-        metadataList[13] = MetadataProvider.getColumnMetadata(catalogName,
-                                                              null,
-                                                              JDBCColumnNames.TYPE_INFO.MINIMUM_SCALE,
+                                                              ResultsMetadataConstants.NULL_TYPES.NULLABLE, this.connection);
+        metadataList[13] = MetadataProvider.getColumnMetadata(catalogName, null, JDBCColumnNames.TYPE_INFO.MINIMUM_SCALE,
                                                               JcrType.DefaultDataTypes.LONG,
-                                                              ResultsMetadataConstants.NULL_TYPES.NOT_NULL,
-                                                              this.connection);
-        metadataList[14] = MetadataProvider.getColumnMetadata(catalogName,
-                                                              null,
-                                                              JDBCColumnNames.TYPE_INFO.MAXIMUM_SCALE,
+                                                              ResultsMetadataConstants.NULL_TYPES.NOT_NULL, this.connection);
+        metadataList[14] = MetadataProvider.getColumnMetadata(catalogName, null, JDBCColumnNames.TYPE_INFO.MAXIMUM_SCALE,
                                                               JcrType.DefaultDataTypes.LONG,
-                                                              ResultsMetadataConstants.NULL_TYPES.NOT_NULL,
-                                                              this.connection);
-        metadataList[15] = MetadataProvider.getColumnMetadata(catalogName,
-                                                              null,
-                                                              JDBCColumnNames.TYPE_INFO.SQL_DATA_TYPE,
+                                                              ResultsMetadataConstants.NULL_TYPES.NOT_NULL, this.connection);
+        metadataList[15] = MetadataProvider.getColumnMetadata(catalogName, null, JDBCColumnNames.TYPE_INFO.SQL_DATA_TYPE,
                                                               JcrType.DefaultDataTypes.LONG,
-                                                              ResultsMetadataConstants.NULL_TYPES.NOT_NULL,
-                                                              this.connection);
-        metadataList[16] = MetadataProvider.getColumnMetadata(catalogName,
-                                                              null,
-                                                              JDBCColumnNames.TYPE_INFO.SQL_DATETIME_SUB,
+                                                              ResultsMetadataConstants.NULL_TYPES.NOT_NULL, this.connection);
+        metadataList[16] = MetadataProvider.getColumnMetadata(catalogName, null, JDBCColumnNames.TYPE_INFO.SQL_DATETIME_SUB,
                                                               JcrType.DefaultDataTypes.LONG,
-                                                              ResultsMetadataConstants.NULL_TYPES.NOT_NULL,
-                                                              this.connection);
-        metadataList[17] = MetadataProvider.getColumnMetadata(catalogName,
-                                                              null,
-                                                              JDBCColumnNames.TYPE_INFO.NUM_PREC_RADIX,
+                                                              ResultsMetadataConstants.NULL_TYPES.NOT_NULL, this.connection);
+        metadataList[17] = MetadataProvider.getColumnMetadata(catalogName, null, JDBCColumnNames.TYPE_INFO.NUM_PREC_RADIX,
                                                               JcrType.DefaultDataTypes.LONG,
-                                                              ResultsMetadataConstants.NULL_TYPES.NOT_NULL,
-                                                              this.connection);
+                                                              ResultsMetadataConstants.NULL_TYPES.NOT_NULL, this.connection);
 
         // Build the result set metadata ...
         MetadataProvider provider = new MetadataProvider(metadataList);

--- a/modeshape-jdbc-local/src/test/java/org/modeshape/jdbc/AbstractJdbcDriverIntegrationTest.java
+++ b/modeshape-jdbc-local/src/test/java/org/modeshape/jdbc/AbstractJdbcDriverIntegrationTest.java
@@ -373,7 +373,8 @@ public abstract class AbstractJdbcDriverIntegrationTest extends AbstractJdbcDriv
             "cars    null    car:Car    jcr:primaryType    12    STRING    20    null    0    0    1        null    0    0    0    14    NO    null    null    null    0",
             "cars    null    car:Car    jcr:score    8    DOUBLE    20    null    0    0    2        null    0    0    0    15    YES    null    null    null    0",
             "cars    null    car:Car    mode:depth    -5    LONG    20    null    0    0    2        null    0    0    0    16    YES    null    null    null    0",
-            "cars    null    car:Car    mode:localName    12    STRING    50    null    0    0    2        null    0    0    0    17    YES    null    null    null    0"};
+            "cars    null    car:Car    mode:id    12    STRING    50    null    0    0    2        null    0    0    0    17    YES    null    null    null    0",
+            "cars    null    car:Car    mode:localName    12    STRING    50    null    0    0    2        null    0    0    0    18    YES    null    null    null    0"};
         ResultSet rs = dbmd.getColumns("%", "%", "car:Car", "%");
 
         assertResultsSetEquals(rs, expected);
@@ -403,7 +404,8 @@ public abstract class AbstractJdbcDriverIntegrationTest extends AbstractJdbcDriv
             "cars    null    car:Car    jcr:primaryType    12    STRING    20    null    0    0    1        null    0    0    0    14    NO    null    null    null    0",
             "cars    null    car:Car    jcr:score    8    DOUBLE    20    null    0    0    2        null    0    0    0    15    YES    null    null    null    0",
             "cars    null    car:Car    mode:depth    -5    LONG    20    null    0    0    2        null    0    0    0    16    YES    null    null    null    0",
-            "cars    null    car:Car    mode:localName    12    STRING    50    null    0    0    2        null    0    0    0    17    YES    null    null    null    0"};
+            "cars    null    car:Car    mode:id    12    STRING    50    null    0    0    2        null    0    0    0    17    YES    null    null    null    0",
+            "cars    null    car:Car    mode:localName    12    STRING    50    null    0    0    2        null    0    0    0    18    YES    null    null    null    0"};
 
         ResultSet rs = dbmd.getColumns("%", "%", "car%", "%");
 

--- a/modeshape-jdbc-local/src/test/java/org/modeshape/jdbc/util/ResultSetReader.java
+++ b/modeshape-jdbc-local/src/test/java/org/modeshape/jdbc/util/ResultSetReader.java
@@ -182,10 +182,13 @@ public class ResultSetReader extends StringLineReader {
             } else if (colName.equalsIgnoreCase("mode:depth")) {
                 JcrType jcrType = JcrType.typeInfo(JcrType.DefaultDataTypes.LONG);
                 assertThat(colTypeName, is(jcrType.getJcrName()));
+            } else if (colName.equalsIgnoreCase("mode:id")) {
+                JcrType jcrType = JcrType.typeInfo(JcrType.DefaultDataTypes.STRING);
+                assertThat(colTypeName, is(jcrType.getJcrName()));
             }
 
             sb.append(colName).append("[") //$NON-NLS-1$
-            .append(colTypeName).append("]"); //$NON-NLS-1$
+              .append(colTypeName).append("]"); //$NON-NLS-1$
             if (col != columnCount) {
                 sb.append(delimiter);
             }


### PR DESCRIPTION
It is now possible to use the 'mode:id' pseudocolumn that exists on all selectors to obtain the `javax.jcr.Node.getIdentifier()` value. It can be used in WHERE constraints and JOIN criteria.
