### PR TITLE
MODE-2408 Fixed the handling of empty ACLs

### DIFF
--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/security/acl/AccessControlEntryImpl.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/security/acl/AccessControlEntryImpl.java
@@ -17,10 +17,12 @@ package org.modeshape.jcr.security.acl;
 
 import java.security.Principal;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import javax.jcr.security.AccessControlEntry;
 import javax.jcr.security.AccessControlException;
 import javax.jcr.security.Privilege;
+import org.modeshape.common.util.HashCode;
 
 /**
  * Implementation for the Access Control entry record. An AccessControlEntry represents the association of one or more
@@ -45,11 +47,10 @@ public class AccessControlEntryImpl implements AccessControlEntry {
         for (Privilege p : privileges) {
             if (p.getName() == null) throw new AccessControlException("Invalid privilege");
         }
+        assert principal != null;
         this.principal = principal;
         this.privileges.clear();
-        for (Privilege privilege : privileges) {
-            this.privileges.add(privilege);
-        }
+        Collections.addAll(this.privileges, privileges);
     }
 
     @Override
@@ -95,9 +96,7 @@ public class AccessControlEntryImpl implements AccessControlEntry {
      */
     protected boolean addIfNotPresent( Privilege[] privileges ) {
         ArrayList<Privilege> list = new ArrayList<Privilege>();
-        for (Privilege privilege : privileges) {
-            list.add(privilege);
-        }
+        Collections.addAll(list, privileges);
 
         boolean res = combineRecursively(list, privileges);
 
@@ -158,6 +157,14 @@ public class AccessControlEntryImpl implements AccessControlEntry {
 
     @Override
     public int hashCode() {
-        return this.principal.hashCode();
+        return HashCode.compute(principal, privileges);
+    }
+
+    @Override
+    public String toString() {
+        final StringBuilder sb = new StringBuilder("ACE: ");
+        sb.append(principal.getName());
+        sb.append("=").append(privileges);
+        return sb.toString();
     }
 }

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/security/acl/JcrAccessControlList.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/security/acl/JcrAccessControlList.java
@@ -19,6 +19,7 @@ import java.security.Principal;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.Iterator;
 import javax.jcr.RepositoryException;
 import javax.jcr.security.AccessControlEntry;
 import javax.jcr.security.AccessControlException;
@@ -57,7 +58,7 @@ public class JcrAccessControlList implements AccessControlList {
      * @return Access Control List with all permissions granted to everyone.
      */
     public static JcrAccessControlList defaultAcl( AccessControlManagerImpl acm ) {
-        JcrAccessControlList acl = new JcrAccessControlList(acm, "/");
+        JcrAccessControlList acl = new JcrAccessControlList("/");
         try {
             acl.principals.put(SimplePrincipal.EVERYONE, new AccessControlEntryImpl(SimplePrincipal.EVERYONE, acm.privileges()));
         } catch (AccessControlException e) {
@@ -68,12 +69,10 @@ public class JcrAccessControlList implements AccessControlList {
 
     /**
      * Creates new empty access control list.
-     * 
-     * @param acm Access Control Manager managing this access list.
+     *
      * @param path the path to which this access list is applied.
      */
-    public JcrAccessControlList( AccessControlManagerImpl acm,
-                                 String path ) {
+    public JcrAccessControlList( String path ) {
         this.path = path;
     }
 
@@ -103,13 +102,13 @@ public class JcrAccessControlList implements AccessControlList {
         if (principal.getName().equals("unknown")) {
             throw new AccessControlException("Unknown principal");
         }
-        // Jast new entry
+        // Just new entry
         if (!principals.containsKey(principal)) {
             principals.put(principal, new AccessControlEntryImpl(principal, privileges));
             return true;
         }
 
-        // there is entry for the given principal so jast add missing privileges
+        // there is entry for the given principal so just add missing privileges
         AccessControlEntryImpl ace = principals.get(principal);
         return ace.addIfNotPresent(privileges);
     }
@@ -212,6 +211,24 @@ public class JcrAccessControlList implements AccessControlList {
     @Override
     public int hashCode() {
         return this.path.hashCode();
+    }
+
+    @Override
+    public String toString() {
+        final StringBuilder sb = new StringBuilder("ACL[");
+        sb.append(path).append(", ");
+        if (principals.isEmpty()) {
+            sb.append(" <is empty>");
+        } else {
+            for (Iterator<AccessControlEntryImpl> entryIterator = principals.values().iterator(); entryIterator.hasNext(); ) {
+                sb.append(entryIterator.next());
+                if (entryIterator.hasNext()) {
+                    sb.append(",");
+                }
+            }
+        }
+        sb.append(']');
+        return sb.toString();
     }
 
     /**

--- a/modeshape-jcr/src/test/java/org/modeshape/jcr/security/acl/AccessControlPolicyIteratorImplTest.java
+++ b/modeshape-jcr/src/test/java/org/modeshape/jcr/security/acl/AccessControlPolicyIteratorImplTest.java
@@ -44,10 +44,10 @@ public class AccessControlPolicyIteratorImplTest {
     public void setUp() throws AccessControlException, RepositoryException {
 
         // acl-1
-        JcrAccessControlList alice = new JcrAccessControlList(null, "alice");
+        JcrAccessControlList alice = new JcrAccessControlList("alice");
         alice.addAccessControlEntry(SimplePrincipal.newInstance("alice"), new Privilege[] {new PrivilegeImpl()});
 
-        JcrAccessControlList bob = new JcrAccessControlList(null, "bob");
+        JcrAccessControlList bob = new JcrAccessControlList("bob");
         bob.addAccessControlEntry(SimplePrincipal.newInstance("bob"), new Privilege[] {new PrivilegeImpl()});
 
         it = new AccessControlPolicyIteratorImpl(alice, bob);

--- a/modeshape-jcr/src/test/java/org/modeshape/jcr/security/acl/JcrAccessControlListTest.java
+++ b/modeshape-jcr/src/test/java/org/modeshape/jcr/security/acl/JcrAccessControlListTest.java
@@ -35,7 +35,7 @@ import org.modeshape.jcr.security.SimplePrincipal;
  */
 public class JcrAccessControlListTest extends MultiUseAbstractTest {
 
-    private JcrAccessControlList acl = new JcrAccessControlList(null, "root");
+    private JcrAccessControlList acl = new JcrAccessControlList("root");
     private Privilege[] rw;
     private Privileges privileges;
 


### PR DESCRIPTION
If a node has empty ACLs, then the nearest non-empty ones in the hierarchy should be taken into account instead of assuming all permissions are granted on that node.