### PR TITLE
MODE-2409 Changed the ClusteredChangeBus to wait until it receives loopback-changesets.

### DIFF
--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/bus/BusI18n.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/bus/BusI18n.java
@@ -28,6 +28,7 @@ public final class BusI18n {
     public static I18n errorSerializingChanges;
     public static I18n errorDeserializingChanges;
     public static I18n errorProcessingEvent;
+    public static I18n loopbackMessageNotReceived;
 
     private BusI18n() {
     }

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/bus/ClusteredChangeBus.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/bus/ClusteredChangeBus.java
@@ -15,6 +15,10 @@
  */
 package org.modeshape.jcr.bus;
 
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import org.modeshape.common.annotation.ThreadSafe;
 import org.modeshape.common.logging.Logger;
 import org.modeshape.common.util.CheckArg;
@@ -50,6 +54,11 @@ public final class ClusteredChangeBus extends MessageConsumer<ChangeSet> impleme
     private final ClusteringService clusteringService;
 
     /**
+     * A map which contains latches used for the thread which places a message on the bus to wait until it gets that message back from JGroups
+     */
+    private final Map<String, CountDownLatch> loopbackLatches = new HashMap<>();
+
+    /**
      * Creates a new clustered repository bus
      * 
      * @param delegate the local bus to which changes will be delegated
@@ -68,8 +77,22 @@ public final class ClusteredChangeBus extends MessageConsumer<ChangeSet> impleme
     @Override
     public void consume( ChangeSet changes ) {
         if (hasObservers()) {
-            delegate.notify(changes);
-            logReceivedOperation(changes);
+            try {
+                delegate.notify(changes);
+                logReceivedOperation(changes);
+            } finally {
+                // if we're waiting for a loopback message to arrive back, always make sure we notify the waiting thread
+                if (!loopbackLatches.isEmpty()) {
+                    String uuid = changes.getUUID();
+                    CountDownLatch latch = loopbackLatches.remove(uuid);
+                    if (latch != null) {
+                        latch.countDown();   
+                        if (LOGGER.isTraceEnabled()) {
+                            LOGGER.trace("Loopback changeset {0} received back on {1}", uuid, clusteringService.toString());
+                        }
+                    }
+                }
+            }
         }
     }
 
@@ -95,6 +118,7 @@ public final class ClusteredChangeBus extends MessageConsumer<ChangeSet> impleme
     @Override
     public synchronized void shutdown() {
         delegate.shutdown();
+        loopbackLatches.clear();
     }
 
     @Override
@@ -111,14 +135,35 @@ public final class ClusteredChangeBus extends MessageConsumer<ChangeSet> impleme
 
         // There are multiple participants in the cluster, so send all changes out to JGroups,
         // letting JGroups do the ordering of messages...
+        // note that JGroups will dispatch our own changeset *in a separate thread* (see below)
         logSendOperation(changeSet);
         clusteringService.sendMessage(changeSet);
+        
+        // Since JGroups will always dispatch incoming message off a separate thread, we need to wait here until JGroups
+        // has dispatched our own message back. This is because we have the semantics of in-thread listeners which must
+        // work correctly. See MODE-2409 for details.
+        CountDownLatch waitForLoopback = new CountDownLatch(1);
+        String uuid = changeSet.getUUID();
+        loopbackLatches.put(uuid, waitForLoopback);
+        try {
+            if (LOGGER.isTraceEnabled()) {
+                LOGGER.trace("Waiting for loopback changeset {0} to be received back on {1}", uuid, clusteringService.toString());
+            }
+            if (!waitForLoopback.await(15, TimeUnit.SECONDS)) {
+                loopbackLatches.remove(uuid);
+                LOGGER.error(BusI18n.loopbackMessageNotReceived, uuid, clusteringService.toString());
+            }
+        } catch (InterruptedException e) {
+            loopbackLatches.remove(uuid);
+            Thread.interrupted();
+            LOGGER.error(e, BusI18n.loopbackMessageNotReceived, uuid, clusteringService.toString());
+        }
     }
 
     protected final void logSendOperation( ChangeSet changeSet ) {
         if (LOGGER.isTraceEnabled()) {
             LOGGER.trace("Sending to cluster '{0}' {1} changes on workspace {2} made by {3} from process '{4}' at {5}",
-                         clusteringService.clusterName(),
+                         clusteringService.toString(),
                          changeSet.size(),
                          changeSet.getWorkspaceName(),
                          changeSet.getUserData(),
@@ -130,7 +175,7 @@ public final class ClusteredChangeBus extends MessageConsumer<ChangeSet> impleme
     protected final void logReceivedOperation( ChangeSet changeSet ) {
         if (LOGGER.isTraceEnabled()) {
             LOGGER.trace("Received from cluster '{0}' {1} changes on workspace {2} made by {3} from process '{4}' at {5}",
-                         clusteringService.clusterName(),
+                         clusteringService.toString(),
                          changeSet.size(),
                          changeSet.getWorkspaceName(),
                          changeSet.getUserId(),

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/clustering/ClusteringService.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/clustering/ClusteringService.java
@@ -270,13 +270,20 @@ public abstract class ClusteringService {
         }
         try {
             byte[] messageData = toByteArray(payload);
-            Message jgMessage = new Message(null, null, messageData);
+            Message jgMessage = new Message(null, channel.getAddress(), messageData);
             channel.send(jgMessage);
             return true;
         } catch (Exception e) {
             // Something went wrong here
             throw new SystemFailureException(ClusteringI18n.errorSendingMessage.text(clusterName()), e);
         }
+    }
+
+    @Override
+    public String toString() {
+        final StringBuilder sb = new StringBuilder("ClusteringService[cluster_name='");
+        sb.append(clusterName()).append("', address=").append(getChannel().getAddress()).append("]");
+        return sb.toString();
     }
 
     /**

--- a/modeshape-jcr/src/main/resources/org/modeshape/jcr/bus/BusI18n.properties
+++ b/modeshape-jcr/src/main/resources/org/modeshape/jcr/bus/BusI18n.properties
@@ -1,3 +1,4 @@
 errorSerializingChanges = Error in channel '{0}' while serializing {1} changes to workspace '{2}' made by {3} from process '{4}' at {5}: {6}
 errorDeserializingChanges = Error deserializing changes obtained from channel '{0}'
 errorProcessingEvent = Unexpected error while processing the event '{0}' with the sequence number '{1}'
+loopbackMessageNotReceived = Loopback changeset '{0}' was never received back on '{1}'. Make sure your JGroups configuration uses 'loopback=true' and if applicable 'loopback_separate_thread=true'

--- a/modeshape-jcr/src/test/java/org/modeshape/jcr/ClusteredRepositoryTest.java
+++ b/modeshape-jcr/src/test/java/org/modeshape/jcr/ClusteredRepositoryTest.java
@@ -70,6 +70,72 @@ public class ClusteredRepositoryTest {
     }
 
     @Test
+    public void shouldCreateVersinableNodeInCluster() throws Exception {
+        JcrRepository repository = TestingUtil.startRepositoryWithConfig("config/clustered-repo-config.json");
+        JcrSession session = repository.login();
+
+        try {
+
+            Node testNode = session.getRootNode().addNode("testNode");
+            testNode.addMixin("mix:versionable");
+            String binary = "test string";
+            testNode.setProperty("binaryProperty", session.getValueFactory().createBinary(binary.getBytes()));
+            session.save();
+            final String testNodePath = testNode.getPath();
+            session.getWorkspace().getVersionManager().checkin(testNodePath);
+
+        } finally {
+            TestingUtil.killRepositories(repository);
+        }
+    }
+
+    @Test
+    public void shouldPropagateVersinableNodeInCluster() throws Exception {
+        JcrRepository repository1 = TestingUtil.startRepositoryWithConfig("config/clustered-repo-config.json");
+        JcrSession session1 = repository1.login();
+
+        JcrRepository repository2 = TestingUtil.startRepositoryWithConfig("config/clustered-repo-config.json");
+        JcrSession session2 = repository2.login();
+
+        try {
+            int eventTypes = Event.NODE_ADDED | Event.PROPERTY_ADDED;
+            ClusteringEventListener listener = new ClusteringEventListener(3);
+            session2.getWorkspace().getObservationManager().addEventListener(listener, eventTypes, null, true, null, null, true);
+
+            Node testNode = session1.getRootNode().addNode("testNode");
+            testNode.addMixin("mix:versionable");
+            String binary = "test string";
+            testNode.setProperty("binaryProperty", session1.getValueFactory().createBinary(binary.getBytes()));
+            session1.save();
+            final String testNodePath = testNode.getPath();
+            session1.getWorkspace().getVersionManager().checkin(testNodePath);
+
+            listener.waitForEvents();
+            List<String> paths = listener.getPaths();
+            assertEquals(9, paths.size());
+            assertTrue(paths.contains("/testNode"));
+            assertTrue(paths.contains("/testNode/binaryProperty"));
+            assertTrue(paths.contains("/testNode/jcr:uuid"));
+            assertTrue(paths.contains("/testNode/jcr:baseVersion"));
+            assertTrue(paths.contains("/testNode/jcr:primaryType"));
+            assertTrue(paths.contains("/testNode/jcr:predecessors"));
+            assertTrue(paths.contains("/testNode/jcr:mixinTypes"));
+            assertTrue(paths.contains("/testNode/jcr:versionHistory"));
+            assertTrue(paths.contains("/testNode/jcr:isCheckedOut"));
+
+            // check whether the node can be found in the second repository ...
+            try {
+                session2.refresh(false);
+                session2.getNode(testNodePath);
+            } catch (PathNotFoundException e) {
+                fail("Should have found the '/testNode' created in other repository in this repository: ");
+            }
+        } finally {
+            TestingUtil.killRepositories(repository1, repository2);
+        }
+    }
+
+    @Test
     @FixFor( {"MODE-1618", "MODE-2830"} )
     public void shouldPropagateNodeChangesInCluster() throws Exception {
         JcrRepository repository1 = TestingUtil.startRepositoryWithConfig("config/clustered-repo-config.json");

--- a/modeshape-jcr/src/test/java/org/modeshape/jcr/bus/AbstractChangeBusTest.java
+++ b/modeshape-jcr/src/test/java/org/modeshape/jcr/bus/AbstractChangeBusTest.java
@@ -241,6 +241,7 @@ public abstract class AbstractChangeBusTest {
 
         private final String workspaceName;
         private final long time;
+        private final String uuid = UUID.randomUUID().toString();
 
         public TestChangeSet() {
             this(UUID.randomUUID().toString());
@@ -332,7 +333,7 @@ public abstract class AbstractChangeBusTest {
 
         @Override
         public String getUUID() {
-            return null;
+            return uuid;
         }
 
         @Override
@@ -409,17 +410,6 @@ public abstract class AbstractChangeBusTest {
                 Thread.interrupted();
                 fail("Interrupted while waiting to verify event count");
             }
-        }
-
-        public void assertEventsSequential() {
-            assertExpectedEventsCount();
-            List<Long> actualOrder = new ArrayList<>(expectedNumberOfEvents);
-            for (ChangeSet changeSet : receivedChangeSet) {
-                actualOrder.add(changeSet.getTimestamp().getMilliseconds());
-            }
-            List<Long> expectedOrder = new ArrayList<>(actualOrder);
-            Collections.sort(expectedOrder);
-            assertEquals("Events received in incorrect order", expectedOrder, actualOrder);
         }
 
         public List<TestChangeSet> getObservedChangeSet() {


### PR DESCRIPTION
This is the only way (apart from not sending loopback messages through JGroups) to ensure that when a thread calls `bus.notify` all the "in-thread" listeners have actually been notified before continuing with that thread. This in turn is a precondition that must hold true for any changes in the system area to work correctly.