### PR TITLE
MODE-2395 - Added Arquillian integration test to reporduce the issue described in MODE-2395

### DIFF
--- a/integration/modeshape-jbossas-integration-tests/src/main/java/org/modeshape/test/integration/StatelessCMTBean.java
+++ b/integration/modeshape-jbossas-integration-tests/src/main/java/org/modeshape/test/integration/StatelessCMTBean.java
@@ -1,0 +1,56 @@
+package org.modeshape.test.integration;
+
+import javax.ejb.Asynchronous;
+import javax.ejb.Stateless;
+import javax.inject.Inject;
+import javax.jcr.Node;
+import javax.jcr.RepositoryException;
+import javax.jcr.Session;
+import java.util.UUID;
+
+/**
+ * A stateless EJB that uses container managed transactions
+ *
+ * @author Richard Lucas
+ */
+@Stateless
+public class StatelessCMTBean {
+
+    @Inject
+    Session session;
+
+    /**
+     * Creates a new node under the root node
+     *
+     * @return the newly created node
+     * @throws javax.jcr.RepositoryException
+     */
+    public Node createNode() throws RepositoryException {
+        String uuid = UUID.randomUUID().toString();
+        Node root = session.getRootNode();
+        Node node = root.addNode(uuid);
+        node.setProperty("testProperty", "test");
+        session.save();
+        System.out.println("Created node " + node.getPath() + " with session " + session);
+        return node;
+    }
+
+    /**
+     * Updates the node at the given node path. Sets the 'testProperty' to test2. The update is performed asynchronously in a separate thread.
+     *
+     * @param nodePath
+     *         the path of node being updated
+     * @throws javax.jcr.RepositoryException
+     */
+    @Asynchronous
+    public void update(String nodePath) throws RepositoryException {
+        System.out.println("Updating node ...");
+
+        Node node = session.getNode(nodePath);
+        node.setProperty("testProperty", "test2");
+        node.getSession().save();
+        System.out.println(node);
+        System.out.println("Updated node new testPropertyValue = " + node.getProperty("testProperty").getString());
+
+    }
+}

--- a/integration/modeshape-jbossas-integration-tests/src/test/java/org/modeshape/test/integration/StatelessAsyncBeanIntegrationTest.java
+++ b/integration/modeshape-jbossas-integration-tests/src/test/java/org/modeshape/test/integration/StatelessAsyncBeanIntegrationTest.java
@@ -1,0 +1,84 @@
+/*
+ * ModeShape (http://www.modeshape.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.modeshape.test.integration;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.ArchivePaths;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import javax.inject.Inject;
+import javax.jcr.Node;
+import javax.jcr.Session;
+import java.io.File;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Integration test that creates a node using a Stateless EJB and updates it using a Stateless Async EJB Method.
+ *
+ * @author Richard Lucas
+ */
+@RunWith(Arquillian.class)
+public class StatelessAsyncBeanIntegrationTest {
+
+    @Deployment
+    public static WebArchive createWarDeployment() {
+        WebArchive archive = ShrinkWrap.create(WebArchive.class, "async-war-test.war").addAsWebInfResource(EmptyAsset.INSTANCE, ArchivePaths.create("beans.xml")).addClass(CDIRepositoryProvider.class)
+                .addClass(StatelessCMTBean.class);
+
+        // Add our custom Manifest, which has the additional Dependencies entry ...
+        archive.setManifest(new File("src/main/webapp/META-INF/MANIFEST.MF"));
+        return archive;
+    }
+
+    @Inject
+    private StatelessCMTBean statelessCMTBean;
+
+    @Inject
+    Session session;
+
+    // This test passes when run against modeshape 4.0.0.Final but fails when run against 4.1.0.Final
+    @Test
+    public void testAsyncUpdate() throws Exception {
+        // Create a node
+        statelessCMTBean.createNode(); // If you comment out this line the test passes
+
+        // Create a second node and update it asynchronously
+        Node node = statelessCMTBean.createNode();
+        statelessCMTBean.update(node.getPath());
+
+        // Give the async method plenty of time to complete
+        for (int i = 0; i < 5; i++) {
+            System.out.println("testProperty = " + session.getNode(node.getPath()).getProperty("testProperty").getString());
+            try {
+                Thread.sleep(500);
+            } catch (InterruptedException e) {
+                e.printStackTrace();
+            }
+        }
+
+        // Validate the node was updated
+        String finalTestProperty = session.getNode(node.getPath()).getProperty("testProperty").getString();
+        System.out.println("Final testProperty = " + finalTestProperty);
+        assertEquals(finalTestProperty, "test2");
+
+    }
+}


### PR DESCRIPTION
Added Arquillian test to recreate the issue described in MODE-2395. When running the test please ensure that standalone-modeshape.xml has the following Infinispan cache configuration:

<local-cache name="sample">
    <locking isolation="READ_COMMITTED" striping="false"/>
    <transaction mode="NON_XA" locking="PESSIMISTIC"/>
    <file-store passivation="false" purge="false" path="modeshape/store/sample"/>
</local-cache>
