### PR TITLE
MODE-2274 Java sequencer doesn't handle files with no package statement

### DIFF
--- a/sequencers/modeshape-sequencer-java/pom.xml
+++ b/sequencers/modeshape-sequencer-java/pom.xml
@@ -63,6 +63,7 @@
             <testResource>
                 <directory>${project.basedir}/src/test/java</directory>
                 <includes>
+                    <include>DefaultPackageClass.java</include>
                     <include>org/modeshape/sequencer/testdata/*.*</include>
                 </includes>
             </testResource>

--- a/sequencers/modeshape-sequencer-java/src/test/java/DefaultPackageClass.java
+++ b/sequencers/modeshape-sequencer-java/src/test/java/DefaultPackageClass.java
@@ -1,0 +1,48 @@
+/*
+ * ModeShape (http://www.modeshape.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * This is a class type test class that is in the default package.
+ *
+ * @since 2.0
+ */
+public class DefaultPackageClass {
+
+    /**
+     * A constant.
+     */
+    public static final String CONSTANT = "constant"; // a line comment
+
+    /**
+     * A field.
+     */
+    private String text = "text";
+
+    /**
+     * @return the text
+     */
+    public String get() {
+        return this.text;
+    }
+
+    /**
+     * @param newText the new text
+     */
+    public final void set(final String newText) {
+        this.text = newText;
+    }
+
+}

--- a/sequencers/modeshape-sequencer-java/src/test/java/org/modeshape/sequencer/javafile/ClassTypeSequencerTest.java
+++ b/sequencers/modeshape-sequencer-java/src/test/java/org/modeshape/sequencer/javafile/ClassTypeSequencerTest.java
@@ -30,6 +30,14 @@ import org.modeshape.sequencer.testdata.ClassType;
 public final class ClassTypeSequencerTest extends AbstractSequencerTest {
 
     @Test
+    public void shouldSequenceClassInDefaultPackage() throws Exception {
+        createNodeWithContentFromFile("defaultpackageclass.java", "DefaultPackageClass.java");
+        final String expectedOutputPath = "java/defaultpackageclass.java";
+        final Node compilationUnitNode = getOutputNode(rootNode, expectedOutputPath);
+        assertThat(compilationUnitNode, is(notNullValue()));
+    }
+
+    @Test
     public void shouldSequenceClassTypeFile() throws Exception {
         final String packagePath = ClassType.class.getName().replaceAll("\\.", "/");
         createNodeWithContentFromFile("classtype.java", packagePath + ".java");


### PR DESCRIPTION
Added a test case to verify the JdtRecorder can process Java files that do not have a package.
