### PR TITLE
MODE-2380 Fixed the dependencies of the modeshape-unit-test module:

### DIFF
--- a/modeshape-unit-test/pom.xml
+++ b/modeshape-unit-test/pom.xml
@@ -42,6 +42,7 @@
         <dependency>
             <groupId>org.modeshape</groupId>
             <artifactId>modeshape-common</artifactId>
+            <scope>compile</scope>
             <type>test-jar</type>
         </dependency>
         <dependency>
@@ -53,14 +54,10 @@
         <dependency>
             <groupId>org.infinispan</groupId>
             <artifactId>infinispan-core</artifactId>
+            <scope>compile</scope>
             <type>test-jar</type>
         </dependency>
-        <dependency>
-            <groupId>org.modeshape</groupId>
-            <artifactId>modeshape-jdbc-local</artifactId>
-            <type>test-jar</type>
-        </dependency>
-
+        
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>


### PR DESCRIPTION
they must have the compile scope for Maven to transitively resolve them and removed the `modeshape-jdbc-local` dependency since it doesn't make sense for this module.
