### PR TITLE
MODE-2253 Updated backup & restore to explicitly suspend/resume any existing user transactions plus a couple of tests (unit & integration) around backup/restore within transactions.

### DIFF
--- a/integration/modeshape-jbossas-integration-tests/src/main/java/org/modeshape/test/integration/BackupRestoreBean.java
+++ b/integration/modeshape-jbossas-integration-tests/src/main/java/org/modeshape/test/integration/BackupRestoreBean.java
@@ -1,0 +1,67 @@
+/*
+ * ModeShape (http://www.modeshape.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.modeshape.test.integration;
+
+import java.io.File;
+import javax.annotation.PostConstruct;
+import javax.ejb.Singleton;
+import javax.ejb.Startup;
+import javax.ejb.TransactionAttribute;
+import javax.ejb.TransactionAttributeType;
+import org.modeshape.common.util.StringUtil;
+import org.modeshape.jcr.api.Problems;
+import org.modeshape.jcr.api.Repository;
+import org.modeshape.jcr.api.RepositoryManager;
+
+/**
+ * Singleton EJB that performs backup/restore from with a startup method.
+ *
+ * @author Horia Chiorean (hchiorea@redhat.com)
+ */
+@Singleton
+@Startup
+public class BackupRestoreBean extends RepositoryProvider {
+
+    private boolean backupRestoreSuccessful = false;
+
+    @PostConstruct
+    @TransactionAttribute( TransactionAttributeType.NOT_SUPPORTED)
+    public void run() throws Exception {
+        final String path = System.getProperty("jboss.server.base.dir");
+        if (StringUtil.isBlank(path)) {
+            throw new IllegalStateException("Cannot locate the jboss server dir");
+        }
+        final File backupDirectory = new File(path);
+
+        Repository repository = (Repository)getRepositoryFromJndi("java:/jcr/sample");
+        org.modeshape.jcr.api.Session session = (org.modeshape.jcr.api.Session)repository.login();
+        final RepositoryManager repoMgr = session.getWorkspace().getRepositoryManager();
+        Problems problems = repoMgr.backupRepository(backupDirectory);
+        if (problems.hasProblems()) {
+            throw new IllegalStateException("Errors while backing up repository:" +  problems.toString());
+        }
+
+        problems = session.getWorkspace().getRepositoryManager().restoreRepository(backupDirectory);
+        if (problems.hasProblems()) {
+            throw new IllegalStateException("Errors while backing up repository:" +  problems.toString());
+        }
+        backupRestoreSuccessful = true;
+    }
+
+    public boolean isBackupRestoreSuccessful() {
+        return backupRestoreSuccessful;
+    }
+}

--- a/integration/modeshape-jbossas-integration-tests/src/test/java/org/modeshape/test/integration/BackupRestoreTest.java
+++ b/integration/modeshape-jbossas-integration-tests/src/test/java/org/modeshape/test/integration/BackupRestoreTest.java
@@ -1,0 +1,60 @@
+/*
+ * ModeShape (http://www.modeshape.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.modeshape.test.integration;
+
+import static org.junit.Assert.assertTrue;
+import java.io.File;
+import javax.ejb.EJB;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.ArchivePaths;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.modeshape.common.FixFor;
+
+/**
+ * Integration test for the backup-restore functionality.
+ *
+ * @author Horia Chiorean (hchiorea@redhat.com)
+ */
+@RunWith( Arquillian.class )
+public class BackupRestoreTest {
+
+    @EJB
+    private BackupRestoreBean backupRestoreBean;
+
+    @Deployment
+    public static WebArchive createDeployment() {
+        WebArchive archive = ShrinkWrap.create(WebArchive.class, "backup-restore-test.war")
+                                       .addAsWebInfResource(EmptyAsset.INSTANCE, ArchivePaths.create("beans.xml"))
+                                       .addClass(BackupRestoreBean.class)
+                                       .addClass(RepositoryProvider.class);
+
+        // Add our custom Manifest, which has the additional Dependencies entry ...
+        archive.setManifest(new File("src/main/webapp/META-INF/MANIFEST.MF"));
+        return archive;
+    }
+
+
+    @Test
+    @FixFor( "MODE-2253" )
+    public void shouldBackupAndRestore() throws Exception {
+        assertTrue(backupRestoreBean.isBackupRestoreSuccessful());
+    }
+}

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/BackupService.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/BackupService.java
@@ -33,6 +33,7 @@ import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import javax.jcr.RepositoryException;
+import javax.transaction.SystemException;
 import org.infinispan.Cache;
 import org.infinispan.schematic.Schematic;
 import org.infinispan.schematic.SchematicEntry;
