### PR TITLE
MODE-2325-3.x Fixed the problem of duplicate JARs inside the CMIS webapp and also removed for the EAP version of the webapp the explicit SAAJ jars which might cause problems.

### DIFF
--- a/deploy/jbossas/modeshape-jbossas-cmis-war/pom.xml
+++ b/deploy/jbossas/modeshape-jbossas-cmis-war/pom.xml
@@ -33,6 +33,20 @@
         <dependency>
             <groupId>org.modeshape</groupId>
             <artifactId>modeshape-web-cmis</artifactId>
+            <exclusions>
+                <!--
+                    We should use the SAAJ implementation that's available in the container
+                    see https://bugzilla.redhat.com/show_bug.cgi?id=1148297
+                -->
+                <exclusion>
+                    <groupId>javax.xml.soap</groupId>
+                    <artifactId>saaj-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.sun.xml.messaging.saaj</groupId>
+                    <artifactId>saaj-impl</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
     </dependencies>
     <build>
@@ -42,6 +56,34 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
                     <skip>true</skip>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-war-plugin</artifactId>
+                <configuration>
+                    <overlays>
+                        <overlay>
+                            <!--
+                            The chemistry-opencmis-server-bindings-war war is a transitive dependency of chemistry-opencmis-server-jcr
+                            and contains some libraries (pre-packaged) which are conflicting with some of our explicit versions
+                            So we're excluding them from the WAR
+                            -->
+                            <groupId>org.apache.chemistry.opencmis</groupId>
+                            <artifactId>chemistry-opencmis-server-bindings-war</artifactId>
+                            <excludes>
+                                <exclude>WEB-INF/lib/jaxb-impl-2.1.11.jar</exclude>
+                                <exclude>WEB-INF/lib/jaxb-api-2.1.jar</exclude>
+                                <exclude>WEB-INF/lib/activation-1.1.jar</exclude>
+                                <!--
+                                    We should use the SAAJ implementation that's available in the container
+                                    see https://bugzilla.redhat.com/show_bug.cgi?id=1148297
+                                -->
+                                <exclude>WEB-INF/lib/saaj-api-1.3.jar</exclude>
+                                <exclude>WEB-INF/lib/saaj-impl-1.3.3.jar</exclude>
+                            </excludes>
+                        </overlay>
+                    </overlays>
                 </configuration>
             </plugin>
         </plugins>

--- a/deploy/jbossas/modeshape-jbossas-cmis-war/src/main/webapp/WEB-INF/jboss-deployment-structure.xml
+++ b/deploy/jbossas/modeshape-jbossas-cmis-war/src/main/webapp/WEB-INF/jboss-deployment-structure.xml
@@ -1,6 +1,11 @@
 <jboss-deployment-structure>
     <deployment>
         <dependencies>
+            <!--
+                We should use the SAAJ implementation that's available in the container
+                see https://bugzilla.redhat.com/show_bug.cgi?id=1148297
+            -->
+            <module name="com.sun.xml.messaging.saaj"/>
             <module name="javax.jcr"/>
             <module name="org.modeshape.jcr.api" services="import"/>
             <module name="org.modeshape" services="import"/>

--- a/integration/modeshape-jbossas-integration-tests/src/main/resources/kit/jboss-eap/standalone/configuration/standalone-modeshape.xml
+++ b/integration/modeshape-jbossas-integration-tests/src/main/resources/kit/jboss-eap/standalone/configuration/standalone-modeshape.xml
@@ -471,6 +471,8 @@
             <!--The list of web applications that is packaged inside the kit and should be deployed when the subsystem starts up-->
             <webapp name="modeshape-rest.war"/>
             <webapp name="modeshape-webdav.war"/>
+            <webapp name="modeshape-explorer.war"/>
+            <webapp name="modeshape-cmis.war"/>
 
             <!-- A sample repository that uses the "sample" cache in the "modeshape" container. All content, binary values,
                  and indexes are stored within the server's data directory. This is the simplest way to configure a repository

--- a/web/modeshape-web-cmis-war/pom.xml
+++ b/web/modeshape-web-cmis-war/pom.xml
@@ -33,6 +33,7 @@
         <dependency>
             <groupId>org.apache.chemistry.opencmis</groupId>
             <artifactId>chemistry-opencmis-client-impl</artifactId>
+            <scope>test</scope>
         </dependency>
 
         <dependency>
@@ -41,30 +42,9 @@
         </dependency>
 
         <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>log4j</groupId>
-            <artifactId>log4j</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
         </dependency>
-
-        <dependency>
-            <groupId>com.googlecode.sardine</groupId>
-            <artifactId>sardine</artifactId>
-        </dependency>
-        
     </dependencies>
     <build>
         <finalName>modeshape-cmis</finalName>
@@ -89,6 +69,28 @@
                     <archive>
                         <manifestFile>${project.build.testOutputDirectory}/META-INF/MANIFEST.MF</manifestFile>
                     </archive>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-war-plugin</artifactId>
+                <configuration>
+                    <overlays>
+                        <overlay>
+                            <!--
+                            The chemistry-opencmis-server-bindings-war war is a transitive dependency of chemistry-opencmis-server-jcr
+                            and contains some libraries (pre-packaged) which are conflicting with some of our explicit versions
+                            So we're excluding them from the WAR
+                            -->
+                            <groupId>org.apache.chemistry.opencmis</groupId>
+                            <artifactId>chemistry-opencmis-server-bindings-war</artifactId>
+                            <excludes>
+                                <exclude>WEB-INF/lib/jaxb-impl-2.1.11.jar</exclude>
+                                <exclude>WEB-INF/lib/jaxb-api-2.1.jar</exclude>
+                                <exclude>WEB-INF/lib/activation-1.1.jar</exclude>
+                            </excludes>
+                        </overlay>
+                    </overlays>
                 </configuration>
             </plugin>
             <plugin>

--- a/web/modeshape-web-cmis-war/src/test/java/org/modeshape/cmis/ModeShapeCmisClientTest.java
+++ b/web/modeshape-web-cmis-war/src/test/java/org/modeshape/cmis/ModeShapeCmisClientTest.java
@@ -10,7 +10,6 @@ import org.apache.chemistry.opencmis.commons.SessionParameter;
 import org.apache.chemistry.opencmis.commons.enums.BindingType;
 import org.junit.Before;
 import org.junit.Test;
-import org.w3c.dom.Element;
 
 /**
  * Unit test for CMIS bridge


### PR DESCRIPTION
@rhauch: this should cherry-pick on the 3.8.x branch, but I need to create an additional PR for master with the SAAJ fix.
