### PR TITLE
MODE-2452 Implemented backup/restore methods for the REST service.

### DIFF
--- a/modeshape-jcr-api/src/main/java/org/modeshape/jcr/api/BackupOptions.java
+++ b/modeshape-jcr-api/src/main/java/org/modeshape/jcr/api/BackupOptions.java
@@ -26,7 +26,7 @@ public abstract class BackupOptions {
      * By default, 100K nodes will be exported to a single backup file. 
      * So, if each node requires about 200 bytes (compressed), the resulting files will be about 19 MB in size.
      */
-    public long DEFAULT_DOCUMENTS_PER_FILE = 100000L;
+    public static final long DEFAULT_DOCUMENTS_PER_FILE = 100000L;
     
     /**
      * Default backup options which will be used when a backup is performed without an explicit set of options.
@@ -59,5 +59,15 @@ public abstract class BackupOptions {
      */
     public boolean compress() {
         return true;
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder builder = new StringBuilder("[backup_options: ");
+        builder.append("include_binaries=").append(includeBinaries());
+        builder.append(", documents_per_file=").append(documentsPerFile());
+        builder.append(", compress=").append(compress());
+        builder.append("]");
+        return builder.toString();
     }
 }

--- a/modeshape-jcr-api/src/main/java/org/modeshape/jcr/api/RestoreOptions.java
+++ b/modeshape-jcr-api/src/main/java/org/modeshape/jcr/api/RestoreOptions.java
@@ -45,4 +45,13 @@ public abstract class RestoreOptions {
     public boolean includeBinaries() {
         return true;
     }
+
+    @Override
+    public String toString() {
+        StringBuilder builder = new StringBuilder("[restore_options: ");
+        builder.append("include_binaries=").append(includeBinaries());
+        builder.append(", reindex_content_on_finish=").append(reindexContentOnFinish());
+        builder.append("]");
+        return builder.toString();
+    }
 }

--- a/web/modeshape-web-jcr-rest-war/src/main/webapp/WEB-INF/web.xml
+++ b/web/modeshape-web-jcr-rest-war/src/main/webapp/WEB-INF/web.xml
@@ -35,6 +35,14 @@
         <param-name>org.modeshape.jcr.URL</param-name>
         <param-value>file:/repository-config.json</param-value>
     </context-param>
+ 
+    <!-- 
+        The default location where repository backups should be stored.
+    -->
+    <context-param>
+        <param-name>backupLocation</param-name>
+        <param-value>target</param-value>
+    </context-param>
 
     <!--
          This parameter defines the JAX-RS application class, which is really just a metadata class

