### PR TITLE
MODE-2394: Due to teiid vdb schema changes, update the sequencer accordi...

### DIFF
--- a/sequencers/modeshape-sequencer-teiid/src/main/java/org/modeshape/sequencer/teiid/VdbDataRole.java
+++ b/sequencers/modeshape-sequencer-teiid/src/main/java/org/modeshape/sequencer/teiid/VdbDataRole.java
@@ -16,6 +16,7 @@
 package org.modeshape.sequencer.teiid;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import org.modeshape.common.util.CheckArg;
 import org.modeshape.common.util.StringUtil;
@@ -28,6 +29,7 @@ public class VdbDataRole implements Comparable<VdbDataRole> {
     private final String name;
     private boolean anyAuthenticated;
     private boolean allowCreateTempTables;
+    private boolean grantAll;
     private String description;
     private final List<Permission> permissions = new ArrayList<VdbDataRole.Permission>();
     private final List<String> roleNames = new ArrayList<String>();
@@ -98,6 +100,13 @@ public class VdbDataRole implements Comparable<VdbDataRole> {
     }
 
     /**
+     * @return <code>true</code> if data role has grant all
+     */
+    public boolean isGrantAll() {
+        return this.grantAll;
+    }
+
+    /**
      * @param newValue the new value for allowCreateTempTables
      */
     public void setAllowCreateTempTables( final boolean newValue ) {
@@ -119,6 +128,13 @@ public class VdbDataRole implements Comparable<VdbDataRole> {
     }
 
     /**
+     * @param grantAll
+     */
+    public void setGrantAll(boolean grantAll) {
+        this.grantAll = grantAll;
+    }
+
+    /**
      * A simple POJO that is used to represent one data role permission found in the VDB manifest ("vdb.xml").
      */
     public class Permission {
@@ -130,6 +146,9 @@ public class VdbDataRole implements Comparable<VdbDataRole> {
         private boolean read;
         private final String resourceName;
         private boolean update;
+        private boolean language;
+        private List<Condition> conditions = Collections.emptyList();
+        private List<Mask> masks = Collections.emptyList();
 
         /**
          * @param resourceName the resource name associated with the permission (cannot be <code>null</code> or empty)
@@ -182,6 +201,13 @@ public class VdbDataRole implements Comparable<VdbDataRole> {
         }
 
         /**
+         * @param language
+         */
+        public void allowLanguage(boolean language) {
+            this.language = language;
+        }
+
+        /**
          * @return <code>true</code> if the permission can alter
          */
         public boolean canAlter() {
@@ -224,10 +250,123 @@ public class VdbDataRole implements Comparable<VdbDataRole> {
         }
 
         /**
+         * @return <code>true</code> if the permission allows languages
+         */
+        public boolean useLanguage() {
+            return this.language;
+        }
+
+        /**
          * @return the resource name associated with the permission (never <code>null</code> or empty)
          */
         public String getResourceName() {
             return this.resourceName;
+        }
+
+        /**
+         * @return the conditions
+         */
+        public List<Condition> getConditions() {
+            return this.conditions;
+        }
+
+        /**
+         * @param conditions associated with the permission
+         */
+        public void setConditions(List<Condition> conditions) {
+            this.conditions = conditions;
+        }
+
+        /**
+         * @return the masks
+         */
+        public List<Mask> getMasks() {
+            return this.masks;
+        }
+
+        /**
+         * @param masks associated with the permission
+         */
+        public void setMasks(List<Mask> masks) {
+            this.masks = masks;
+        }
+    }
+
+    /**
+     * A simple POJO that is used to represent a data role permission's single condition found in the
+     * VDB manifest ("vdb.xml").
+     */
+    public class Condition {
+
+        private boolean constraint = true;
+
+        private String rule;
+
+        /**
+         * @return constraint flag
+         */
+        public boolean isConstraint() {
+            return constraint;
+        }
+
+        /**
+         * @param the constraint flag
+         */
+        public void setConstraint(boolean constraint) {
+            this.constraint = constraint;
+        }
+
+        /**
+         * @return the rule
+         */
+        public String getRule() {
+            return this.rule;
+        }
+
+        /**
+         * @param rule
+         */
+        public void setRule(String rule) {
+            this.rule = rule;
+        }
+    }
+
+    /**
+     * A simple POJO that is used to represent a data role permission's single mask found in the
+     * VDB manifest ("vdb.xml").
+     */
+    public class Mask {
+
+        private int order;
+
+        private String rule;
+
+        /**
+         * @return order value
+         */
+        public int getOrder() {
+            return order;
+        }
+
+        /**
+         * @param the order value
+         */
+        public void setOrder(int order) {
+            this.order = order;
+        }
+
+        /**
+         * @return the rule
+         */
+        public String getRule() {
+            return this.rule;
+        }
+
+        /**
+         * @param rule
+         */
+        public void setRule(String rule) {
+            this.rule = rule;
         }
     }
 }

--- a/sequencers/modeshape-sequencer-teiid/src/main/java/org/modeshape/sequencer/teiid/VdbModel.java
+++ b/sequencers/modeshape-sequencer-teiid/src/main/java/org/modeshape/sequencer/teiid/VdbModel.java
@@ -40,9 +40,7 @@ public class VdbModel implements Comparable<VdbModel> {
     private String name;
     private String type;
     private String pathInVdb;
-    private String sourceTranslator;
-    private String sourceJndiName;
-    private String sourceName;
+    private List<Source> sources = new ArrayList<Source>();
     private boolean visible = true;
     private boolean builtIn = false;
     private long checksum;
@@ -196,48 +194,6 @@ public class VdbModel implements Comparable<VdbModel> {
     }
 
     /**
-     * @return sourceTranslator
-     */
-    public String getSourceTranslator() {
-        return sourceTranslator;
-    }
-
-    /**
-     * @param sourceTranslator Sets sourceTranslator to the specified value.
-     */
-    public void setSourceTranslator( String sourceTranslator ) {
-        this.sourceTranslator = sourceTranslator;
-    }
-
-    /**
-     * @return sourceJndiName
-     */
-    public String getSourceJndiName() {
-        return sourceJndiName;
-    }
-
-    /**
-     * @param sourceJndiName Sets sourceJndiName to the specified value.
-     */
-    public void setSourceJndiName( String sourceJndiName ) {
-        this.sourceJndiName = sourceJndiName;
-    }
-
-    /**
-     * @return the source name
-     */
-    public String getSourceName() {
-        return sourceName;
-    }
-
-    /**
-     * @param sourceName Sets sourceName to the specified value.
-     */
-    public void setSourceName( String sourceName ) {
-        this.sourceName = sourceName;
-    }
-
-    /**
      * @return the paths of the imported models (never <code>null</code> but can be empty)
      */
     public Set<String> getImports() {
@@ -250,6 +206,21 @@ public class VdbModel implements Comparable<VdbModel> {
     public void addImport( final String newImport ) {
         CheckArg.isNotEmpty(newImport, "newImport");
         this.imports.add(newImport);
+    }
+
+    /**
+     * @return the sources of this models
+     */
+    public List<Source> getSources() {
+        return this.sources;
+    }
+
+    /**
+     * @param source a source of this model
+     */
+    public void addSource(Source source) {
+        CheckArg.isNotNull(source, "source");
+        this.sources.add(source);
     }
 
     /**
@@ -297,6 +268,58 @@ public class VdbModel implements Comparable<VdbModel> {
         }
         // Otherwise, neither model depends upon each other, so base the order upon the number of models ...
         return this.getImports().size() - that.getImports().size();
+    }
+
+    /**
+     * A simple POJO that is used to represent the information for a model's source
+     * read in from a VDB manifest ("vdb.xml").
+     */
+    public class Source {
+        private String name;
+        private String translator;
+        private String jndiName;
+
+        /**
+         * Create a new source with the given name and translator
+         *
+         * @param name the source name (cannot be <code>null</code> or empty)
+         * @param translator the source translator (can be <code>null</code>)
+         */
+        public Source(String name, String translator) {
+            CheckArg.isNotEmpty(name, "name");
+            CheckArg.isNotNull(translator, "translator");
+
+            this.name = name;
+            this.translator = translator;
+        }
+
+        /**
+         * @return the name
+         */
+        public String getName() {
+            return this.name;
+        }
+
+        /**
+         * @return the translator
+         */
+        public String getTranslator() {
+            return this.translator;
+        }
+
+        /**
+         * @return the jndiName
+         */
+        public String getJndiName() {
+            return this.jndiName;
+        }
+
+        /**
+         * @param jndiName the jndiName to set
+         */
+        public void setJndiName(String jndiName) {
+            this.jndiName = jndiName;
+        }
     }
 
     /** The 'vdb.cnd' and 'teiid.cnd' files contain a property definition for 'vdb:severity' with these literal values. */

--- a/sequencers/modeshape-sequencer-teiid/src/main/java/org/modeshape/sequencer/teiid/model/CoreModelObjectHandler.java
+++ b/sequencers/modeshape-sequencer-teiid/src/main/java/org/modeshape/sequencer/teiid/model/CoreModelObjectHandler.java
@@ -97,13 +97,27 @@ public final class CoreModelObjectHandler extends ModelObjectHandler {
                 modelNode.setProperty(VdbLexicon.Model.BUILT_IN, vdbModel.isBuiltIn());
                 setProperty(modelNode, VdbLexicon.Model.DESCRIPTION, vdbModel.getDescription());
                 setProperty(modelNode, VdbLexicon.Model.PATH_IN_VDB, vdbModel.getPathInVdb());
-                setProperty(modelNode, VdbLexicon.Model.SOURCE_TRANSLATOR, vdbModel.getSourceTranslator());
-                setProperty(modelNode, VdbLexicon.Model.SOURCE_NAME, vdbModel.getSourceName());
-                setProperty(modelNode, VdbLexicon.Model.SOURCE_JNDI_NAME, vdbModel.getSourceJndiName());
 
                 // write out any model properties from vdb.xml file
                 for (final Entry<String, String> entry : vdbModel.getProperties().entrySet()) {
                     setProperty(modelNode, entry.getKey(), entry.getValue());
+                }
+
+                // write out the model sources
+                if (! vdbModel.getSources().isEmpty()) {
+                    final Node modelSourcesGroupNode = modelNode.addNode(VdbLexicon.Vdb.SOURCES, VdbLexicon.Vdb.SOURCES);
+
+                    for (final VdbModel.Source source : vdbModel.getSources()) {
+                        Node sourceNode = modelSourcesGroupNode.addNode(source.getName(), VdbLexicon.Source.SOURCE);
+                        sourceNode.setProperty(VdbLexicon.Source.TRANSLATOR, source.getTranslator());
+                        sourceNode.setProperty(VdbLexicon.Source.JNDI_NAME, source.getJndiName());
+
+                        LOGGER.debug("added source to model {0} with values [name=>{1}, translator=>{2}, jndiname=>{3}",
+                                     vdbModel.getName(),
+                                     source.getName(),
+                                     source.getTranslator(),
+                                     source.getJndiName());
+                    }
                 }
 
                 // write out and validation markers

--- a/sequencers/modeshape-sequencer-teiid/src/test/java/org/modeshape/sequencer/teiid/VdbManifestTest.java
+++ b/sequencers/modeshape-sequencer-teiid/src/test/java/org/modeshape/sequencer/teiid/VdbManifestTest.java
@@ -17,6 +17,7 @@ package org.modeshape.sequencer.teiid;
 
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsNull.notNullValue;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
@@ -29,6 +30,7 @@ import java.util.Set;
 import org.junit.Test;
 import org.modeshape.sequencer.teiid.VdbDataRole.Permission;
 import org.modeshape.sequencer.teiid.VdbModel.Severity;
+import org.modeshape.sequencer.teiid.VdbModel.Source;
 import org.modeshape.sequencer.teiid.VdbModel.ValidationMarker;
 import org.modeshape.sequencer.teiid.lexicon.CoreLexicon;
 
@@ -86,9 +88,11 @@ public class VdbManifestTest {
                 }
 
                 { // source
-                    assertThat(model2.getSourceTranslator(), is("MyBooks_mysql5"));
-                    assertThat(model2.getSourceJndiName(), is("MyBooks"));
-                    assertThat(model2.getSourceName(), is("MyBooks"));
+                    assertEquals(1, model2.getSources().size());
+                    Source source = model2.getSources().iterator().next();
+                    assertThat(source.getTranslator(), is("MyBooks_mysql5"));
+                    assertThat(source.getJndiName(), is("MyBooks"));
+                    assertThat(source.getName(), is("MyBooks"));
                 }
             }
 
@@ -297,9 +301,11 @@ public class VdbManifestTest {
         for (VdbModel model : models) {
             if (!foundSource && "twitter".equals(model.getName())) {
                 assertThat(model.getType(), is(CoreLexicon.ModelType.PHYSICAL));
-                assertThat(model.getSourceTranslator(), is("rest"));
-                assertThat(model.getSourceJndiName(), is("java:/twitterDS"));
-                assertThat(model.getSourceName(), is("twitter"));
+                assertEquals(1, model.getSources().size());
+                Source source = model.getSources().iterator().next();
+                assertThat(source.getTranslator(), is("rest"));
+                assertThat(source.getJndiName(), is("java:/twitterDS"));
+                assertThat(source.getName(), is("twitter"));
                 foundSource = true;
             } else if (!foundVirtual && "twitterview".equals(model.getName())) {
                 assertThat(model.getType(), is(CoreLexicon.ModelType.VIRTUAL));

--- a/sequencers/modeshape-sequencer-teiid/src/test/java/org/modeshape/sequencer/teiid/VdbSequencerTest.java
+++ b/sequencers/modeshape-sequencer-teiid/src/test/java/org/modeshape/sequencer/teiid/VdbSequencerTest.java
@@ -83,9 +83,17 @@ public class VdbSequencerTest extends AbstractSequencerTest {
             assertThat(modelNode.getProperty(VdbLexicon.Model.VISIBLE).getBoolean(), is(true));
             assertThat(modelNode.getProperty(CoreLexicon.JcrId.MODEL_TYPE).getString(), is(CoreLexicon.ModelType.PHYSICAL));
             assertThat(modelNode.getProperty(VdbLexicon.Model.BUILT_IN).getBoolean(), is(false));
-            assertThat(modelNode.getProperty(VdbLexicon.Model.SOURCE_TRANSLATOR).getString(), is("MyBooks_mysql5"));
-            assertThat(modelNode.getProperty(VdbLexicon.Model.SOURCE_JNDI_NAME).getString(), is("MyBooks"));
-            assertThat(modelNode.getProperty(VdbLexicon.Model.SOURCE_NAME).getString(), is("MyBooks"));
+
+            Node sourcesNode = modelNode.getNode(VdbLexicon.Vdb.SOURCES);
+            assertNotNull(sourcesNode);
+            assertThat(sourcesNode.getPrimaryNodeType().getName(), is(VdbLexicon.Vdb.SOURCES));
+
+            Node sourceNode = sourcesNode.getNode("MyBooks");
+            assertNotNull(sourceNode);
+            assertThat(sourceNode.getPrimaryNodeType().getName(), is(VdbLexicon.Source.SOURCE));
+            assertThat(sourceNode.getProperty(VdbLexicon.Source.TRANSLATOR).getString(), is("MyBooks_mysql5"));
+            assertThat(sourceNode.getProperty(VdbLexicon.Source.JNDI_NAME).getString(), is("MyBooks"));
+
             assertThat(modelNode.getProperty("modelClass").getString(), is("Relational"));
             assertThat(modelNode.getProperty("indexName").getString(), is("718925066.INDEX"));
 
@@ -312,9 +320,16 @@ public class VdbSequencerTest extends AbstractSequencerTest {
             assertThat(modelNode.getProperty(CoreLexicon.JcrId.MODEL_TYPE).getString(), is(CoreLexicon.ModelType.PHYSICAL));
             assertThat(modelNode.getProperty("modelClass").getString(), is("Relational"));
             assertThat(modelNode.getProperty("indexName").getString(), is("1388555674.INDEX"));
-            assertThat(modelNode.getProperty(VdbLexicon.Model.SOURCE_TRANSLATOR).getString(), is("oracle"));
-            assertThat(modelNode.getProperty(VdbLexicon.Model.SOURCE_JNDI_NAME).getString(), is("Books_Oracle"));
-            assertThat(modelNode.getProperty(VdbLexicon.Model.SOURCE_NAME).getString(), is("Books_Oracle"));
+
+            Node sourcesNode = modelNode.getNode(VdbLexicon.Vdb.SOURCES);
+            assertNotNull(sourcesNode);
+            assertThat(sourcesNode.getPrimaryNodeType().getName(), is(VdbLexicon.Vdb.SOURCES));
+
+            Node sourceNode = sourcesNode.getNode("Books_Oracle");
+            assertNotNull(sourceNode);
+            assertThat(sourceNode.getPrimaryNodeType().getName(), is(VdbLexicon.Source.SOURCE));
+            assertThat(sourceNode.getProperty(VdbLexicon.Source.TRANSLATOR).getString(), is("oracle"));
+            assertThat(sourceNode.getProperty(VdbLexicon.Source.JNDI_NAME).getString(), is("Books_Oracle"));
         }
 
         { // BooksView model child node
@@ -553,9 +568,17 @@ public class VdbSequencerTest extends AbstractSequencerTest {
             assertNotNull(declarativeModelNode);
             assertThat(declarativeModelNode.getPrimaryNodeType().getName(), is(VdbLexicon.Vdb.DECLARATIVE_MODEL));
             assertThat(declarativeModelNode.getProperty(VdbLexicon.Model.VISIBLE).getBoolean(), is(true));
-            assertThat(declarativeModelNode.getProperty(VdbLexicon.Model.SOURCE_TRANSLATOR).getString(), is("rest"));
-            assertThat(declarativeModelNode.getProperty(VdbLexicon.Model.SOURCE_JNDI_NAME).getString(), is("java:/twitterDS"));
-            assertThat(declarativeModelNode.getProperty(VdbLexicon.Model.SOURCE_NAME).getString(), is("twitter"));
+
+            Node sourcesNode = declarativeModelNode.getNode(VdbLexicon.Vdb.SOURCES);
+            assertNotNull(sourcesNode);
+            assertThat(sourcesNode.getPrimaryNodeType().getName(), is(VdbLexicon.Vdb.SOURCES));
+
+            Node sourceNode = sourcesNode.getNode("twitter");
+            assertNotNull(sourceNode);
+            assertThat(sourceNode.getPrimaryNodeType().getName(), is(VdbLexicon.Source.SOURCE));
+            assertThat(sourceNode.getProperty(VdbLexicon.Source.TRANSLATOR).getString(), is("rest"));
+            assertThat(sourceNode.getProperty(VdbLexicon.Source.JNDI_NAME).getString(), is("java:/twitterDS"));
+
             assertThat(declarativeModelNode.getProperty(CoreLexicon.JcrId.MODEL_TYPE).getString(),
                        is(CoreLexicon.ModelType.PHYSICAL));
         }
@@ -597,9 +620,17 @@ public class VdbSequencerTest extends AbstractSequencerTest {
             assertNotNull(declarativeModelNode);
             assertThat(declarativeModelNode.getPrimaryNodeType().getName(), is(VdbLexicon.Vdb.DECLARATIVE_MODEL));
             assertThat(declarativeModelNode.getProperty(VdbLexicon.Model.VISIBLE).getBoolean(), is(true));
-            assertThat(declarativeModelNode.getProperty(VdbLexicon.Model.SOURCE_TRANSLATOR).getString(), is("rest"));
-            assertThat(declarativeModelNode.getProperty(VdbLexicon.Model.SOURCE_JNDI_NAME).getString(), is("java:/twitterDS"));
-            assertThat(declarativeModelNode.getProperty(VdbLexicon.Model.SOURCE_NAME).getString(), is("twitter"));
+
+            Node sourcesNode = declarativeModelNode.getNode(VdbLexicon.Vdb.SOURCES);
+            assertNotNull(sourcesNode);
+            assertThat(sourcesNode.getPrimaryNodeType().getName(), is(VdbLexicon.Vdb.SOURCES));
+
+            Node sourceNode = sourcesNode.getNode("twitter");
+            assertNotNull(sourceNode);
+            assertThat(sourceNode.getPrimaryNodeType().getName(), is(VdbLexicon.Source.SOURCE));
+            assertThat(sourceNode.getProperty(VdbLexicon.Source.TRANSLATOR).getString(), is("rest"));
+            assertThat(sourceNode.getProperty(VdbLexicon.Source.JNDI_NAME).getString(), is("java:/twitterDS"));
+
             assertThat(declarativeModelNode.getProperty(CoreLexicon.JcrId.MODEL_TYPE).getString(),
                        is(CoreLexicon.ModelType.PHYSICAL));
         }


### PR DESCRIPTION
...ngly
- Updates the Vdb Sequencer to reflect the changes made to the Teiid Vdb
  cnd schema. In light of the changes made to the latter to reflect Teiid's
  own latest Vdb schema, the sequencer will now observe the following:
  *\* vdb connection type
  *\* vdb name
  *\* multiple model sources
  *\* data role grant-all flag
  *\* data role permission conditions and masks
  *\* data role allow language permission
- Updates sequencer tests to test for the new changes
