### PR TITLE
MODE-2299, MODE-2305 Updated the build system to use a newer version of the BOM (CR13). 

### DIFF
--- a/boms/modeshape-bom-embedded/pom.xml
+++ b/boms/modeshape-bom-embedded/pom.xml
@@ -91,7 +91,7 @@
         <eclipse.emf.ecorexmi.version>2.4.1</eclipse.emf.ecorexmi.version>
         <javaassist.version>3.18.1-GA</javaassist.version>
         <jaudiotagger.version>2.0.3</jaudiotagger.version>
-        <poi.version>3.10-FINAL</poi.version>
+        <poi.version>3.10.1</poi.version>
         <jcommander.version>1.5</jcommander.version>
         <wsdl4j.version>1.6.2</wsdl4j.version>
         <javax.jta.version>1.1</javax.jta.version>

--- a/connectors/modeshape-connector-cmis/pom.xml
+++ b/connectors/modeshape-connector-cmis/pom.xml
@@ -20,9 +20,34 @@
     -->
     <dependencies>
         <dependency>
+            <groupId>org.modeshape</groupId>
+            <artifactId>modeshape-schematic</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.modeshape</groupId>
+            <artifactId>modeshape-jcr-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.chemistry.opencmis</groupId>
+            <artifactId>chemistry-opencmis-client-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.chemistry.opencmis</groupId>
+            <artifactId>chemistry-opencmis-commons-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.chemistry.opencmis</groupId>
+            <artifactId>chemistry-opencmis-commons-impl</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.apache.chemistry.opencmis</groupId>
             <artifactId>chemistry-opencmis-client-impl</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.apache.chemistry.opencmis</groupId>
+            <artifactId>chemistry-opencmis-client-bindings</artifactId>
+        </dependency>
+
         <dependency>
             <groupId>org.apache.chemistry.opencmis</groupId>
             <artifactId>chemistry-opencmis-server-inmemory</artifactId>

--- a/connectors/modeshape-connector-git/pom.xml
+++ b/connectors/modeshape-connector-git/pom.xml
@@ -20,6 +20,14 @@
     -->
     <dependencies>
         <dependency>
+            <groupId>org.modeshape</groupId>
+            <artifactId>modeshape-schematic</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.modeshape</groupId>
+            <artifactId>modeshape-jcr-api</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.eclipse.jgit</groupId>
             <artifactId>org.eclipse.jgit</artifactId>
         </dependency>

--- a/connectors/modeshape-connector-jdbc-metadata/pom.xml
+++ b/connectors/modeshape-connector-jdbc-metadata/pom.xml
@@ -20,6 +20,14 @@
     -->
     <dependencies>
         <dependency>
+            <groupId>org.modeshape</groupId>
+            <artifactId>modeshape-schematic</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.modeshape</groupId>
+            <artifactId>modeshape-jcr-api</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.mchange</groupId>
             <artifactId>c3p0</artifactId>
         </dependency>

--- a/demos/embedded-repo/pom.xml
+++ b/demos/embedded-repo/pom.xml
@@ -22,6 +22,10 @@
         </dependency>
         <dependency>
             <groupId>org.modeshape</groupId>
+            <artifactId>modeshape-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.modeshape</groupId>
             <artifactId>modeshape-jcr</artifactId>
         </dependency>
         <!-- PicketBox (JAAS implementation, configured optionally) -->

--- a/demos/sequencers/pom.xml
+++ b/demos/sequencers/pom.xml
@@ -22,6 +22,10 @@
         </dependency>
         <dependency>
             <groupId>org.modeshape</groupId>
+            <artifactId>modeshape-jcr-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.modeshape</groupId>
             <artifactId>modeshape-jcr</artifactId>
         </dependency>
         <dependency>

--- a/deploy/jbossas/modeshape-jbossas-subsystem/pom.xml
+++ b/deploy/jbossas/modeshape-jbossas-subsystem/pom.xml
@@ -55,7 +55,26 @@
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
         </dependency>
-
     </dependencies>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <executions>
+                    <!--
+                        This particular execution doesn't make sense here because ALL of the
+                        jboss.as dependencies are internal (-redhat suffix and they have some other crazy transitive dependencies)
+
+                        For example: JBoss DMR
+                    -->
+                    <execution>
+                        <id>enforce-direct-dependencies</id>
+                        <phase>non-existant</phase>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/extractors/modeshape-extractor-tika/pom.xml
+++ b/extractors/modeshape-extractor-tika/pom.xml
@@ -18,6 +18,10 @@
         <dependency>
             <groupId>org.apache.tika</groupId>
             <artifactId>tika-parsers</artifactId>
