### PR TITLE
MODE-2418 Fixed potential ConcurrentModificationException

### DIFF
--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrI18n.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrI18n.java
@@ -425,6 +425,7 @@ public final class JcrI18n {
     public static I18n versionHistoryForNewlyVersionableNodesNotAvailableUntilSave;
     public static I18n versionHistoryNotEmpty;
     public static I18n nodeIsShareable;
+    public static I18n cannotLocateBaseVersion;
 
     public static I18n creatingWorkspacesIsNotAllowedInRepository;
     public static I18n workspaceHasBeenDeleted;

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/document/LocalDocumentStore.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/document/LocalDocumentStore.java
@@ -81,7 +81,7 @@ public class LocalDocumentStore implements DocumentStore {
     public void updateDocument( String key,
                                 Document document,
                                 SessionNode sessionNode ) {
-        // do nothing, the way the local store updates is via deltas
+        // do nothing, the way the local store updates is via editing schematic entry literals
     }
 
     @Override

--- a/modeshape-jcr/src/main/resources/org/modeshape/jcr/JcrI18n.properties
+++ b/modeshape-jcr/src/main/resources/org/modeshape/jcr/JcrI18n.properties
@@ -410,6 +410,7 @@ noVersionHistoryForTransientVersionableNodes = Node '{0}' is versionable but was
 versionHistoryForNewlyVersionableNodesNotAvailableUntilSave = Node '{0}' was made 'mix:versionable' in the session but this change has not been saved, and therefore no version history is available yet
 versionHistoryNotEmpty = Cannot remove node '{0}' because its version history is not empty. Make sure all the versions have been removed before attempting to remove the node.
 nodeIsShareable = Cannot remove node '{0}' because it is a shareable node.
+cannotLocateBaseVersion = Cannot find the base version with the key '{0}' for the node '{1}'. Make sure that any checkin/checkout operations are atomic for that node.
 
 creatingWorkspacesIsNotAllowedInRepository = Creating workspaces is not allowed in the '{0}' repository. Check the configuration.
 workspaceHasBeenDeleted = The workspace "{0}" has been deleted.

--- a/modeshape-jcr/src/test/java/org/modeshape/jcr/ConcurrentWriteTest.java
+++ b/modeshape-jcr/src/test/java/org/modeshape/jcr/ConcurrentWriteTest.java
@@ -25,6 +25,7 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.UUID;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
@@ -41,7 +42,11 @@ import javax.jcr.NodeIterator;
 import javax.jcr.Repository;
 import javax.jcr.RepositoryException;
 import javax.jcr.Session;
+import javax.jcr.nodetype.NodeType;
+import javax.jcr.version.VersionManager;
+import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.modeshape.common.FixFor;
 import org.modeshape.common.annotation.Immutable;
@@ -212,14 +217,7 @@ public class ConcurrentWriteTest extends SingleUseAbstractTest {
     @Test
     @FixFor( "MODE-2216" )
     public void shouldMoveFileAndFoldersConcurrently() throws Exception {
-        if (repository != null) {
-            try {
-                TestingUtil.killRepositories(repository);
-            } finally {
-                repository = null;
-                config = null;
-            }
-        }
+        shutdownDefaultRepo();
 
         FileUtil.delete("target/move_repository");
 
@@ -263,6 +261,74 @@ public class ConcurrentWriteTest extends SingleUseAbstractTest {
 
         assertThat("Incorrect number of nodes moved", (long)movedNodeIds.size(), is(expectedMoveCount));
         assertFalse("The source parent is not empty", session.getNode(sourcePath).getNodes().hasNext());
+    }
+    
+    @Test
+    @FixFor( "MODE-2418" )
+    @Ignore("This fails wih various exceptions which are to be expected, but can be used to track down the ConcurrentModificationException (see JIRA)")
+    public void shouldVersionNodesConcurrently() throws Exception {
+        shutdownDefaultRepo();
+        FileUtil.delete("target/persistent_repository/store");
+        repository = TestingUtil.startRepositoryWithConfig("config/repo-config-filesystem-jbosstxn-pessimistic.json");
+        
+        Session session = repository.login();
+        Node uploads = session.getRootNode().addNode("uploads", NodeType.NT_FOLDER);
+        uploads.addMixin(NodeType.MIX_VERSIONABLE);
+        session.save();
+        session.logout();
+
+        List<Future<Boolean>> futures = new ArrayList<>();
+        ExecutorService pool = Executors.newCachedThreadPool();
+        int threadCount = 40;
+        for (int i = 0; i < threadCount; i++) {
+            Future<Boolean> submit = pool.submit(new Callable<Boolean>() {
+                @Override
+                public Boolean call() throws Exception {
+                    Session session = repository.login();
+                    VersionManager versionManager = session.getWorkspace().getVersionManager();
+
+                    // create sub node
+                    String path = "/uploads";
+                    versionManager.checkout(path);
+                    Node node = session.getNode(path);
+                    String uuid = UUID.randomUUID().toString();
+                    String name = Thread.currentThread().getName() + "_" + uuid;
+                    node.addNode(name, NodeType.NT_FOLDER);
+                    session.save();
+                    versionManager.checkin(path);
+
+                    // read existing nodes
+                    NodeIterator nodes = node.getNodes();
+                    while (nodes.hasNext()) {
+                        Node nextNode = nodes.nextNode();
+                        nextNode.getName();
+                    }
+
+                    session.logout();
+                    return true;
+                }
+            });
+            futures.add(submit);
+        }
+        
+        // wait for all to finish
+        boolean success = true;
+        for (Future<Boolean> future : futures) {
+            success = success && future.get(2, TimeUnit.SECONDS);
+        }
+        pool.shutdown();
+        Assert.assertTrue(success);
+    }
+
+    private void shutdownDefaultRepo() {
+        if (repository != null) {
+            try {
+                TestingUtil.killRepositories(repository);
+            } finally {
+                repository = null;
+                config = null;
+            }
+        }
     }
 
     private class MoveNodeTask implements Callable<String> {

--- a/modeshape-schematic/src/main/java/org/infinispan/schematic/internal/SchematicEntryLiteral.java
+++ b/modeshape-schematic/src/main/java/org/infinispan/schematic/internal/SchematicEntryLiteral.java
@@ -27,15 +27,10 @@ import org.infinispan.schematic.SchematicEntry;
 import org.infinispan.schematic.document.Document;
 import org.infinispan.schematic.document.Document.Field;
 import org.infinispan.schematic.document.EditableDocument;
-import org.infinispan.schematic.document.Path;
-import org.infinispan.schematic.internal.delta.Operation;
 import org.infinispan.schematic.internal.document.BasicDocument;
 import org.infinispan.schematic.internal.document.DocumentEditor;
 import org.infinispan.schematic.internal.document.MutableDocument;
-import org.infinispan.schematic.internal.document.Paths;
 import org.infinispan.schematic.internal.marshall.Ids;
-import org.infinispan.util.logging.Log;
-import org.infinispan.util.logging.LogFactory;
 
 /**
  * The primary implementation of {@link SchematicEntry}.
@@ -44,15 +39,6 @@ import org.infinispan.util.logging.LogFactory;
  */
 @SerializeWith( SchematicEntryLiteral.Externalizer.class )
 public class SchematicEntryLiteral implements SchematicEntry {
-
-    private static final Log LOGGER = LogFactory.getLog(SchematicEntryLiteral.class);
-
-    protected static class FieldPath {
-        protected static final Path ROOT = Paths.path();
-        protected static final Path METADATA = Paths.path(FieldName.METADATA);
-        protected static final Path CONTENT = Paths.path(FieldName.CONTENT);
-        protected static final Path ID = Paths.path(FieldName.METADATA, FieldName.ID);
-    }
 
     /**
      * Construction only allowed through this factory method. This factory is intended for use internally by the CacheDelegate.
@@ -186,20 +172,8 @@ public class SchematicEntryLiteral implements SchematicEntry {
         return new SchematicEntryLiteral((MutableDocument)value.clone());
     }
 
-    boolean apply( Iterable<Operation> changes ) {
-        try {
-            for (Operation o : changes) {
-                o.replay(value);
-            }
-        } catch (AssertionError e) {
-            LOGGER.debug("Assertion while applying changes to " + value + " --> " + changes);
-            throw e;
-        }
-        return true;
-    }
-
     /**
-     * The {@link org.infinispan.marshall.Externalizer Externalizer} for {@link SchematicEntryLiteral} instances.
+     * The {@link org.infinispan.commons.marshall.Externalizer} for {@link SchematicEntryLiteral} instances.
      */
     public static final class Externalizer extends SchematicExternalizer<SchematicEntryLiteral> {
         private static final long serialVersionUID = 1L;


### PR DESCRIPTION
This PR contains 2 commits:
- one which adds a small optimization & a better exception message for the `JcrVersionManager`
- one which fixes a potentially much more critical issue: when using local transactions (i.e. started & committed by ModeShape during session.save) there was a potential leakage of nodes that were being changed/edited in that transaction into the shared workspace cache (used by everyone else incl. readers), __before the transaction was committed__ The solution was to make sure that a `TransactionalWorkspaceCache` is used *always*, regardless whether a user or a local transaction in active.