### PR TITLE
MODE-2336 Changed the way ModeShape deals with user transactions

### DIFF
--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrRepository.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrRepository.java
@@ -1279,7 +1279,7 @@ public class JcrRepository implements org.modeshape.jcr.api.Repository {
                 case AUTO:
                     break;
             }
-            return new SynchronizedTransactions(txnMgr);
+            return new SynchronizedTransactions(txnMgr, documentStore.localStore().localCache());
         }
 
         /**

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/document/AbstractSessionCache.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/document/AbstractSessionCache.java
@@ -23,7 +23,6 @@ import java.util.UUID;
 import java.util.concurrent.atomic.AtomicReference;
 import javax.transaction.RollbackException;
 import javax.transaction.Status;
-import javax.transaction.Synchronization;
 import javax.transaction.SystemException;
 import javax.transaction.Transaction;
 import org.modeshape.common.annotation.Immutable;
@@ -37,6 +36,7 @@ import org.modeshape.jcr.cache.NodeCache;
 import org.modeshape.jcr.cache.NodeKey;
 import org.modeshape.jcr.cache.SessionCache;
 import org.modeshape.jcr.cache.SessionEnvironment;
+import org.modeshape.jcr.txn.Transactions;
 import org.modeshape.jcr.value.NameFactory;
 import org.modeshape.jcr.value.Path;
 import org.modeshape.jcr.value.PathFactory;
@@ -76,6 +76,7 @@ public abstract class AbstractSessionCache implements SessionCache, DocumentCach
     private final SessionEnvironment sessionContext;
 
     private ExecutionContext context;
+    private AtomicReference<Transactions.TransactionFunction> completeTransactionFunction = new AtomicReference<>();
 
     protected AbstractSessionCache( ExecutionContext context,
                                     WorkspaceCache sharedWorkspaceCache,
@@ -103,28 +104,33 @@ public abstract class AbstractSessionCache implements SessionCache, DocumentCach
     @Override
     public void checkForTransaction() {
         try {
-            Transaction txn = sessionContext.getTransactions().getTransactionManager().getTransaction();
+            Transactions transactions = sessionContext.getTransactions();
+            Transaction txn = transactions.getTransactionManager().getTransaction();
             if (txn != null && txn.getStatus() == Status.STATUS_ACTIVE) {
                 // There is an active transaction, so we need a transaction-specific workspace cache ...
                 workspaceCache.set(sessionContext.getTransactionalWorkspaceCacheFactory()
                                                  .getTransactionalWorkspaceCache(sharedWorkspaceCache));
-                // Register a synchronization to reset this workspace cache when the transaction completes ...
-                txn.registerSynchronization(new Synchronization() {
-
-                    @Override
-                    public void beforeCompletion() {
-                        // do nothing ...
+                // only register the function if there's an active ModeShape transaction because we need to run the
+                // function *only after* ISPN has committed its transaction & updated the cache
+                // if there isn't an active ModeShape transaction, one will become active later during "save"
+                // otherwise, "save" is never called meaning this cache should be discarded
+                Transactions.Transaction modeshapeTx = transactions.currentTransaction();
+                if (modeshapeTx != null) {
+                    if (this.completeTransactionFunction.get() == null) {
+                        // create and register the complete transaction function only once
+                        this.completeTransactionFunction.compareAndSet(null, new Transactions.TransactionFunction() {
+                            @Override
+                            public void execute() {
+                                completeTransaction();
+                            }
+                        });
+                        // always run this function, regardless whether the transaction succeeds or not
+                        modeshapeTx.uponCompletion(this.completeTransactionFunction.get());
                     }
-
-                    @Override
-                    public void afterCompletion( int status ) {
-                        // Tell the session that the transaction has completed ...
-                        completeTransaction();
-                    }
-                });
+                }
             } else {
                 // There is no active transaction, so just use the shared workspace cache ...
-                workspaceCache.set(sharedWorkspaceCache);
+                completeTransaction();
             }
         } catch (SystemException e) {
             logger().error(e, JcrI18n.errorDeterminingCurrentTransactionAssumingNone, workspaceName(), e.getMessage());

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/document/WritableSessionCache.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/document/WritableSessionCache.java
@@ -438,9 +438,9 @@ public class WritableSessionCache extends AbstractSessionCache {
                     logChangesBeingSaved(this.changedNodesInOrder, this.changedNodes, null, null);
                     events = persistChanges(this.changedNodesInOrder, persistedCache);
 
-                    // If there are any binary changes, add a tx synchronization which will update the binary store
+                    // If there are any binary changes, add a function which will update the binary store
                     if (events.hasBinaryChanges()) {
-                        txn.uponCompletion(binaryUsageUpdateFunction(events.usedBinaries(), events.unusedBinaries()));
+                        txn.uponCommit(binaryUsageUpdateFunction(events.usedBinaries(), events.unusedBinaries()));
                     }
 
                     LOGGER.debug("Altered {0} node(s)", numNodes);
@@ -594,13 +594,13 @@ public class WritableSessionCache extends AbstractSessionCache {
                         logChangesBeingSaved(this.changedNodesInOrder, this.changedNodes, that.changedNodesInOrder,
                                              that.changedNodes);
                         events1 = persistChanges(this.changedNodesInOrder, thisPersistedCache);
-                        // If there are any binary changes, add a tx synchronization which will update the binary store
+                        // If there are any binary changes, add a function which will update the binary store
                         if (events1.hasBinaryChanges()) {
-                            txn.uponCompletion(binaryUsageUpdateFunction(events1.usedBinaries(), events1.unusedBinaries()));
+                            txn.uponCommit(binaryUsageUpdateFunction(events1.usedBinaries(), events1.unusedBinaries()));
                         }
                         events2 = that.persistChanges(that.changedNodesInOrder, thatPersistedCache);
                         if (events2.hasBinaryChanges()) {
-                            txn.uponCompletion(binaryUsageUpdateFunction(events2.usedBinaries(), events2.unusedBinaries()));
+                            txn.uponCommit(binaryUsageUpdateFunction(events2.usedBinaries(), events2.unusedBinaries()));
                         }
                     } catch (org.infinispan.util.concurrent.TimeoutException e) {
                         txn.rollback();
@@ -760,13 +760,13 @@ public class WritableSessionCache extends AbstractSessionCache {
                         // Now persist the changes ...
                         logChangesBeingSaved(savedNodesInOrder, this.changedNodes, that.changedNodesInOrder, that.changedNodes);
                         events1 = persistChanges(savedNodesInOrder, thisPersistedCache);
-                        // If there are any binary changes, add a tx synchronization which will update the binary store
+                        // If there are any binary changes, add a function which will update the binary store
                         if (events1.hasBinaryChanges()) {
-                            txn.uponCompletion(binaryUsageUpdateFunction(events1.usedBinaries(), events1.unusedBinaries()));
+                            txn.uponCommit(binaryUsageUpdateFunction(events1.usedBinaries(), events1.unusedBinaries()));
                         }
                         events2 = that.persistChanges(that.changedNodesInOrder, thatPersistedCache);
                         if (events2.hasBinaryChanges()) {
-                            txn.uponCompletion(binaryUsageUpdateFunction(events2.usedBinaries(), events2.unusedBinaries()));
+                            txn.uponCommit(binaryUsageUpdateFunction(events2.usedBinaries(), events2.unusedBinaries()));
                         }
                     } catch (org.infinispan.util.concurrent.TimeoutException e) {
                         txn.rollback();
@@ -1329,7 +1329,7 @@ public class WritableSessionCache extends AbstractSessionCache {
         final BinaryStore binaryStore = getContext().getBinaryStore();
         return new Transactions.TransactionFunction() {
             @Override
-            public void transactionComplete() {
+            public void execute() {
                 if (!usedBinaries.isEmpty()) {
                     if (LOGGER.isDebugEnabled()) {
                         LOGGER.debug("Marking binary values as used: {0}", usedBinaries);

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/federation/ExternalDocumentStore.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/federation/ExternalDocumentStore.java
@@ -25,7 +25,6 @@ import java.util.Map;
 import java.util.Set;
 import javax.transaction.TransactionManager;
 import javax.transaction.xa.XAResource;
-import org.infinispan.schematic.SchematicDb;
 import org.infinispan.schematic.SchematicEntry;
 import org.infinispan.schematic.document.Document;
 import org.infinispan.schematic.document.EditableDocument;
@@ -72,7 +71,6 @@ public class ExternalDocumentStore implements DocumentStore {
      * Creates a new instance with the given connectors and local db.
      * 
      * @param connectors a {@code non-null} {@link Connectors} instance
-     * @param localDb a {@code non-null} {@link SchematicDb} instance
      */
     public ExternalDocumentStore( Connectors connectors) {
         this.connectors = connectors;

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/txn/NoClientTransactions.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/txn/NoClientTransactions.java
@@ -15,11 +15,7 @@
  */
 package org.modeshape.jcr.txn;
 
-import java.util.concurrent.atomic.AtomicInteger;
-import javax.transaction.HeuristicMixedException;
-import javax.transaction.HeuristicRollbackException;
 import javax.transaction.NotSupportedException;
-import javax.transaction.RollbackException;
 import javax.transaction.SystemException;
 import javax.transaction.TransactionManager;
 import org.modeshape.jcr.cache.SessionCache;
@@ -36,7 +32,7 @@ public final class NoClientTransactions extends Transactions {
      * nested simple transactions, so we need effective make sure that only 1 instance of an active transaction can exist at any
      * given time. We cannot use multiple instance because completion functions are instance-dependent
      */
-    protected static final ThreadLocal<NoClientTransaction> ACTIVE_TRANSACTION = new ThreadLocal<NoClientTransaction>();
+    private static final ThreadLocal<NestableThreadLocalTransaction> ACTIVE_TRANSACTION = new ThreadLocal<NestableThreadLocalTransaction>();
 
     /**
      * Creates a new instance passing in the given monitor factory and transaction manager
@@ -48,6 +44,11 @@ public final class NoClientTransactions extends Transactions {
     }
 
     @Override
+    public Transaction currentTransaction() {
+        return ACTIVE_TRANSACTION.get();
+    }
+
+    @Override
     public synchronized Transaction begin() throws NotSupportedException, SystemException {
         if (ACTIVE_TRANSACTION.get() == null) {
             // Start a transaction ...
@@ -55,39 +56,8 @@ public final class NoClientTransactions extends Transactions {
             if (logger.isTraceEnabled()) {
                 logger.trace("Begin transaction {0}", currentTransactionId());
             }
-            ACTIVE_TRANSACTION.set(new NoClientTransaction(txnMgr));
+            ACTIVE_TRANSACTION.set(new NestableThreadLocalTransaction(txnMgr, ACTIVE_TRANSACTION));
         }
-        return ACTIVE_TRANSACTION.get().transactionBegin();
-    }
-
-    protected class NoClientTransaction extends TraceableSimpleTransaction {
-        private final AtomicInteger nestedLevel = new AtomicInteger(0);
-
-        public NoClientTransaction( TransactionManager txnMgr ) {
-            super(txnMgr);
-        }
-
-        @Override
-        public void commit()
-            throws RollbackException, HeuristicMixedException, HeuristicRollbackException, SecurityException,
-            IllegalStateException, SystemException {
-            if (nestedLevel.getAndDecrement() == 1) {
-                NoClientTransactions.ACTIVE_TRANSACTION.remove();
-                super.commit();
-            } else {
-                logger.trace("Not committing transaction because it's nested within another transaction. Only the top level transaction should commit");
-            }
-        }
-
-        @Override
-        public void rollback() throws IllegalStateException, SecurityException, SystemException {
-            NoClientTransactions.ACTIVE_TRANSACTION.remove();
-            super.rollback();
-        }
-
-        protected NoClientTransaction transactionBegin() {
-            nestedLevel.incrementAndGet();
-            return this;
-        }
+        return ACTIVE_TRANSACTION.get().begin();
     }
 }

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/txn/SynchronizedTransactions.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/txn/SynchronizedTransactions.java
@@ -16,8 +16,6 @@
 package org.modeshape.jcr.txn;
 
 import java.util.HashSet;
-import java.util.LinkedList;
-import java.util.List;
 import java.util.Set;
 import javax.transaction.NotSupportedException;
 import javax.transaction.RollbackException;
@@ -25,6 +23,10 @@ import javax.transaction.Status;
 import javax.transaction.Synchronization;
 import javax.transaction.SystemException;
 import javax.transaction.TransactionManager;
+import org.infinispan.Cache;
+import org.infinispan.notifications.Listener;
+import org.infinispan.notifications.cachelistener.annotation.TransactionCompleted;
+import org.infinispan.notifications.cachelistener.event.TransactionCompletedEvent;
 import org.modeshape.jcr.cache.change.ChangeSet;
 import org.modeshape.jcr.cache.document.TransactionalWorkspaceCache;
 import org.modeshape.jcr.cache.document.WorkspaceCache;
@@ -34,42 +36,62 @@ import org.modeshape.jcr.cache.document.WorkspaceCache;
  */
 public final class SynchronizedTransactions extends Transactions {
 
+    private static final ThreadLocal<Transaction> ACTIVE_TRANSACTION = new ThreadLocal<Transaction>();
+
+    @SuppressWarnings( "rawtypes")
+    private final Cache localCache;
+
     /**
      * Creates a new instance which wrapps a transaction manager and monitor factory
-     * 
-     * @param txnMgr a {@link TransactionManager} instance; never null
+     *
+     * @param txnMgr a {@link javax.transaction.TransactionManager} instance; never null
+     * @param localCache a {@link org.infinispan.Cache} instance representing the main ISPN cache
      */
-    public SynchronizedTransactions( TransactionManager txnMgr ) {
+    @SuppressWarnings( "rawtypes")
+    public SynchronizedTransactions( TransactionManager txnMgr, Cache localCache ) {
         super(txnMgr);
+        this.localCache = localCache;
         assert txnMgr != null;
+        assert localCache != null;
+    }
+
+    @Override
+    public Transaction currentTransaction() {
+        return ACTIVE_TRANSACTION.get();
     }
 
     @Override
     public Transaction begin() throws NotSupportedException, SystemException {
+        // check if there isn't an active transaction already
+        Transaction result = ACTIVE_TRANSACTION.get();
+        if (result != null) {
+            // we have an existing transaction so depending on the type we either need to be aware of nesting
+            // or return as-is
+            return result instanceof NestableThreadLocalTransaction ?
+                   ((NestableThreadLocalTransaction) result).begin() :
+                   result;
+        }
+
         // Get the transaction currently associated with this thread (if there is one) ...
         javax.transaction.Transaction txn = txnMgr.getTransaction();
-        Transaction result = null;
         if (txn == null) {
             // There is no transaction, so start one ...
             txnMgr.begin();
             // and return our wrapper ...
-            result = new SimpleTransaction(txnMgr);
+            result = new NestableThreadLocalTransaction(txnMgr, ACTIVE_TRANSACTION).begin();
         } else {
-            // Otherwise, there's already a transaction, so wrap it ...
-            try {
-                result = new SynchronizedTransaction(txnMgr); // may throw RollbackException ...
-            } catch (RollbackException e) {
-                // This transaction has been marked for rollback only ...
-                return new RollbackOnlyTransaction();
-            }
+            // Otherwise, there's already a transaction, so wrap it with a cache listener
+            result = new ListenerTransaction(txnMgr);
         }
+        // Store it
+        ACTIVE_TRANSACTION.set(result);
         if (logger.isTraceEnabled()) {
             if (txn == null) txn = txnMgr.getTransaction();
             assert txn != null;
             final String id = txn.toString();
             // Register a synchronization for this transaction ...
             if (!ACTIVE_TRACE_SYNCHRONIZATIONS.contains(id)) {
-                if (result instanceof SynchronizedTransaction) {
+                if (result instanceof ListenerTransaction) {
                     logger.trace("Found user transaction {0}", txn);
                 } else {
                     logger.trace("Begin transaction {0}", id);
@@ -89,18 +111,18 @@ public final class SynchronizedTransactions extends Transactions {
     }
 
     @Override
-    public void updateCache( WorkspaceCache workspace,
-                             ChangeSet changes,
+    public void updateCache( final WorkspaceCache workspace,
+                             final ChangeSet changes,
                              Transaction transaction ) {
         if (changes != null && !changes.isEmpty()) {
-            if (transaction instanceof SynchronizedTransaction) {
-                // We're in a transaction being managed outside of ModeShape (e.g., container-managed, user-managed,
-                // distributed, etc.) ...
-                // Capture the changes so they can be applied if and only if the transaction is committed succesfully ...
-                SynchronizedTransaction synched = (SynchronizedTransaction)transaction;
-                synched.addUpdate(new WorkspaceUpdates(workspace, changes));
-                // Also, if we're in a transaction then the workspace should be a TransactionalWorkspaceCache, in which case
-                // we should also immediately notify the workspace of the changes ...
+            if (transaction instanceof ListenerTransaction) {
+                // only issue the changes when the transaction is successfully committed
+                transaction.uponCommit(new TransactionFunction() {
+                    @Override
+                    public void execute() {
+                        workspace.changed(changes);
+                    }
+                });
                 if (workspace instanceof TransactionalWorkspaceCache) {
                     ((TransactionalWorkspaceCache)workspace).changedWithinTransaction(changes);
                 }
@@ -108,80 +130,69 @@ public final class SynchronizedTransactions extends Transactions {
                 // The transaction has been marked for rollback only, so no need to even capture these changes because
                 // no changes will ever escape the Session ...
             } else {
-                // We're not in a transaction anymore (the changes were succesfully committed already),
-                // so immediately fire the changes ...
+                // in all other cases we want to dispatch the changes immediately
                 workspace.changed(changes);
             }
         }
     }
 
-    protected class SynchronizedTransaction extends BaseTransaction {
-
-        private final Synchronization synchronization;
-        private final List<WorkspaceUpdates> updates = new LinkedList<WorkspaceUpdates>();
-        private boolean finished = false;
-
-        protected SynchronizedTransaction( TransactionManager txnMgr ) throws SystemException, RollbackException {
+    /**
+     * A transaction implementation that is an Infinispan listener. This is the only reliable way to be able to tell, when
+     * using user transactions, that ISPN has finished updating the data after a "commit" call.
+     */
+    @Listener
+    @SuppressWarnings( "rawtypes")
+    protected final class ListenerTransaction extends BaseTransaction {
+        protected ListenerTransaction( TransactionManager txnMgr ) {
             super(txnMgr);
-            this.synchronization = new Synchronization() {
-
-                @Override
-                public void beforeCompletion() {
-                    // do nothing ...
-                }
-
-                @Override
-                public void afterCompletion( int status ) {
-                    switch (status) {
-                        case Status.STATUS_COMMITTED:
-                            afterCommit();
-                            break;
-                        case Status.STATUS_ROLLEDBACK:
-                            break;
-                        default:
-                            // Don't do anything ...
-                            break;
-                    }
-                }
-            };
-            txnMgr.getTransaction().registerSynchronization(synchronization);
+            localCache.addListener(this);
         }
 
-        protected void addUpdate( WorkspaceUpdates updates ) {
-            assert updates != null;
-            assert !finished;
-            this.updates.add(updates);
+        /**
+         * Method which will be invoked by Infinispan once a tx.commit or tx.rollback has finished processing at a cache-level.
+         * @param event a {@link TransactionCompletedEvent} instance.
+         */
+        @TransactionCompleted
+        public void transactionCompleted( TransactionCompletedEvent event ) {
+            if (!event.isOriginLocal()) {
+                // if the event is not local, we're not interested in processing it
+                return;
+            }
+            try {
+                if (event.isTransactionSuccessful()) {
+                    // run the functions for a successful commit
+                    executeFunctionsUponCommit();
+                }
+                // run all the other (both commit & rollback) functions
+                executeFunctionsUponCompletion();
+            } finally {
+                // always remove the active transaction
+                ACTIVE_TRANSACTION.remove();
+                // after we've been invoked, it means that ISPN has finished processing the transaction, we need to always
+                // remove ourselves from the cache
+                localCache.removeListener(this);
+            }
         }
 
         @Override
-        public void commit() {
-            // This transaction spans more than just our usage, so we don't commit anything here ...
+        public void commit()  {
+            //nothing by default
         }
 
         @Override
         public void rollback() {
-            // This transaction spans more than just our usage, so we don't rollback anything here ...
-        }
-
-        /**
-         * Method called after the transaction has successfully completed via commit (not rollback). Override this method in
-         * subclasses to alter the behavior.
-         */
-        protected void afterCommit() {
-            // Execute the functions
-            executeFunctions();
-
-            // Apply the updates, and do AFTER the monitor is updated ...
-            for (WorkspaceUpdates update : updates) {
-                update.apply();
-            }
-            finished = true;
+            // nothing by default
         }
     }
 
     protected class RollbackOnlyTransaction implements Transaction {
 
         public RollbackOnlyTransaction() {
+        }
+
+        @Override
+        public int status() throws SystemException {
+            return Status.STATUS_UNKNOWN;
         }
 
         @Override
@@ -198,20 +209,10 @@ public final class SynchronizedTransactions extends Transactions {
         public void uponCompletion( TransactionFunction function ) {
             // do nothing
         }
-    }
 
-    protected static final class WorkspaceUpdates {
-        private final WorkspaceCache workspace;
-        private final ChangeSet changes;
-
-        protected WorkspaceUpdates( WorkspaceCache workspace,
-                                    ChangeSet changes ) {
-            this.workspace = workspace;
-            this.changes = changes;
-        }
-
-        protected void apply() {
-            workspace.changed(changes);
+        @Override
+        public void uponCommit( TransactionFunction function ) {
+            // do nothing
         }
     }
 

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/txn/Transactions.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/txn/Transactions.java
@@ -15,15 +15,14 @@
  */
 package org.modeshape.jcr.txn;
 
-import java.util.Collections;
-import java.util.LinkedList;
-import java.util.List;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
 import javax.transaction.HeuristicMixedException;
 import javax.transaction.HeuristicRollbackException;
 import javax.transaction.InvalidTransactionException;
 import javax.transaction.NotSupportedException;
 import javax.transaction.RollbackException;
-import javax.transaction.Status;
 import javax.transaction.Synchronization;
 import javax.transaction.SystemException;
 import javax.transaction.TransactionManager;
@@ -79,7 +78,7 @@ public abstract class Transactions {
 
     /**
      * Determine if the current thread is already associated with an existing transaction.
-     * 
+     *
      * @return true if there is an existing transaction, or false if there is none
      * @throws SystemException If the transaction service fails in an unexpected way.
      */
@@ -89,7 +88,7 @@ public abstract class Transactions {
 
     /**
      * Get a string representation of the current transaction if there already is an existing transaction.
-     * 
+     *
      * @return a string representation of the transaction if there is an existing transaction, or null if there is none
      */
     public String currentTransactionId() {
@@ -103,7 +102,7 @@ public abstract class Transactions {
 
     /**
      * Get the transaction manager.
-     * 
+     *
      * @return the transaction manager
      */
     public TransactionManager getTransactionManager() {
@@ -112,7 +111,7 @@ public abstract class Transactions {
 
     /**
      * Starts a new transaction if one does not already exist, and associate it with the calling thread.
-     * 
+     *
      * @return the ModeShape transaction
      * @throws NotSupportedException If the calling thread is already associated with a transaction, and nested transactions are
      *         not supported.
@@ -121,11 +120,18 @@ public abstract class Transactions {
     public abstract Transaction begin() throws NotSupportedException, SystemException;
 
     /**
+     * Returns a the current transaction, if one exists.
+     *
+     * @return either a {@link org.modeshape.jcr.txn.Transactions.Transaction instance} or {@code null}
+     */
+    public abstract Transaction currentTransaction();
+
+    /**
      * Notify the workspace of the supplied changes, if and when the current transaction is completed. If the current thread is
      * not associated with a transaction when this method is called (e.g., the transaction was started, changes were made, the
      * transaction was committed, and then this method was called), then the workspace is notified immediately. Otherwise, the
      * notifications will be accumulated until the current transaction is committed.
-     * 
+     *
      * @param workspace the workspace to which the changes were made; may not be null
      * @param changes the changes; may be null if there are no changes
      * @param transaction the transaction with which the changes were made; may not be null
@@ -142,7 +148,7 @@ public abstract class Transactions {
 
     /**
      * Suspends the existing transaction, if there is one.
-     * 
+     *
      * @return either the {@link javax.transaction.Transaction} which was suspended or {@code null} if there isn't such a
      *         transaction.
      * @throws SystemException if the operation fails.
@@ -155,7 +161,7 @@ public abstract class Transactions {
     /**
      * Resumes a transaction that was previously suspended via the {@link org.modeshape.jcr.txn.Transactions#suspend()} call. If
      * there is no such transaction or there is another active transaction, nothing happens.
-     * 
+     *
      * @param transaction a {@link javax.transaction.Transaction} instance which was suspended previously or {@code null}
      * @throws javax.transaction.SystemException if the operation fails.
      * @see javax.transaction.TransactionManager#resume(javax.transaction.Transaction)
@@ -179,16 +185,34 @@ public abstract class Transactions {
     public static interface Transaction {
 
         /**
+         * Returns the status associated with the current transaction
+         *
+         * @return an {@code int} code representing a transaction status.
+         * @throws SystemException - If the transaction service fails in an unexpected way.
+         * @see {@link javax.transaction.Status}
+         */
+        int status() throws SystemException;
+
+        /**
          * Register a function that will be called when the current transaction completes, or immediately if there is not
          * currently an active transaction.
-         * 
+         * The function will be executed regardless whether the transaction was committed or rolled back.
+         *
          * @param function the completion function
          */
         void uponCompletion( TransactionFunction function );
 
         /**
+         * Register a function that will be called after the current transaction has been committed successfully, or immediately if there is not
+         * currently an active transaction. If the transaction is rolled back, this function will not be executed.
+         *
+         * @param function the completion function
+         */
+        void uponCommit( TransactionFunction function );
+
+        /**
          * Commit the transaction currently associated with the calling thread.
-         * 
+         *
          * @throws RollbackException If the transaction was marked for rollback only, the transaction is rolled back and this
          *         exception is thrown.
          * @throws IllegalStateException If the calling thread is not associated with a transaction.
@@ -204,9 +228,9 @@ public abstract class Transactions {
 
         /**
          * Rolls back the transaction currently associated with the calling thread.
-         * 
+         *
          * @throws IllegalStateException If the transaction is in a state where it cannot be rolled back. This could be because
-         *         the calling thread is not associated with a transaction, or because it is in the {@link Status#STATUS_PREPARED
+         *         the calling thread is not associated with a transaction, or because it is in the {@link javax.transaction.Status#STATUS_PREPARED
          *         prepared state}.
          * @throws SecurityException If the caller is not allowed to roll back this transaction.
          * @throws SystemException If the transaction service fails in an unexpected way.
@@ -214,41 +238,67 @@ public abstract class Transactions {
         void rollback() throws IllegalStateException, SecurityException, SystemException;
     }
 
+    /**
+     * A function that should be executed in relation to a transaction.
+     */
     public static interface TransactionFunction {
-        void transactionComplete();
+        void execute();
     }
 
     protected abstract class BaseTransaction implements Transaction {
         protected final TransactionManager txnMgr;
-        private List<TransactionFunction> functions;
+        private Set<TransactionFunction> uponCompletionFunctions;
+        private Set<TransactionFunction> uponCommitFunctions;
 
         protected BaseTransaction( TransactionManager txnMgr ) {
             this.txnMgr = txnMgr;
         }
 
-        protected void executeFunctions() {
-            // Execute the functions immediately ...
-            if (functions != null) {
-                for (TransactionFunction function : functions) {
-                    function.transactionComplete();
-                }
+        @Override
+        public void uponCompletion( TransactionFunction function ) {
+            if (uponCompletionFunctions == null) {
+                uponCompletionFunctions = new LinkedHashSet<>();
             }
+            uponCompletionFunctions.add(function);
         }
 
         @Override
-        public void uponCompletion( TransactionFunction function ) {
-            if (functions == null) {
-                functions = Collections.singletonList(function);
-            } else {
-                if (functions.size() == 1) {
-                    functions = new LinkedList<TransactionFunction>(functions);
-                }
-                functions.add(function);
+        public void uponCommit( TransactionFunction function ) {
+            if (uponCommitFunctions == null) {
+                uponCommitFunctions = new LinkedHashSet<>();
             }
+            uponCommitFunctions.add(function);
+        }
+
+        @Override
+        public int status() throws SystemException {
+            return txnMgr.getStatus();
+        }
+
+        protected void executeFunctionsUponCompletion() {
+            if (uponCompletionFunctions != null) {
+                executeFunctions(uponCompletionFunctions);
+                uponCompletionFunctions = null;
+            }
+        }
+
+        protected void executeFunctionsUponCommit() {
+            if (uponCommitFunctions != null) {
+                executeFunctions(uponCommitFunctions);
+                uponCommitFunctions = null;
+            }
+        }
+
+        protected void executeFunctions( Set<TransactionFunction> functions ) {
+            // Execute the functions immediately ...
+            for (TransactionFunction function : functions) {
+                function.execute();
+            }
+            functions.clear();
         }
     }
 
-    protected class SimpleTransaction extends BaseTransaction {
+    protected abstract class SimpleTransaction extends BaseTransaction {
 
         protected SimpleTransaction( TransactionManager txnMgr ) {
             super(txnMgr);
@@ -256,21 +306,25 @@ public abstract class Transactions {
 
         @Override
         public void rollback() throws IllegalStateException, SecurityException, SystemException {
+            // rollback first
             txnMgr.rollback();
+            // if rollback succeeded execute the functions
+            executeFunctionsUponCompletion();
         }
 
         @Override
         public void commit()
-            throws RollbackException, HeuristicMixedException, HeuristicRollbackException, SecurityException,
-            IllegalStateException, SystemException {
+                throws RollbackException, HeuristicMixedException, HeuristicRollbackException, SecurityException,
+                       IllegalStateException, SystemException {
+            // commit first
             txnMgr.commit();
-
-            // Execute the functions immediately ...
-            executeFunctions();
+            // if the above succeeded, ISPN should have been updated so execute the functions
+            executeFunctionsUponCommit();
+            executeFunctionsUponCompletion();
         }
     }
 
-    protected class TraceableSimpleTransaction extends SimpleTransaction {
+    protected abstract class TraceableSimpleTransaction extends SimpleTransaction {
 
         protected TraceableSimpleTransaction( TransactionManager txnMgr ) {
             super(txnMgr);
@@ -286,8 +340,8 @@ public abstract class Transactions {
 
         @Override
         public void commit()
-            throws RollbackException, HeuristicMixedException, HeuristicRollbackException, SecurityException,
-            IllegalStateException, SystemException {
+                throws RollbackException, HeuristicMixedException, HeuristicRollbackException, SecurityException,
+                       IllegalStateException, SystemException {
             if (logger.isTraceEnabled()) {
                 String id = currentTransactionId();
                 super.commit();
@@ -298,4 +352,42 @@ public abstract class Transactions {
         }
     }
 
+    protected class NestableThreadLocalTransaction extends TraceableSimpleTransaction {
+        private AtomicInteger nestedLevel = new AtomicInteger(0);
+        private ThreadLocal<? extends Transaction> txReference;
+
+        protected NestableThreadLocalTransaction( TransactionManager txnMgr, ThreadLocal<? extends Transaction> txReference) {
+            super(txnMgr);
+            this.txReference = txReference;
+        }
+
+        @Override
+        public void rollback() throws IllegalStateException, SecurityException, SystemException {
+            // cleanup first, regardless of what happens
+            cleanup();
+            super.rollback();
+        }
+
+        @Override
+        public void commit() throws RollbackException, HeuristicMixedException, HeuristicRollbackException, SecurityException, IllegalStateException, SystemException {
+            if (nestedLevel.getAndDecrement() == 1) {
+                // cleanup first, regardless of what happens
+                cleanup();
+                super.commit();
+            } else {
+                logger.trace("Not committing transaction because it's nested within another transaction. Only the top level transaction should commit");
+            }
+        }
+
+        protected void cleanup() {
+            txReference.remove();
+            txReference = null;
+            nestedLevel = null;
+        }
+
+        protected NestableThreadLocalTransaction begin() {
+            nestedLevel.incrementAndGet();
+            return this;
+        }
+    }
 }

--- a/modeshape-jcr/src/test/java/org/modeshape/jcr/JcrRepositoryTest.java
+++ b/modeshape-jcr/src/test/java/org/modeshape/jcr/JcrRepositoryTest.java
@@ -1067,7 +1067,7 @@ public class JcrRepositoryTest {
         new Thread(worker2).start();
 
         // Wait for the threads to complete ...
-        completionBarrier.await();
+        completionBarrier.await(10, TimeUnit.SECONDS);
     }
 
     protected abstract class SessionWorker implements Runnable {


### PR DESCRIPTION
Instead of using synchronizers which cannot be ordered with respects to ISPN's synchronizer that actually persists the data, ModeShape now uses an Infinispan transaction listener which will only be called once ISPN has processed the transaction.
This is the only way that ModeShape can be consistently notified only after ISPN has finished processing a transaction.