-        </dependency>      
+        </dependency>
+        <dependency>
+            <groupId>org.apache.tika</groupId>
+            <artifactId>tika-core</artifactId>
+        </dependency>
     </dependencies>      
 </project>

--- a/integration/modeshape-jbossas-integration-tests/pom.xml
+++ b/integration/modeshape-jbossas-integration-tests/pom.xml
@@ -36,12 +36,22 @@
         <!-- Import the JCR API (and ModeShape's extension), we use provided scope as the API is included in JBoss AS 7 -->
         <dependency>
             <groupId>org.modeshape</groupId>
+            <artifactId>modeshape-common</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.modeshape</groupId>
             <artifactId>modeshape-jcr</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.modeshape</groupId>
             <artifactId>modeshape-jcr-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <artifactId>jboss-logging</artifactId>
+            <groupId>org.jboss.logging</groupId>
             <scope>provided</scope>
         </dependency>
         <!-- Import the CDI API, we use provided scope as the API is included in JBoss AS 7 -->

--- a/modeshape-client/pom.xml
+++ b/modeshape-client/pom.xml
@@ -102,18 +102,18 @@
                                         <move file="${ant.jdbc.parseDirectory}/META-INF/NOTICE.txt"
                                               tofile="${ant.jdbc.parseDirectory}/META-INF/NOTICE_joda-time.txt"/>
 
-                                        <unzip src="${project.build.directory}/tempjars/httpclient-${version.org.apache.httpcomponents}.jar"
+                                        <unzip src="${project.build.directory}/tempjars/httpclient-${version.org.apache.httpcomponents.httpclient}.jar"
                                                dest="${ant.jdbc.parseDirectory}"/>
-                                        <move file="${ant.jdbc.parseDirectory}/META-INF/LICENSE.txt"
+                                        <move file="${ant.jdbc.parseDirectory}/META-INF/LICENSE"
                                               tofile="${ant.jdbc.parseDirectory}/META-INF/LICENSE_httpclient.txt"/>
-                                        <move file="${ant.jdbc.parseDirectory}/META-INF/NOTICE.txt"
+                                        <move file="${ant.jdbc.parseDirectory}/META-INF/NOTICE"
                                               tofile="${ant.jdbc.parseDirectory}/META-INF/NOTICE_httpclient.txt"/>
 
-                                        <unzip src="${project.build.directory}/tempjars/httpcore-${version.org.apache.httpcomponents}.jar"
+                                        <unzip src="${project.build.directory}/tempjars/httpcore-${version.org.apache.httpcomponents.httpcore}.jar"
                                                dest="${ant.jdbc.parseDirectory}"/>
-                                        <move file="${ant.jdbc.parseDirectory}/META-INF/LICENSE.txt"
+                                        <move file="${ant.jdbc.parseDirectory}/META-INF/LICENSE"
                                               tofile="${ant.jdbc.parseDirectory}/META-INF/LICENSE_httpcore.txt"/>
-                                        <move file="${ant.jdbc.parseDirectory}/META-INF/NOTICE.txt"
+                                        <move file="${ant.jdbc.parseDirectory}/META-INF/NOTICE"
                                               tofile="${ant.jdbc.parseDirectory}/META-INF/NOTICE_httpcore.txt"/>
 
                                         <unzip src="${project.build.directory}/tempjars/jettison-${version.org.codehaus.jettison}.jar"

--- a/modeshape-jca/pom.xml
+++ b/modeshape-jca/pom.xml
@@ -24,6 +24,10 @@
         </dependency>
         <dependency>
             <groupId>org.modeshape</groupId>
+            <artifactId>modeshape-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.modeshape</groupId>
             <artifactId>modeshape-jcr</artifactId>
         </dependency>
         <dependency>

--- a/modeshape-jcr/pom.xml
+++ b/modeshape-jcr/pom.xml
@@ -41,6 +41,11 @@
             <groupId>org.modeshape</groupId>
             <artifactId>modeshape-schematic</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.infinispan</groupId>
+            <artifactId>infinispan-core</artifactId>
+        </dependency>
+
         <!--Event bus clustering. Note the scope in the parent (provided) - this should be optional from a MS perspective -->
         <dependency>
             <groupId>org.jgroups</groupId>
@@ -56,6 +61,11 @@
                     <artifactId>hibernate-search-analyzers</artifactId>
                 </exclusion>
             </exclusions>
+        </dependency>
+        <!--Required by Hibernate Search-->
+        <dependency>
+            <groupId>org.hibernate.common</groupId>
+            <artifactId>hibernate-commons-annotations</artifactId>
         </dependency>
         <!-- Hibernate Search engine (does not use Hibernate Core or JPA!) -->
         <dependency>
@@ -76,49 +86,46 @@
              if MIME type detection is to be disabled in ModeShape. -->
         <dependency>
             <groupId>org.apache.tika</groupId>
-            <artifactId>tika-parsers</artifactId>
-            <exclusions>
-                <!--
-                Exclude a few more things that we don't need for MIME type detection.
-                We do this here instead of in the parent POM because the Tika-based
-                text extractor will want these.
-                -->
-                <exclusion>
-                    <groupId>org.apache.james</groupId>
-                    <artifactId>apache-mime4j-core</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.apache.james</groupId>
-                    <artifactId>apache-mime4j-dom</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.ccil.cowan.tagsoup</groupId>
-                    <artifactId>tagsoup</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>asm</groupId>
-                    <artifactId>asm</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.apache.pdfbox</groupId>
-                    <artifactId>pdfbox</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.googlecode.juniversalchardet</groupId>
-                    <artifactId>juniversalchardet</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.apache.geronimo.specs</groupId>
-                    <artifactId>geronimo-stax-api_1.0_spec</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.googlecode.mp4parser</groupId>
-                    <artifactId>isoparser</artifactId>
-                </exclusion>
-            </exclusions>
+            <artifactId>tika-core</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jboss.spec.javax.servlet</groupId>
+            <artifactId>jboss-servlet-api_3.0_spec</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jboss.spec.javax.security.jacc</groupId>
+            <artifactId>jboss-jacc-api_1.4_spec</artifactId>
+            <scope>provided</scope>
         </dependency>
 
         <!--  Used in tests -->
+
+        <!--
+            not used directly, but
+             a) is a transitive dep of some of the test dependencies and
+             b) the BOM brings it as compile,
+            so we need to overwrite it here
+        -->
+        <dependency>
+            <groupId>commons-codec</groupId>
+            <artifactId>commons-codec</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <!--
+            not used directly, but
+             a) is a transitive dep of some of the test dependencies and
+             b) the BOM brings it as compile,
+            so we need to overwrite it here
+        -->
+        <dependency>
+            <groupId>commons-lang</groupId>
+            <artifactId>commons-lang</artifactId>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>org.modeshape</groupId>
             <artifactId>modeshape-common</artifactId>
