### PR TITLE
MODE-2411 Extended the default JAAS provider to be able to interact with the JBoss container's SecurityManagementService.

### DIFF
--- a/boms/modeshape-bom-embedded/pom.xml
+++ b/boms/modeshape-bom-embedded/pom.xml
@@ -53,7 +53,7 @@
         <infinispan.version>6.0.2.Final</infinispan.version>
         <jgroups.version>3.4.3.Final</jgroups.version>
         <c3p0.version>0.9.1.2</c3p0.version>  <!-- same as the one used by Infinispan's JDBC cache store -->
-        <picketbox.version>4.0.17.SP2</picketbox.version>
+        <picketbox.version>4.0.21.Final</picketbox.version>
         <atomikos.version>3.8.0</atomikos.version>
         <jbossjta.version>5.0.0.Final</jbossjta.version>
         <mongo.driver.version>2.7.3</mongo.driver.version>

--- a/boms/modeshape-bom-jbossas/pom.xml
+++ b/boms/modeshape-bom-jbossas/pom.xml
@@ -92,6 +92,14 @@
                 <version>${jboss.server.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
+            </dependency>   
+            
+            <dependency>
+                <groupId>org.wildfly.bom</groupId>
+                <artifactId>jboss-javaee-7.0-with-security</artifactId>
+                <version>${jboss.server.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
             </dependency>
 
             <dependency>

--- a/deploy/jbossas/kit/jboss-wf8/org/modeshape/main/module.xml
+++ b/deploy/jbossas/kit/jboss-wf8/org/modeshape/main/module.xml
@@ -57,10 +57,13 @@
         <module name="org.jboss.logging"/>
         <!-- For the subsystem ... -->
         <module name="org.jboss.as.controller"/>
+        <module name="org.jboss.as.security"/>
         <module name="org.jboss.staxmapper"/>
         <module name="org.jboss.modules"/>
         <module name="org.jboss.msc"/>
         <module name="org.jboss.as.server"/>
+        <!-- For security -->
+        <module name="org.picketbox"/>        
 
         <!--Needed for clustering configurations-->
         <module name="org.jboss.as.clustering.infinispan"/>

--- a/deploy/jbossas/modeshape-jbossas-subsystem/pom.xml
+++ b/deploy/jbossas/modeshape-jbossas-subsystem/pom.xml
@@ -58,6 +58,15 @@
         </dependency>
         <dependency>
             <groupId>org.wildfly</groupId>
+            <artifactId>wildfly-security</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.picketbox</groupId>
+            <artifactId>picketbox-bare</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.wildfly</groupId>
             <artifactId>wildfly-clustering-jgroups</artifactId>
         </dependency>
         <dependency>

--- a/deploy/jbossas/modeshape-jbossas-subsystem/src/main/java/org/modeshape/jboss/security/JBossDomainAuthenticationProvider.java
+++ b/deploy/jbossas/modeshape-jbossas-subsystem/src/main/java/org/modeshape/jboss/security/JBossDomainAuthenticationProvider.java
@@ -1,0 +1,161 @@
+/*
+ * ModeShape (http://www.modeshape.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.modeshape.jboss.security;
+
+import java.security.AccessController;
+import java.util.Map;
+import javax.jcr.Credentials;
+import javax.jcr.SimpleCredentials;
+import javax.security.auth.Subject;
+import org.jboss.security.AuthenticationManager;
+import org.modeshape.jboss.service.RepositoryService;
+import org.modeshape.jcr.ExecutionContext;
+import org.modeshape.jcr.api.JaasCredentials;
+import org.modeshape.jcr.security.JaasSecurityContext;
+import org.modeshape.jcr.security.JaccSubjectResolver;
+import org.modeshape.jcr.security.SecurityContext;
+import org.modeshape.jcr.security.EnvironmentAuthenticationProvider;
+import org.modeshape.jcr.security.SimplePrincipal;
+
+/**
+ * {@link org.modeshape.jcr.security.EnvironmentAuthenticationProvider} used to interact with the security subsystem from a
+ * JBoss Application Server.
+ *
+ * @author Horia Chiorean (hchiorea@redhat.com)
+ * @see <a href="http://issues.jboss.org/browse/MODE-2411">MODE-2411</a>
+ */
+public class JBossDomainAuthenticationProvider extends EnvironmentAuthenticationProvider {
+
+    private static final org.jboss.logging.Logger LOGGER = org.jboss.logging.Logger.getLogger(
+            JBossDomainAuthenticationProvider.class.getPackage().getName());
+    
+    private AuthenticationManager authenticationManager;
+    private JaccSubjectResolver jaccSubjectResolver;
+    
+    @Override
+    public void initialize() {
+        String domainName = securityDomain();
+        this.authenticationManager = environment().getSecurityManagementServiceInjector().getValue().getAuthenticationManager(domainName);
+        assert this.authenticationManager != null;
+        // any JBoss container should be JACC compliant, so the necessary jars should be present in the classpath
+        this.jaccSubjectResolver = new JaccSubjectResolver();
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug("Initialized JBoss authentication provider using the container's authentication manager....");
+        }
+    }
+
+    @Override
+    public ExecutionContext authenticate( Credentials credentials, String repositoryName, String workspaceName,
+                                          ExecutionContext repositoryContext, Map<String, Object> sessionAttributes ) {
+        if (credentials == null) {
+            return getPreauthenticatedSubject(repositoryContext);
+        }
+        if (credentials instanceof SimpleCredentials) {
+            return validateSimpleCredentials((SimpleCredentials)credentials, repositoryContext);
+        }
+        if (credentials instanceof JaasCredentials) {
+            return getSubjectFromJaas((JaasCredentials)credentials, repositoryContext);             
+        }
+        LOGGER.warnv("Unknown {0} implementation: {1}. Please user either {2} or {3}", Credentials.class.getName(),
+                     credentials.getClass().getName(), SimpleCredentials.class.getName(), JaasCredentials.class.getName());
+        return null;
+    }
+
+    private ExecutionContext getSubjectFromJaas( JaasCredentials credentials, ExecutionContext repositoryContext ) {
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug("Looking for an active subject in the JaasCredentials instance...");
+        }
+        Subject subject = credentials.getLoginContext().getSubject();
+        if (subject == null) {
+            LOGGER.warn("Cannot authenticate because the JassCredentials instance has a login context with a null subject...");
+            return null; 
+        }
+        return repositoryContext.with(new JBossSecurityContext(new JaasSecurityContext(subject)));
+    }
+
+    private ExecutionContext validateSimpleCredentials( SimpleCredentials credentials, ExecutionContext repositoryContext) {
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debugv("Authenticating {0} in the {1} security domain using the JBoss Server security manager", credentials.getUserID(),
+                          securityDomain());
+        }
+        Subject subject = new Subject();
+        if (authenticationManager.isValid(SimplePrincipal.newInstance(credentials.getUserID()), credentials.getPassword(),
+                                          subject)) {
+            if (LOGGER.isDebugEnabled()) {
+                LOGGER.debug("Authentication successful....");
+            }
+            return repositoryContext.with(new JBossSecurityContext(new JaasSecurityContext(subject)));
+        } else {
+            if (LOGGER.isDebugEnabled()) {
+                LOGGER.debugv("Credentials for {0} are not valid for the {1} security domain", credentials.getUserID(), securityDomain());
+            }
+            return null;
+        }
+    }
+
+    private ExecutionContext getPreauthenticatedSubject( ExecutionContext repositoryContext ) {
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug("Received null credentials, attempting to search for an active subject on the calling thread via JACC");
+        }
+        // There are no credentials, so see if there is an authenticated Subject ...
+        Subject subject = Subject.getSubject(AccessController.getContext());
+        if (subject != null) {
+            // There is, so use this subject ...
+            return repositoryContext.with(new JBossSecurityContext(new JaasSecurityContext(subject)));
+        }
+        subject = jaccSubjectResolver.resolveSubject();
+        // there are no credentials and we failed to find a pre-authenticated subject, so return null.
+        return subject != null ? repositoryContext.with(new JBossSecurityContext(new JaasSecurityContext(subject))) : null;
+    }
+     
+    @Override
+    protected RepositoryService environment() {
+        return (RepositoryService)super.environment();
+    }
+
+    private final class JBossSecurityContext implements SecurityContext {
+        private final JaasSecurityContext jaasSecurityContext;
+
+        private JBossSecurityContext( JaasSecurityContext jaasSecurityContext ) {
+            assert jaasSecurityContext != null;
+            this.jaasSecurityContext = jaasSecurityContext;
+        }
+
+        @Override
+        public boolean isAnonymous() {
+            return jaasSecurityContext.isAnonymous();
+        }
+
+        @Override
+        public String getUserName() {
+            return jaasSecurityContext.getUserName();
+        }
+
+        @Override
+        public boolean hasRole( String roleName ) {
+            return jaasSecurityContext.hasRole(roleName);
+        }
+
+        @Override
+        public void logout() {
+            if (LOGGER.isDebugEnabled()) {
+                LOGGER.debug("Logging out security context....");
+            }
+            authenticationManager.logout(SimplePrincipal.newInstance(jaasSecurityContext.getUserName()), null);
+            jaasSecurityContext.logout();
+        }
+    }
+}

