### PR TITLE
MODE-2268 Changed the ChangeSet implementation to expose the `sessionId` together with the `processId` and fixed the behavior of non-local event listeners.

### DIFF
--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/Connectors.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/Connectors.java
@@ -499,9 +499,11 @@ public final class Connectors {
             public ConnectorChangeSet newChangeSet() {
                 PathMappings mappings = getPathMappings(c);
                 RunningState repository = repository();
-                return new ConnectorChangeSetImpl(Connectors.this, mappings, repository.context().getProcessId(),
+                final ExecutionContext context = repository.context();
+                return new ConnectorChangeSetImpl(Connectors.this, mappings,
+                                                  context.getId(), context.getProcessId(),
                                                   repository.repositoryKey(), repository.changeBus(),
-                                                  repository.context().getValueFactories().getDateFactory(),
+                                                  context.getValueFactories().getDateFactory(),
                                                   repository().journalId());
             }
         };

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrObservationManager.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrObservationManager.java
@@ -1095,7 +1095,7 @@ final class JcrObservationManager implements ObservationManager, ChangeSetListen
          * @return <code>true</code> if event occurred in a different session or if events from same session should be processed
          */
         private boolean acceptBasedOnOriginatingSession( ChangeSet changeSet ) {
-            return !this.noLocal || !getSessionId().equals(changeSet.getProcessKey());
+            return !this.noLocal || !getSessionId().equals(changeSet.getSessionId());
         }
 
         /**
@@ -1187,7 +1187,7 @@ final class JcrObservationManager implements ObservationManager, ChangeSetListen
         }
 
         private String getSessionId() {
-            return session.context().getProcessId();
+            return session.sessionId();
         }
 
         private String getWorkspaceName() {

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrSession.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrSession.java
@@ -198,7 +198,7 @@ public class JcrSession implements org.modeshape.jcr.api.Session {
         this.workspace = new JcrWorkspace(this, workspaceName);
 
         // Create the session cache ...
-        this.cache = repositoryCache.createSession(context, workspaceName, readOnly);
+        this.cache = repositoryCache.createSession(this.context, workspaceName, readOnly);
         this.rootNode = new JcrRootNode(this, this.cache.getRootKey());
         this.jcrNodes.put(this.rootNode.key(), this.rootNode);
         this.sessionAttributes = sessionAttributes != null ? sessionAttributes : Collections.<String, Object>emptyMap();

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/SequencingRunner.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/SequencingRunner.java
@@ -304,7 +304,8 @@ final class SequencingRunner implements Runnable {
                                       JcrSession outputSession,
                                       String sequencerName ) throws RepositoryException {
 
-        RecordingChanges sequencingChanges = new RecordingChanges(outputSession.context().getProcessId(),
+        final ExecutionContext context = outputSession.context();
+        RecordingChanges sequencingChanges = new RecordingChanges(outputSession.sessionId(), context.getProcessId(),
                                                                   outputSession.getRepository().repositoryKey(),
                                                                   outputSession.workspaceName(), outputSession.getRepository()
                                                                                                               .journalId());
@@ -316,7 +317,7 @@ final class SequencingRunner implements Runnable {
                                             outputNode.path(), work.getOutputPath(), work.getUserId(), work.getSelectedPath(),
                                             sequencerName, sequencedNode.node().isQueryable(outputSession.cache()));
         }
-        sequencingChanges.freeze(outputSession.getUserID(), null, outputSession.context().getValueFactories().getDateFactory().create());
+        sequencingChanges.freeze(outputSession.getUserID(), null, context.getValueFactories().getDateFactory().create());
         repository.changeBus().notify(sequencingChanges);
     }
 
@@ -328,7 +329,8 @@ final class SequencingRunner implements Runnable {
         assert inputSession != null;
         Name primaryType = sequencedNode.getPrimaryTypeName();
         Set<Name> mixinTypes = sequencedNode.getMixinTypeNames();
-        RecordingChanges sequencingChanges = new RecordingChanges(inputSession.context().getProcessId(),
+        final ExecutionContext context = inputSession.context();
+        RecordingChanges sequencingChanges = new RecordingChanges(inputSession.sessionId(), context.getProcessId(),
                                                                   inputSession.getRepository().repositoryKey(),
                                                                   inputSession.workspaceName(), inputSession.getRepository()
                                                                                                             .journalId());

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/RepositoryCache.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/RepositoryCache.java
@@ -398,7 +398,8 @@ public class RepositoryCache {
             String userId = context.getSecurityContext().getUserName();
             Map<String, String> userData = context.getData();
             DateTime timestamp = context.getValueFactories().getDateFactory().create();
-            RecordingChanges changes = new RecordingChanges(context.getId(), this.getKey(), null, sessionContext.journalId());
+            RecordingChanges changes = new RecordingChanges(context.getId(),
+                    context.getProcessId(), this.getKey(), null, sessionContext.journalId());
             changes.repositoryMetadataChanged();
             changes.freeze(userId, userData, timestamp);
             this.changeBus.notify(changes);
@@ -885,7 +886,8 @@ public class RepositoryCache {
             String userId = context.getSecurityContext().getUserName();
             Map<String, String> userData = context.getData();
             DateTime timestamp = context.getValueFactories().getDateFactory().create();
-            RecordingChanges changes = new RecordingChanges(context.getId(), this.getKey(), null, sessionContext.journalId());
+            RecordingChanges changes = new RecordingChanges(context.getId(),
+                    context.getProcessId(), this.getKey(), null, sessionContext.journalId());
             changes.workspaceAdded(name);
             changes.freeze(userId, userData, timestamp);
             this.changeBus.notify(changes);
@@ -941,7 +943,8 @@ public class RepositoryCache {
             String userId = context.getSecurityContext().getUserName();
             Map<String, String> userData = context.getData();
             DateTime timestamp = context.getValueFactories().getDateFactory().create();
-            RecordingChanges changes = new RecordingChanges(context.getId(), this.getKey(), null, sessionContext.journalId());
+            RecordingChanges changes = new RecordingChanges(context.getId(),
+                    context.getProcessId(), this.getKey(), null, sessionContext.journalId());
             changes.workspaceRemoved(name);
             changes.freeze(userId, userData, timestamp);
             this.changeBus.notify(changes);

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/change/ChangeSet.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/change/ChangeSet.java
@@ -90,6 +90,13 @@ public interface ChangeSet extends Iterable<Change>, Serializable {
     public Set<NodeKey> changedNodes();
 
     /**
+     * Returns the ID of the session in which the changes occurred.
+     *
+     * @return the id of a session, never {@code null}
+     */
+    public String getSessionId();
+
+    /**
      * Returns the identifier of the local {@link org.modeshape.jcr.journal.ChangeJournal} instance.
      * 
      * @return either a non-null {@link String} if journaling is enabled, or {@code null} if journaling isn't enabled.

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/change/RecordingChanges.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/change/RecordingChanges.java
@@ -52,6 +52,7 @@ public class RecordingChanges implements Changes, ChangeSet {
     private final String repositoryKey;
     private final String workspaceName;
     private final String journalId;
+    private final String sessionId;
     private final Queue<Change> events = new ConcurrentLinkedQueue<Change>();
     private final String uuid = UUID.randomUUID().toString();
     private Set<NodeKey> nodeKeys = Collections.emptySet();
@@ -61,21 +62,24 @@ public class RecordingChanges implements Changes, ChangeSet {
 
     /**
      * Creates a new change set.
-     * 
+     * @param sessionId  the ID of the session in which the change set was created; may not be null;
      * @param processKey the UUID of the process which created the change set; may not be null
      * @param repositoryKey the key of the repository for which the changes set is created; may not be null.
      * @param workspaceName the name of the workspace in which the changes occurred; may be null.
      * @param journalId the ID of the journal where this change set will be saved; may be null
      */
-    public RecordingChanges( String processKey,
+    public RecordingChanges( String sessionId,
+                             String processKey,
                              String repositoryKey,
                              String workspaceName,
                              String journalId ) {
+        this.sessionId = sessionId;
         this.processKey = processKey;
         this.repositoryKey = repositoryKey;
         this.workspaceName = workspaceName;
         this.journalId = journalId;
 
+        assert this.sessionId != null;
         assert this.processKey != null;
         assert this.repositoryKey != null;
     }
@@ -317,6 +321,11 @@ public class RecordingChanges implements Changes, ChangeSet {
     @Override
     public String getUserId() {
         return userId;
+    }
+
+    @Override
+    public String getSessionId() {
+        return sessionId;
     }
 
     @Override

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/document/WorkspaceCache.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/document/WorkspaceCache.java
@@ -138,10 +138,6 @@ public class WorkspaceCache implements DocumentCache {
         return this;
     }
 
-    public final String getProcessKey() {
-        return context.getProcessId();
-    }
-
     public final String getRepositoryKey() {
         return repositoryKey;
     }

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/document/WritableSessionCache.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/document/WritableSessionCache.java
@@ -834,8 +834,8 @@ public class WritableSessionCache extends AbstractSessionCache {
         DateTime timestamp = context.getValueFactories().getDateFactory().create();
         String workspaceName = persistedCache.getWorkspaceName();
         String repositoryKey = persistedCache.getRepositoryKey();
-        String processKey = persistedCache.getProcessKey();
-        RecordingChanges changes = new RecordingChanges(processKey, repositoryKey, workspaceName, sessionContext().journalId());
+        RecordingChanges changes = new RecordingChanges(context.getId(),
+                context.getProcessId(), repositoryKey, workspaceName, sessionContext().journalId());
 
         // Get the documentStore ...
         DocumentStore documentStore = persistedCache.documentStore();

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/federation/ConnectorChangeSetImpl.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/federation/ConnectorChangeSetImpl.java
@@ -48,14 +48,16 @@ public class ConnectorChangeSetImpl implements ConnectorChangeSet {
     private final Map<String, RecordingChanges> changesByWorkspace = new HashMap<String, RecordingChanges>();
     private final DateTimeFactory timeFactory;
     private final String journalId;
+    private final String sessionId;
 
     public ConnectorChangeSetImpl( Connectors connectors,
                                    PathMappings mappings,
+                                   String sessionId,
                                    String processId,
                                    String repositoryKey,
                                    ChangeBus bus,
                                    DateTimeFactory timeFactory,
-                                   String journalId ) {
+                                   String journalId) {
         this.connectors = connectors;
         this.connectorSourceName = mappings.getConnectorSourceName();
         this.timeFactory = timeFactory;
@@ -64,6 +66,7 @@ public class ConnectorChangeSetImpl implements ConnectorChangeSet {
         this.repositoryKey = repositoryKey;
         this.bus = bus;
         this.journalId = journalId;
+        this.sessionId = sessionId;
         assert this.connectors != null;
         assert this.connectorSourceName != null;
         assert this.pathMappings != null;
@@ -80,7 +83,7 @@ public class ConnectorChangeSetImpl implements ConnectorChangeSet {
     protected final RecordingChanges changesFor( String workspaceName ) {
         RecordingChanges changes = changesByWorkspace.get(workspaceName);
         if (changes == null) {
-            changes = new RecordingChanges(processId, repositoryKey, workspaceName, journalId);
+            changes = new RecordingChanges(sessionId, processId, repositoryKey, workspaceName, journalId);
             changesByWorkspace.put(workspaceName, changes);
         }
         return changes;

--- a/modeshape-jcr/src/test/java/org/modeshape/jcr/JcrObservationManagerTest.java
+++ b/modeshape-jcr/src/test/java/org/modeshape/jcr/JcrObservationManagerTest.java
@@ -2105,6 +2105,37 @@ public final class JcrObservationManagerTest extends SingleUseAbstractTest {
     }
 
     @Test
+    @FixFor( "MODE-2268" )
+    public void shouldReceiveNonLocalEvents() throws Exception {
+        // register a non-local listener with the 1st session
+        SimpleListener listener = new SimpleListener(1, 1, Event.NODE_ADDED);
+        session.getWorkspace()
+               .getObservationManager()
+               .addEventListener(listener, Event.NODE_ADDED, null, true, null, null, true);
+
+        //create a node in the 1st session - the listener should not get this event
+        session.getRootNode().addNode("session1Node");
+        session.save();
+
+        // Create a new session ...
+        Session session2 = login(WORKSPACE);
+
+        // add node and save
+        Node addedNode = session2.getRootNode().addNode("session2Node");
+        session2.save();
+
+        // event handling
+        listener.waitForEvents();
+        removeListener(listener);
+
+        // tests
+        checkResults(listener);
+        assertTrue("Path for added node is wrong: actual=" + listener.getEvents().get(0).getPath() + ", expected="
+                   + addedNode.getPath(),
+                   containsPath(listener, addedNode.getPath()));
+    }
+
+    @Test
     @FixFor( "MODE-2019" )
     public void shouldProvideFullEventJournal() throws Exception {
         // add node

--- a/modeshape-jcr/src/test/java/org/modeshape/jcr/bus/AbstractChangeBusTest.java
+++ b/modeshape-jcr/src/test/java/org/modeshape/jcr/bus/AbstractChangeBusTest.java
@@ -290,6 +290,11 @@ public abstract class AbstractChangeBusTest {
         }
 
         @Override
+        public String getSessionId() {
+            return null;
+        }
+
+        @Override
         public String getRepositoryKey() {
             return null;
         }

--- a/modeshape-jcr/src/test/java/org/modeshape/jcr/journal/LocalJournalTest.java
+++ b/modeshape-jcr/src/test/java/org/modeshape/jcr/journal/LocalJournalTest.java
@@ -248,6 +248,11 @@ public class LocalJournalTest {
         }
 
         @Override
+        public String getSessionId() {
+            return null;
+        }
+
+        @Override
         public String getJournalId() {
             return journalId;
         }


### PR DESCRIPTION
The only thing that was exposed (and checked) up until now was the `processKey`. However, this is unique per cluster node and has _the same value_ for all the sessions on a repository on any given cluster node.
This PR also exposes the `sessionId` which is unique per-session and is read from the `ExecutionContext`.

If the change is ok, the issue will require a separate PR for the `3.x` branches, as there are significant changes & differences between the 2 codebases and affected paths.
