### PR TITLE
MODE-2342: Remove lock tokens from sessions upon logout().

### DIFF
--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrLockManager.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrLockManager.java
@@ -64,7 +64,9 @@ class JcrLockManager implements LockManager {
      */
     final void cleanLocks() throws RepositoryException {
         lockManager.cleanLocks(session);
-        lockTokens.clear();
+        for (String token : lockTokens.keySet()) {
+            removeLockToken(token);
+        }
     }
 
     @Override


### PR DESCRIPTION
When a session ends (via logout()) any lock tokens held by that session were left in a state where they couldn't be associated with another session (or removed from the terminated session).

This small change (and illustrative test) changes that behavior in a way that is not inconsistent with the JCR spec and simplifies use of locks in sessions.
