### PR TITLE
MODE-2396: Fixes Teiid DDL sequencer logic for creating views

### DIFF
--- a/sequencers/modeshape-sequencer-ddl/src/main/java/org/modeshape/sequencer/ddl/dialect/teiid/CreateTableParser.java
+++ b/sequencers/modeshape-sequencer-ddl/src/main/java/org/modeshape/sequencer/ddl/dialect/teiid/CreateTableParser.java
@@ -167,17 +167,15 @@ final class CreateTableParser extends StatementParser {
             stmt = DdlStatement.CREATE_FOREIGN_TABLE;
             view = false;
             schemaElementType = SchemaElementType.FOREIGN;
-        } else if (tokens.canConsume(DdlStatement.CREATE_VIRTUAL_VIEW.tokens())) {
-            stmt = DdlStatement.CREATE_VIRTUAL_VIEW;
-            schemaElementType = SchemaElementType.VIRTUAL;
-        } else if (tokens.canConsume(DdlStatement.CREATE_VIEW.tokens())) {
+        } else if (tokens.canConsume(DdlStatement.CREATE_VIEW.tokens()) ||
+                        tokens.canConsume(DdlStatement.CREATE_VIRTUAL_VIEW.tokens())) {
             stmt = DdlStatement.CREATE_VIEW;
-            schemaElementType = SchemaElementType.FOREIGN;
+            schemaElementType = SchemaElementType.VIRTUAL;
         } else {
-            throw new TeiidDdlParsingException(tokens, "Unparsable create table statement");
+            throw new TeiidDdlParsingException(tokens, "Unparsable create table or view statement");
         }
 
-        assert (stmt != null) : "Create table statement is null";
+        assert (stmt != null) : "Create table or view statement is null";
 
         // parse identifier
         final String id = parseIdentifier(tokens);

--- a/sequencers/modeshape-sequencer-ddl/src/test/java/org/modeshape/sequencer/ddl/dialect/teiid/CreateTableParserTest.java
+++ b/sequencers/modeshape-sequencer-ddl/src/test/java/org/modeshape/sequencer/ddl/dialect/teiid/CreateTableParserTest.java
@@ -621,7 +621,7 @@ public class CreateTableParserTest extends TeiidDdlTest {
         final AstNode viewNode = this.parser.parse(getTokens(content), this.rootNode);
         assertThat(viewNode.getName(), is("V1"));
         assertMixinType(viewNode, TeiidDdlLexicon.CreateTable.VIEW_STATEMENT);
-        assertProperty(viewNode, TeiidDdlLexicon.SchemaElement.TYPE, SchemaElementType.FOREIGN.toDdl());
+        assertProperty(viewNode, TeiidDdlLexicon.SchemaElement.TYPE, SchemaElementType.VIRTUAL.toDdl());
         assertProperty(viewNode, TeiidDdlLexicon.CreateTable.QUERY_EXPRESSION, "SELECT * FROM PM1.G1");
 
         // columns
@@ -641,7 +641,7 @@ public class CreateTableParserTest extends TeiidDdlTest {
         final AstNode viewNode = this.parser.parse(getTokens(content), this.rootNode);
         assertThat(viewNode.getName(), is("G1"));
         assertMixinType(viewNode, TeiidDdlLexicon.CreateTable.VIEW_STATEMENT);
-        assertProperty(viewNode, TeiidDdlLexicon.SchemaElement.TYPE, SchemaElementType.FOREIGN.toDdl());
+        assertProperty(viewNode, TeiidDdlLexicon.SchemaElement.TYPE, SchemaElementType.VIRTUAL.toDdl());
         assertProperty(viewNode, TeiidDdlLexicon.CreateTable.QUERY_EXPRESSION, "select e1, e2 from foo.bar");
 
         // columns
@@ -691,7 +691,7 @@ public class CreateTableParserTest extends TeiidDdlTest {
         final AstNode viewNode = this.parser.parse(getTokens(content), this.rootNode);
         assertThat(viewNode.getName(), is("FOO"));
         assertMixinType(viewNode, TeiidDdlLexicon.CreateTable.VIEW_STATEMENT);
-        assertProperty(viewNode, TeiidDdlLexicon.SchemaElement.TYPE, SchemaElementType.FOREIGN.toDdl());
+        assertProperty(viewNode, TeiidDdlLexicon.SchemaElement.TYPE, SchemaElementType.VIRTUAL.toDdl());
 
         // columns
         assertThat(viewNode.getChildren(TeiidDdlLexicon.CreateTable.TABLE_ELEMENT).size(), is(0));


### PR DESCRIPTION
- Collapses 'CREATE VIEW' and 'CREATE VIRTUAL VIEW' together to do the
  same thing ensuring that the token VIRTUAL is totally optional.
- See MODE-2396 for details of Teiid BNF and parser.
