### PR TITLE
MODE-2343 Removed the EVENT related statistics from the JcrObservationManager and fixed the cleanup code required when a session is terminated (either via logout or repository shutdown)

### DIFF
--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrSession.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrSession.java
@@ -1764,8 +1764,7 @@ public class JcrSession implements org.modeshape.jcr.api.Session {
 
     @Override
     public synchronized void logout() {
-        this.isLive = false;
-        cleanLocks();
+        terminate(true);
         try {
             RunningState running = repository.runningState();
             long lifetime = Math.abs(System.nanoTime() - this.nanosCreated);

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrVersionManager.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrVersionManager.java
@@ -721,22 +721,18 @@ final class JcrVersionManager implements org.modeshape.jcr.api.version.VersionMa
 
         // Create a new session in which we'll finish the restore, so this session remains thread-safe ...
         JcrSession restoreSession = session.spawnSession(false);
-        try {
-            Path path = restoreSession.absolutePathFor(absPath);
+        Path path = restoreSession.absolutePathFor(absPath);
 
-            if (failIfNodeAlreadyExists) {
-                try {
-                    AbstractJcrNode existingNode = restoreSession.node(path);
-                    String msg = JcrI18n.unableToRestoreAtAbsPathNodeAlreadyExists.text(absPath, existingNode.key());
-                    throw new VersionException(msg);
-                } catch (PathNotFoundException e) {
-                    // expected
-                }
+        if (failIfNodeAlreadyExists) {
+            try {
+                AbstractJcrNode existingNode = restoreSession.node(path);
+                String msg = JcrI18n.unableToRestoreAtAbsPathNodeAlreadyExists.text(absPath, existingNode.key());
+                throw new VersionException(msg);
+            } catch (PathNotFoundException e) {
+                // expected
             }
-            restore(restoreSession, path, version, null, removeExisting);
-        } finally {
-            restoreSession.logout();
         }
+        restore(restoreSession, path, version, null, removeExisting);
     }
 
     @Override

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrWorkspace.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrWorkspace.java
@@ -521,13 +521,9 @@ class JcrWorkspace implements org.modeshape.jcr.api.Workspace {
         CheckArg.isNotEmpty(destAbsPath, "destAbsPath");
 
         // Create a new JCR session, perform the move, and then save the session ...
-        JcrSession session = this.session.spawnSession(false);
-        try {
-            session.move(srcAbsPath, destAbsPath);
-            session.save();
-        } finally {
-            session.logout();
-        }
+        JcrSession moveSession = this.session.spawnSession(false);
+        moveSession.move(srcAbsPath, destAbsPath);
+        moveSession.save();
     }
 
     @Override
@@ -624,8 +620,7 @@ class JcrWorkspace implements org.modeshape.jcr.api.Workspace {
             try {
                 lock.lock();
                 if (observationManager == null) {
-                    observationManager = new JcrObservationManager(session, repository().changeBus(),
-                                                                   repository().getRepositoryStatistics());
+                    observationManager = new JcrObservationManager(session, repository().changeBus());
                 }
             } finally {
                 lock.unlock();

--- a/modeshape-jcr/src/test/java/org/modeshape/jcr/JcrRepositoryTest.java
+++ b/modeshape-jcr/src/test/java/org/modeshape/jcr/JcrRepositoryTest.java
@@ -1520,6 +1520,26 @@ public class JcrRepositoryTest {
         assertTrue(repository.repositoryCache().lockingUsed());
     }
 
+    @Test
+    @FixFor( "MODE-2343" )
+    public void shouldReleaseObservationManagerThreadsOnLogout() throws Exception {
+        // take a snapshot of the current thread count
+        int oldCount = Thread.activeCount();
+        int sessionsCount = 10;
+        for (int i = 0; i < sessionsCount; ++i) {
+            // create a new session
+            final Session newSession = createSession();
+            // this will spawn a new thread for the observation manager
+            newSession.getWorkspace().getObservationManager();
+            // this will spawn a new thread for the listener
+            addListener(newSession, 0, 0, Event.NODE_ADDED, "/", true, null, null, false);
+            newSession.logout();
+        }
+        // each iteration creates and should release 1 new thread, but activeThreadCount is not accurate, since a thread may
+        // have finished its work but is being kept alive in the thread pool. So we're only approximating the next assert
+        assertTrue("Observation threads not released when session was logged out", Thread.activeCount() - oldCount  < sessionsCount);
+    }
+
     protected void nodeExists( Session session,
                                String parentPath,
                                String childName,


### PR DESCRIPTION
Fixing the cleanup required by `session.logout` exposed another "interesting" issue: internal sessions (created via `session.spawnSession`) should never be logged out because doing do would invalidate their context (and therefore the context of the owner session).
