### PR TITLE
MODE-2400: Adds support for GLOBAL TEMPORARY tables in DDL Sequencer

### DIFF
--- a/sequencers/modeshape-sequencer-ddl/src/main/java/org/modeshape/sequencer/ddl/datatype/DataType.java
+++ b/sequencers/modeshape-sequencer-ddl/src/main/java/org/modeshape/sequencer/ddl/datatype/DataType.java
@@ -32,6 +32,8 @@ public class DataType {
     private int precision = DEFAULT_PRECISION;
     private int scale = DEFAULT_SCALE;
     private int arrayDimensions = DEFAULT_ARRAY_DIMENSIONS;
+    private boolean autoIncrement = false;
+    private boolean notNull = false;
 
     /**
      * The statement source.
@@ -107,6 +109,33 @@ public class DataType {
      */
     public void setArrayDimensions(int arrayDimensions) {
         this.arrayDimensions = arrayDimensions;
+    }
+    /**
+     * @return auto increment
+     */
+    public boolean isAutoIncrement() {
+        return this.autoIncrement;
+    }
+
+    /**
+     * @param autoIncrement the autoIncrement flag to set
+     */
+    public void setAutoIncrement(boolean autoIncrement) {
+        this.autoIncrement = autoIncrement;
+    }
+
+    /**
+     * @return not null flag
+     */
+    public boolean isNotNull() {
+        return this.notNull;
+    }
+
+    /**
+     * @param notNull the notNull flag to set
+     */
+    public void setNotNull(boolean notNull) {
+        this.notNull = notNull;
     }
     @Override
     public String toString() {

--- a/sequencers/modeshape-sequencer-ddl/src/main/java/org/modeshape/sequencer/ddl/dialect/teiid/TeiidDataTypeParser.java
+++ b/sequencers/modeshape-sequencer-ddl/src/main/java/org/modeshape/sequencer/ddl/dialect/teiid/TeiidDataTypeParser.java
@@ -47,6 +47,10 @@ class TeiidDataTypeParser extends DataTypeParser {
         int[] precisionScale = DEFAULT_PRECISION_SCALE;
         int arrayDimensions = DataType.DEFAULT_ARRAY_DIMENSIONS;
 
+        // flags for dealing with the SERIAL pseudo data type
+        boolean autoIncrement = false;
+        boolean notNull = false;
+
         for (final TeiidDataType teiidDataType : TeiidDataType.values()) {
             if (tokens.canConsume(teiidDataType.toDdl())) {
                 teiidType = teiidDataType;
@@ -87,8 +91,21 @@ class TeiidDataTypeParser extends DataTypeParser {
             }
         }
 
+        if (teiidType == null && tokens.canConsume(TeiidDdlConstants.TeiidNonReservedWord.SERIAL.toDdl())) {
+            // SERIAL is an alias for an auto-incremented not-null integer
+            teiidType = TeiidDataType.INTEGER;
+            autoIncrement = true;
+            notNull = true;
+        }
+
         if (teiidType != null) {
             final DataType type = new DataType(teiidType.toDdl());
+
+            // set auto increment
+            type.setAutoIncrement(autoIncrement);
+
+            // set not null
+            type.setNotNull(notNull);
 
             // set length
             if (length != DataType.DEFAULT_LENGTH) {

--- a/sequencers/modeshape-sequencer-ddl/src/main/java/org/modeshape/sequencer/ddl/dialect/teiid/TeiidDdlConstants.java
+++ b/sequencers/modeshape-sequencer-ddl/src/main/java/org/modeshape/sequencer/ddl/dialect/teiid/TeiidDdlConstants.java
@@ -25,6 +25,12 @@ import org.modeshape.sequencer.ddl.DdlConstants;
  */
 public interface TeiidDdlConstants extends DdlConstants {
 
+    /*
+     * Teiid DDL Keywords
+     */
+    public static final String GLOBAL = "GLOBAL";
+    public static final String TEMPORARY = "TEMPORARY";
+
     /**
      * An object that has a DDL representation.
      */
@@ -52,6 +58,7 @@ public interface TeiidDdlConstants extends DdlConstants {
          * </code>
          */
         CREATE_FOREIGN_TABLE(CREATE, FOREIGN, TABLE),
+        CREATE_GLOBAL_TEMPORARY_TABLE(CREATE, GLOBAL, TEMPORARY, TABLE),
         CREATE_VIRTUAL_VIEW(CREATE, TeiidReservedWord.VIRTUAL.name(), VIEW),
         CREATE_VIEW(CREATE, VIEW),
 


### PR DESCRIPTION
- Enhances the Teiid DDL Sequencer with supporting the CREATE GLOBAL
  TEMPORARY TABLE syntax, present in Teiid's BNF.
