### PR TITLE
MODE-2168 Updated the ModeShape EAP kit to 6.3.0.GA and the integration-platorm-bom to CR10.

### DIFF
--- a/bin/install-eap.bat
+++ b/bin/install-eap.bat
@@ -12,5 +12,5 @@ REM ----------------------------------------------------------------------------
 if "%1" == "" (
     echo "Usage: install-eap.bat <eap_zip_file>"
 ) else (
-    mvn install:install-file -Dfile="%1" -DgroupId=org.jboss.as -DartifactId=jboss-eap -Dversion=6.3.0.Beta1 -Dpackaging=zip
+    mvn install:install-file -Dfile="%1" -DgroupId=org.jboss.as -DartifactId=jboss-eap -Dversion=6.3.0.GA -Dpackaging=zip
 )

--- a/bin/install-eap.sh
+++ b/bin/install-eap.sh
@@ -13,5 +13,5 @@ if [ "$#" -ne 1 ] ; then
 	echo "Usage: install-eap.sh <eap_zip_file>"
 	exit 1
 else
-	 mvn install:install-file -Dfile="$1" -DgroupId=org.jboss.as -DartifactId=jboss-eap -Dversion=6.3.0.Beta1 -Dpackaging=zip
+	 mvn install:install-file -Dfile="$1" -DgroupId=org.jboss.as -DartifactId=jboss-eap -Dversion=6.3.0.GA -Dpackaging=zip
 fi

--- a/boms/modeshape-bom-jbosseap/pom.xml
+++ b/boms/modeshape-bom-jbosseap/pom.xml
@@ -56,7 +56,7 @@
         <jboss.snapshots.repo.url>https://repository.jboss.org/nexus/content/repositories/snapshots/</jboss.snapshots.repo.url>
 
         <jcr.version>2.0</jcr.version>
-        <version.org.jboss.eap.bom>6.3.0.Beta1</version.org.jboss.eap.bom>
+        <version.org.jboss.eap.bom>6.3.0.GA</version.org.jboss.eap.bom>
     </properties>
 
     <!--

--- a/modeshape-parent/pom.xml
+++ b/modeshape-parent/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.jboss.integration-platform</groupId>
         <artifactId>jboss-integration-platform-parent</artifactId>
-        <version>6.0.0.CR9</version>
+        <version>6.0.0.CR10</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
@@ -283,13 +283,13 @@
              JBOSS AS/EAP constants
          -->
         <!--Version of the artifacts (API) needed by the EAP subsystem and provided as part of EAP-->
-        <version.org.jboss.eap>7.4.0.Final-redhat-11</version.org.jboss.eap>
-        <version.org.jboss.eap.bom>6.3.0.Beta1</version.org.jboss.eap.bom>
+        <version.org.jboss.eap>7.4.0.Final-redhat-19</version.org.jboss.eap>
+        <version.org.jboss.eap.bom>6.3.0.GA</version.org.jboss.eap.bom>
 
         <!--Properties which must be used when installing locally an EAP ZIP distribution -->
         <jboss.eap.groupId>org.jboss.as</jboss.eap.groupId>
         <jboss.eap.artifactId>jboss-eap</jboss.eap.artifactId>
-        <jboss.eap.version>6.3.0.Beta1</jboss.eap.version>
+        <jboss.eap.version>6.3.0.GA</jboss.eap.version>
         <jboss.eap.root.folder>jboss-eap-6.3</jboss.eap.root.folder>
 
         <!--The root folder under EAP/AS where the ModeShape & related modules should be placed-->

--- a/settings.xml
+++ b/settings.xml
@@ -66,7 +66,7 @@
                 <repository>
                     <id>eap</id>
                     <name>EAP Repository</name>
-                    <url>http://maven.repository.redhat.com/techpreview/eap6/6.3.0.Beta/maven-repository</url>
+                    <url>http://maven.repository.redhat.com/techpreview/eap6/6.3.0/maven-repository</url>
                     <layout>default</layout>
                     <releases>
                         <enabled>true</enabled>


### PR DESCRIPTION
## Before running the code
1. Download EAP 6.3.0.GA from http://www.jboss.org/download-manager/file/jboss-eap-6.3.0.GA.zip and install it in your local Maven repo via `bin/install-eap.sh`
2. Change your local `settings.xml` to use the new Maven repo (see the project's settings.xml) **OR** build using the project's `settings.xml`
