### PR TITLE
MODE-2341 Fixed the reindexing behavior

### DIFF
--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrRepository.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrRepository.java
@@ -1293,7 +1293,6 @@ public class JcrRepository implements org.modeshape.jcr.api.Repository {
             try {
                 refreshWorkspaces();
 
-                this.repositoryQueryManager.initialize();
                 this.sequencers.initialize();
 
                 // import the preconfigured node types before the initial content, in case the latter use custom types
@@ -1317,6 +1316,10 @@ public class JcrRepository implements org.modeshape.jcr.api.Repository {
 
                 // connectors must be initialized after initial content because that can have an influence on projections
                 this.connectors.initialize();
+
+                // only mark the query manager as initialed *after* all the other components have finished initializing
+                // otherwise we risk getting indexing/scanning events for components which have not finished initializing (e.g. connectors)
+                this.repositoryQueryManager.initialize();
 
                 // Now record in the content that we're finished initializing the repository.
                 // This will commit the startup transaction.

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/RepositoryQueryManager.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/RepositoryQueryManager.java
@@ -93,10 +93,12 @@ class RepositoryQueryManager implements ChangeSetListener {
 
     @Override
     public synchronized void notify( ChangeSet changeSet ) {
-        boolean scanRequired = this.toBeScanned.add(this.indexManager.notify(changeSet));
-        if (scanRequired && initialized.get()) {
-            // It's initialized, so we have to call it ...
-            reindexIfNeeded();
+        if (initialized.get()) {
+            boolean scanRequired = this.toBeScanned.add(this.indexManager.notify(changeSet));
+            if (scanRequired) {
+                // It's initialized, so we have to call it ...
+                reindexIfNeeded();
+            }
         }
         // If not yet initialized, the "reindexIfNeeded" method will be called by the JcrRepository.
     }

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/index/local/LocalIndexProvider.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/index/local/LocalIndexProvider.java
@@ -173,26 +173,26 @@ public class LocalIndexProvider extends IndexProvider {
         ManagedLocalIndexBuilder<?> builder = ManagedLocalIndexBuilder.create(context(), defn, nodeTypesSupplier, matcher);
         logger().debug("Index provider '{0}' is creating index in workspace '{1}': {2}", getName(), workspaceName, defn);
         final ManagedLocalIndex index = builder.build(workspaceName, db);
-        if (index.isNew()) {
-            feedback.scan(workspaceName, new IndexFeedback.IndexingCallback() {
+        // this is a new [index definition, workspace] pair so we should always scan
+        feedback.scan(workspaceName, new IndexFeedback.IndexingCallback() {
 
-                @SuppressWarnings( "synthetic-access" )
-                @Override
-                public void beforeIndexing() {
-                    logger().debug("Disabling index '{0}' from provider '{1}' in workspace '{2}' while it is reindexed. It will not be used in queries until reindexing has completed",
-                                   defn.getName(), defn.getProviderName(), workspaceName);
-                    index.enable(false);
-                }
+            @SuppressWarnings( "synthetic-access" )
+            @Override
+            public void beforeIndexing() {
+                logger().debug(
+                        "Disabling index '{0}' from provider '{1}' in workspace '{2}' while it is reindexed. It will not be used in queries until reindexing has completed",
+                        defn.getName(), defn.getProviderName(), workspaceName);
+                index.enable(false);
+            }
 
-                @SuppressWarnings( "synthetic-access" )
-                @Override
-                public void afterIndexing() {
-                    index.enable(true);
-                    logger().debug("Enabled index '{0}' from provider '{1}' in workspace '{2}' after reindexing has completed",
-                                   defn.getName(), defn.getProviderName(), workspaceName);
-                }
-            });
-        }
+            @SuppressWarnings( "synthetic-access" )
+            @Override
+            public void afterIndexing() {
+                index.enable(true);
+                logger().debug("Enabled index '{0}' from provider '{1}' in workspace '{2}' after reindexing has completed",
+                               defn.getName(), defn.getProviderName(), workspaceName);
+            }
+        });
         return index;
     }
 

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/spi/index/provider/IndexProvider.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/spi/index/provider/IndexProvider.java
@@ -130,7 +130,7 @@ public abstract class IndexProvider {
     private String name;
 
     /**
-     * The execution context, seet via reflection
+     * The execution context, set via reflection
      */
     private ExecutionContext context;
 

--- a/modeshape-jcr/src/test/resources/config/repo-config-persistent-cache-fs-connector2.json
+++ b/modeshape-jcr/src/test/resources/config/repo-config-persistent-cache-fs-connector2.json
@@ -24,5 +24,20 @@
                 "default:/fs2 => /"
             ]
         }
+    },
+    "indexProviders" : {
+        "local" : {
+            "classname" : "org.modeshape.jcr.index.local.LocalIndexProvider",
+            "directory" : "target/startup_test_indexes"
+        }
+    },
+    "indexes" : {
+        "nodesByAuthor": {
+            "kind": "value",
+            "provider": "local",
+            "nodeType": "nt:hierarchyNode",
+            "columns": "jcr:createdBy(STRING)",
+            "description": "Indexing nodes by user name"
+        }
     }
 }


### PR DESCRIPTION
This PR contains 2 fixes:
- the `RepositoryQueryManager` should not be marked as initialized until all components (including connectors) have finished initializing
- the `LocalIndexProvider` should always scan whenever `createIndex` is called because that means the index definition is new for the given workspace
