### PR TITLE
MODE-2464: Ensures all input stream in Vdb Sequencers are closed

### DIFF
--- a/sequencers/modeshape-sequencer-teiid/src/main/java/org/modeshape/sequencer/teiid/VdbDynamicSequencer.java
+++ b/sequencers/modeshape-sequencer-teiid/src/main/java/org/modeshape/sequencer/teiid/VdbDynamicSequencer.java
@@ -34,10 +34,14 @@ public class VdbDynamicSequencer extends VdbSequencer {
         final Binary binaryValue = inputProperty.getBinary();
         CheckArg.isNotNull(binaryValue, "binary");
 
-        InputStream stream = binaryValue.getStream();
-        VdbManifest manifest = readManifest(binaryValue, stream, outputNode, context);
-        if (manifest == null) {
-            throw new Exception("VdbDynamicSequencer.execute failed. The xml cannot be read.");
+        try (final InputStream stream = binaryValue.getStream()) {
+
+            VdbManifest manifest = readManifest(binaryValue, stream, outputNode, context);
+            if (manifest == null) {
+                throw new Exception("VdbDynamicSequencer.execute failed. The xml cannot be read.");
+            }
+        } catch (final Exception e) {
+            throw new RuntimeException(TeiidI18n.errorReadingVdbFile.text(inputProperty.getPath(), e.getMessage()), e);
         }
 
         return true;

--- a/sequencers/modeshape-sequencer-teiid/src/main/java/org/modeshape/sequencer/teiid/VdbManifest.java
+++ b/sequencers/modeshape-sequencer-teiid/src/main/java/org/modeshape/sequencer/teiid/VdbManifest.java
@@ -1091,19 +1091,26 @@ public class VdbManifest implements Comparable<VdbManifest> {
                                  final Context context ) throws Exception {
             VdbManifest manifest = null;
             final XMLInputFactory factory = XMLInputFactory.newInstance();
-            final XMLStreamReader streamReader = factory.createXMLStreamReader(stream);
+            XMLStreamReader streamReader = null;
 
-            if (streamReader.hasNext()) {
-                if (streamReader.next() == XMLStreamConstants.START_ELEMENT) {
-                    final String elementName = streamReader.getLocalName();
+            try {
+                streamReader = factory.createXMLStreamReader(stream);
 
-                    if (VdbLexicon.ManifestIds.VDB.equals(elementName)) {
-                        manifest = parseVdb(streamReader);
-                        assert (manifest != null) : "manifest is null";
-                    } else {
-                        LOGGER.debug("**** unhandled vdb read element ****");
+                if (streamReader.hasNext()) {
+                    if (streamReader.next() == XMLStreamConstants.START_ELEMENT) {
+                        final String elementName = streamReader.getLocalName();
+
+                        if (VdbLexicon.ManifestIds.VDB.equals(elementName)) {
+                            manifest = parseVdb(streamReader);
+                            assert (manifest != null) : "manifest is null";
+                        } else {
+                            LOGGER.debug("**** unhandled vdb read element ****");
+                        }
                     }
                 }
+            } finally {
+                if (streamReader != null)
+                    streamReader.close();
             }
 
             return manifest;


### PR DESCRIPTION
* VdbDynamicSequencer
 * Closes the initial input stream taken from the inputProperty's
   binaryValue

* VdbManifest
 * Closes the XML StreamReader instance on completion of its reading

* Closing these ensures that the streams are closed and releases any locks
  created on the original binary property value, avoiding the possibility
  of future deadlocks when saving the property.

Is it possible to backport this to a release of 4.2.x??