### PR TITLE
MODE-2350 OracleDdlParser update for multi-op ALTER TABLE

### DIFF
--- a/sequencers/modeshape-sequencer-ddl/src/test/java/org/modeshape/sequencer/ddl/dialect/oracle/OracleDdlParserTest.java
+++ b/sequencers/modeshape-sequencer-ddl/src/test/java/org/modeshape/sequencer/ddl/dialect/oracle/OracleDdlParserTest.java
@@ -113,9 +113,19 @@ public class OracleDdlParserTest extends DdlParserTestHelper {
         // This is a one-off case where there is a custom datatype (i.e. skill_table_type)
         printTest("shouldParseAlterTableADDWithNESTED_TABLE()");
         String content = "ALTER TABLE employees ADD (skills skill_table_type) NESTED TABLE skills STORE AS nested_skill_table;";
-        assertScoreAndParse(content, null, 2); // ALTER TABLE + 1 PROBLEM
+        assertScoreAndParse(content, null, 1); // ALTER TABLE + NO MORE PROBLEM
         AstNode childNode = rootNode.getChildren().get(0);
         assertTrue(hasMixinType(childNode, TYPE_ALTER_TABLE_STATEMENT));
+    }
+
+    @Test
+    public void shouldParseAlterTableMultipleOps() {
+        printTest("shouldParseAlterTableMultipleOps()");
+        String content = "ALTER TABLE employees ADD (add_field NUMBER) MODIFY (mod_field VARCHAR2(10));";
+        assertScoreAndParse(content, null, 1);
+        AstNode childNode = rootNode.getChildren().get(0);
+        assertTrue(hasMixinType(childNode, TYPE_ALTER_TABLE_STATEMENT));
+        assertTrue(childNode.getChildCount() == 2);
     }
 
     @Test


### PR DESCRIPTION
Method parseAlterTableStatement now supports basic chained ADD and/or
MODIFY commands. The existing functionality should be the same (ran
tests without issues).

Will do some more coding later to add complete column definitions as
ALTER TABLE MODIFY currently only detects changes that include datatype
modifications.

 * modified parseAlterTableStatement

 * modified parseColumns and overloaded for compatibility

 * created Oracle local parseColumnDefinition

 * hopefuly not broken things (... much)