### PR TITLE
MODE-2295 Fixed a number of issues with indexes

### DIFF
--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrI18n.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrI18n.java
@@ -49,6 +49,7 @@ public final class JcrI18n {
     public static I18n failureDuringUpgradeOperation;
     public static I18n errorShuttingDownIndexProvider;
     public static I18n indexProviderMissingPlanner;
+    public static I18n errorNotifyingNodeTypesListener;
 
     public static I18n cannotConvertValue;
     public static I18n loginFailed;

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/NodeTypes.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/NodeTypes.java
@@ -60,6 +60,15 @@ public class NodeTypes {
         NodeTypes getNodeTypes();
     }
 
+    public static interface Listener {
+        /**
+         * Notification that the NodeTypes instance has changed.
+         *
+         * @param updatedNodeTypes the new NodeTypes instance; never null
+         */
+        void notify( NodeTypes updatedNodeTypes );
+    }
+
     /**
      * List of ways to filter the returned property definitions
      *
@@ -392,6 +401,18 @@ public class NodeTypes {
             }
         }
         return true;
+    }
+
+    public Set<Name> getAllSubtypes( Name nodeTypeName ) {
+        Set<Name> subtypes = new HashSet<>();
+        JcrNodeType type = getNodeType(nodeTypeName);
+        if (type != null) {
+            subtypes.add(nodeTypeName);
+            for (JcrNodeType subtype : subtypesFor(type)) {
+                subtypes.add(subtype.getInternalName());
+            }
+        }
+        return Collections.unmodifiableSet(subtypes);
     }
 
     /**

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/RepositoryIndexManager.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/RepositoryIndexManager.java
@@ -83,7 +83,7 @@ import org.modeshape.jcr.value.WorkspaceAndPath;
  * index manager maintains an immutable view of all index definitions.
  */
 @ThreadSafe
-class RepositoryIndexManager implements IndexManager {
+class RepositoryIndexManager implements IndexManager, NodeTypes.Listener {
 
     /**
      * Names of properties that are known to have non-unique values when used in a single-valued index.
@@ -195,6 +195,14 @@ class RepositoryIndexManager implements IndexManager {
         refreshIndexWriter();
         initialized.set(true);
         return feedback;
+    }
+
+    @Override
+    public void notify( NodeTypes updatedNodeTypes ) {
+        // Notify all of the providers about the change in node types ...
+        for (IndexProvider provider : providers.values()) {
+            provider.notify(updatedNodeTypes);
+        }
     }
 
     synchronized void importIndexDefinitions() throws RepositoryException {

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/RepositoryQueryManager.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/RepositoryQueryManager.java
@@ -65,6 +65,7 @@ import org.modeshape.jcr.value.WorkspaceAndPath;
 class RepositoryQueryManager implements ChangeSetListener {
 
     private final Logger logger = Logger.getLogger(getClass());
+    private final Logger indexLogger = Logger.getLogger(getClass().getPackage().getName() + ".index");
     private final RunningState runningState;
     private final ExecutorService indexingExecutorService;
     private final RepositoryConfiguration repoConfig;
@@ -419,6 +420,11 @@ class RepositoryQueryManager implements ChangeSetListener {
         Path nodePath = paths.getPath(node);
 
         // Index the first node ...
+        if (indexLogger.isTraceEnabled()) {
+            String path = runningState.context().getValueFactories().getStringFactory().create(nodePath);
+            indexLogger.debug("Reindexing node '{0}' in workspace '{1}' of repository '{2}': {3}", path, workspaceName,
+                              runningState.name(), node);
+        }
         indexes.add(workspaceName, node.getKey(), nodePath, node.getPrimaryType(cache), node.getMixinTypes(cache),
                     node.getPropertiesByName(cache));
 
@@ -466,6 +472,11 @@ class RepositoryQueryManager implements ChangeSetListener {
             nodePath = paths.getPath(node);
 
             // Index the node ...
+            if (indexLogger.isTraceEnabled()) {
+                String path = runningState.context().getValueFactories().getStringFactory().create(nodePath);
+                indexLogger.debug("Reindexing node '{0}' in workspace '{1}' of repository '{2}': {3}", path, workspaceName,
+                                  runningState.name(), node);
+            }
             indexes.add(workspaceName, node.getKey(), nodePath, node.getPrimaryType(cache), node.getMixinTypes(cache),
                         node.getPropertiesByName(cache));
 

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/NodeKey.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/NodeKey.java
@@ -61,6 +61,7 @@ public final class NodeKey implements Serializable, Comparable<NodeKey> {
         }
     }
 
+    @SuppressWarnings( "synthetic-access" )
     public static final Comparator<NodeKey> COMPARATOR = new NodeKeyComparator();
 
     private static final int UUID_LENGTH = UUID.randomUUID().toString().length();

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/index/local/IndexChangeAdapters.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/index/local/IndexChangeAdapters.java
@@ -23,6 +23,7 @@ import org.modeshape.jcr.JcrLexicon;
 import org.modeshape.jcr.cache.CachedNode.Properties;
 import org.modeshape.jcr.cache.NodeKey;
 import org.modeshape.jcr.cache.change.AbstractPropertyChange;
+import org.modeshape.jcr.cache.change.ChangeSetAdapter.NodeTypePredicate;
 import org.modeshape.jcr.cache.change.PropertyChanged;
 import org.modeshape.jcr.spi.index.provider.IndexChangeAdapter;
 import org.modeshape.jcr.value.Name;
@@ -41,90 +42,103 @@ public class IndexChangeAdapters {
      * Create an {@link IndexChangeAdapter} implementation that handles the "mode:nodeDepth" property.
      *
      * @param context the execution context; may not be null
+     * @param matcher the node type matcher used to determine which nodes should be included in the index; may not be null
      * @param workspaceName the name of the workspace; may not be null
      * @param index the local index that should be used; may not be null
      * @return the new {@link IndexChangeAdapter}; never null
      */
     public static IndexChangeAdapter forNodeDepth( ExecutionContext context,
+                                                   NodeTypePredicate matcher,
                                                    String workspaceName,
                                                    LocalDuplicateIndex<Long> index ) {
-        return new NodeDepthChangeAdapter(context, workspaceName, index);
+        return new NodeDepthChangeAdapter(context, matcher, workspaceName, index);
     }
 
     /**
      * Create an {@link IndexChangeAdapter} implementation that handles the "jcr:name" property.
      *
      * @param context the execution context; may not be null
+     * @param matcher the node type matcher used to determine which nodes should be included in the index; may not be null
      * @param workspaceName the name of the workspace; may not be null
      * @param index the local index that should be used; may not be null
      * @return the new {@link IndexChangeAdapter}; never null
      */
     public static IndexChangeAdapter forNodeName( ExecutionContext context,
+                                                  NodeTypePredicate matcher,
                                                   String workspaceName,
                                                   LocalDuplicateIndex<Name> index ) {
-        return new NodeNameChangeAdapter(context, workspaceName, index);
+        return new NodeNameChangeAdapter(context, matcher, workspaceName, index);
     }
 
     /**
      * Create an {@link IndexChangeAdapter} implementation that handles the "mode:localName" property.
      *
      * @param context the execution context; may not be null
+     * @param matcher the node type matcher used to determine which nodes should be included in the index; may not be null
      * @param workspaceName the name of the workspace; may not be null
      * @param index the local index that should be used; may not be null
      * @return the new {@link IndexChangeAdapter}; never null
      */
     public static IndexChangeAdapter forNodeLocalName( ExecutionContext context,
+                                                       NodeTypePredicate matcher,
                                                        String workspaceName,
                                                        LocalDuplicateIndex<String> index ) {
-        return new NodeLocalNameChangeAdapter(context, workspaceName, index);
+        return new NodeLocalNameChangeAdapter(context, matcher, workspaceName, index);
     }
 
     /**
      * Create an {@link IndexChangeAdapter} implementation that handles the "jcr:path" property.
      *
      * @param context the execution context; may not be null
+     * @param matcher the node type matcher used to determine which nodes should be included in the index; may not be null
      * @param workspaceName the name of the workspace; may not be null
      * @param index the local index that should be used; may not be null
      * @return the new {@link IndexChangeAdapter}; never null
      */
     public static IndexChangeAdapter forNodePath( ExecutionContext context,
+                                                  NodeTypePredicate matcher,
                                                   String workspaceName,
                                                   LocalDuplicateIndex<Path> index ) {
-        return new NodePathChangeAdapter(context, workspaceName, index);
+        return new NodePathChangeAdapter(context, matcher, workspaceName, index);
     }
 
     /**
      * Create an {@link IndexChangeAdapter} implementation that handles the "jcr:primaryType" property.
      *
      * @param context the execution context; may not be null
+     * @param matcher the node type matcher used to determine which nodes should be included in the index; may not be null
      * @param workspaceName the name of the workspace; may not be null
      * @param index the local index that should be used; may not be null
      * @return the new {@link IndexChangeAdapter}; never null
      */
     public static IndexChangeAdapter forPrimaryType( ExecutionContext context,
+                                                     NodeTypePredicate matcher,
                                                      String workspaceName,
                                                      LocalDuplicateIndex<Name> index ) {
-        return new PrimaryTypeChangeAdatper(context, workspaceName, index);
+        return new PrimaryTypeChangeAdatper(context, matcher, workspaceName, index);
     }
 
     /**
      * Create an {@link IndexChangeAdapter} implementation that handles the "jcr:mixinTypes" property.
      *
      * @param context the execution context; may not be null
+     * @param matcher the node type matcher used to determine which nodes should be included in the index; may not be null
      * @param workspaceName the name of the workspace; may not be null
      * @param index the local index that should be used; may not be null
      * @return the new {@link IndexChangeAdapter}; never null
      */
     public static IndexChangeAdapter forMixinTypes( ExecutionContext context,
+                                                    NodeTypePredicate matcher,
                                                     String workspaceName,
                                                     LocalDuplicateIndex<Name> index ) {
-        return new PrimaryTypeChangeAdatper(context, workspaceName, index);
+        return new PrimaryTypeChangeAdatper(context, matcher, workspaceName, index);
     }
 
     /**
      * Create an {@link IndexChangeAdapter} implementation that handles a single-valued property.
      *
      * @param context the execution context; may not be null
+     * @param matcher the node type matcher used to determine which nodes should be included in the index; may not be null
      * @param workspaceName the name of the workspace; may not be null
      * @param propertyName the name of the property; may not be null
      * @param factory the value factory for the property's value type; may not be null
@@ -132,17 +146,19 @@ public class IndexChangeAdapters {
      * @return the new {@link IndexChangeAdapter}; never null
      */
     public static <T> IndexChangeAdapter forSingleValuedProperty( ExecutionContext context,
+                                                                  NodeTypePredicate matcher,
                                                                   String workspaceName,
                                                                   Name propertyName,
                                                                   ValueFactory<T> factory,
                                                                   LocalDuplicateIndex<T> index ) {
-        return new SingleValuedPropertyChangeAdapter<T>(context, workspaceName, propertyName, factory, index);
+        return new SingleValuedPropertyChangeAdapter<T>(context, matcher, workspaceName, propertyName, factory, index);
     }
 
     /**
      * Create an {@link IndexChangeAdapter} implementation that handles a multi-valued property.
      *
      * @param context the execution context; may not be null
+     * @param matcher the node type matcher used to determine which nodes should be included in the index; may not be null
      * @param workspaceName the name of the workspace; may not be null
      * @param propertyName the name of the property; may not be null
      * @param factory the value factory for the property's value type; may not be null
@@ -150,11 +166,12 @@ public class IndexChangeAdapters {
      * @return the new {@link IndexChangeAdapter}; never null
      */
     public static <T> IndexChangeAdapter forMultiValuedProperty( ExecutionContext context,
+                                                                 NodeTypePredicate matcher,
                                                                  String workspaceName,
                                                                  Name propertyName,
                                                                  ValueFactory<T> factory,
                                                                  LocalDuplicateIndex<T> index ) {
-        return new MultiValuedPropertyChangeAdapter<T>(context, workspaceName, propertyName, factory, index);
+        return new MultiValuedPropertyChangeAdapter<T>(context, matcher, workspaceName, propertyName, factory, index);
     }
 
     /**
@@ -162,6 +179,7 @@ public class IndexChangeAdapters {
      * unique across all nodes.
      *
      * @param context the execution context; may not be null
+     * @param matcher the node type matcher used to determine which nodes should be included in the index; may not be null
      * @param workspaceName the name of the workspace; may not be null
      * @param propertyName the name of the property; may not be null
      * @param factory the value factory for the property's value type; may not be null
@@ -169,11 +187,12 @@ public class IndexChangeAdapters {
      * @return the new {@link IndexChangeAdapter}; never null
      */
     public static <T> IndexChangeAdapter forUniqueValuedProperty( ExecutionContext context,
+                                                                  NodeTypePredicate matcher,
                                                                   String workspaceName,
                                                                   Name propertyName,
                                                                   ValueFactory<T> factory,
                                                                   LocalUniqueIndex<T> index ) {
-        return new UniquePropertyChangeAdapter<T>(context, workspaceName, propertyName, factory, index);
+        return new UniquePropertyChangeAdapter<T>(context, matcher, workspaceName, propertyName, factory, index);
     }
 
     /**
@@ -181,16 +200,18 @@ public class IndexChangeAdapters {
      * enumerated values are distinct, they are treated as strings.
      *
      * @param context the execution context; may not be null
+     * @param matcher the node type matcher used to determine which nodes should be included in the index; may not be null
      * @param workspaceName the name of the workspace; may not be null
      * @param propertyName the name of the property; may not be null
      * @param index the local index that should be used; may not be null
      * @return the new {@link IndexChangeAdapter}; never null
      */
     public static IndexChangeAdapter forSingleValuedEnumeratedProperty( ExecutionContext context,
+                                                                        NodeTypePredicate matcher,
                                                                         String workspaceName,
                                                                         Name propertyName,
                                                                         LocalEnumeratedIndex index ) {
-        return new SingleValuedEnumeratedPropertyChangeAdapter(context, workspaceName, propertyName, index);
+        return new SingleValuedEnumeratedPropertyChangeAdapter(context, matcher, workspaceName, propertyName, index);
     }
 
     /**
@@ -198,30 +219,34 @@ public class IndexChangeAdapters {
      * values are distinct, they are treated as strings.
      *
      * @param context the execution context; may not be null
+     * @param matcher the node type matcher used to determine which nodes should be included in the index; may not be null
      * @param workspaceName the name of the workspace; may not be null
      * @param propertyName the name of the property; may not be null
      * @param index the local index that should be used; may not be null
      * @return the new {@link IndexChangeAdapter}; never null
      */
     public static IndexChangeAdapter forMultiValuedEnumeratedProperty( ExecutionContext context,
+                                                                       NodeTypePredicate matcher,
                                                                        String workspaceName,
                                                                        Name propertyName,
                                                                        LocalEnumeratedIndex index ) {
-        return new MultiValuedEnumeratedPropertyChangeAdapter(context, workspaceName, propertyName, index);
+        return new MultiValuedEnumeratedPropertyChangeAdapter(context, matcher, workspaceName, propertyName, index);
     }
 
     /**
      * Create an {@link IndexChangeAdapter} implementation that handles node type information.
      *
      * @param context the execution context; may not be null
+     * @param matcher the node type matcher used to determine which nodes should be included in the index; may not be null
      * @param workspaceName the name of the workspace; may not be null
      * @param index the local index that should be used; may not be null
      * @return the new {@link IndexChangeAdapter}; never null
      */
     public static IndexChangeAdapter forNodeTypes( ExecutionContext context,
+                                                   NodeTypePredicate matcher,
                                                    String workspaceName,
                                                    LocalIndex<String> index ) {
-        return new NodeTypesChangeAdapter(context, workspaceName, index);
+        return new NodeTypesChangeAdapter(context, matcher, workspaceName, index);
     }
 
     private IndexChangeAdapters() {
@@ -232,10 +257,11 @@ public class IndexChangeAdapters {
         private final boolean includeRoot;
 
         protected PathBasedChangeAdapter( ExecutionContext context,
+                                          NodeTypePredicate matcher,
                                           String workspaceName,
                                           LocalDuplicateIndex<T> index,
                                           boolean includeRoot ) {
-            super(context, workspaceName);
+            super(context, workspaceName, matcher);
             this.index = index;
             this.includeRoot = includeRoot;
         }
@@ -303,13 +329,19 @@ public class IndexChangeAdapters {
             index.commit();
             super.completeWorkspaceChanges();
         }
+
+        @Override
+        public String toString() {
+            return getClass().getSimpleName() + "(\"" + index.getName() + "\")";
+        }
     }
 
     protected static final class NodeDepthChangeAdapter extends PathBasedChangeAdapter<Long> {
         public NodeDepthChangeAdapter( ExecutionContext context,
+                                       NodeTypePredicate matcher,
                                        String workspaceName,
                                        LocalDuplicateIndex<Long> index ) {
-            super(context, workspaceName, index, true);
+            super(context, matcher, workspaceName, index, true);
         }
 
         @Override
@@ -325,9 +357,10 @@ public class IndexChangeAdapters {
 
     protected static final class NodeNameChangeAdapter extends PathBasedChangeAdapter<Name> {
         public NodeNameChangeAdapter( ExecutionContext context,
+                                      NodeTypePredicate matcher,
                                       String workspaceName,
                                       LocalDuplicateIndex<Name> index ) {
-            super(context, workspaceName, index, true);
+            super(context, matcher, workspaceName, index, true);
         }
 
         @Override
@@ -343,9 +376,10 @@ public class IndexChangeAdapters {
 
     protected static final class NodeLocalNameChangeAdapter extends PathBasedChangeAdapter<String> {
         public NodeLocalNameChangeAdapter( ExecutionContext context,
+                                           NodeTypePredicate matcher,
                                            String workspaceName,
                                            LocalDuplicateIndex<String> index ) {
-            super(context, workspaceName, index, true);
+            super(context, matcher, workspaceName, index, true);
         }
 
         @Override
@@ -361,9 +395,10 @@ public class IndexChangeAdapters {
 
     protected static final class NodePathChangeAdapter extends PathBasedChangeAdapter<Path> {
         public NodePathChangeAdapter( ExecutionContext context,
+                                      NodeTypePredicate matcher,
                                       String workspaceName,
                                       LocalDuplicateIndex<Path> index ) {
-            super(context, workspaceName, index, true);
+            super(context, matcher, workspaceName, index, true);
         }
 
         @Override
@@ -386,10 +421,11 @@ public class IndexChangeAdapters {
         protected final ValueFactory<T> valueFactory;
 
         public AbstractPropertyChangeAdapter( ExecutionContext context,
+                                              NodeTypePredicate matcher,
                                               String workspaceName,
                                               Name propertyName,
                                               ValueFactory<T> valueFactory ) {
-            super(context, workspaceName);
+            super(context, workspaceName, matcher);
             this.propertyName = propertyName;
             this.valueFactory = valueFactory;
         }
@@ -447,11 +483,12 @@ public class IndexChangeAdapters {
         protected final LocalDuplicateIndex<T> index;
 
         public PropertyChangeAdapter( ExecutionContext context,
+                                      NodeTypePredicate matcher,
                                       String workspaceName,
                                       Name propertyName,
                                       ValueFactory<T> valueFactory,
                                       LocalDuplicateIndex<T> index ) {
-            super(context, workspaceName, propertyName, valueFactory);
+            super(context, matcher, workspaceName, propertyName, valueFactory);
             this.index = index;
         }
 
@@ -485,15 +522,21 @@ public class IndexChangeAdapters {
             index.commit();
             super.completeWorkspaceChanges();
         }
+
+        @Override
+        public String toString() {
+            return getClass().getSimpleName() + "(\"" + index.getName() + "\")";
+        }
     }
 
     protected static final class SingleValuedPropertyChangeAdapter<T> extends PropertyChangeAdapter<T> {
         public SingleValuedPropertyChangeAdapter( ExecutionContext context,
+                                                  NodeTypePredicate matcher,
                                                   String workspaceName,
                                                   Name propertyName,
                                                   ValueFactory<T> valueFactory,
                                                   LocalDuplicateIndex<T> index ) {
-            super(context, workspaceName, propertyName, valueFactory, index);
+            super(context, matcher, workspaceName, propertyName, valueFactory, index);
         }
 
         @Override
@@ -505,19 +548,21 @@ public class IndexChangeAdapters {
 
     protected static final class MultiValuedPropertyChangeAdapter<T> extends PropertyChangeAdapter<T> {
         public MultiValuedPropertyChangeAdapter( ExecutionContext context,
+                                                 NodeTypePredicate matcher,
                                                  String workspaceName,
                                                  Name propertyName,
                                                  ValueFactory<T> valueFactory,
                                                  LocalDuplicateIndex<T> index ) {
-            super(context, workspaceName, propertyName, valueFactory, index);
+            super(context, matcher, workspaceName, propertyName, valueFactory, index);
         }
     }
 
     protected static final class PrimaryTypeChangeAdatper extends PropertyChangeAdapter<Name> {
         public PrimaryTypeChangeAdatper( ExecutionContext context,
+                                         NodeTypePredicate matcher,
                                          String workspaceName,
                                          LocalDuplicateIndex<Name> index ) {
-            super(context, workspaceName, JcrLexicon.PRIMARY_TYPE, context.getValueFactories().getNameFactory(), index);
+            super(context, matcher, workspaceName, JcrLexicon.PRIMARY_TYPE, context.getValueFactories().getNameFactory(), index);
         }
 
         @Override
@@ -534,9 +579,10 @@ public class IndexChangeAdapters {
 
     protected static final class MixinTypesChangeAdatper extends PropertyChangeAdapter<Name> {
         public MixinTypesChangeAdatper( ExecutionContext context,
+                                        NodeTypePredicate matcher,
                                         String workspaceName,
                                         LocalDuplicateIndex<Name> index ) {
-            super(context, workspaceName, JcrLexicon.MIXIN_TYPES, context.getValueFactories().getNameFactory(), index);
+            super(context, matcher, workspaceName, JcrLexicon.MIXIN_TYPES, context.getValueFactories().getNameFactory(), index);
         }
 
         @Override
@@ -559,11 +605,12 @@ public class IndexChangeAdapters {
         protected final LocalUniqueIndex<T> index;
 
         public UniquePropertyChangeAdapter( ExecutionContext context,
+                                            NodeTypePredicate matcher,
                                             String workspaceName,
                                             Name propertyName,
                                             ValueFactory<T> valueFactory,
                                             LocalUniqueIndex<T> index ) {
-            super(context, workspaceName, propertyName, valueFactory);
+            super(context, matcher, workspaceName, propertyName, valueFactory);
             this.index = index;
         }
 
@@ -596,16 +643,22 @@ public class IndexChangeAdapters {
             super.completeWorkspaceChanges();
         }
 
+        @Override
+        public String toString() {
+            return getClass().getSimpleName() + "(\"" + index.getName() + "\")";
+        }
+
     }
 
     protected static abstract class EnumeratedPropertyChangeAdapter extends AbstractPropertyChangeAdapter<String> {
         protected final LocalIndex<String> index;
 
         public EnumeratedPropertyChangeAdapter( ExecutionContext context,
+                                                NodeTypePredicate matcher,
                                                 String workspaceName,
                                                 Name propertyName,
                                                 LocalIndex<String> index ) {
-            super(context, workspaceName, propertyName, context.getValueFactories().getStringFactory());
+            super(context, matcher, workspaceName, propertyName, context.getValueFactories().getStringFactory());
             this.index = index;
         }
 
@@ -639,14 +692,20 @@ public class IndexChangeAdapters {
             index.commit();
             super.completeWorkspaceChanges();
         }
+
+        @Override
+        public String toString() {
+            return getClass().getSimpleName() + "(\"" + index.getName() + "\")";
+        }
     }
 
     protected static final class SingleValuedEnumeratedPropertyChangeAdapter extends EnumeratedPropertyChangeAdapter {
         public SingleValuedEnumeratedPropertyChangeAdapter( ExecutionContext context,
+                                                            NodeTypePredicate matcher,
                                                             String workspaceName,
                                                             Name propertyName,
                                                             LocalEnumeratedIndex index ) {
-            super(context, workspaceName, propertyName, index);
+            super(context, matcher, workspaceName, propertyName, index);
         }
 
         @Override
@@ -658,18 +717,20 @@ public class IndexChangeAdapters {
 
     protected static final class MultiValuedEnumeratedPropertyChangeAdapter extends EnumeratedPropertyChangeAdapter {
         public MultiValuedEnumeratedPropertyChangeAdapter( ExecutionContext context,
+                                                           NodeTypePredicate matcher,
                                                            String workspaceName,
                                                            Name propertyName,
                                                            LocalEnumeratedIndex index ) {
-            super(context, workspaceName, propertyName, index);
+            super(context, matcher, workspaceName, propertyName, index);
         }
     }
 
     protected static final class NodeTypesChangeAdapter extends EnumeratedPropertyChangeAdapter {
         public NodeTypesChangeAdapter( ExecutionContext context,
+                                       NodeTypePredicate matcher,
                                        String workspaceName,
                                        LocalIndex<String> index ) {
-            super(context, workspaceName, null, index);
+            super(context, matcher, workspaceName, null, index);
         }
 
         protected final void removeValues( NodeKey key,

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/index/local/IndexValues.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/index/local/IndexValues.java
@@ -22,7 +22,6 @@ import javax.jcr.query.qom.StaticOperand;
 import org.modeshape.jcr.api.index.IndexDefinition.IndexKind;
 import org.modeshape.jcr.index.local.MapDB.UniqueKey;
 import org.modeshape.jcr.query.model.Literal;
-import org.modeshape.jcr.query.model.LiteralValue;
 import org.modeshape.jcr.value.ValueFactory;
 
 /**
@@ -126,8 +125,8 @@ public class IndexValues {
         @Override
         public T toUpperValue( StaticOperand operand,
                                Map<String, Object> variables ) {
-            if (operand instanceof LiteralValue) {
-                LiteralValue literal = (LiteralValue)operand;
+            if (operand instanceof Literal) {
+                Literal literal = (Literal)operand;
                 return factory.create(literal.value());
             }
             if (operand instanceof BindVariableValue) {

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/index/local/LocalIndex.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/index/local/LocalIndex.java
@@ -26,6 +26,13 @@ import org.modeshape.jcr.spi.index.provider.Filter;
 public interface LocalIndex<T> extends Filter, Costable {
 
     /**
+     * Get the name of the index.
+     * 
+     * @return the index name; never null
+     */
+    String getName();
+
+    /**
      * Remove all of the index entries from the index. This is typically called prior to reindexing.
      */
     void removeAll();

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/index/local/LocalIndexProvider.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/index/local/LocalIndexProvider.java
@@ -33,6 +33,7 @@ import org.modeshape.jcr.api.index.IndexColumnDefinition;
 import org.modeshape.jcr.api.index.IndexDefinition;
 import org.modeshape.jcr.api.query.qom.QueryObjectModelConstants;
 import org.modeshape.jcr.api.query.qom.Relike;
+import org.modeshape.jcr.cache.change.ChangeSetAdapter.NodeTypePredicate;
 import org.modeshape.jcr.query.QueryContext;
 import org.modeshape.jcr.query.model.Comparison;
 import org.modeshape.jcr.query.model.FullTextSearch;
@@ -159,15 +160,16 @@ public class LocalIndexProvider extends IndexProvider {
                                        IndexDefinition defn,
                                        NodeTypes.Supplier nodeTypeSupplier,
                                        Problems problems ) {
-        ManagedLocalIndexBuilder.create(context, defn, nodeTypeSupplier).validate(problems);
+        ManagedLocalIndexBuilder.create(context, defn, nodeTypeSupplier, null).validate(problems);
     }
 
     @Override
     protected ManagedIndex createIndex( IndexDefinition defn,
                                         String workspaceName,
                                         Supplier nodeTypesSupplier,
+                                        NodeTypePredicate matcher,
                                         IndexFeedback feedback ) {
-        ManagedLocalIndexBuilder<?> builder = ManagedLocalIndexBuilder.create(context(), defn, nodeTypesSupplier);
+        ManagedLocalIndexBuilder<?> builder = ManagedLocalIndexBuilder.create(context(), defn, nodeTypesSupplier, matcher);
         logger().debug("Index provider '{0}' is creating index in workspace '{1}': {2}", getName(), workspaceName, defn);
         ManagedIndex index = builder.build(workspaceName, db);
         feedback.scan(workspaceName);
@@ -180,6 +182,7 @@ public class LocalIndexProvider extends IndexProvider {
                                         ManagedIndex existingIndex,
                                         String workspaceName,
                                         Supplier nodeTypesSupplier,
+                                        NodeTypePredicate matcher,
                                         IndexFeedback feedback ) {
         if (!isChanged(oldDefn, updatedDefn)) {
             // Nothing about the index definition that we care about really changed, so don't do anything ...
@@ -189,7 +192,7 @@ public class LocalIndexProvider extends IndexProvider {
         }
         // This is very crude, but we'll just destroy the old index and rebuild the new one ...
         existingIndex.shutdown(true);
-        ManagedLocalIndexBuilder<?> builder = ManagedLocalIndexBuilder.create(context(), updatedDefn, nodeTypesSupplier);
+        ManagedLocalIndexBuilder<?> builder = ManagedLocalIndexBuilder.create(context(), updatedDefn, nodeTypesSupplier, matcher);
         logger().debug("Index provider '{0}' is updating index in workspace '{1}': {2}", getName(), workspaceName, updatedDefn);
         ManagedIndex index = builder.build(workspaceName, db);
         feedback.scan(workspaceName);

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/index/local/LocalMapIndex.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/index/local/LocalMapIndex.java
@@ -42,7 +42,7 @@ import org.modeshape.jcr.value.ValueComparators;
  */
 abstract class LocalMapIndex<T, V> implements LocalIndex<V> {
 
-    private static final Logger LOGGER = Logger.getLogger(LocalMapIndex.class);
+    protected final Logger logger = Logger.getLogger(getClass());
 
     protected final String name;
     protected final String workspace;
@@ -69,12 +69,12 @@ abstract class LocalMapIndex<T, V> implements LocalIndex<V> {
         this.converter = converter;
         this.db = db;
         if (db.exists(name)) {
-            LOGGER.debug("Reopening storage for '{0}' index in workspace '{1}'", name, workspaceName);
+            logger.debug("Reopening storage for '{0}' index in workspace '{1}'", name, workspaceName);
             this.options = db.getHashMap(name + "/options");
             this.keysByValue = db.getTreeMap(name);
             this.valuesByKey = db.getTreeSet(name + "/inverse");
         } else {
-            LOGGER.debug("Creating storage for '{0}' index in workspace '{1}'", name, workspaceName);
+            logger.debug("Creating storage for '{0}' index in workspace '{1}'", name, workspaceName);
             this.options = db.createHashMap(name + "/options").make();
             this.keysByValue = db.createTreeMap(name).counterEnable().comparator(valueSerializer.getComparator())
                                  .keySerializer(valueSerializer).make();
@@ -122,14 +122,6 @@ abstract class LocalMapIndex<T, V> implements LocalIndex<V> {
     public long estimateCardinality( Constraint constraint,
                                      Map<String, Object> variables ) {
         return Operations.createFilter(keysByValue, converter, Collections.singleton(constraint), variables).estimateCount();
-    }
-
-    @Override
-    public void remove( String nodeKey ) {
-        // Find all of the T values (entry keys) for the given node key (entry values) ...
-        for (T key : Fun.filter(valuesByKey, nodeKey)) {
-            keysByValue.remove(key);
-        }
     }
 
     @Override

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/index/local/LocalUniqueIndex.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/index/local/LocalUniqueIndex.java
@@ -77,6 +77,7 @@ class LocalUniqueIndex<T> extends LocalMapIndex<T, T> {
     @Override
     public void add( String nodeKey,
                      T value ) {
+        logger.trace("Adding node '{0}' to '{1}' index with value '{2}'", nodeKey, name, value);
         keysByValue.put(value, nodeKey);
     }
 
@@ -85,9 +86,20 @@ class LocalUniqueIndex<T> extends LocalMapIndex<T, T> {
                         T value ) {
         // Find all of the T values (entry keys) for the given node key (entry values) ...
         for (T key : Fun.filter(valuesByKey, nodeKey)) {
-            if (comparator.compare(value, key) == 1) {
+            if (comparator.compare(value, key) == 0) {
+                logger.trace("Removing node '{0}' from '{1}' index with value '{2}'", nodeKey, name, value);
                 keysByValue.remove(key);
             }
         }
     }
+
+    @Override
+    public void remove( String nodeKey ) {
+        // Find all of the T values (entry keys) for the given node key (entry values) ...
+        for (T key : Fun.filter(valuesByKey, nodeKey)) {
+            logger.trace("Removing node '{0}' from '{1}' index with value '{2}'", nodeKey, name, key);
+            keysByValue.remove(key);
+        }
+    }
+
 }

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/index/local/MapDB.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/index/local/MapDB.java
@@ -748,6 +748,18 @@ public class MapDB {
             int i = aComparator.compare(o1.a, o2.a);
             if (i != 0) return i;
             // Before we check the second value in the tuples, check them against the "positive infinity" values ...
+            if (o1.b == null) {
+                // This is negative infinity ...
+                if (o2.b == null) {
+                    // Both are negative infinity ...
+                    return 0;
+                }
+                // o1.b is negative infinity, but o2.b is not
+                return -1;
+            } else if (o2.b == null) {
+                // This is negative infinity, but o1.b is not ...
+                return 1;
+            }
             if (o1.b == Fun.HI) {
                 if (o2.b == Fun.HI) {
                     // Both are positive infinity ...

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/index/local/Operations.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/index/local/Operations.java
@@ -287,13 +287,13 @@ class Operations {
                     T upperValue = converter.toUpperValue(operand, variables);
                     return create(keysByValue.subMap(lowerValue, true, upperValue, true));
                 case GREATER_THAN:
-                    T value = converter.toLowerValue(operand, variables);
+                    T value = converter.toUpperValue(operand, variables);
                     return create(keysByValue.tailMap(value, false));
                 case GREATER_THAN_OR_EQUAL_TO:
                     value = converter.toLowerValue(operand, variables);
                     return create(keysByValue.tailMap(value, true));
                 case LESS_THAN:
-                    value = converter.toUpperValue(operand, variables);
+                    value = converter.toLowerValue(operand, variables);
                     return create(keysByValue.headMap(value, false));
                 case LESS_THAN_OR_EQUAL_TO:
                     value = converter.toUpperValue(operand, variables);

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/spi/index/IndexCostCalculator.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/spi/index/IndexCostCalculator.java
@@ -17,6 +17,7 @@ package org.modeshape.jcr.spi.index;
 
 import java.util.Collection;
 import java.util.Map;
+import java.util.Set;
 import javax.jcr.query.qom.Constraint;
 import org.modeshape.common.annotation.NotThreadSafe;
 import org.modeshape.jcr.query.model.BindVariableName;
@@ -53,18 +54,11 @@ public interface IndexCostCalculator {
     }
 
     /**
-     * Get the name of the node type that the query is selecting.
+     * Get the name of the node type that the query is selecting, including aliases.
      *
-     * @return the node type name; never null
+     * @return the node type names; never null
      */
-    String selectedNodeType();
-
-    /**
-     * Get the name (or alias) of the selector for which the {@link #selectedNodeType()} applies.
-     * 
-     * @return the name or alias; never null
-     */
-    String selectorNameOrAlias();
+    Set<String> selectedNodeTypes();
 
     /**
      * Get the ANDed constraints that apply to the index to which this filter is submitted.

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/spi/index/provider/IndexChangeAdapter.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/spi/index/provider/IndexChangeAdapter.java
@@ -32,8 +32,9 @@ public class IndexChangeAdapter extends ChangeSetAdapter {
     private final String workspaceName;
 
     public IndexChangeAdapter( ExecutionContext context,
-                               String workspaceName ) {
-        super(context);
+                               String workspaceName,
+                               ChangeSetAdapter.NodeTypePredicate predicate ) {
+        super(context, predicate);
         assert workspaceName != null;
         this.workspaceName = workspaceName;
     }
@@ -54,14 +55,17 @@ public class IndexChangeAdapter extends ChangeSetAdapter {
      * @param properties the properties of the node; may not be null but may be empty
      * @param queryable true if the node is queryable, false otherwise
      */
-    protected void index( String workspaceName,
-                          NodeKey key,
-                          Path path,
-                          Name primaryType,
-                          Set<Name> mixinTypes,
-                          Properties properties,
-                          boolean queryable ) {
-        super.addNode(workspaceName, key, path, primaryType, mixinTypes, properties, queryable);
+    protected final void index( String workspaceName,
+                                NodeKey key,
+                                Path path,
+                                Name primaryType,
+                                Set<Name> mixinTypes,
+                                Properties properties,
+                                boolean queryable ) {
+        if (predicate.matchesType(primaryType, mixinTypes)) {
+            removeNode(workspaceName, key, null, path, primaryType, mixinTypes, queryable);
+            addNode(workspaceName, key, path, primaryType, mixinTypes, properties, queryable);
+        }
     }
 
 }

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/spi/index/provider/NodeTypeMatcher.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/spi/index/provider/NodeTypeMatcher.java
@@ -1,0 +1,130 @@
+/*
+ * ModeShape (http://www.modeshape.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.modeshape.jcr.spi.index.provider;
+
+import java.util.Set;
+import org.modeshape.common.annotation.ThreadSafe;
+import org.modeshape.jcr.JcrNtLexicon;
+import org.modeshape.jcr.cache.change.ChangeSetAdapter.NodeTypePredicate;
+import org.modeshape.jcr.value.Name;
+
+/**
+ * @author Randall Hauch (rhauch@redhat.com)
+ */
+@ThreadSafe
+public abstract class NodeTypeMatcher implements NodeTypePredicate {
+
+    public static NodeTypeMatcher create( Set<Name> nodeTypeNames ) {
+        NodeTypePredicate delegate = null;
+        if (nodeTypeNames == null || nodeTypeNames.isEmpty()) {
+            delegate = MatchNonePredicate.INSTANCE;
+        } else if (nodeTypeNames.contains(JcrNtLexicon.BASE)) {
+            delegate = NtBaseMatchPredicate.INSTANCE;
+        } else {
+            delegate = new NodeTypeSetMatcher(nodeTypeNames);
+        }
+        return new MutableNodeTypeMatcher(delegate);
+    }
+
+    public abstract void use( NodeTypePredicate other );
+
+    private static final class MutableNodeTypeMatcher extends NodeTypeMatcher {
+
+        private volatile NodeTypePredicate delegate;
+
+        protected MutableNodeTypeMatcher( NodeTypePredicate delegate ) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public boolean matchesType( Name primaryType,
+                                    Set<Name> mixinTypes ) {
+            return delegate.matchesType(primaryType, mixinTypes);
+        }
+
+        @Override
+        public void use( NodeTypePredicate other ) {
+            if (other instanceof MatchNonePredicate) {
+                delegate = MatchNonePredicate.INSTANCE;
+            } else if (other instanceof NtBaseMatchPredicate) {
+                delegate = NtBaseMatchPredicate.INSTANCE;
+            }
+            assert other instanceof MutableNodeTypeMatcher;
+            delegate = ((MutableNodeTypeMatcher)other).delegate;
+        }
+
+        @Override
+        public String toString() {
+            return delegate.toString();
+        }
+    }
+
+    private static final class NodeTypeSetMatcher implements NodeTypePredicate {
+        private final Set<Name> allNodeTypes;
+
+        protected NodeTypeSetMatcher( final Set<Name> allNodeTypes ) {
+            this.allNodeTypes = allNodeTypes;
+        }
+
+        @Override
+        public boolean matchesType( Name primaryType,
+                                    Set<Name> mixinTypes ) {
+            if (allNodeTypes.contains(primaryType)) return true;
+            if (mixinTypes != null) {
+                for (Name mixinType : mixinTypes) {
+                    if (allNodeTypes.contains(mixinType)) return true;
+                }
+            }
+            return false;
+        }
+
+        @Override
+        public String toString() {
+            return "<Match=" + allNodeTypes + ">";
+        }
+    }
+
+    private static final class NtBaseMatchPredicate implements NodeTypePredicate {
+        protected static final NtBaseMatchPredicate INSTANCE = new NtBaseMatchPredicate();
+
+        @Override
+        public boolean matchesType( Name primaryType,
+                                    Set<Name> mixinTypes ) {
+            return true;
+        }
+
+        @Override
+        public String toString() {
+            return "<MatchAll>";
+        }
+    }
+
+    private static final class MatchNonePredicate implements NodeTypePredicate {
+        protected static final MatchNonePredicate INSTANCE = new MatchNonePredicate();
+
+        @Override
+        public boolean matchesType( Name primaryType,
+                                    Set<Name> mixinTypes ) {
+            return false;
+        }
+
+        @Override
+        public String toString() {
+            return "<MatchNone>";
+        }
+    }
+}

--- a/modeshape-jcr/src/main/resources/org/modeshape/jcr/JcrI18n.properties
+++ b/modeshape-jcr/src/main/resources/org/modeshape/jcr/JcrI18n.properties
@@ -39,6 +39,7 @@ repositoryWasNeverUpgradedAfterMinutes = Repository '{0}' is still not fully upg
 failureDuringUpgradeOperation = Repository '{0}' could not be upgrade due to a failure of the upgrade steps: {1}
 errorShuttingDownIndexProvider = Error while shutting down the '{1}' index provider for repository '{0}': {2}
 indexProviderMissingPlanner = Index provider '{0}' in repository '{1}' has no index planner. No indexes in this provider can be used.
+errorNotifyingNodeTypesListener = Error while notifying the NodeTypes.Listener of changes to node types: {0}
 
 cannotConvertValue = Cannot convert {0} value to {1}
 loginFailed = Unable to create session for workspace {1} in repository {0}: authentication or authorization failed. Check credentials.

--- a/modeshape-jcr/src/test/java/org/modeshape/jcr/index/local/AbstractLocalIndexTest.java
+++ b/modeshape-jcr/src/test/java/org/modeshape/jcr/index/local/AbstractLocalIndexTest.java
@@ -1,0 +1,284 @@
+/*
+ * ModeShape (http://www.modeshape.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.modeshape.jcr.index.local;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.Map;
+import javax.jcr.query.qom.Constraint;
+import org.junit.Before;
+import org.mapdb.BTreeKeySerializer;
+import org.mapdb.DB;
+import org.mapdb.DBMaker;
+import org.mapdb.Serializer;
+import org.modeshape.jcr.ExecutionContext;
+import org.modeshape.jcr.api.query.qom.Operator;
+import org.modeshape.jcr.cache.NodeKey;
+import org.modeshape.jcr.index.local.IndexValues.Converter;
+import org.modeshape.jcr.index.local.MapDB.Serializers;
+import org.modeshape.jcr.query.model.Comparison;
+import org.modeshape.jcr.query.model.DynamicOperand;
+import org.modeshape.jcr.query.model.Literal;
+import org.modeshape.jcr.query.model.PropertyValue;
+import org.modeshape.jcr.query.model.SelectorName;
+import org.modeshape.jcr.query.model.StaticOperand;
+import org.modeshape.jcr.spi.index.IndexConstraints;
+import org.modeshape.jcr.spi.index.ResultWriter;
+import org.modeshape.jcr.spi.index.provider.Filter;
+import org.modeshape.jcr.value.PropertyType;
+import org.modeshape.jcr.value.ValueFactories;
+import org.modeshape.jcr.value.ValueFactory;
+
+public abstract class AbstractLocalIndexTest {
+
+    protected Serializers serializers;
+    protected ExecutionContext context;
+    protected DB db;
+    protected String propertyName = "indexedProperty";
+
+    @Before
+    public void beforeEach() {
+        context = new ExecutionContext();
+        db = DBMaker.newMemoryDB().make();
+        serializers = MapDB.serializers(context.getValueFactories());
+    }
+
+    protected void loadLongIndex( LocalUniqueIndex<Long> index,
+                                  int numValues ) {
+        for (int i = 1; i <= numValues; ++i) {
+            index.add(key(i), (long)(i * 10));
+        }
+    }
+
+    protected void loadStringIndex( LocalUniqueIndex<String> index,
+                                    int numValues ) {
+        for (int i = 1; i <= numValues; ++i) {
+            index.add(key(i), "" + (i * 10));
+        }
+    }
+
+    protected void loadLongIndexWithNoDuplicates( LocalDuplicateIndex<Long> index,
+                                                  int numValues ) {
+        for (int i = 1; i <= numValues; ++i) {
+            index.add(key(i), (long)(i * 10));
+        }
+    }
+
+    protected void loadStringIndexWithNoDuplicates( LocalDuplicateIndex<String> index,
+                                                    int numValues ) {
+        for (int i = 1; i <= numValues; ++i) {
+            index.add(key(i), "" + (i * 10));
+        }
+    }
+
+    @SuppressWarnings( "unchecked" )
+    protected <T> LocalUniqueIndex<T> uniqueValueIndex( Class<T> valueType ) {
+        PropertyType type = PropertyType.discoverType(valueType);
+        ValueFactory<T> valueFactory = (ValueFactory<T>)context.getValueFactories().getValueFactory(type);
+        Converter<T> converter = IndexValues.converter(valueFactory);
+        Serializer<T> serializer = (Serializer<T>)serializers.serializerFor(type.getValueClass());
+        BTreeKeySerializer<T> keySerializer = (BTreeKeySerializer<T>)serializers.bTreeKeySerializerFor(type.getValueClass(),
+                                                                                                       type.getComparator(),
+                                                                                                       false);
+        return new LocalUniqueIndex<T>("myIndex", "myWorkspace", db, converter, keySerializer, serializer);
+    }
+
+    @SuppressWarnings( "unchecked" )
+    protected <T> LocalDuplicateIndex<T> duplicateValueIndex( Class<T> valueType ) {
+        PropertyType type = PropertyType.discoverType(valueType);
+        Comparator<T> comparator = (Comparator<T>)type.getComparator();
+        ValueFactory<T> valueFactory = (ValueFactory<T>)context.getValueFactories().getValueFactory(type);
+        Converter<T> converter = IndexValues.converter(valueFactory);
+        Serializer<T> serializer = (Serializer<T>)serializers.serializerFor(type.getValueClass());
+        return new LocalDuplicateIndex<T>("myIndex", "myWorkspace", db, converter, serializer, comparator);
+    }
+
+    public <T> void assertNoMatch( LocalUniqueIndex<T> index,
+                                   Operator op,
+                                   T value ) {
+        assertMatch(index, op, value, new String[] {});
+    }
+
+    public <T> void assertNoMatch( LocalDuplicateIndex<T> index,
+                                   Operator op,
+                                   T value ) {
+        assertMatch(index, op, value, new String[] {});
+    }
+
+    public <T> void assertMatch( LocalUniqueIndex<T> index,
+                                 Operator op,
+                                 T value,
+                                 String... keys ) {
+        assertMatch(index, op, value, keyList(keys));
+    }
+
+    public <T> void assertMatch( LocalUniqueIndex<T> index,
+                                 Operator op,
+                                 T value,
+                                 int... keys ) {
+        assertMatch(index, op, value, keyList(keys));
+    }
+
+    public <T> void assertMatch( LocalUniqueIndex<T> index,
+                                 Operator op,
+                                 T value,
+                                 LinkedList<String> expectedValues ) {
+        Filter.Results results = index.filter(constraints(propertyName, op, value));
+        ResultWriter writer = verify(expectedValues);
+        for (;;) {
+            if (!results.getNextBatch(writer, Integer.MAX_VALUE)) break;
+        }
+        assertTrue("Not all expected values were found in results: " + expectedValues, expectedValues.isEmpty());
+    }
+
+    public <T> void assertMatch( LocalDuplicateIndex<T> index,
+                                 Operator op,
+                                 T value,
+                                 String... keys ) {
+        assertMatch(index, op, value, keyList(keys));
+    }
+
+    public <T> void assertMatch( LocalDuplicateIndex<T> index,
+                                 Operator op,
+                                 T value,
+                                 int... keys ) {
+        assertMatch(index, op, value, keyList(keys));
+    }
+
+    public <T> void assertMatch( LocalDuplicateIndex<T> index,
+                                 Operator op,
+                                 T value,
+                                 LinkedList<String> expectedValues ) {
+        Filter.Results results = index.filter(constraints(propertyName, op, value));
+        ResultWriter writer = verify(expectedValues);
+        for (;;) {
+            if (!results.getNextBatch(writer, Integer.MAX_VALUE)) break;
+        }
+        assertTrue("Not all expected values were found in results: " + expectedValues, expectedValues.isEmpty());
+    }
+
+    protected static SelectorName selector() {
+        return selector("selectorA");
+    }
+
+    protected static SelectorName selector( String name ) {
+        return new SelectorName(name);
+    }
+
+    protected <T> IndexConstraints constraints( String propertyName,
+                                                Operator op,
+                                                Object literalValue ) {
+        DynamicOperand dynOp = new PropertyValue(selector(), propertyName);
+        StaticOperand statOp = new Literal(literalValue);
+        return constraints(new Comparison(dynOp, op, statOp));
+    }
+
+    protected IndexConstraints constraints( final Constraint comparison ) {
+        return new IndexConstraints() {
+            @Override
+            public Collection<Constraint> getConstraints() {
+                return Collections.singletonList(comparison);
+            }
+
+            @Override
+            public Map<String, Object> getParameters() {
+                return Collections.emptyMap();
+            }
+
+            @Override
+            public ValueFactories getValueFactories() {
+                return context.getValueFactories();
+            }
+
+            @Override
+            public Map<String, Object> getVariables() {
+                return Collections.emptyMap();
+            }
+
+            @Override
+            public boolean hasConstraints() {
+                return true;
+            }
+        };
+    }
+
+    protected LinkedList<String> keyList( int... keys ) {
+        LinkedList<String> expected = new LinkedList<String>();
+        for (int i = 0; i != keys.length; ++i) {
+            expected.add(key(keys[i]));
+        }
+        return expected;
+    }
+
+    protected LinkedList<String> keyList( String... keys ) {
+        LinkedList<String> expected = new LinkedList<String>();
+        for (int i = 0; i != keys.length; ++i) {
+            expected.add(keys[i]);
+        }
+        return expected;
+    }
+
+    protected ResultWriter verify( final LinkedList<String> keys ) {
+        return new ResultWriter() {
+            @Override
+            public void add( Iterable<NodeKey> nodeKeys,
+                             float score ) {
+                for (NodeKey actual : nodeKeys) {
+                    assertTrue("Got actual result '" + actual + "' but expected nothing", !keys.isEmpty());
+                    assertThat(actual, is(nodeKey(keys.removeFirst())));
+                }
+            }
+
+            @Override
+            public void add( Iterator<NodeKey> nodeKeys,
+                             float score ) {
+                while (nodeKeys.hasNext()) {
+                    NodeKey actual = nodeKeys.next();
+                    assertTrue("Got actual result '" + actual + "' but expected nothing", !keys.isEmpty());
+                    assertThat(actual, is(nodeKey(keys.removeFirst())));
+                }
+            }
+
+            @Override
+            public void add( NodeKey nodeKey,
+                             float score ) {
+                assertTrue("Got actual result '" + nodeKey + "' but expected nothing", !keys.isEmpty());
+                assertThat(nodeKey, is(nodeKey(keys.removeFirst())));
+            }
+        };
+    }
+
+    private static final String NODE_KEY_PREFIX = "12345671234567-";
+
+    protected static String key( int value ) {
+        return NODE_KEY_PREFIX + value;
+    }
+
+    protected static String key( String value ) {
+        return NODE_KEY_PREFIX + value;
+    }
+
+    protected static NodeKey nodeKey( String value ) {
+        return new NodeKey(value);
+    }
+}

--- a/modeshape-jcr/src/test/java/org/modeshape/jcr/index/local/LocalDuplicateIndexTest.java
+++ b/modeshape-jcr/src/test/java/org/modeshape/jcr/index/local/LocalDuplicateIndexTest.java
@@ -1,0 +1,147 @@
+/*
+ * ModeShape (http://www.modeshape.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.modeshape.jcr.index.local;
+
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsNull.notNullValue;
+import static org.junit.Assert.assertThat;
+import org.junit.Test;
+import org.modeshape.jcr.api.query.qom.Operator;
+
+public class LocalDuplicateIndexTest extends AbstractLocalIndexTest {
+
+    @Test
+    public void shouldAllowCreatingLongValueIndex() {
+        LocalDuplicateIndex<Long> index = duplicateValueIndex(Long.class);
+        assertThat(index, is(notNullValue()));
+        assertThat(index.estimateTotalCount(), is(0L));
+    }
+
+    @Test
+    public void shouldAllowBasicQueryOperationsOnLongValueIndexWithNoDuplicates() {
+        LocalDuplicateIndex<Long> index = duplicateValueIndex(Long.class);
+        loadLongIndexWithNoDuplicates(index, 10);
+        assertThat(index.estimateTotalCount(), is(10L));
+
+        // Check a value that's in the index ...
+        assertMatch(index, Operator.EQUAL_TO, 50L, key(5));
+        assertMatch(index, Operator.NOT_EQUAL_TO, 50L, 1, 2, 3, 4, 6, 7, 8, 9, 10);
+        assertMatch(index, Operator.LESS_THAN_OR_EQUAL_TO, 50L, 1, 2, 3, 4, 5);
+        assertMatch(index, Operator.LESS_THAN, 50L, 1, 2, 3, 4);
+        assertMatch(index, Operator.GREATER_THAN_OR_EQUAL_TO, 50L, 5, 6, 7, 8, 9, 10);
+        assertMatch(index, Operator.GREATER_THAN, 50L, 6, 7, 8, 9, 10);
+
+        // Check a value that's not in the index but is between values that are ...
+        assertNoMatch(index, Operator.EQUAL_TO, 45L);
+        assertMatch(index, Operator.NOT_EQUAL_TO, 45L, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+        assertMatch(index, Operator.LESS_THAN_OR_EQUAL_TO, 45L, 1, 2, 3, 4);
+        assertMatch(index, Operator.LESS_THAN, 45L, 1, 2, 3, 4);
+        assertMatch(index, Operator.GREATER_THAN_OR_EQUAL_TO, 45L, 5, 6, 7, 8, 9, 10);
+        assertMatch(index, Operator.GREATER_THAN, 45L, 5, 6, 7, 8, 9, 10);
+
+        // Check a value that's not in the index but is greater than all values that are ...
+        assertNoMatch(index, Operator.EQUAL_TO, 450L);
+        assertMatch(index, Operator.NOT_EQUAL_TO, 450L, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+        assertMatch(index, Operator.LESS_THAN_OR_EQUAL_TO, 450L, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+        assertMatch(index, Operator.LESS_THAN, 450L, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+        assertNoMatch(index, Operator.GREATER_THAN_OR_EQUAL_TO, 450L);
+        assertNoMatch(index, Operator.GREATER_THAN, 450L);
+
+        // Check a value that's not in the index but is less than all values that are ...
+        assertNoMatch(index, Operator.EQUAL_TO, -1L);
+        assertMatch(index, Operator.NOT_EQUAL_TO, -1L, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+        assertNoMatch(index, Operator.LESS_THAN_OR_EQUAL_TO, -1L);
+        assertNoMatch(index, Operator.LESS_THAN, -1L);
+        assertMatch(index, Operator.GREATER_THAN_OR_EQUAL_TO, -1L, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+        assertMatch(index, Operator.GREATER_THAN, -1L, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+    }
+
+    @Test
+    public void shouldAllowBasicQueryOperationsOnStringValueIndex() {
+        LocalDuplicateIndex<String> index = duplicateValueIndex(String.class);
+        loadStringIndexWithNoDuplicates(index, 10);
+        assertThat(index.estimateTotalCount(), is(10L));
+
+        // Note the sorting of the string-based values puts key 10 after key 1 but before key 2
+        assertThat(key(10).compareTo(key(1)), is(1));
+        assertThat(key(10).compareTo(key(2)), is(-1));
+
+        // Check a value that's in the index ...
+        assertMatch(index, Operator.EQUAL_TO, "50", key(5));
+        assertMatch(index, Operator.NOT_EQUAL_TO, "50", 1, 10, 2, 3, 4, 6, 7, 8, 9);
+        assertMatch(index, Operator.LESS_THAN_OR_EQUAL_TO, "50", 1, 10, 2, 3, 4, 5);
+        assertMatch(index, Operator.LESS_THAN, "50", 1, 10, 2, 3, 4);
+        assertMatch(index, Operator.GREATER_THAN_OR_EQUAL_TO, "50", 5, 6, 7, 8, 9);
+        assertMatch(index, Operator.GREATER_THAN, "50", 6, 7, 8, 9);
+
+        // Check a value that's not in the index but is between values that are ...
+        assertNoMatch(index, Operator.EQUAL_TO, "45");
+        assertMatch(index, Operator.NOT_EQUAL_TO, "45", 1, 10, 2, 3, 4, 5, 6, 7, 8, 9);
+        assertMatch(index, Operator.LESS_THAN_OR_EQUAL_TO, "45", 1, 10, 2, 3, 4);
+        assertMatch(index, Operator.LESS_THAN, "45", 1, 10, 2, 3, 4);
+        assertMatch(index, Operator.GREATER_THAN_OR_EQUAL_TO, "45", 5, 6, 7, 8, 9);
+        assertMatch(index, Operator.GREATER_THAN, "45", 5, 6, 7, 8, 9);
+
+        // Check a value that's not in the index but is greater than all values that are ...
+        assertNoMatch(index, Operator.EQUAL_TO, "abcdef");
+        assertMatch(index, Operator.NOT_EQUAL_TO, "abcdef", 1, 10, 2, 3, 4, 5, 6, 7, 8, 9);
+        assertMatch(index, Operator.LESS_THAN_OR_EQUAL_TO, "abcdef", 1, 10, 2, 3, 4, 5, 6, 7, 8, 9);
+        assertMatch(index, Operator.LESS_THAN, "abcdef", 1, 10, 2, 3, 4, 5, 6, 7, 8, 9);
+        assertNoMatch(index, Operator.GREATER_THAN_OR_EQUAL_TO, "abcdef");
+        assertNoMatch(index, Operator.GREATER_THAN, "abcdef");
+
+        // Check a value that's not in the index but is less than all values that are ...
+        assertNoMatch(index, Operator.EQUAL_TO, "");
+        assertMatch(index, Operator.NOT_EQUAL_TO, "", 1, 10, 2, 3, 4, 5, 6, 7, 8, 9);
+        assertNoMatch(index, Operator.LESS_THAN_OR_EQUAL_TO, "");
+        assertNoMatch(index, Operator.LESS_THAN, "");
+        assertMatch(index, Operator.GREATER_THAN_OR_EQUAL_TO, "", 1, 10, 2, 3, 4, 5, 6, 7, 8, 9);
+        assertMatch(index, Operator.GREATER_THAN, "", 1, 10, 2, 3, 4, 5, 6, 7, 8, 9);
+    }
+
+    @Test
+    public void shouldAllowRemovingAllValuesForKey() {
+        LocalDuplicateIndex<Long> index = duplicateValueIndex(Long.class);
+        loadLongIndexWithNoDuplicates(index, 10);
+        assertThat(index.estimateTotalCount(), is(10L));
+
+        // Check the values that are in the index ...
+        assertThat(index.estimateTotalCount(), is(10L));
+        assertMatch(index, Operator.EQUAL_TO, 20L, key(2));
+
+        // Remove the value associated with a given key and verify they are indeed gone ...
+        index.remove(key(2));
+        assertNoMatch(index, Operator.EQUAL_TO, 20L);
+        assertThat(index.estimateTotalCount(), is(9L));
+
+        // Try to remove the values associated with a key not in the index ...
+        assertNoMatch(index, Operator.EQUAL_TO, 200L);
+        index.remove(key(20));
+        assertNoMatch(index, Operator.EQUAL_TO, 200L);
+        assertThat(index.estimateTotalCount(), is(9L));
+
+        // Remove a value and key pair that's in the index, and verify they are indeed gone ...
+        index.remove(key(3), 30L);
+        assertNoMatch(index, Operator.EQUAL_TO, 30L);
+        assertThat(index.estimateTotalCount(), is(8L));
+
+        // Try to remove a non-existant value-key pair, and verify nothing is removed ...
+        index.remove(key(3), 3000L);
+        assertNoMatch(index, Operator.EQUAL_TO, 30L);
+        assertThat(index.estimateTotalCount(), is(8L));
+    }
+}

--- a/modeshape-jcr/src/test/java/org/modeshape/jcr/index/local/LocalUniqueIndexTest.java
+++ b/modeshape-jcr/src/test/java/org/modeshape/jcr/index/local/LocalUniqueIndexTest.java
@@ -1,0 +1,146 @@
+/*
+ * ModeShape (http://www.modeshape.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.modeshape.jcr.index.local;
+
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsNull.notNullValue;
+import static org.junit.Assert.assertThat;
+import org.junit.Test;
+import org.modeshape.jcr.api.query.qom.Operator;
+
+public class LocalUniqueIndexTest extends AbstractLocalIndexTest {
+
+    @Test
+    public void shouldAllowCreatingLongValueIndex() {
+        LocalUniqueIndex<Long> index = uniqueValueIndex(Long.class);
+        assertThat(index, is(notNullValue()));
+        assertThat(index.estimateTotalCount(), is(0L));
+    }
+
+    @Test
+    public void shouldAllowBasicQueryOperationsOnLongValueIndex() {
+        LocalUniqueIndex<Long> index = uniqueValueIndex(Long.class);
+        loadLongIndex(index, 10);
+        assertThat(index.estimateTotalCount(), is(10L));
+
+        // Check a value that's in the index ...
+        assertMatch(index, Operator.EQUAL_TO, 50L, key(5));
+        assertMatch(index, Operator.NOT_EQUAL_TO, 50L, 1, 2, 3, 4, 6, 7, 8, 9, 10);
+        assertMatch(index, Operator.LESS_THAN_OR_EQUAL_TO, 50L, 1, 2, 3, 4, 5);
+        assertMatch(index, Operator.LESS_THAN, 50L, 1, 2, 3, 4);
+        assertMatch(index, Operator.GREATER_THAN_OR_EQUAL_TO, 50L, 5, 6, 7, 8, 9, 10);
+        assertMatch(index, Operator.GREATER_THAN, 50L, 6, 7, 8, 9, 10);
+
+        // Check a value that's not in the index but is between values that are ...
+        assertNoMatch(index, Operator.EQUAL_TO, 45L);
+        assertMatch(index, Operator.NOT_EQUAL_TO, 45L, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+        assertMatch(index, Operator.LESS_THAN_OR_EQUAL_TO, 45L, 1, 2, 3, 4);
+        assertMatch(index, Operator.LESS_THAN, 45L, 1, 2, 3, 4);
+        assertMatch(index, Operator.GREATER_THAN_OR_EQUAL_TO, 45L, 5, 6, 7, 8, 9, 10);
+        assertMatch(index, Operator.GREATER_THAN, 45L, 5, 6, 7, 8, 9, 10);
+
+        // Check a value that's not in the index but is greater than all values that are ...
+        assertNoMatch(index, Operator.EQUAL_TO, 450L);
+        assertMatch(index, Operator.NOT_EQUAL_TO, 450L, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+        assertMatch(index, Operator.LESS_THAN_OR_EQUAL_TO, 450L, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+        assertMatch(index, Operator.LESS_THAN, 450L, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+        assertNoMatch(index, Operator.GREATER_THAN_OR_EQUAL_TO, 450L);
+        assertNoMatch(index, Operator.GREATER_THAN, 450L);
+
+        // Check a value that's not in the index but is less than all values that are ...
+        assertNoMatch(index, Operator.EQUAL_TO, -1L);
+        assertMatch(index, Operator.NOT_EQUAL_TO, -1L, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+        assertNoMatch(index, Operator.LESS_THAN_OR_EQUAL_TO, -1L);
+        assertNoMatch(index, Operator.LESS_THAN, -1L);
+        assertMatch(index, Operator.GREATER_THAN_OR_EQUAL_TO, -1L, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+        assertMatch(index, Operator.GREATER_THAN, -1L, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+    }
+
+    @Test
+    public void shouldAllowBasicQueryOperationsOnStringValueIndex() {
+        LocalUniqueIndex<String> index = uniqueValueIndex(String.class);
+        loadStringIndex(index, 10);
+        assertThat(index.estimateTotalCount(), is(10L));
+
+        // Note the sorting of the string-based values puts key 10 after key 1 but before key 2
+        assertThat(key(10).compareTo(key(1)), is(1));
+        assertThat(key(10).compareTo(key(2)), is(-1));
+
+        // Check a value that's in the index ...
+        assertMatch(index, Operator.EQUAL_TO, "50", key(5));
+        assertMatch(index, Operator.NOT_EQUAL_TO, "50", 1, 10, 2, 3, 4, 6, 7, 8, 9);
+        assertMatch(index, Operator.LESS_THAN_OR_EQUAL_TO, "50", 1, 10, 2, 3, 4, 5);
+        assertMatch(index, Operator.LESS_THAN, "50", 1, 10, 2, 3, 4);
+        assertMatch(index, Operator.GREATER_THAN_OR_EQUAL_TO, "50", 5, 6, 7, 8, 9);
+        assertMatch(index, Operator.GREATER_THAN, "50", 6, 7, 8, 9);
+
+        // Check a value that's not in the index but is between values that are ...
+        assertNoMatch(index, Operator.EQUAL_TO, "45");
+        assertMatch(index, Operator.NOT_EQUAL_TO, "45", 1, 10, 2, 3, 4, 5, 6, 7, 8, 9);
+        assertMatch(index, Operator.LESS_THAN_OR_EQUAL_TO, "45", 1, 10, 2, 3, 4);
+        assertMatch(index, Operator.LESS_THAN, "45", 1, 10, 2, 3, 4);
+        assertMatch(index, Operator.GREATER_THAN_OR_EQUAL_TO, "45", 5, 6, 7, 8, 9);
+        assertMatch(index, Operator.GREATER_THAN, "45", 5, 6, 7, 8, 9);
+
+        // Check a value that's not in the index but is greater than all values that are ...
+        assertNoMatch(index, Operator.EQUAL_TO, "abcdef");
+        assertMatch(index, Operator.NOT_EQUAL_TO, "abcdef", 1, 10, 2, 3, 4, 5, 6, 7, 8, 9);
+        assertMatch(index, Operator.LESS_THAN_OR_EQUAL_TO, "abcdef", 1, 10, 2, 3, 4, 5, 6, 7, 8, 9);
+        assertMatch(index, Operator.LESS_THAN, "abcdef", 1, 10, 2, 3, 4, 5, 6, 7, 8, 9);
+        assertNoMatch(index, Operator.GREATER_THAN_OR_EQUAL_TO, "abcdef");
+        assertNoMatch(index, Operator.GREATER_THAN, "abcdef");
+
+        // Check a value that's not in the index but is less than all values that are ...
+        assertNoMatch(index, Operator.EQUAL_TO, "");
+        assertMatch(index, Operator.NOT_EQUAL_TO, "", 1, 10, 2, 3, 4, 5, 6, 7, 8, 9);
+        assertNoMatch(index, Operator.LESS_THAN_OR_EQUAL_TO, "");
+        assertNoMatch(index, Operator.LESS_THAN, "");
+        assertMatch(index, Operator.GREATER_THAN_OR_EQUAL_TO, "", 1, 10, 2, 3, 4, 5, 6, 7, 8, 9);
+        assertMatch(index, Operator.GREATER_THAN, "", 1, 10, 2, 3, 4, 5, 6, 7, 8, 9);
+    }
+
+    @Test
+    public void shouldAllowRemovingAllValuesForKey() {
+        LocalUniqueIndex<Long> index = uniqueValueIndex(Long.class);
+        loadLongIndex(index, 10);
+
+        // Check the values that are in the index ...
+        assertThat(index.estimateTotalCount(), is(10L));
+        assertMatch(index, Operator.EQUAL_TO, 20L, key(2));
+
+        // Remove the value associated with a given key and verify they are indeed gone ...
+        index.remove(key(2));
+        assertNoMatch(index, Operator.EQUAL_TO, 20L);
+        assertThat(index.estimateTotalCount(), is(9L));
+
+        // Try to remove the values associated with a key not in the index ...
+        assertNoMatch(index, Operator.EQUAL_TO, 200L);
+        index.remove(key(20));
+        assertNoMatch(index, Operator.EQUAL_TO, 200L);
+        assertThat(index.estimateTotalCount(), is(9L));
+
+        // Remove a value and key pair that's in the index, and verify they are indeed gone ...
+        index.remove(key(3), 30L);
+        assertNoMatch(index, Operator.EQUAL_TO, 30L);
+        assertThat(index.estimateTotalCount(), is(8L));
+
+        // Try to remove a non-existant value-key pair, and verify nothing is removed ...
+        index.remove(key(3), 3000L);
+        assertNoMatch(index, Operator.EQUAL_TO, 30L);
+        assertThat(index.estimateTotalCount(), is(8L));
+    }
+}


### PR DESCRIPTION
Indexes were not properly removing values, nor were they adding only nodes that satisfied their
definition's node type. Correcting the latter required handling when the node types in the repository
were changed, which might affect which node types are to be included in a given index. Therefore,
care was taken so that the index provider implementations' IndexChangeAdapters automatically handled
changes in the repository's node types.

A number of tests were added to replicate the problems reported in MODE-2295, and even more were
added to verify the proper behavior (including removing values) in the low-level local index
implementations. In particular, the UniqueKeyComparator logic was not quite handling all of the negative
infinity cases it should have (it was already correctly handling the positive infinity cases).
