### PR TITLE
MODE-2297 Corrected getNodes() functionality

### DIFF
--- a/modeshape-jcr/src/test/java/org/modeshape/jcr/LocalIndexProviderTest.java
+++ b/modeshape-jcr/src/test/java/org/modeshape/jcr/LocalIndexProviderTest.java
@@ -307,7 +307,7 @@ public class LocalIndexProviderTest extends SingleUseAbstractTest {
         session.save();
         waitForIndexes();
 
-        print = true;
+        // print = true;
         String sql1 = "SELECT BASE.* from [nt:formInstVersion] as BASE " //
                       + "JOIN  [nt:formInst] AS FORMINST ON ISCHILDNODE(BASE,FORMINST)";
         Query query = session.getWorkspace().getQueryManager().createQuery(sql1, Query.JCR_SQL2);

--- a/modeshape-jcr/src/test/java/org/modeshape/jcr/ValidateQuery.java
+++ b/modeshape-jcr/src/test/java/org/modeshape/jcr/ValidateQuery.java
@@ -270,6 +270,8 @@ public class ValidateQuery {
                 } catch (RepositoryException e) {
                     // expected; can't call this when the query uses multiple selectors ...
                 }
+            } else {
+                nodes = result.getNodes();
             }
 
             // Check the row count ...
@@ -293,12 +295,15 @@ public class ValidateQuery {
             assertRowCount(iter.getSize());
 
             if (nodes != null) {
-                // Check the results via node iterator ...
+                // Check the single-selector results via node iterator ...
+                assertTrue(result.getSelectorNames().length == 1);
                 while (nodes.hasNext()) {
                     Node node = nodes.nextNode();
                     assert node != null || node == null; // duh!
                     // if (print) printer.printNode(node);
                 }
+            } else {
+                assertTrue(result.getSelectorNames().length != 1);
             }
         }
 


### PR DESCRIPTION
Changed the tests to always check the query via rows and, if there's only one selector in the query, also by nodes. Fix a problem when getting the nodes on some queries.
