### PR TITLE
MODE-2151 Added support for CHILDCOUNT dynamic operand and the 'mode:childCount' pseudocolumn

### DIFF
--- a/modeshape-jcr-api/src/main/java/org/modeshape/jcr/api/query/qom/ChildCount.java
+++ b/modeshape-jcr-api/src/main/java/org/modeshape/jcr/api/query/qom/ChildCount.java
@@ -1,0 +1,32 @@
+/*
+ * ModeShape (http://www.modeshape.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.modeshape.jcr.api.query.qom;
+
+import javax.jcr.query.qom.Comparison;
+
+/**
+ * A dynamic operand that evaluates to the number of children of a node given by a selector, used in a {@link Comparison}
+ * constraint.
+ */
+public interface ChildCount extends javax.jcr.query.qom.DynamicOperand {
+
+    /**
+     * Get the selector symbol upon which this operand applies.
+     *
+     * @return the one selector names used by this operand; never null
+     */
+    public String getSelectorName();
+}

--- a/modeshape-jcr-api/src/main/java/org/modeshape/jcr/api/query/qom/QueryObjectModelFactory.java
+++ b/modeshape-jcr-api/src/main/java/org/modeshape/jcr/api/query/qom/QueryObjectModelFactory.java
@@ -149,6 +149,19 @@ public interface QueryObjectModelFactory extends javax.jcr.query.qom.QueryObject
                             boolean all ) throws InvalidQueryException, RepositoryException;
 
     /**
+     * Evaluates to a <code>LONG</code> value equal to the number of children for each of the node(s) in the specified selector.
+     * <p>
+     * The query is invalid if <code>selector</code> is not the name of a selector in the query.
+     *
+     * @param selectorName the selector name; non-null
+     * @return the operand; non-null
+     * @throws InvalidQueryException if a particular validity test is possible on this method, the implemention chooses to perform
+     *         that test (and not leave it until later, on {@link #createQuery}), and the parameters given fail that test
+     * @throws RepositoryException if the operation otherwise fails
+     */
+    public ChildCount childCount( String selectorName ) throws InvalidQueryException, RepositoryException;
+
+    /**
      * Evaluates to a <code>LONG</code> value equal to the depth of a node in the specified selector.
      * <p>
      * The query is invalid if <code>selector</code> is not the name of a selector in the query.

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrQueryManager.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrQueryManager.java
@@ -345,6 +345,12 @@ class JcrQueryManager implements QueryManager {
         }
 
         @Override
+        public long getChildCount( CachedNode node ) {
+            assert node != null;
+            return node.getChildReferences(session.cache()).size();
+        }
+
+        @Override
         public String getIdentifier( CachedNode node ) {
             // the identifier format varies depending upon the node ...
             return session.nodeIdentifier(node.getKey());

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/index/local/ManagedLocalIndexBuilder.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/index/local/ManagedLocalIndexBuilder.java
@@ -306,12 +306,22 @@ public abstract class ManagedLocalIndexBuilder<T> {
         public void validate( Problems problems ) {
             switch (defn.getKind()) {
                 case VALUE:
+                    if ((matches(columnDefn, JcrLexicon.PATH) && !isType(getColumnType(), PropertyType.PATH))) {
+                        problems.addError(JcrI18n.localIndexMustHaveOneColumnOfSpecificType, defn.getProviderName(),
+                                          defn.getName(), columnDefn.getPropertyName(), type, PropertyType.PATH);
+                    }
+                    if ((matches(columnDefn, ModeShapeLexicon.LOCALNAME) && !isType(getColumnType(), PropertyType.STRING))
+                        || (matches(columnDefn, ModeShapeLexicon.ID) && !isType(getColumnType(), PropertyType.STRING))) {
+                        problems.addError(JcrI18n.localIndexMustHaveOneColumnOfSpecificType, defn.getProviderName(),
+                                          defn.getName(), columnDefn.getPropertyName(), type, PropertyType.STRING);
+                    }
+                    if ((matches(columnDefn, ModeShapeLexicon.DEPTH) && !isType(getColumnType(), PropertyType.LONG))) {
+                        problems.addError(JcrI18n.localIndexMustHaveOneColumnOfSpecificType, defn.getProviderName(),
+                                          defn.getName(), columnDefn.getPropertyName(), type, PropertyType.LONG);
+                    }
                     if ((matches(columnDefn, JcrLexicon.PRIMARY_TYPE) && !isType(getColumnType(), PropertyType.NAME))
                         || (matches(columnDefn, JcrLexicon.MIXIN_TYPES) && !isType(getColumnType(), PropertyType.NAME))
-                        || (matches(columnDefn, JcrLexicon.NAME) && !isType(getColumnType(), PropertyType.NAME))
-                        || (matches(columnDefn, JcrLexicon.PATH) && !isType(getColumnType(), PropertyType.PATH))
-                        || (matches(columnDefn, ModeShapeLexicon.LOCALNAME) && !isType(getColumnType(), PropertyType.STRING))
-                        || (matches(columnDefn, ModeShapeLexicon.DEPTH) && !isType(getColumnType(), PropertyType.LONG))) {
+                        || (matches(columnDefn, JcrLexicon.NAME) && !isType(getColumnType(), PropertyType.NAME))) {
                         problems.addError(JcrI18n.localIndexMustHaveOneColumnOfSpecificType, defn.getProviderName(),
                                           defn.getName(), columnDefn.getPropertyName(), type, PropertyType.NAME);
                     }

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/query/JcrQueryContext.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/query/JcrQueryContext.java
@@ -163,6 +163,14 @@ public interface JcrQueryContext {
     long getDepth( CachedNode node );
 
     /**
+     * Get the number of children of the supplied cached node.
+     *
+     * @param node the cached node; may not be null
+     * @return the child count
+     */
+    long getChildCount( CachedNode node );
+
+    /**
      * Get the UUID identifier of the supplied cached node. Note that the node must have the 'mix:referenceable' mixin for it to
      * have a UUID.
      * 

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/query/JcrQueryResult.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/query/JcrQueryResult.java
@@ -389,6 +389,12 @@ public class JcrQueryResult implements org.modeshape.jcr.api.query.QueryResult {
             return context.createValue(PropertyType.LONG, context.getDepth(node));
         }
 
+        protected Value jcrChildCount( CachedNode node ) {
+            assert node != null;
+            // Every node has a child count ...
+            return context.createValue(PropertyType.LONG, context.getChildCount(node));
+        }
+
         protected Value jcrId( CachedNode node ) {
             assert node != null;
             // Every node has an identifier, but we need to figure out the correct version that's exposed

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/query/QueryBuilder.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/query/QueryBuilder.java
@@ -35,6 +35,7 @@ import org.modeshape.jcr.query.model.ArithmeticOperand;
 import org.modeshape.jcr.query.model.ArithmeticOperator;
 import org.modeshape.jcr.query.model.Between;
 import org.modeshape.jcr.query.model.BindVariableName;
+import org.modeshape.jcr.query.model.ChildCount;
 import org.modeshape.jcr.query.model.ChildNode;
 import org.modeshape.jcr.query.model.ChildNodeJoinCondition;
 import org.modeshape.jcr.query.model.Column;
@@ -785,6 +786,15 @@ public class QueryBuilder {
         public OrderByBuilder fullTextSearchScore( String table );
 
         /**
+         * Adds to the order-by clause by using the child count of the node given by the named table.
+         *
+         * @param table the name of the table; may not be null and must refer to a valid name or alias of a table appearing in the
+         *        FROM clause
+         * @return the interface for completing the order-by specification; never null
+         */
+        public OrderByBuilder childCount( String table );
+
+        /**
          * Adds to the order-by clause by using the depth of the node given by the named table.
          * 
          * @param table the name of the table; may not be null and must refer to a valid name or alias of a table appearing in the
@@ -944,6 +954,11 @@ public class QueryBuilder {
         @Override
         public OrderByBuilder fullTextSearchScore( String table ) {
             return addOrdering(new FullTextSearchScore(selector(table)));
+        }
+
+        @Override
+        public OrderByBuilder childCount( String table ) {
+            return addOrdering(new ChildCount(selector(table)));
         }
 
         @Override
@@ -1175,6 +1190,15 @@ public class QueryBuilder {
          * @return the interface for completing the value portion of the criteria specification; never null
          */
         public ComparisonBuilder fullTextSearchScore( String table );