--- a/deploy/jbossas/modeshape-jbossas-subsystem/src/main/java/org/modeshape/jboss/service/RepositoryService.java
+++ b/deploy/jbossas/modeshape-jbossas-subsystem/src/main/java/org/modeshape/jboss/service/RepositoryService.java
@@ -36,6 +36,7 @@ import org.jboss.msc.service.StartContext;
 import org.jboss.msc.service.StartException;
 import org.jboss.msc.service.StopContext;
 import org.jboss.msc.value.InjectedValue;
+import org.jboss.security.ISecurityManagement;
 import org.modeshape.common.collection.Problems;
 import org.modeshape.common.util.DelegatingClassLoader;
 import org.modeshape.common.util.StringUtil;
@@ -68,6 +69,7 @@ public class RepositoryService implements Service<JcrRepository>, Environment {
     private final InjectedValue<String> dataDirectoryPathInjector = new InjectedValue<String>();
     private final InjectedValue<ModuleLoader> moduleLoaderInjector = new InjectedValue<ModuleLoader>();
     private final InjectedValue<RepositoryStatistics> monitorInjector = new InjectedValue<RepositoryStatistics>();
+    private final InjectedValue<ISecurityManagement> securityManagementServiceInjector = new InjectedValue<ISecurityManagement>();
 
     private RepositoryConfiguration repositoryConfiguration;
     private String journalPath;
@@ -594,6 +596,10 @@ public class RepositoryService implements Service<JcrRepository>, Environment {
      */
     public InjectedValue<CacheContainer> getWorkspacesCacheContainerInjector() {
         return workspacesCacheContainerInjector;
+    }
+    
+    public InjectedValue<ISecurityManagement> getSecurityManagementServiceInjector() {
+        return securityManagementServiceInjector;
     }
 
     private ModuleLoader moduleLoader() {

--- a/integration/modeshape-jbossas-integration-tests/src/test/java/org/modeshape/test/integration/SecurityIntegrationTest.java
+++ b/integration/modeshape-jbossas-integration-tests/src/test/java/org/modeshape/test/integration/SecurityIntegrationTest.java
@@ -75,15 +75,18 @@ public class SecurityIntegrationTest {
     }
 
     @Test
-    public void shouldAuthenticateUsingJAASProvider() throws Exception {
+    @FixFor( "MODE-2411" )
+    public void shouldAuthenticateUsingJBossProvider() throws Exception {
         JcrSession adminSession = sampleRepo.login(new SimpleCredentials("admin", "admin".toCharArray()));
         assertNotNull(adminSession);
         assertTrue(adminSession.hasPermission("/", permissionsString(ModeShapePermissions.ALL_PERMISSIONS)));
+        adminSession.logout();
 
         JcrSession guestSession = sampleRepo.login(new SimpleCredentials("guest", "guest".toCharArray()));
         assertNotNull(guestSession);
         assertTrue(guestSession.hasPermission("/", ModeShapePermissions.READ));
         assertFalse(guestSession.hasPermission("/", permissionsString(ModeShapePermissions.ALL_CHANGE_PERMISSIONS)));
+        guestSession.logout();
 
         try {
             sampleRepo.login(new SimpleCredentials("admin", "invalid".toCharArray()));

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrRepository.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrRepository.java
@@ -124,6 +124,7 @@ import org.modeshape.jcr.query.xpath.XPathQueryParser;
 import org.modeshape.jcr.security.AnonymousProvider;
 import org.modeshape.jcr.security.AuthenticationProvider;
 import org.modeshape.jcr.security.AuthenticationProviders;
+import org.modeshape.jcr.security.EnvironmentAuthenticationProvider;
 import org.modeshape.jcr.security.JaasProvider;
 import org.modeshape.jcr.security.SecurityContext;
 import org.modeshape.jcr.spi.index.IndexManager;
@@ -1598,6 +1599,13 @@ public class JcrRepository implements org.modeshape.jcr.api.Repository {
                         if (Boolean.TRUE.equals(value)) {
                             useAnonymouOnFailedLogins.set(true);
                         }
+                    }
+                    if (provider instanceof EnvironmentAuthenticationProvider) {
+                        EnvironmentAuthenticationProvider envProvider = (EnvironmentAuthenticationProvider) provider;
+                        String securityDomain = component.getDocument().getString(FieldName.DOMAIN_NAME);
+                        envProvider.setSecurityDomain(securityDomain);
+                        envProvider.setEnvironment(environment());
+                        envProvider.initialize();
                     }
                 } catch (Throwable t) {
                     logger.error(t, JcrI18n.unableToInitializeAuthenticationProvider, component, repositoryName(), t.getMessage());

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/RepositoryConfiguration.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/RepositoryConfiguration.java
@@ -379,6 +379,11 @@ public class RepositoryConfiguration {
         public static final String SECURITY = "security";
 
         /**
+         * The name of the security domain used together with a {@link org.modeshape.jcr.security.EnvironmentAuthenticationProvider}
+         */
+        public static final String DOMAIN_NAME = "domainName";
+
+        /**
          * The name for the field under "security" specifying the optional JAAS configuration.
          */
         public static final String JAAS = "jaas";

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/security/EnvironmentAuthenticationProvider.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/security/EnvironmentAuthenticationProvider.java
@@ -1,0 +1,70 @@
+/*
+ * ModeShape (http://www.modeshape.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.modeshape.jcr.security;
+
+import org.modeshape.common.util.CheckArg;
+import org.modeshape.jcr.Environment;
+
+/**
+ * Base class for {@link org.modeshape.jcr.security.AuthenticationProvider} implementations which leverage the active
+ * {@link org.modeshape.jcr.Environment} instance to perform custom authentication.
+ * 
+ * @author Horia Chiorean (hchiorea@redhat.com)
+ */
+public abstract class EnvironmentAuthenticationProvider implements AuthenticationProvider {
+    
+    private Environment environment;
+    private String securityDomain;
+    
+    /**
+     * No-arg constructor, required in order for these providers to be created via reflection at repository start.
+     */                                                               
+    public EnvironmentAuthenticationProvider() {
+    }
+
+    /**
+     * Sets the active repository environment for this provider.
+     * 
+     * @param environment a {@link org.modeshape.jcr.Environment} instance, never {@code null}
+     */
+    public void setEnvironment( Environment environment ) {
+        CheckArg.isNotNull(environment, "environment");
+        this.environment = environment;
+    }
+
+    /**
+     * Sets the name of the security domain in which authentication will be attempted.
+     * 
+     * @param securityDomain the name of a valid security domain, never {@code null}
+     */
+    public void setSecurityDomain( String securityDomain ) {
+        CheckArg.isNotNull(securityDomain, "securityDomain");
+        this.securityDomain = securityDomain;
+    }
+    
+    protected Environment environment() {
+        return environment;
+    }
+
+    protected String securityDomain() {
+        return securityDomain;
+    }
+
+    /**
+     * Initializes this provider instance, after the {@link org.modeshape.jcr.Environment) and the security domain have been set
+     */
+    public abstract void initialize();
+}

--- a/modeshape-parent/pom.xml
+++ b/modeshape-parent/pom.xml
@@ -240,7 +240,7 @@
         <jackrabbit.lucene.version>3.6.0</jackrabbit.lucene.version>
         <jbossjta.version>5.0.0.Final</jbossjta.version>
         <atomikos.version>3.8.0</atomikos.version>
-        <picketbox.version>4.0.20.Beta2</picketbox.version>
+        <picketbox.version>4.0.21.Final</picketbox.version>
         <lucene.version>3.6.2</lucene.version>
         <lucene.regex.version>3.0.3</lucene.regex.version>
 
@@ -2125,6 +2125,12 @@
             <dependency>
                 <groupId>org.wildfly</groupId>
                 <artifactId>wildfly-naming</artifactId>
+                <version>${jboss.server.version}</version>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.wildfly</groupId>
+                <artifactId>wildfly-security</artifactId>
                 <version>${jboss.server.version}</version>
                 <scope>provided</scope>
             </dependency>


### PR DESCRIPTION
This should make sure whatever caching is configured via the container is being leveraged by ModeShape.