### PR TITLE
MODE-2388: Enhance DDL Sequencer to account for array data types

### DIFF
--- a/sequencers/modeshape-sequencer-ddl/src/main/java/org/modeshape/sequencer/ddl/DdlConstants.java
+++ b/sequencers/modeshape-sequencer-ddl/src/main/java/org/modeshape/sequencer/ddl/DdlConstants.java
@@ -36,6 +36,8 @@ public interface DdlConstants {
     public static final String L_PAREN = "(";
     public static final String R_PAREN = ")";
     public static final String L_SQUOTE = "’";
+    public static final String LS_BRACE = "[";
+    public static final String RS_BRACE = "]";
 
     /*
      * Table Constraint ID's

--- a/sequencers/modeshape-sequencer-ddl/src/main/java/org/modeshape/sequencer/ddl/StandardDdlLexicon.java
+++ b/sequencers/modeshape-sequencer-ddl/src/main/java/org/modeshape/sequencer/ddl/StandardDdlLexicon.java
@@ -151,6 +151,7 @@ public class StandardDdlLexicon {
     public static final String DATATYPE_LENGTH = PREFIX + ":datatypeLength";
     public static final String DATATYPE_PRECISION = PREFIX + ":datatypePrecision";
     public static final String DATATYPE_SCALE = PREFIX + ":datatypeScale";
+    public static final String DATATYPE_ARRAY_DIMENSIONS = PREFIX + ":datatypeArrayDimensions";
     public static final String DEFAULT_VALUE = PREFIX + ":defaultValue";
     public static final String DEFAULT_PRECISION = PREFIX + ":defaultprecision";
     public static final String VALUE = PREFIX + ":value";

--- a/sequencers/modeshape-sequencer-ddl/src/main/java/org/modeshape/sequencer/ddl/datatype/DataType.java
+++ b/sequencers/modeshape-sequencer-ddl/src/main/java/org/modeshape/sequencer/ddl/datatype/DataType.java
@@ -25,11 +25,13 @@ public class DataType {
     public static final long DEFAULT_LENGTH = -1;
     public static final int DEFAULT_PRECISION = -1;
     public static final int DEFAULT_SCALE = -1;
+    public static final int DEFAULT_ARRAY_DIMENSIONS = 0;
 
     private String name;
     private long length = DEFAULT_LENGTH;
     private int precision = DEFAULT_PRECISION;
     private int scale = DEFAULT_SCALE;
+    private int arrayDimensions = DEFAULT_ARRAY_DIMENSIONS;
 
     /**
      * The statement source.
@@ -93,6 +95,19 @@ public class DataType {
         this.scale = value;
     }
 
+    /**
+     * @return array dimensions
+     */
+    public int getArrayDimensions() {
+        return arrayDimensions;
+    }
+
+    /**
+     * @param arrayDimensions
+     */
+    public void setArrayDimensions(int arrayDimensions) {
+        this.arrayDimensions = arrayDimensions;
+    }
     @Override
     public String toString() {
         StringBuilder result = new StringBuilder(100);

--- a/sequencers/modeshape-sequencer-ddl/src/main/java/org/modeshape/sequencer/ddl/datatype/DataTypeParser.java
+++ b/sequencers/modeshape-sequencer-ddl/src/main/java/org/modeshape/sequencer/ddl/datatype/DataTypeParser.java
@@ -15,6 +15,7 @@
  */
 package org.modeshape.sequencer.ddl.datatype;
 
+import static org.modeshape.sequencer.ddl.StandardDdlLexicon.DATATYPE_ARRAY_DIMENSIONS;
 import static org.modeshape.sequencer.ddl.StandardDdlLexicon.DATATYPE_LENGTH;
 import static org.modeshape.sequencer.ddl.StandardDdlLexicon.DATATYPE_NAME;
 import static org.modeshape.sequencer.ddl.StandardDdlLexicon.DATATYPE_PRECISION;
@@ -938,6 +939,9 @@ public class DataTypeParser implements DdlConstants {
         }
         if (datatype.getScale() >= 0) {
             columnNode.setProperty(DATATYPE_SCALE, datatype.getScale());
+        }
+        if (datatype.getArrayDimensions() >= 0) {
+            columnNode.setProperty(DATATYPE_ARRAY_DIMENSIONS, datatype.getArrayDimensions());
         }
     }
 }