+
+        /**
+         * Constrains the nodes in the the supplied table based upon criteria on the node's number of children.
+         *
+         * @param table the name of the table; may not be null and must refer to a valid name or alias of a table appearing in the
+         *        FROM clause
+         * @return the interface for completing the value portion of the criteria specification; never null
+         */
+        public ComparisonBuilder childCount( String table );
 
         /**
          * Constrains the nodes in the the supplied table based upon criteria on the node's depth.
@@ -1457,6 +1481,11 @@ public class QueryBuilder {
         @Override
         public ComparisonBuilder fullTextSearchScore( String table ) {
             return comparisonBuilder(new FullTextSearchScore(selector(table)));
+        }
+
+        @Override
+        public ComparisonBuilder childCount( String table ) {
+            return comparisonBuilder(new ChildCount(selector(table)));
         }
 
         @Override
@@ -2594,6 +2623,17 @@ public class QueryBuilder {
          */
         public ComparisonBuilder depth( String table ) {
             return comparisonBuilder(new NodeDepth(selector(table)));
+        }
+
+        /**
+         * Constrains the nodes in the the supplied table based upon criteria on the node's number of children.
+         *
+         * @param table the name of the table; may not be null and must refer to a valid name or alias of a table appearing in the
+         *        FROM clause
+         * @return the interface for completing the value portion of the criteria specification; never null
+         */
+        public ComparisonBuilder childCount( String table ) {
+            return comparisonBuilder(new ChildCount(selector(table)));
         }
 
         // /**

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/query/model/ChildCount.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/query/model/ChildCount.java
@@ -1,0 +1,84 @@
+/*
+ * ModeShape (http://www.modeshape.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.modeshape.jcr.query.model;
+
+import java.util.Set;
+import org.modeshape.common.annotation.Immutable;
+
+/**
+ * A dynamic operand that evaluates to the number of children for each node given by a selector, used in a {@link Comparison}
+ * constraint.
+ */
+@Immutable
+public class ChildCount implements DynamicOperand, org.modeshape.jcr.api.query.qom.ChildCount {
+    private static final long serialVersionUID = 1L;
+
+    private final Set<SelectorName> selectorNames;
+
+    /**
+     * Create a dynamic operand that evaluates to the depth of the node identified by the selector.
+     *
+     * @param selectorName the name of the selector
+     * @throws IllegalArgumentException if the selector name or property name are null
+     */
+    public ChildCount( SelectorName selectorName ) {
+        this.selectorNames = SelectorName.nameSetFrom(selectorName);
+    }
+
+    /**
+     * Get the selector symbol upon which this operand applies.
+     *
+     * @return the one selector names used by this operand; never null
+     */
+    public SelectorName selectorName() {
+        return selectorNames.iterator().next();
+    }
+
+    @Override
+    public Set<SelectorName> selectorNames() {
+        return selectorNames;
+    }
+
+    @Override
+    public String getSelectorName() {
+        return selectorName().getString();
+    }
+
+    @Override
+    public String toString() {
+        return Visitors.readable(this);
+    }
+
+    @Override
+    public int hashCode() {
+        return selectorNames().hashCode();
+    }
+
+    @Override
+    public boolean equals( Object obj ) {
+        if (obj == this) return true;
+        if (obj instanceof ChildCount) {
+            ChildCount that = (ChildCount)obj;
+            return this.selectorNames().equals(that.selectorNames());
+        }
+        return false;
+    }
+
+    @Override
+    public void accept( Visitor visitor ) {
+        visitor.visit(this);
+    }
+}

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/query/model/QueryObjectModelFactory.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/query/model/QueryObjectModelFactory.java
@@ -415,6 +415,12 @@ public class QueryObjectModelFactory implements org.modeshape.jcr.api.query.qom.
     }
 
     @Override