@@ -130,8 +131,20 @@ public class BackupService {
         // Create the activity ...
         final BackupActivity backupActivity = createBackupActivity(backupDirectory, documentsPerFile, compress);
 
-        // Run the backup and return the problems ...
-        return new JcrProblems(backupActivity.execute());
+        //suspend any existing transactions
+        try {
+            if (runningState.suspendExistingUserTransaction()) {
+                LOGGER.debug("Suspended existing active user transaction before the backup operation starts");
+            }
+            try {
+                // Run the backup and return the problems ...
+                return new JcrProblems(backupActivity.execute());
+            } finally {
+                runningState.resumeExistingUserTransaction();
+            }
+        } catch (SystemException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     /**
@@ -152,15 +165,26 @@ public class BackupService {
         // Create the activity ...
         final RestoreActivity restoreActivity = createRestoreActivity(backupDirectory);
 
-        org.modeshape.jcr.api.Problems problems = new JcrProblems(restoreActivity.execute());
-        if (!problems.hasProblems()) {
-            // restart the repository ...
-            try {
-                repository.completeRestore();
-            } catch (Throwable t) {
-                restoreActivity.problems.addError(JcrI18n.repositoryCannotBeRestartedAfterRestore, repository.getName(),
-                                                  t.getMessage());
+        org.modeshape.jcr.api.Problems problems = null;
+        try {
+            if (runningState.suspendExistingUserTransaction()) {
+                LOGGER.debug("Suspended existing active user transaction before the restore operation starts");
             }
+
+            problems = new JcrProblems(restoreActivity.execute());
+            if (!problems.hasProblems()) {
+                // restart the repository ...
+                try {
+                    repository.completeRestore();
+                } catch (Throwable t) {
+                    restoreActivity.problems.addError(JcrI18n.repositoryCannotBeRestartedAfterRestore, repository.getName(),
+                                                      t.getMessage());
+                } finally {
+                    runningState.resumeExistingUserTransaction();
+                }
+            }
+        } catch (SystemException e) {
+            throw new RuntimeException(e);
         }
         LOGGER.debug("Completed restore of '{0}' repository from {1}", repository.getName(), backupLocString);
         return problems;

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrRepository.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrRepository.java
@@ -1853,9 +1853,10 @@ public class JcrRepository implements org.modeshape.jcr.api.Repository {
             }
         }
 
-        void suspendExistingUserTransaction() throws SystemException {
+        boolean suspendExistingUserTransaction() throws SystemException {
             // suspend any potential existing transaction, so that the initialization is "atomic"
             this.existingUserTransaction = this.transactions.suspend();
+            return this.existingUserTransaction != null;
         }
 
         void resumeExistingUserTransaction() throws SystemException {

--- a/modeshape-jcr/src/test/java/org/modeshape/jcr/RepositoryRestoreTest.java
+++ b/modeshape-jcr/src/test/java/org/modeshape/jcr/RepositoryRestoreTest.java
@@ -31,9 +31,16 @@ import javax.jcr.RepositoryException;
 import javax.jcr.Session;
 import javax.jcr.query.Query;
 import javax.jcr.query.QueryResult;
+import javax.transaction.HeuristicMixedException;
+import javax.transaction.HeuristicRollbackException;
+import javax.transaction.NotSupportedException;
+import javax.transaction.RollbackException;
+import javax.transaction.SystemException;
+import javax.transaction.TransactionManager;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
+import org.modeshape.common.FixFor;
 import org.modeshape.common.statistic.Stopwatch;
 import org.modeshape.common.util.FileUtil;
 import org.modeshape.jcr.api.Problems;
@@ -168,6 +175,37 @@ public class RepositoryRestoreTest extends SingleUseAbstractTest {
         assertContentInWorkspace(repository(), "ws3");
         assertContentNotInWorkspace(repository(), "default", "/node-not-in-backup");
         queryContentInWorkspace(repository(), null);
+    }
+
+    @Test
+    @FixFor( "MODE-2253" )
+    public void shouldBackupAndRestoreWithExistingUserTransaction() throws Exception {
+        loadContent();
+
+        startTransaction();
+
+        Problems problems = session().getWorkspace().getRepositoryManager().backupRepository(backupDirectory);
+        assertNoProblems(problems);
+        problems = session().getWorkspace().getRepositoryManager().restoreRepository(backupDirectory);
+        assertNoProblems(problems);
+
+        rollbackTransaction();
+
+        assertContentInWorkspace(repository(), "default");
+        assertContentInWorkspace(repository(), "ws2");
+        assertContentInWorkspace(repository(), "ws3");
+    }
+
+    private void startTransaction() throws NotSupportedException, SystemException {
+        TransactionManager txnMgr = session.repository.transactionManager();
+        txnMgr.begin();
+    }
+
+    private void rollbackTransaction()
+            throws SystemException, SecurityException, IllegalStateException, RollbackException, HeuristicMixedException,
+                   HeuristicRollbackException {
+        TransactionManager txnMgr = session.repository.transactionManager();
+        txnMgr.rollback();
     }
 
     private void assertWorkspaces( JcrRepository newRepository,


### PR DESCRIPTION
A separate PR is required for `3.x`.