@@ -164,22 +171,6 @@
             <groupId>de.flapdoodle.embed</groupId>
             <artifactId>de.flapdoodle.embed.mongo</artifactId>
         </dependency>
-        
-        <dependency>
-            <groupId>org.jboss.spec.javax.servlet</groupId>
-            <artifactId>jboss-servlet-api_3.0_spec</artifactId>
-            <scope>provided</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.jboss.spec.javax.security.jacc</groupId>
-            <artifactId>jboss-jacc-api_1.4_spec</artifactId>
-            <scope>provided</scope>
-        </dependency>
-
-        <!--
-            Testing (note the scope)
-        -->
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
@@ -206,6 +197,14 @@
         <dependency>
             <groupId>org.jboss</groupId>
             <artifactId>jboss-common-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <!--
+            Tika Parsers for testing, so that we test using a Tika environment with all the specific extensions
+        -->
+        <dependency>
+            <groupId>org.apache.tika</groupId>
+            <artifactId>tika-parsers</artifactId>
             <scope>test</scope>
         </dependency>
         <!--
@@ -245,7 +244,7 @@
             <groupId>com.atomikos</groupId>
             <artifactId>transactions-jta</artifactId>
         </dependency>
-        
+
         <!-- Cassandra binary storage -->
         <dependency>
             <groupId>org.apache-extras.cassandra-jdbc</groupId>
@@ -262,7 +261,7 @@
         <dependency>
             <groupId>org.apache.avro</groupId>
             <artifactId>avro</artifactId>
-        </dependency>    
+        </dependency>
     </dependencies>
     <build>
         <resources>

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/value/binary/CassandraBinaryStore.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/value/binary/CassandraBinaryStore.java
@@ -31,7 +31,7 @@ import java.util.Date;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.concurrent.TimeUnit;
-import org.apache.commons.compress.utils.IOUtils;
+import org.modeshape.common.util.IoUtil;
 import org.modeshape.jcr.JcrI18n;
 import org.modeshape.jcr.value.BinaryKey;
 import org.modeshape.jcr.value.BinaryValue;
