### PR TITLE
MODE-2412 Fixed the handling of large extracted text values for the database binary stores

### DIFF
--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrI18n.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrI18n.java
@@ -535,6 +535,7 @@ public final class JcrI18n {
     public static I18n noIndexesExist;
 
     public static I18n errorCreatingDatabaseTable;
+    public static I18n warnExtractedTextTooLarge;
 
     public static I18n cannotLocateConnectionFactory;
     public static I18n cannotLocateQueue;

--- a/modeshape-jcr/src/main/resources/org/modeshape/jcr/JcrI18n.properties
+++ b/modeshape-jcr/src/main/resources/org/modeshape/jcr/JcrI18n.properties
@@ -517,6 +517,7 @@ reindexAll = All content will be re-indexed for repository {0}.
 noIndexesExist = Repository '{0}' cannot start because no indexes exist and the index rebuild configuration is '{1}'
 
 errorCreatingDatabaseTable = Error attempting to create the database table '{0}' using the connection to '{1}'
+warnExtractedTextTooLarge = The size of the extracted text is larger than the '{0}' column's max size of '{1}' chars and will therefore be trimmed. If this is not desirable, increase the '{0}' column size from the '{2}' table.
 
 cannotLocateConnectionFactory = Cannot locate in JNDI the JMS connection factory: '{0}'
 cannotLocateQueue = Cannot locate in JNDI the JMS queue: '{0}'

--- a/modeshape-jcr/src/main/resources/org/modeshape/jcr/database/binary_store_h2_database.properties
+++ b/modeshape-jcr/src/main/resources/org/modeshape/jcr/database/binary_store_h2_database.properties
@@ -1,0 +1,46 @@
+# In all of the following statements, the '{0}' variable represents the table name
+
+# The statement that creates the table.
+create_table = CREATE TABLE {0} ( \
+                 cid VARCHAR(255) NOT NULL, \
+                 mime_type VARCHAR(255), \
+                 ext_text VARCHAR(1000), \
+                 usage INTEGER, \
+                 usage_time TIMESTAMP, \
+                 payload BLOB, \
+                 primary key(cid) \
+               )
+
+# The query that is used to determine if the table already exists by returning any result set.
+table_exists_query = SELECT COUNT(*) FROM {0}
+
+# Insert a new binary value into the table
+add_content = INSERT INTO {0} (cid, usage_time, payload, usage) VALUES ( ?,?,?,1 )
+
+# Get the content for the binary with the supplied key
+get_used_content = SELECT payload FROM {0} WHERE cid = ? AND usage=1
+get_unused_content = SELECT payload FROM {0} WHERE cid = ? AND usage=0
+
+# Mark the binary with the specified key as being unused
+mark_unused = UPDATE {0} SET usage=0, usage_time = ? WHERE cid = ?
+
+# Mark the binary with the specified key as being used
+mark_used = UPDATE {0} SET usage=1 WHERE cid = ?
+
+# Remove all rows that have been unused for less than the supplied time
+remove_expired = DELETE FROM {0} WHERE usage_time < ? and usage=0
+
+# Get the MIME type for the binary with the specified key
+get_mimetype = SELECT mime_type FROM {0} WHERE cid = ?
+
+# Set the MIME type for the binary with the specified key
+set_mimetype = UPDATE {0} SET mime_type = ? WHERE cid = ?
+
+# Get the text that was extracted from the binary with the specified key
+get_extracted_text = SELECT ext_text FROM {0} WHERE cid = ?
+
+# Set the text that was extracted from the binary with the specified key
+set_extracted_text = UPDATE {0} SET ext_text = ? WHERE cid = ?
+
+# Get all of the binary keys
+get_binary_keys = SELECT cid FROM {0} WHERE usage = 1

--- a/modeshape-jcr/src/test/java/org/modeshape/jcr/value/binary/DatabaseBinaryStoreTest.java
+++ b/modeshape-jcr/src/test/java/org/modeshape/jcr/value/binary/DatabaseBinaryStoreTest.java
@@ -15,10 +15,16 @@
  */
 package org.modeshape.jcr.value.binary;
 
+import static org.junit.Assert.assertEquals;
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.Test;
+import org.modeshape.common.FixFor;
+import org.modeshape.common.util.StringUtil;
 import org.modeshape.jcr.store.DataSourceConfig;
+import org.modeshape.jcr.value.BinaryValue;
 
 /**
  * @author kulikov
@@ -55,5 +61,14 @@ public class DatabaseBinaryStoreTest extends AbstractBinaryStoreTest {
             return;
         }
         super.shouldStoreZeroLengthBinary();
+    }
+    
+    @Test
+    @FixFor( "MODE-2412" )
+    public void shouldTrimExtractedTextLargerThanDefaultColumnSize() throws Exception {
+        BinaryValue res = getBinaryStore().storeValue(new ByteArrayInputStream(STORED_MEDIUM_BINARY), false);
+        String largeString = StringUtil.createString('x', Database.DEFAULT_MAX_EXTRACTED_TEXT_LENGTH + 1);
+        store.storeExtractedText(res, largeString);
+        assertEquals(largeString.substring(0, Database.DEFAULT_MAX_EXTRACTED_TEXT_LENGTH), store.getExtractedText(res));
     }
 }

--- a/modeshape-parent/pom.xml
+++ b/modeshape-parent/pom.xml
@@ -557,7 +557,7 @@
                     <!--Must be JDBC 4 (Java 6) compliant-->
                     <groupId>postgresql</groupId>
                     <artifactId>postgresql</artifactId>
-                    <version>${jdbc.postgresql9.version}</version>
+                    <version>${jdbc.postgresql8.version}</version>
                     <scope>test</scope>
                 </dependency>
             </dependencies>


### PR DESCRIPTION
 If the length of the text is larger than the size of the DB column, it will be trimmed.