--- a/web/modeshape-web-jcr-rest/src/main/java/org/modeshape/web/jcr/rest/RestHelper.java
+++ b/web/modeshape-web-jcr-rest/src/main/java/org/modeshape/web/jcr/rest/RestHelper.java
@@ -56,7 +56,9 @@ public final class RestHelper {
     public static final String QUERY_PLAN_METHOD_NAME = "queryPlan";
     public static final String NODE_TYPES_METHOD_NAME = "nodetypes";
     public static final String UPLOAD_METHOD_NAME = "upload";
-
+    public static final String BACKUP_METHOD_NAME = "backup";
+    public static final String RESTORE_METHOD_NAME = "restore";
+    
     private static final List<String> ALL_METHODS = Arrays.asList(BINARY_METHOD_NAME,
                                                                   ITEMS_METHOD_NAME,
                                                                   NODES_METHOD_NAME,

--- a/web/modeshape-web-jcr-rest/src/main/java/org/modeshape/web/jcr/rest/handler/RestRepositoryHandler.java
+++ b/web/modeshape-web-jcr-rest/src/main/java/org/modeshape/web/jcr/rest/handler/RestRepositoryHandler.java
@@ -16,10 +16,29 @@
 
 package org.modeshape.web.jcr.rest.handler;
 
+import java.io.File;
+import java.net.MalformedURLException;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
 import javax.jcr.RepositoryException;
 import javax.jcr.Session;
+import javax.servlet.ServletContext;
 import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.core.Response;
+import org.codehaus.jettison.json.JSONException;
+import org.codehaus.jettison.json.JSONObject;
+import org.modeshape.common.util.StringUtil;
+import org.modeshape.jcr.api.BackupOptions;
+import org.modeshape.jcr.api.Problem;
+import org.modeshape.jcr.api.Problems;
+import org.modeshape.jcr.api.Repository;
+import org.modeshape.jcr.api.RepositoryManager;
+import org.modeshape.jcr.api.RestoreOptions;
 import org.modeshape.web.jcr.rest.RestHelper;
+import org.modeshape.web.jcr.rest.model.JSONAble;
+import org.modeshape.web.jcr.rest.model.RestException;
 import org.modeshape.web.jcr.rest.model.RestWorkspaces;
 
 /**
@@ -28,6 +47,12 @@ import org.modeshape.web.jcr.rest.model.RestWorkspaces;
  * @author Horia Chiorean (hchiorea@redhat.com)
  */
 public final class RestRepositoryHandler extends AbstractHandler {
+
+    private static final String BACKUP_LOCATION_INIT_PARAM = "backupLocation";
+    private static final String JBOSS_DOMAIN_DATA_DIR = "jboss.domain.data.dir";
+    private static final String JBOSS_SERVER_DATA_DIR = "jboss.server.data.dir";
+    private static final String USER_HOME = "user.home";
+    private static final SimpleDateFormat DATE_FORMAT = new SimpleDateFormat("ddMMyyyy_HHmmss");
 
     /**
      * Returns the list of workspaces available to this user within the named repository.
@@ -50,5 +75,163 @@ public final class RestRepositoryHandler extends AbstractHandler {
             workspaces.addWorkspace(workspaceName, repositoryUrl);
         }
         return workspaces;
+    }
+
+    /**
+     * Performs a repository backup.
+     */
+    public Response backupRepository( ServletContext context, 
+                                      HttpServletRequest request, 
+                                      String repositoryName,
+                                      BackupOptions options ) throws RepositoryException {
+        final File backupLocation = resolveBackupLocation(context);
+
+        Session session = getSession(request, repositoryName, null);
+        String repositoryVersion = session.getRepository().getDescriptorValue(Repository.REP_VERSION_DESC).getString().replaceAll("\\.","");
+        final String backupName = "modeshape_" + repositoryVersion + "_" + repositoryName + "_backup_" + DATE_FORMAT.format(new Date());
+        final File backup = new File(backupLocation, backupName);
+        if (!backup.mkdirs()) {
+            throw new RuntimeException("Cannot create backup folder: " + backup);
+        }
+        logger.debug("Backing up repository '{0}' to '{1}', using '{2}'", repositoryName, backup, options);
+
+
+        RepositoryManager repositoryManager = ((org.modeshape.jcr.api.Workspace)session.getWorkspace()).getRepositoryManager();
+        repositoryManager.backupRepository(backup, options);
+        final String backupURL;
+        try {
+            backupURL = backup.toURI().toURL().toString();
+        } catch (MalformedURLException e) {
+            //should never happen
+            throw new RuntimeException(e);
+        }
+        JSONAble responseContent = new JSONAble() {
+            @Override
+            public JSONObject toJSON() throws JSONException {
+                JSONObject object = new JSONObject();
+                object.put("name", backupName);
+                object.put("url", backupURL);
+                return object;
+            }
+        }; 
+        return Response.status(Response.Status.CREATED).entity(responseContent).build();
+    }
+
+    /**
+     * Restores a repository using an existing backup.
+     */
+    public Response restoreRepository( ServletContext context, 
+                                       HttpServletRequest request, 
+                                       String repositoryName,
+                                       String backupName, 
+                                       RestoreOptions options ) throws RepositoryException {
+        if (StringUtil.isBlank(backupName)) {
+            throw new IllegalArgumentException("The name of the backup cannot be null");
+        }
+        File backup = resolveBackup(context, backupName);
+        logger.debug("Restoring repository '{0}' from backup '{1}' using '{2}'", repositoryName, backup, options);
+        Session session = getSession(request, repositoryName, null);
+        RepositoryManager repositoryManager = ((org.modeshape.jcr.api.Workspace)session.getWorkspace()).getRepositoryManager();
+        final Problems problems = repositoryManager.restoreRepository(backup, options);
+        if (!problems.hasProblems()) {
+            return Response.ok().build();
+        }
+        List<JSONAble> response = new ArrayList<JSONAble>(problems.size());
+        for (Problem problem : problems) {
+            RestException exception = problem.getThrowable() != null ? 
+                                      new RestException(problem.getMessage(), problem.getThrowable()) : 
+                                      new RestException(problem.getMessage());
+            response.add(exception);
+        }
+        return Response.status(Response.Status.INTERNAL_SERVER_ERROR).entity(response).build();
+    }
+    
+    private File resolveBackup( ServletContext context, String backupName ) {
+        // first look at the servlet init param
+        String backupRoot = context.getInitParameter(BACKUP_LOCATION_INIT_PARAM);
+        if (!StringUtil.isBlank(backupRoot)) {
+            if (isValidDir(backupRoot + "/" + backupName)) {
+                return new File(backupRoot + "/" + backupName);
+            }
+
+            // try resolving it as a system property
+            backupRoot = System.getProperty(backupRoot);
+            if (isValidDir(backupRoot + "/" + backupName)) {
+                return new File(backupRoot + "/" + backupName);
+            }
+        }
+
+        // jboss.domain.data.dir
+        backupRoot = System.getProperty(JBOSS_DOMAIN_DATA_DIR);
+        if (isValidDir(backupRoot + "/" + backupName)) {
+            return new File(backupRoot + "/" + backupName);
+        }
+
+        // jboss.server.data.dir
+        backupRoot = System.getProperty(JBOSS_SERVER_DATA_DIR);
+        if (isValidDir(backupRoot + "/" + backupName)) {
+            return new File(backupRoot + "/" + backupName);
+        }
+
+        // finally user.home
+        backupRoot = System.getProperty(USER_HOME);
+        if (isValidDir(backupRoot + "/" + backupName)) {
+            return new File(backupRoot + "/" + backupName);
+        }
+
+        // none of the above are available, so fail
+        throw new IllegalArgumentException(
+                "Cannot locate backup '" + backupName + "' anywhere on the server in the following locations:" +
+                BACKUP_LOCATION_INIT_PARAM + " context param, " + JBOSS_DOMAIN_DATA_DIR + ", " + JBOSS_SERVER_DATA_DIR + ", "
+                + USER_HOME);
+
+    }
+
+    private File resolveBackupLocation( ServletContext context ) {
+        // first look at the servlet init param 'backupLocation'
+        String backupLocation = context.getInitParameter(BACKUP_LOCATION_INIT_PARAM);
+        if (!StringUtil.isBlank(backupLocation)) {
+            if (isValidDir(backupLocation)) {
+                return new File(backupLocation);
+            }
+
+            // try resolving it as a system property
+            backupLocation = System.getProperty(backupLocation);
+            if (isValidDir(backupLocation)) {
+                return new File(backupLocation);
+            }
+        }
+
+        // jboss.domain.data.dir
+        backupLocation = System.getProperty(JBOSS_DOMAIN_DATA_DIR);
+        if (isValidDir(backupLocation)) {
+            return new File(backupLocation);
+        }
+
+        // jboss.server.data.dir
+        backupLocation = System.getProperty(JBOSS_SERVER_DATA_DIR);
+        if (isValidDir(backupLocation)) {
+            return new File(backupLocation);
+        }
+
+        // finally user.home
+        backupLocation = System.getProperty(USER_HOME);
+        if (isValidDir(backupLocation)) {
+            return new File(backupLocation);
+        }
+
+        // none of the above are available, so fail
+        throw new IllegalArgumentException(
+                "None of the following locations are writable folders on the server: " +
+                BACKUP_LOCATION_INIT_PARAM + " context param, " + JBOSS_DOMAIN_DATA_DIR + ", " + JBOSS_SERVER_DATA_DIR + ", "
+                + USER_HOME);
+    }
+
+    private boolean isValidDir( String dir ) {
+        if (StringUtil.isBlank(dir)) {
+            return false;
+        }
+        File dirFile = new File(dir);
+        return dirFile.exists() && dirFile.canWrite() && dirFile.isDirectory();
     }
 }

--- a/web/modeshape-web-jcr-rest/src/main/java/org/modeshape/web/jcr/rest/handler/RestServerHandler.java
+++ b/web/modeshape-web-jcr-rest/src/main/java/org/modeshape/web/jcr/rest/handler/RestServerHandler.java
@@ -22,7 +22,6 @@ import javax.jcr.Repository;
 import javax.jcr.Value;
 import javax.servlet.http.HttpServletRequest;
 import org.modeshape.web.jcr.RepositoryManager;
-import org.modeshape.web.jcr.rest.RestHelper;
 import org.modeshape.web.jcr.rest.model.RestRepositories;
 
 /**
@@ -30,7 +29,8 @@ import org.modeshape.web.jcr.rest.model.RestRepositories;
  *
  * @author Horia Chiorean (hchiorea@redhat.com)
  */
-public class RestServerHandler extends AbstractHandler {
+public class 
+        RestServerHandler extends AbstractHandler {
 
     /**
      * Returns the list of JCR repositories available on this server
@@ -49,8 +49,7 @@ public class RestServerHandler extends AbstractHandler {
     private void addRepository( HttpServletRequest request,
                                 RestRepositories repositories,
                                 String repositoryName ) {
-        RestRepositories.Repository repository = repositories.addRepository(repositoryName, RestHelper.urlFrom(request,
-                                                                                                               repositoryName));
+        RestRepositories.Repository repository = repositories.addRepository(repositoryName, request);
         try {
             Repository jcrRepository = RepositoryManager.getRepository(repositoryName);
             repository.setActiveSessionsCount(((org.modeshape.jcr.api.Repository)jcrRepository).getActiveSessionsCount());

--- a/web/modeshape-web-jcr-rest/src/main/java/org/modeshape/web/jcr/rest/model/RestException.java
+++ b/web/modeshape-web-jcr-rest/src/main/java/org/modeshape/web/jcr/rest/model/RestException.java
@@ -42,6 +42,19 @@ public final class RestException implements JSONAble {
     }
 
     /**
+     * Creates a new exception, using a message and a {@link Throwable}
+     *
+     * @param message a {@code non-null} string
+     * @param t a {@code non-null} {@link Exception}
+     */
+    public RestException( String message, Throwable t ) {
+        this.message = message;
+        StringWriter stringWriter = new StringWriter();
+        t.printStackTrace(new PrintWriter(stringWriter));
+        this.stackTrace = stringWriter.toString();
+    }
+
+    /**
      * Creates a new exception, based on an existing {@link Throwable}
      *
      * @param t a {@code non-null} {@link Exception}


### PR DESCRIPTION
The backup/restore methods have the following signature
```
POST http://localhost:8090/modeshape-rest/repo_name/backup 
or
POST http://localhost:8090/modeshape-rest/repo_name/backup?includeBinaries=false&documentsPerFile=1000&compress=false
```
and the response
```
{
  "name": "modeshape_382GA_repo_backup_28032015_115755",
  "url": "file:/d:/Work/hchiorean.jboss-integration.modeshape/web/modeshape-web-jcr-rest-war/target/modeshape_382GA_repo_backup_28032015_115755/"
}
```
The result will be placed on the server in one of the following locations (in order):
- backupLocation context param
- jboss.domain.data.dir
- jboss.server.data.dir
- user.home

and the name of the backup folder will have the pattern: `modeshape_version_repoName_backup_DDmmyyyy_HHmmss`

The restore methods have the following signature:
```
POST http://localhost:8090/modeshape-rest/repo_name/restore?name=modeshape_382GA_repo_backup_28032015_115755
or
POST http://localhost:8090/modeshape-rest/repo_name/restore?name=modeshape_382GA_repo_backup_28032015_115755&includeBinaries=false&reindexContent=false
```
and the backup `name` will searched on the server in the same locations & order as above.