### PR TITLE
MODE-2297 Corrected how result sets are built from columns when queries use set operations

### DIFF
--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/query/JcrQueryResult.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/query/JcrQueryResult.java
@@ -167,8 +167,10 @@ public class JcrQueryResult implements org.modeshape.jcr.api.query.QueryResult {
         accessed = true;
         final Columns columns = results.getColumns();
         if (columns.getSelectorNames().size() == 1) {
-            return new SingleSelectorQueryResultRowIterator(context, queryStatement, sequence, results.getColumns());
+            // Then we know that there is only one selector in the results ...
+            return new SingleSelectorQueryResultRowIterator(context, queryStatement, sequence, columns);
         }
+        // There may be 1 or more selectors in the columns, but the results definitely have more than one selector ...
         return new QueryResultRowIterator(context, queryStatement, sequence, results.getColumns());
     }
 
@@ -445,7 +447,13 @@ public class JcrQueryResult implements org.modeshape.jcr.api.query.QueryResult {
                                                         NodeSequence sequence,
                                                         Columns columns ) {
             super(context, query, sequence, columns);
-            this.selectorIndex = columns.getSelectorIndex(columns.getSelectorNames().get(0));
+            int selectorIndex = columns.getSelectorIndex(columns.getSelectorNames().get(0));
+            if (selectorIndex >= sequence.width()) {
+                // The columns were built on top of other columns that expose multiple selectors, but this sequenc only has
+                // one selector ...
+                selectorIndex = 0;
+            }
+            this.selectorIndex = selectorIndex;
         }
 
         @Override

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/query/engine/process/SecureSequence.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/query/engine/process/SecureSequence.java
@@ -58,4 +58,9 @@ public class SecureSequence extends DelegatingSequence {
         //we do not know up front how many rows there will be
         return -1;
     }
+
+    @Override
+    public String toString() {
+        return "(secure " + super.delegate + ")";
+    }
 }


### PR DESCRIPTION
If one of the queries in a set query uses a join and returned values from only the second selector (e.g., the right side of the join), then the result object was built incorrectly to access the values by the wrong index. This commit adds a test to replicate the situation and fixes the underlying problem.