@@ -300,7 +300,7 @@ public class CassandraBinaryStore extends AbstractBinaryStore {
     private ByteBuffer buffer( InputStream stream ) throws IOException {
         stream.reset();
         ByteArrayOutputStream bout = new ByteArrayOutputStream();
-        IOUtils.copy(stream, bout);
+        IoUtil.write(stream, bout);
         return ByteBuffer.wrap(bout.toByteArray());
     }
 

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/value/binary/FileUrlBinaryValue.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/value/binary/FileUrlBinaryValue.java
@@ -3,7 +3,7 @@ package org.modeshape.jcr.value.binary;
 import java.io.File;
 import java.net.URISyntaxException;
 import java.net.URL;
-import org.apache.http.annotation.ThreadSafe;
+import org.modeshape.common.annotation.ThreadSafe;
 import org.modeshape.common.util.SecureHash;
 import org.modeshape.jcr.mimetype.MimeTypeDetector;
 import org.modeshape.jcr.value.BinaryKey;

--- a/modeshape-jcr/src/test/java/org/modeshape/jcr/value/binary/CassandraBinaryStoreTest.java
+++ b/modeshape-jcr/src/test/java/org/modeshape/jcr/value/binary/CassandraBinaryStoreTest.java
@@ -33,7 +33,6 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import org.apache.cassandra.service.EmbeddedCassandraService;
-import org.apache.commons.io.IOUtils;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Rule;
@@ -41,6 +40,7 @@ import org.junit.Test;
 import org.junit.rules.TestRule;
 import org.modeshape.common.junit.SkipOnOS;
 import org.modeshape.common.junit.SkipTestRule;
+import org.modeshape.common.util.IoUtil;
 import org.modeshape.jcr.ClusteringHelper;
 import org.modeshape.jcr.value.BinaryKey;
 import org.modeshape.jcr.value.BinaryValue;
@@ -128,7 +128,7 @@ public class CassandraBinaryStoreTest {
         assertTrue(stream != null);
 
         ByteArrayOutputStream bout = new ByteArrayOutputStream();
-        IOUtils.copy(stream, bout);
+        IoUtil.write(stream, bout);
 
         String s = new String(bout.toByteArray());
         assertEquals("Binary value", s);

--- a/modeshape-jdbc/pom.xml
+++ b/modeshape-jdbc/pom.xml
@@ -27,6 +27,14 @@
         </dependency>
         <dependency>
             <groupId>org.modeshape</groupId>
+            <artifactId>modeshape-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.modeshape</groupId>
+            <artifactId>modeshape-jcr-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.modeshape</groupId>
             <artifactId>modeshape-jdbc-local</artifactId>
         </dependency>
         <dependency>

--- a/modeshape-parent/pom.xml
+++ b/modeshape-parent/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.jboss.integration-platform</groupId>
         <artifactId>jboss-integration-platform-parent</artifactId>
-        <version>6.0.0.CR10</version>
+        <version>6.0.0.CR13</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
@@ -195,7 +195,7 @@
 
     <properties>
 
-        <version.ip-bom>6.0.0.CR9</version.ip-bom>
+        <version.ip-bom>6.0.0.CR13</version.ip-bom>
 
         <!--
             Versions of COMPILE artifacts *specific* to ModeShape, which do not appear in the BOM or are in conflict
@@ -301,6 +301,7 @@
         <!--Skip long running tests by default-->
         <skipLongRunningTests>true</skipLongRunningTests>
 
+        <!-- PLUGIN BUG: Test dependencies not correctly checked  -->
         <managed-deps.checkProfiles>false</managed-deps.checkProfiles>
     </properties>
 
@@ -939,6 +940,15 @@
      -->
     <dependencyManagement>
         <dependencies>
+            <!--IP-Platform BOM-->
+            <dependency>
+                <groupId>org.jboss.integration-platform</groupId>
+                <artifactId>jboss-integration-platform-bom</artifactId>
+                <version>${version.ip-bom}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+
             <!-- ModeShape subprojects -->
             <dependency>
                 <groupId>org.modeshape</groupId>
@@ -1428,15 +1438,6 @@
                 <type>zip</type>
             </dependency>
 
-            <!--IP-Platform BOM-->
-            <dependency>
-                <groupId>org.jboss.integration-platform</groupId>
-                <artifactId>jboss-integration-platform-bom</artifactId>
-                <version>${version.ip-bom}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-
             <!--Inherited from BOM, but changes the default scope to "test"-->
             <dependency>
                 <groupId>junit</groupId>
@@ -1589,7 +1590,7 @@
             <dependency>
                 <groupId>org.apache.chemistry.opencmis</groupId>
                 <artifactId>chemistry-opencmis-server-inmemory</artifactId>
-                <version>${version.org.apache.chemistry}</version>
+                <version>${version.org.apache.chemistry.opencmis}</version>
                 <type>war</type>
                 <scope>test</scope>
             </dependency>
@@ -1822,11 +1823,7 @@
                 most of them and only keep a few that are for Microsoft Office documents,
                 HTML, XML and PDF. When others are needed, they can simply be added to
                 an application's dependencies.
-
-                Note that 'modeshape-jcr' excludes even more transitive dependencies, since it
-                only uses the MIME type detector functionality, whereas the 'modeshape-extractor-tika'
-                uses everything defined here.
-                -->
+             -->
 
             <!--Defined in BOM but needs custom exclusions-->
             <dependency>
@@ -1922,7 +1919,7 @@
             <dependency>
                 <groupId>org.jboss.jbossts.jta</groupId>
                 <artifactId>narayana-jta</artifactId>
-                <version>${version.org.jboss.jbossts.jbossxts}</version>
+                <version>${version.org.jboss.jbossts.jta}</version>
                 <scope>test</scope>
                 <exclusions>
                     <exclusion>
@@ -2163,6 +2160,14 @@
                 <artifactId>transactions-jta</artifactId>
                 <version>${version.com.atomikos.transactions}</version>
                 <scope>test</scope>
+            </dependency>
+
+            <!-- Mongo DB JDBC driver (changes scope from BOM) -->
+            <dependency>
+                <groupId>org.mongodb</groupId>
+                <artifactId>mongo-java-driver</artifactId>
+                <version>${version.org.mongodb.mongo-java-driver}</version>
+                <scope>provided</scope>
             </dependency>
 
             <!-- Cassandra JDBC driver (changes scope from BOM) -->

--- a/web/modeshape-web-cmis/pom.xml
+++ b/web/modeshape-web-cmis/pom.xml
@@ -18,6 +18,14 @@
     <dependencies>
         <dependency>
             <groupId>org.modeshape</groupId>
+            <artifactId>modeshape-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.modeshape</groupId>
+            <artifactId>modeshape-jcr-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.modeshape</groupId>
             <artifactId>modeshape-web-jcr</artifactId>
         </dependency>
 

--- a/web/modeshape-web-explorer-war/pom.xml
+++ b/web/modeshape-web-explorer-war/pom.xml
@@ -10,7 +10,7 @@
     <artifactId>modeshape-web-explorer-war</artifactId>
     <packaging>war</packaging>
     <name>ModeShape Repository Explorer (Full)</name>
-    <description>ModeShape repository explorer that embeds ModeShape and can be deloyed standalone</description>
+    <description>ModeShape repository explorer that embeds ModeShape and can be deployed standalone</description>
     <url>http://www.modeshape.org</url>
     <dependencies>
         <dependency>

--- a/web/modeshape-web-jcr-rest-client/pom.xml
+++ b/web/modeshape-web-jcr-rest-client/pom.xml
@@ -54,6 +54,10 @@
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpcore</artifactId>
+        </dependency>
         <!-- Testing dependencies-->
         <dependency>
             <groupId>org.modeshape</groupId>

--- a/web/modeshape-web-jcr-rest/pom.xml
+++ b/web/modeshape-web-jcr-rest/pom.xml
@@ -17,6 +17,14 @@
     <dependencies>
         <dependency>
             <groupId>org.modeshape</groupId>
+            <artifactId>modeshape-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.modeshape</groupId>
+            <artifactId>modeshape-jcr-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.modeshape</groupId>
             <artifactId>modeshape-web-jcr</artifactId>
         </dependency>
         <dependency>

--- a/web/modeshape-web-jcr-webdav/pom.xml
+++ b/web/modeshape-web-jcr-webdav/pom.xml
@@ -16,9 +16,16 @@
     <dependencies>
         <dependency>
             <groupId>org.modeshape</groupId>
+            <artifactId>modeshape-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.modeshape</groupId>
+            <artifactId>modeshape-jcr-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.modeshape</groupId>
             <artifactId>modeshape-web-jcr</artifactId>
         </dependency>
-
         <dependency>
             <groupId>org.modeshape</groupId>
             <artifactId>modeshape-webdav</artifactId>


### PR DESCRIPTION
This solves the CVEs around Apache HttpClient and Apache POI.

Since this version of the BOM also uses the transitive dependency check rule, most of the ModeShape modules were changed & fixed to explicitly define used dependencies.