+    public ChildCount childCount( String selectorName ) {
+        CheckArg.isNotNull(selectorName, "selectorName");
+        return new ChildCount(selectorName(selectorName));
+    }
+
+    @Override
     public NodeDepth nodeDepth( String selectorName ) {
         CheckArg.isNotNull(selectorName, "selectorName");
         return new NodeDepth(selectorName(selectorName));

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/query/model/Visitor.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/query/model/Visitor.java
@@ -30,6 +30,8 @@ public interface Visitor {
 
     void visit( BindVariableName obj );
 
+    void visit( ChildCount obj );
+
     void visit( ChildNode obj );
 
     void visit( ChildNodeJoinCondition obj );

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/query/model/Visitors.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/query/model/Visitors.java
@@ -404,6 +404,10 @@ public class Visitors {
         }
 
         @Override
+        public void visit( ChildCount obj ) {
+        }
+
+        @Override
         public void visit( ChildNode obj ) {
         }
 
@@ -635,6 +639,12 @@ public class Visitors {
         @Override
         public void visit( BindVariableName variableName ) {
             strategy.visit(variableName);
+            visitNext();
+        }
+
+        @Override
+        public void visit( ChildCount childCount ) {
+            strategy.visit(childCount);
             visitNext();
         }
 
@@ -991,6 +1001,11 @@ public class Visitors {
         @Override
         public void visit( BindVariableName variable ) {
             append('$').append(variable.getBindVariableName());
+        }
+
+        @Override
+        public void visit( ChildCount childCount ) {
+            append("CHILDCOUNT(").append(childCount.selectorName()).append(')');
         }
 
         @Override

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/query/plan/PlanUtil.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/query/plan/PlanUtil.java
@@ -30,6 +30,7 @@ import org.modeshape.jcr.query.model.ArithmeticOperand;
 import org.modeshape.jcr.query.model.ArithmeticOperator;
 import org.modeshape.jcr.query.model.Between;
 import org.modeshape.jcr.query.model.BindVariableName;
+import org.modeshape.jcr.query.model.ChildCount;
 import org.modeshape.jcr.query.model.ChildNode;
 import org.modeshape.jcr.query.model.ChildNodeJoinCondition;
 import org.modeshape.jcr.query.model.Column;
@@ -466,6 +467,12 @@ public class PlanUtil {
             SelectorName replacement = rewrittenSelectors.get(path.selectorName());
             if (replacement == null) return operand;
             return new NodePath(replacement);
+        }
+        if (operand instanceof ChildCount) {
+            ChildCount count = (ChildCount)operand;
+            SelectorName replacement = rewrittenSelectors.get(count.selectorName());
+            if (replacement == null) return operand;
+            return new ChildCount(replacement);
         }
         return operand;
     }
@@ -936,6 +943,13 @@ public class PlanUtil {
             node.addSelector(mapping.getSingleMappedSelectorName());
             return new NodePath(mapping.getSingleMappedSelectorName());
         }
+        if (operand instanceof ChildCount) {
+            ChildCount count = (ChildCount)operand;
+            if (!mapping.getOriginalName().equals(count.selectorName())) return count;
+            if (!mapping.isMappedToSingleSelector()) return count;
+            node.addSelector(mapping.getSingleMappedSelectorName());
+            return new ChildCount(mapping.getSingleMappedSelectorName());
+        }
         return operand;
     }
 
@@ -1247,6 +1261,9 @@ public class PlanUtil {
             return operand;
         }
         if (operand instanceof NodePath) {
+            return operand;
+        }
+        if (operand instanceof ChildCount) {
             return operand;
         }
         return operand;

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/query/validate/Validator.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/query/validate/Validator.java
@@ -30,6 +30,7 @@ import org.modeshape.jcr.api.query.qom.Operator;
 import org.modeshape.jcr.query.QueryContext;
 import org.modeshape.jcr.query.model.AllNodes;
 import org.modeshape.jcr.query.model.ArithmeticOperand;
+import org.modeshape.jcr.query.model.ChildCount;
 import org.modeshape.jcr.query.model.ChildNode;
 import org.modeshape.jcr.query.model.ChildNodeJoinCondition;
 import org.modeshape.jcr.query.model.Column;
@@ -113,6 +114,8 @@ public class Validator extends AbstractVisitor {
         // The left and right operands must have LONG or DOUBLE types ...
         if (operand instanceof NodeDepth) {
             // good to go
+        } else if (operand instanceof ChildCount) {
+            // good to go
         } else if (operand instanceof Length) {
             // good to go
         } else if (operand instanceof ArithmeticOperand) {
@@ -143,6 +146,11 @@ public class Validator extends AbstractVisitor {
             I18n msg = GraphI18n.dynamicOperandCannotBeUsedInArithmeticOperation;
             problems.addError(msg, operand);
         }
+    }
+
+    @Override
+    public void visit( ChildCount obj ) {
+        verify(obj.selectorName());
     }
 
     @Override

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/spi/index/provider/IndexUsage.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/spi/index/provider/IndexUsage.java
@@ -35,6 +35,7 @@ import org.modeshape.jcr.api.index.IndexColumnDefinition;
 import org.modeshape.jcr.api.index.IndexDefinition;
 import org.modeshape.jcr.api.query.qom.ArithmeticOperand;
 import org.modeshape.jcr.api.query.qom.Between;
+import org.modeshape.jcr.api.query.qom.ChildCount;
 import org.modeshape.jcr.api.query.qom.NodeDepth;
 import org.modeshape.jcr.api.query.qom.NodeId;
 import org.modeshape.jcr.api.query.qom.NodePath;
@@ -173,6 +174,9 @@ public class IndexUsage {
         if (operand instanceof NodeDepth) {
             return applies((NodeDepth)operand);
         }
+        if (operand instanceof ChildCount) {
+            return applies((ChildCount)operand);
+        }
         if (operand instanceof ReferenceValue) {
             return applies((ReferenceValue)operand);
         }
@@ -225,8 +229,13 @@ public class IndexUsage {
     }
 
     protected boolean applies( NodeDepth operand ) {
-        // This should apply to the 'jcr:id' pseudo-column on the index ...
+        // This should apply to the 'mode:depth' pseudo-column on the index ...
         return defn.appliesToProperty("mode:depth");
+    }
+
+    protected boolean applies( ChildCount operand ) {
+        // This should apply to the 'mode:childCount' pseudo-column on the index ...
+        return defn.appliesToProperty("mode:childCount");
     }
 
     protected boolean applies( ReferenceValue operand ) {

--- a/modeshape-jcr/src/test/java/org/modeshape/jcr/query/parse/SqlQueryParserTest.java
+++ b/modeshape-jcr/src/test/java/org/modeshape/jcr/query/parse/SqlQueryParserTest.java
@@ -36,6 +36,7 @@ import org.modeshape.jcr.api.value.DateTime;
 import org.modeshape.jcr.query.model.And;
 import org.modeshape.jcr.query.model.Between;
 import org.modeshape.jcr.query.model.BindVariableName;
+import org.modeshape.jcr.query.model.ChildCount;
 import org.modeshape.jcr.query.model.ChildNode;
 import org.modeshape.jcr.query.model.Constraint;
 import org.modeshape.jcr.query.model.DescendantNode;
@@ -1471,6 +1472,47 @@ public class SqlQueryParserTest {
     @Test( expected = ParsingException.class )
     public void shouldFailToParseDynamicOperandFromStringContainingUpperWithoutOpeningParenthesis() {
         parser.parseDynamicOperand(tokens("Upper tableA.property other"), typeSystem, mock(Source.class));
+    }
+
+    // ----------------------------------------------------------------------------------------------------------------
+    // parseDynamicOperand - CHILDCOUNT
+    // ----------------------------------------------------------------------------------------------------------------
+
+    @Test
+    public void shouldParseDynamicOperandFromStringContainingChildCountOfSelector() {
+        DynamicOperand operand = parser.parseDynamicOperand(tokens("CHILDCOUNT(tableA)"), typeSystem, mock(Source.class));
+        assertThat(operand, is(instanceOf(ChildCount.class)));
+        ChildCount count = (ChildCount)operand;
+        assertThat(count.selectorName(), is(selectorName("tableA")));
+    }
+
+    @Test
+    public void shouldParseDynamicOperandFromStringContainingChildCountWithNoSelectorOnlyIfThereIsOneSelectorAsSource() {
+        Source source = new NamedSelector(selectorName("tableA"));
+        DynamicOperand operand = parser.parseDynamicOperand(tokens("CHILDCOUNT()"), typeSystem, source);
+        assertThat(operand, is(instanceOf(ChildCount.class)));
+        ChildCount count = (ChildCount)operand;
+        assertThat(count.selectorName(), is(selectorName("tableA")));
+    }
+
+    @Test( expected = ParsingException.class )
+    public void shouldFailToParseDynamicOperandFromStringContainingChildCountWithNoSelectorIfTheSourceIsNotASelector() {
+        parser.parseDynamicOperand(tokens("CHILDCOUNT()"), typeSystem, mock(Source.class));
+    }
+
+    @Test( expected = ParsingException.class )
+    public void shouldFailToParseDynamicOperandFromStringContainingChildCountWithSelectorNameAndProperty() {
+        parser.parseDynamicOperand(tokens("CHILDCOUNT(tableA.property) other"), typeSystem, mock(Source.class));
+    }
+
+    @Test( expected = ParsingException.class )
+    public void shouldFailToParseDynamicOperandFromStringContainingChildCountWithoutClosingParenthesis() {
+        parser.parseDynamicOperand(tokens("CHILDCOUNT(tableA other"), typeSystem, mock(Source.class));
+    }
+
+    @Test( expected = ParsingException.class )
+    public void shouldFailToParseDynamicOperandFromStringContainingChildCountWithoutOpeningParenthesis() {
+        parser.parseDynamicOperand(tokens("Childcount  tableA other"), typeSystem, mock(Source.class));
     }
 
     // ----------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Pretty basic support that should prove quite useful in certain situations. This may be relatively expensive when the repository has nodes with lots of children since it requires loading the parent node's child references in order to obtain the count. The `CHILDCOUNT` criteria would therefore work much better/faster as filtering criteria in a query that already defines criteria that indexes can use.

BTW, because the index update mechanism is based upon change events, and because change events never include the number of children, it's currently not possible to define an index on `mode:childCount`.
