### PR TITLE
MODE-2283 Corrected behavior when removing and then replacing strong reference props

### DIFF
--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/document/SessionNode.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/document/SessionNode.java
@@ -846,7 +846,29 @@ public class SessionNode implements MutableCachedNode {
                 if (referencesToRemove.contains(updatedReference)) {
                     // the reference is already present on a property with the same name, so this is a no-op for that reference
                     // therefore we remove it from the list of references that will be removed
-                    referencesToRemove.remove(updatedReference);
+                    if (referencesToRemove.remove(updatedReference)) {
+
+                        // Make sure that the referenced node is not modified to remove the back-reference to this node.
+                        // See MODE-2283 for an example ...
+                        NodeKey referredKey = nodeKeyFromReference(updatedReference);
+                        CachedNode referredNode = cache.getNode(referredKey);
+                        if (referredNode instanceof SessionNode) {
+                            // The node was modified during this session and has unsaved changes ...
+                            SessionNode changedReferrerNode = (SessionNode)referredNode;
+                            ReferrerChanges changes = changedReferrerNode.getReferrerChanges();
+                            if (changes != null) {
+                                // There are changes to that node's referrers ...
+                                ReferenceType type = updatedReference.isWeak() ? ReferenceType.WEAK : ReferenceType.STRONG;
+                                if (changes.isRemovedReferrer(key, type)) {
+                                    // The referenced node had a back reference to this node, but we're no longer removing
+                                    // this node's reference to the referenced node, and that means we should no longer remove
+                                    // the referenced node's backreference to this node ...
+                                    if (updatedReference.isWeak()) changes.addWeakReferrer(propertyWhichWasRemoved, key);
+                                    else changes.addStrongReferrer(propertyWhichWasRemoved, key);
+                                }
+                            }
+                        }
+                    }
                 } else {
                     // this is a new reference (either via key or type)
                     referencesToAdd.add(updatedReference);
@@ -2370,6 +2392,19 @@ public class SessionNode implements MutableCachedNode {
             return null;
         }
 
+        public boolean isRemovedReferrer( NodeKey key,
+                                          ReferenceType type ) {
+            switch (type) {
+                case STRONG:
+                    return containsKey(key, removedStrong);
+                case WEAK:
+                    return containsKey(key, removedWeak);
+                case BOTH:
+                    return containsKey(key, removedStrong) || containsKey(key, removedWeak);
+            }
+            return false;
+        }
+
         public List<NodeKey> getRemovedReferrers( ReferenceType type ) {
             switch (type) {
                 case STRONG:
@@ -2381,6 +2416,14 @@ public class SessionNode implements MutableCachedNode {
             }
             assert false : "Should never get here";
             return null;
+        }
+
+        private final boolean containsKey( NodeKey key,
+                                           Map<String, Set<NodeKey>> source ) {
+            for (Set<NodeKey> sourceKeys : source.values()) {
+                if (sourceKeys.contains(key)) return true;
+            }
+            return false;
         }
 
         @SafeVarargs

--- a/modeshape-jcr/src/test/java/org/modeshape/jcr/JcrSessionTest.java
+++ b/modeshape-jcr/src/test/java/org/modeshape/jcr/JcrSessionTest.java
@@ -43,12 +43,14 @@ import javax.jcr.Node;
 import javax.jcr.NodeIterator;
 import javax.jcr.PathNotFoundException;
 import javax.jcr.Property;
+import javax.jcr.PropertyIterator;
 import javax.jcr.PropertyType;
 import javax.jcr.ReferentialIntegrityException;
 import javax.jcr.Repository;
 import javax.jcr.RepositoryException;
 import javax.jcr.Session;
 import javax.jcr.UnsupportedRepositoryOperationException;
+import javax.jcr.Value;
 import javax.jcr.ValueFactory;
 import javax.jcr.nodetype.ConstraintViolationException;
 import javax.jcr.nodetype.NodeDefinitionTemplate;
@@ -91,6 +93,31 @@ public class JcrSessionTest extends SingleUseAbstractTest {
         c.setProperty("stringProperty", "value");
         c.setProperty("multiLineProperty", MULTI_LINE_VALUE);
         session.save();
+    }
+
+    @FixFor( "MODE-2283" )
+    @Test
+    public void shouldAllowRemovingAndRestoringPersistedReference() throws Exception {
+        Node referenceableNode = session.getRootNode().addNode("referenceable");
+        referenceableNode.addMixin(JcrMixLexicon.REFERENCEABLE.toString());
+        Value strongRefValue = session.getValueFactory().createValue(referenceableNode, false);
+
+        Node node1 = session.getRootNode().addNode("node1");
+        node1.setProperty("prop1", strongRefValue);
+
+        session.save();
+
+        // First remove the property ...
+        node1.setProperty("prop1", (Value)null);
+        // And then set the property to the same value that's persisted. Essentially, this session is trying to restore
+        // the reference that we just removed (transitively). The result should be no net changes in this session.
+        node1.setProperty("prop1", strongRefValue);
+
+        // Now save the changes (even though there should be none) ...
+        session.save();
+
+        PropertyIterator propertyIterator = referenceableNode.getReferences();
+        assertEquals(1, propertyIterator.getSize());
     }
 
     @Test


### PR DESCRIPTION
When a reference value is changed, the `SessionNode` methods attempt to look for the special case where the new (transient) reference value matches that of the persisted value. IOW, given this code that sets up an initial persisted state:

```
Node referenceableNode = session.getRootNode().addNode("referenceable");
referenceableNode.addMixin(JcrMixLexicon.REFERENCEABLE.toString());

Node node1 = session.getRootNode().addNode("node1");
node1.setProperty("prop1", session.getValueFactory().createValue(referenceableNode, false));
session.save();
```

making the following changes transiently in the session:

```
node1.setProperty("prop1", session.getValueFactory().createValue(referenceableNode, false));
```

sets the property to the exact same value as persisted. `SessionNode` discovers this case and that this operation makes no net changes to the persisted content, so it alters the session's state to reflect this no-net-change.

Notice that the reported scenario is _close_ to this, but it first removes the property before resetting it back to the same value:

```
node1.setProperty("prop1",(Value)null); // removes the property
node1.setProperty("prop1", session.getValueFactory().createValue(referenceableNode, false));
```

This is a special case that the `SessionNode` logic did not properly handle.

This PR corrects this behavior and adds a test case that replicated the problem before the fix is applied, and verifies the fix works.