--- a/sequencers/modeshape-sequencer-ddl/src/main/java/org/modeshape/sequencer/ddl/dialect/teiid/CreateProcedureParser.java
+++ b/sequencers/modeshape-sequencer-ddl/src/main/java/org/modeshape/sequencer/ddl/dialect/teiid/CreateProcedureParser.java
@@ -15,6 +15,7 @@
  */
 package org.modeshape.sequencer.ddl.dialect.teiid;
 
+import static org.modeshape.sequencer.ddl.StandardDdlLexicon.DATATYPE_ARRAY_DIMENSIONS;
 import static org.modeshape.sequencer.ddl.StandardDdlLexicon.DATATYPE_LENGTH;
 import static org.modeshape.sequencer.ddl.StandardDdlLexicon.DATATYPE_NAME;
 import static org.modeshape.sequencer.ddl.StandardDdlLexicon.DATATYPE_PRECISION;
@@ -316,6 +317,10 @@ final class CreateProcedureParser extends StatementParser {
 
                 if (dataType.getScale() != DataType.DEFAULT_SCALE) {
                     resultNode.setProperty(DATATYPE_SCALE, dataType.getScale());
+                }
+
+                if (dataType.getArrayDimensions() != DataType.DEFAULT_ARRAY_DIMENSIONS) {
+                    resultNode.setProperty(DATATYPE_ARRAY_DIMENSIONS, dataType.getArrayDimensions());
                 }
             }
 

--- a/sequencers/modeshape-sequencer-ddl/src/main/java/org/modeshape/sequencer/ddl/dialect/teiid/TeiidDataTypeParser.java
+++ b/sequencers/modeshape-sequencer-ddl/src/main/java/org/modeshape/sequencer/ddl/dialect/teiid/TeiidDataTypeParser.java
@@ -45,6 +45,7 @@ class TeiidDataTypeParser extends DataTypeParser {
         TeiidDataType teiidType = null;
         long length = DataType.DEFAULT_LENGTH;
         int[] precisionScale = DEFAULT_PRECISION_SCALE;
+        int arrayDimensions = DataType.DEFAULT_ARRAY_DIMENSIONS;
 
         for (final TeiidDataType teiidDataType : TeiidDataType.values()) {
             if (tokens.canConsume(teiidDataType.toDdl())) {
@@ -106,6 +107,12 @@ class TeiidDataTypeParser extends DataTypeParser {
                     type.setScale(precisionScale[1]);
                 }
             }
+            // Array dimensions of the data type
+            while (tokens.canConsume(LS_BRACE)) {
+                tokens.consume(RS_BRACE);
+                arrayDimensions++;
+            }
+            type.setArrayDimensions(arrayDimensions);
 
             return type;
         }

--- a/sequencers/modeshape-sequencer-ddl/src/main/resources/org/modeshape/sequencer/ddl/dialect/teiid/TeiidDdl.cnd
+++ b/sequencers/modeshape-sequencer-ddl/src/main/resources/org/modeshape/sequencer/ddl/dialect/teiid/TeiidDdl.cnd
@@ -53,6 +53,7 @@
 
 [teiidddl:tableElement] > ddl:columnDefinition, mix:referenceable mixin
 - teiidddl:autoIncrement (boolean) = 'false'
+- teiidddl:arrayDimensions (long)
 - ddl:nullable (string) = 'NULL' mandatory autocreated < 'NULL', 'NOT NULL'
 + * (ddl:statementOption) = ddl:statementOption 
 


### PR DESCRIPTION
- To support Teiid BNF, allow parsing of array data types, eg. integer[],
  and store the number of dimensions in the arrayDimensions property.
