### PR TITLE
MODE-2465 Changed DdlTokenizer to ignore "$"

### DIFF
--- a/sequencers/modeshape-sequencer-ddl/src/main/java/org/modeshape/sequencer/ddl/DdlTokenStream.java
+++ b/sequencers/modeshape-sequencer-ddl/src/main/java/org/modeshape/sequencer/ddl/DdlTokenStream.java
@@ -374,7 +374,6 @@ public class DdlTokenStream extends TokenStream {
                     case '+':
                     case '%':
                     case '?':
-                    case '$':
                     case '[':
                     case ']':
                     case '!':
@@ -474,7 +473,7 @@ public class DdlTokenStream extends TokenStream {
                         startIndex = input.index();
                         Position startPosition = input.position(startIndex);
                         // Read until another whitespace/symbol/decimal/slash is found
-                        while (input.hasNext() && !(input.isNextWhitespace() || input.isNextAnyOf("/.-(){}*,;+%?$[]!<>|=:"))) {
+                        while (input.hasNext() && !(input.isNextWhitespace() || input.isNextAnyOf("/.-(){}*,;+%?[]!<>|=:"))) {
                             c = input.next();
                         }
                         endIndex = input.index() + 1; // beyond last character that was included

--- a/sequencers/modeshape-sequencer-ddl/src/test/java/org/modeshape/sequencer/ddl/dialect/oracle/OracleDdlParserTest.java
+++ b/sequencers/modeshape-sequencer-ddl/src/test/java/org/modeshape/sequencer/ddl/dialect/oracle/OracleDdlParserTest.java
@@ -682,17 +682,19 @@ public class OracleDdlParserTest extends DdlParserTestHelper {
         final String content = "CREATE TABLE EL$VIS (\n" //$NON-NLS-1$
                                + "COL_A VARCHAR2(20) NOT NULL,\n" //$NON-NLS-1$
                                + "COL@B VARCHAR2(10) NOT NULL,\n" //$NON-NLS-1$
-                               + "COL#C NUMBER(10));"; //$NON-NLS-1$
+                               + "COL#C NUMBER(10),\n" //$NON-NLS-1$
+                               + "COL$D NUMBER(10));"; //$NON-NLS-1$
         this.parser.parse(content, this.rootNode, null);
         assertThat(this.rootNode.getChildCount(), is(1));
 
         final AstNode tableNode = this.rootNode.getChildren().get(0);
         assertThat(tableNode.getName(), is("EL$VIS"));
-        assertThat(tableNode.getChildCount(), is(3)); // 3 columns
+        assertThat(tableNode.getChildCount(), is(4)); // 4 columns
 
         assertThat(tableNode.childrenWithName("COL_A").size(), is(1));
         assertThat(tableNode.childrenWithName("COL@B").size(), is(1));
         assertThat(tableNode.childrenWithName("COL#C").size(), is(1));
+        assertThat(tableNode.childrenWithName("COL$D").size(), is(1));
     }
 
 }


### PR DESCRIPTION
Oracle, MySQL and postgres dialects consider a dollar sign as
a valid schema object name character. 

Table name was already handled previously but all other cases 
failed as subsection of ddl statement is created out of a list 
of tokens (at least in Oracle dialect).

Example:
Column definition like "COL$D VARCHAR2" was tokenized as
"COL", "$", "D", "VARCHAR2" and when rebuilt from tokens it
became "COL $ D VARCHAR2".
All subsequent parsing failed.

This is a generic solution.

Test result:
Tests run: 456, Failures: 0, Errors: 0, Skipped: 1