### PR TITLE
MODE-2401 Added support for handling mixins which have the "noquery" type attribute

### DIFF
--- a/modeshape-jcr/src/main/java/org/modeshape/connector/filesystem/FileSystemConnector.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/connector/filesystem/FileSystemConnector.java
@@ -924,7 +924,7 @@ public class FileSystemConnector extends WritableConnector implements Pageable {
                                                                            connector.lastModifiedTimeFor(file));
             // there is no way to observe the previous value, so fire <null>
             connectorChangeSet.propertyChanged(contentId, JcrNtLexicon.RESOURCE, Collections.<Name>emptySet(), contentId, null,
-                                               modifiedProperty, queryable);
+                                               modifiedProperty);
 
             // fire PROPERTY_CHANGED for nt:file/jcr:content/jcr:data/jcr:lastModifiedBy
             String owner = connector.ownerFor(file);
@@ -932,7 +932,7 @@ public class FileSystemConnector extends WritableConnector implements Pageable {
                 Property modifiedByProperty = connector.propertyFactory().create(JcrLexicon.LAST_MODIFIED_BY, owner);
                 // there is no way to observe the previous value, so fire <null>
                 connectorChangeSet.propertyChanged(contentId, JcrNtLexicon.RESOURCE, Collections.<Name>emptySet(), contentId,
-                                                   null, modifiedByProperty, queryable);
+                                                   null, modifiedByProperty);
             }
 
             try {
@@ -940,7 +940,7 @@ public class FileSystemConnector extends WritableConnector implements Pageable {
                 BinaryValue binaryValue = connector.binaryFor(file);
                 Property binaryProperty = connector.propertyFactory().create(JcrLexicon.DATA, binaryValue);
                 connectorChangeSet.propertyChanged(contentId, JcrNtLexicon.RESOURCE, Collections.<Name>emptySet(), contentId,
-                                                   null, binaryProperty, queryable);
+                                                   null, binaryProperty);
 
                 if (connector.addMimeTypeMixin) {
                     try {
@@ -948,7 +948,7 @@ public class FileSystemConnector extends WritableConnector implements Pageable {
                         String mimeType = binaryValue.getMimeType();
                         Property mimeTypeProperty = connector.propertyFactory().create(JcrLexicon.MIMETYPE, mimeType);
                         connectorChangeSet.propertyChanged(contentId, JcrNtLexicon.RESOURCE, Collections.<Name>emptySet(),
-                                                           contentId, null, mimeTypeProperty, queryable);
+                                                           contentId, null, mimeTypeProperty);
 
                     } catch (Throwable e) {
                         connector.getLogger().error(e, JcrI18n.couldNotGetMimeType, connector.getSourceName(), contentId,
@@ -982,7 +982,7 @@ public class FileSystemConnector extends WritableConnector implements Pageable {
             }
 
             connectorChangeSet.nodeRemoved(id, connector.idFor(parentPath.toFile()), id, primaryType,
-                                           Collections.<Name>emptySet(), queryable, parentPrimaryType, 
+                                           Collections.<Name>emptySet(), parentPrimaryType, 
                                            Collections.<Name>emptySet());
         }
 
@@ -1005,37 +1005,37 @@ public class FileSystemConnector extends WritableConnector implements Pageable {
             boolean queryable = connector.isQueryable();
             // fire NODE_ADDED for nt:file
             connectorChangeSet.nodeCreated(docId, connector.idFor(resolvedPath.getParent().toFile()), docId, primaryType,
-                                           Collections.<Name>emptySet(), Collections.<Name, Property>emptyMap(), queryable);
+                                           Collections.<Name>emptySet(), Collections.<Name, Property>emptyMap());
             // fire PROPERTY_ADDED for nt:file/jcr:created
             Property createdProperty = connector.propertyFactory().create(JcrLexicon.CREATED, connector.createdTimeFor(file));
-            connectorChangeSet.propertyAdded(docId, primaryType, Collections.<Name>emptySet(), docId, createdProperty, queryable);
+            connectorChangeSet.propertyAdded(docId, primaryType, Collections.<Name>emptySet(), docId, createdProperty);
 
             String owner = connector.ownerFor(file);
             if (owner != null) {
                 // fire PROPERTY_ADDED for nt:file/jcr:createdBy
                 Property createdByProperty = connector.propertyFactory().create(JcrLexicon.CREATED_BY, owner);
-                connectorChangeSet.propertyAdded(docId, primaryType, Collections.<Name>emptySet(), docId, createdByProperty,
-                                                 queryable);
+                connectorChangeSet.propertyAdded(docId, primaryType, Collections.<Name>emptySet(), docId, createdByProperty
+                                                );
             }
             if (Files.isRegularFile(resolvedPath, LinkOption.NOFOLLOW_LINKS)) {
                 // for files we need to fire extra events for their content
                 String contentId = connector.contentChildId(docId, false);
                 // fire NODE_ADDED for the nt:file/jcr:content
                 connectorChangeSet.nodeCreated(contentId, docId, contentId, JcrNtLexicon.RESOURCE, Collections.<Name>emptySet(),
-                                               Collections.<Name, Property>emptyMap(), queryable);
+                                               Collections.<Name, Property>emptyMap());
                 try {
                     // fire PROPERTY_ADDED for nt:file/jcr:content/jcr:data
                     BinaryValue binaryValue = connector.binaryFor(file);
                     Property dataProperty = connector.propertyFactory().create(JcrLexicon.DATA, binaryValue);
                     connectorChangeSet.propertyAdded(contentId, JcrNtLexicon.RESOURCE, Collections.<Name>emptySet(), contentId,
-                                                     dataProperty, queryable);
+                                                     dataProperty);
                     if (connector.addMimeTypeMixin) {
                         try {
                             // fire PROPERTY_ADDED for nt:file/jcr:content/jcr:mimetype
                             String mimeType = binaryValue.getMimeType();
                             Property mimeTypeProperty = connector.propertyFactory().create(JcrLexicon.MIMETYPE, mimeType);
                             connectorChangeSet.propertyAdded(contentId, JcrNtLexicon.RESOURCE, Collections.<Name>emptySet(),
-                                                             contentId, mimeTypeProperty, queryable);
+                                                             contentId, mimeTypeProperty);
 
                         } catch (Throwable e) {
                             connector.getLogger().error(e, JcrI18n.couldNotGetMimeType, connector.getSourceName(), contentId,
@@ -1050,12 +1050,12 @@ public class FileSystemConnector extends WritableConnector implements Pageable {
                 Property lastModified = connector.propertyFactory().create(JcrLexicon.LAST_MODIFIED,
                                                                            connector.lastModifiedTimeFor(file));
                 connectorChangeSet.propertyAdded(contentId, JcrNtLexicon.RESOURCE, Collections.<Name>emptySet(), contentId,
-                                                 lastModified, queryable);
+                                                 lastModified);
                 if (owner != null) {
                     // fire PROPERTY_ADDED for nt:file/jcr:content/jcr:lastModifiedBy
                     Property lastModifiedBy = connector.propertyFactory().create(JcrLexicon.LAST_MODIFIED_BY, owner);
                     connectorChangeSet.propertyAdded(contentId, JcrNtLexicon.RESOURCE, Collections.<Name>emptySet(), contentId,
-                                                     lastModifiedBy, queryable);
+                                                     lastModifiedBy);
                 }
             }
         }

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/NodeTypes.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/NodeTypes.java
@@ -805,13 +805,25 @@ public class NodeTypes {
     }
 
     /**
-     * Check if the node type with the given name is queryable or not, based on its node type definition.
+     * Check if the node type and mixin types are queryable or not. 
      *
      * @param nodeTypeName a {@link Name}, never {@code null}
-     * @return {@code true} if the node type is queryable, {@code false} otherwise.
+     * @param mixinTypes the mixin type names; may not be null but may be empty 
+     * 
+     * @return {@code false} if at least one of the node types is not queryable, {@code true} otherwise
      */
-    public boolean isQueryable(Name nodeTypeName) {
-        return !nonQueryableNodeTypes.contains(nodeTypeName);    
+    public boolean isQueryable(Name nodeTypeName, Set<Name> mixinTypes) {
+        if (nonQueryableNodeTypes.contains(nodeTypeName)) {
+            return false;
+        }
+        if (!mixinTypes.isEmpty()) {
+            for (Name mixinType : mixinTypes) {
+                if (nonQueryableNodeTypes.contains(mixinType)) {
+                    return false;
+                }
+            }
+        }
+        return true;    
     }
 
     /**

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/RepositoryQueryManager.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/RepositoryQueryManager.java
@@ -424,7 +424,7 @@ class RepositoryQueryManager implements ChangeSetListener {
                                    final IndexWriter indexes ) {
         assert indexes != null;
         if (indexes.canBeSkipped()) return;
-        if (!node.isQueryable(cache)) {
+        if (node.isExcludedFromSearch(cache)) {
             return;
         }
 
@@ -483,7 +483,7 @@ class RepositoryQueryManager implements ChangeSetListener {
     
                 // Look up the node and find the path ...
                 node = cache.getNode(key);
-                if (node == null || !node.isQueryable(cache)) {
+                if (node == null || node.isExcludedFromSearch(cache)) {
                     continue;
                 }
                 nodePath = paths.getPath(node);

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/SequencingRunner.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/SequencingRunner.java
@@ -324,7 +324,7 @@ final class SequencingRunner implements Runnable {
 
             sequencingChanges.nodeSequenced(sequencedNode.key(), sequencedNode.path(), primaryType, mixinTypes, outputNode.key(),
                                             outputNode.path(), work.getOutputPath(), work.getUserId(), work.getSelectedPath(),
-                                            sequencerName, sequencedNode.node().isQueryable(outputSession.cache()));
+                                            sequencerName);
         }
         sequencingChanges.freeze(outputSession.getUserID(), null, context.getValueFactories().getDateFactory().create());
         repository.changeBus().notify(sequencingChanges);
@@ -345,7 +345,7 @@ final class SequencingRunner implements Runnable {
                                                                                                             .journalId());
         sequencingChanges.nodeSequencingFailure(sequencedNode.key(), sequencedNode.path(), primaryType, mixinTypes,
                                                 work.getOutputPath(), work.getUserId(), work.getSelectedPath(), sequencerName,
-                                                sequencedNode.node().isQueryable(inputSession.cache()), cause);
+                                                cause);
         repository.changeBus().notify(sequencingChanges);
     }
 

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/SystemContentInitializer.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/SystemContentInitializer.java
@@ -51,7 +51,7 @@ class SystemContentInitializer implements ContentInitializer {
 
         // Create the "/jcr:system/jcr:versionStorage" node which we don't want to index
         MutableCachedNode versionStorage = createNode(session, system, "jcr:versionStorage", JcrLexicon.VERSION_STORAGE, ModeShapeLexicon.VERSION_STORAGE);
-        versionStorage.setQueryable(false);
+        versionStorage.excludeFromSearch();
 
         // Create the "/jcr:system/mode:namespaces" node ...
         namespaces = createNode(session, system, "mode:namespaces", ModeShapeLexicon.NAMESPACES, ModeShapeLexicon.NAMESPACES);
@@ -79,11 +79,11 @@ class SystemContentInitializer implements ContentInitializer {
 
         // Create the "/jcr:system/mode:locks" node which we don't want to index
         MutableCachedNode locks = createNode(session, system, "mode:locks", ModeShapeLexicon.LOCKS, ModeShapeLexicon.LOCKS);
-        locks.setQueryable(false);
+        locks.excludeFromSearch();
 
         // Create the "/jcr:system/mode:indexes" node which we don't want to index
         MutableCachedNode indexes = createNode(session, system, INDEXES_NODE_ID, ModeShapeLexicon.INDEXES, ModeShapeLexicon.INDEXES);
-        indexes.setQueryable(false);
+        indexes.excludeFromSearch();
     }
 
     protected MutableCachedNode createNode( SessionCache session,

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/CachedNode.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/CachedNode.java
@@ -252,13 +252,13 @@ public interface CachedNode {
                          Path path );
 
     /**
-     * Determine if this node should be indexed and therefore available for querying. By default, every node is queryable, so only
-     * in certain cases can a node be made non-queryable.
+     * Determine if this node and *all* of its children should be taken into account when searching/indexing or not. 
+     * A node which should be excluded from search will be completely ignored when indexing, together with all its children.
      * 
      * @param cache the cache to which this node belongs, required in case this node needs to use the cache; may not be null
      * @return {@code true} if the node should be indexed, {@code false} otherwise
      */
-    boolean isQueryable( NodeCache cache );
+    boolean isExcludedFromSearch( NodeCache cache );
 
     /**
      * Determine if there is an access control list for this node only, not taking into account any possible parents.

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/MutableCachedNode.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/MutableCachedNode.java
@@ -409,11 +409,9 @@ public interface MutableCachedNode extends CachedNode {
     public boolean hasOnlyChangesToAdditionalParents();
 
     /**
-     * Sets a flag indicating if this node should be queryable or not.
-     * 
-     * @param queryable a {@code boolean}.
+     * Sets a flag indicating if this node and anything below it should be excluded from all searches and indexing operations.
      */
-    public void setQueryable( boolean queryable );
+    public void excludeFromSearch();
 
     /**
      * Returns an object encapsulating all the different changes that this session node contains.

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/change/AbstractNodeChange.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/change/AbstractNodeChange.java
@@ -40,13 +40,10 @@ public abstract class AbstractNodeChange extends Change {
 
     protected final Path path;
 
-    private final boolean queryable;
-
     protected AbstractNodeChange( NodeKey key,
                                   Path path,
                                   Name primaryType,
-                                  Set<Name> mixinTypes,
-                                  boolean queryable ) {
+                                  Set<Name> mixinTypes ) {
         assert key != null;
         assert path != null;
 
@@ -59,7 +56,6 @@ public abstract class AbstractNodeChange extends Change {
             assert mixinTypes != null;
             System.arraycopy(mixinTypes.toArray(new Name[0]), 0, types, 1, mixinTypes.size());
         }
-        this.queryable = queryable;
     }
 
     /**
@@ -112,12 +108,4 @@ public abstract class AbstractNodeChange extends Change {
         return nodeTypes.isTypeOrSubtype(types, nodeTypeName);
     }
 
-    /**
-     * Return whether this node is queryable.
-     * 
-     * @return true if this node is queryable, or false otherwise
-     */
-    public boolean isQueryable() {
-        return queryable;
-    }
 }

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/change/AbstractPropertyChange.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/change/AbstractPropertyChange.java
@@ -34,9 +34,8 @@ public abstract class AbstractPropertyChange extends AbstractNodeChange {
                                       Name nodePrimaryType,
                                       Set<Name> nodeMixinTypes,
                                       Path nodePath,
-                                      Property property,
-                                      boolean queryable ) {
-        super(key, nodePath, nodePrimaryType, nodeMixinTypes, queryable);
+                                      Property property ) {
+        super(key, nodePath, nodePrimaryType, nodeMixinTypes);
         this.property = property;
     }
 

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/change/AbstractSequencingChange.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/change/AbstractSequencingChange.java
@@ -39,12 +39,11 @@ public abstract class AbstractSequencingChange extends AbstractNodeChange {
                                         Path sequencedNodePath,
                                         Name sequencedNodePrimaryType,
                                         Set<Name> sequencedNodeMixinTypes,
-                                        boolean queryable,
                                         String outputPath,
                                         String userId,
                                         String selectedPath,
                                         String sequencerName ) {
-        super(sequencedNodeKey, sequencedNodePath, sequencedNodePrimaryType, sequencedNodeMixinTypes, queryable);
+        super(sequencedNodeKey, sequencedNodePath, sequencedNodePrimaryType, sequencedNodeMixinTypes);
         assert outputPath != null;
         assert userId != null;
         assert selectedPath != null;

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/change/Changes.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/change/Changes.java
@@ -49,32 +49,27 @@ public interface Changes {
 
     /**
      * Signal that a new node was created.
-     * 
      * @param key the key for the new node; may not be null
      * @param parentKey the key for the parent of the new node; may not be null
      * @param path the path to the new node; may not be null
      * @param primaryType the primary type of the node; may not be null
      * @param mixinTypes the mixin types of the node; may not be null
      * @param properties the properties in the new node, or null if there are none
-     * @param queryable true if this node is queryable, or false otherwise
      */
     void nodeCreated( NodeKey key,
                       NodeKey parentKey,
                       Path path,
                       Name primaryType,
                       Set<Name> mixinTypes,
-                      Map<Name, Property> properties,
-                      boolean queryable );
+                      Map<Name, Property> properties );
 
     /**
      * Signal that a node was removed.
-     * 
      * @param key the key for the removed node; may not be null
      * @param parentKey the key for the old parent of the removed node; may not be null
      * @param path the path to the removed node; may not be null
      * @param primaryType the primary type of the node; may not be null
      * @param mixinTypes the mixin types of the node; may not be null
-     * @param queryable true if this node is queryable, or false otherwise
      * @param parentPrimaryType the primary type of the parent of the node; may be null if this information is not available
      * @param parentMixinTypes the mixin types of the parent of the node; may be null if this information is not available
      */
@@ -83,30 +78,25 @@ public interface Changes {
                       Path path,
                       Name primaryType,
                       Set<Name> mixinTypes,
-                      boolean queryable, 
-                      Name parentPrimaryType, 
+                      Name parentPrimaryType,
                       Set<Name> parentMixinTypes );
 
     /**
      * Signal that a node was renamed (but still has the same parent)
-     * 
      * @param key the key for the node; may not be null
      * @param newPath the new path for the node; may not be null
      * @param oldName the old name (including SNS index); may not be null
      * @param primaryType the primary type of the node; may not be null
      * @param mixinTypes the mixin types of the node; may not be null
-     * @param queryable true if this node is queryable, or false otherwise
      */
     void nodeRenamed( NodeKey key,
                       Path newPath,
                       Path.Segment oldName,
                       Name primaryType,
-                      Set<Name> mixinTypes,
-                      boolean queryable );
+                      Set<Name> mixinTypes );
 
     /**
      * Signal that a node was moved from one parent to another, and may have also been renamed.
-     * 
      * @param key the key for the node; may not be null
      * @param primaryType the primary type of the node; may not be null
      * @param mixinTypes the mixin types of the node; may not be null
@@ -114,7 +104,6 @@ public interface Changes {
      * @param oldParent the old parent for the node; may not be null
      * @param newPath the new path for the node after it has been moved; may not be null
      * @param oldPath the old path for the node before it was moved; may not be null
-     * @param queryable true if this node is queryable, or false otherwise
      */
     void nodeMoved( NodeKey key,
                     Name primaryType,
@@ -122,12 +111,11 @@ public interface Changes {
                     NodeKey newParent,
                     NodeKey oldParent,
                     Path newPath,
-                    Path oldPath,
-                    boolean queryable );
+                    Path oldPath );
 
     /**
      * Signal that a node was placed into a new location within the same parent.
-     * 
+     *
      * @param key the key for the node; may not be null
      * @param primaryType the primary type of the node; may not be null
      * @param mixinTypes the mixin types of the node; may not be null
@@ -135,7 +123,6 @@ public interface Changes {
      * @param newPath the new path for the node after it has been reordered; may not be null
      * @param oldPath the old path for the node before it was reordered; may be null in the case of transient reorderings
      * @param reorderedBeforePath the path of the node before which the node was moved; or null if the node was reordered to the
-     * @param queryable true if this node is queryable, or false otherwise
      */
     void nodeReordered( NodeKey key,
                         Name primaryType,
@@ -143,27 +130,23 @@ public interface Changes {
                         NodeKey parent,
                         Path newPath,
                         Path oldPath,
-                        Path reorderedBeforePath,
-                        boolean queryable );
+                        Path reorderedBeforePath );
 
     /**
      * Create an event signifying that something about the node (other than the properties or location) changed.
-     * 
      * @param key the node key; may not be null
      * @param path the path
      * @param primaryType the primary type of the node; may not be null
      * @param mixinTypes the mixin types of the node; may not be null
-     * @param queryable true if this node is queryable, or false otherwise
      */
     void nodeChanged( NodeKey key,
                       Path path,
                       Name primaryType,
-                      Set<Name> mixinTypes,
-                      boolean queryable );
+                      Set<Name> mixinTypes );
 
     /**
      * Signal that a node was successfully sequenced.
-     * 
+     *
      * @param sequencedNodeKey the key of the node that was used as input and sequenced; may not be null
      * @param sequencedNodePath the path of the node that was used as input and sequenced; may not be null
      * @param sequencedNodePrimaryType the primary type of the node that was used as input and sequenced; may not be null
@@ -175,7 +158,6 @@ public interface Changes {
      * @param selectedPath the string representation of the path that led to the sequencing operation (which may or may not be the
      *        same as the sequenced node path); may not be null
      * @param sequencerName the name of the sequencer; may not be null
-     * @param queryable true if this node is queryable, or false otherwise
      */
     void nodeSequenced( NodeKey sequencedNodeKey,
                         Path sequencedNodePath,
@@ -186,12 +168,10 @@ public interface Changes {
                         String outputPath,
                         String userId,
                         String selectedPath,
-                        String sequencerName,
-                        boolean queryable );
+                        String sequencerName );
 
     /**
      * Signal that a node was not sequenced successfully.
-     * 
      * @param sequencedNodeKey the key of the node that was used as input and sequenced; may not be null
      * @param sequencedNodePath the path of the node that was used as input and sequenced; may not be null
      * @param sequencedNodePrimaryType the primary type of the node that was used as input and sequenced; may not be null
@@ -201,7 +181,6 @@ public interface Changes {
      * @param selectedPath the string representation of the path that led to the (failed) sequencing operation (which may or may
      *        not be the same as the sequenced node path); may not be null
      * @param sequencerName the name of the sequencer; may not be null
-     * @param queryable true if this node is queryable, or false otherwise
      * @param cause the exception that caused the failure; may not be null
      */
     void nodeSequencingFailure( NodeKey sequencedNodeKey,
@@ -212,61 +191,51 @@ public interface Changes {
                                 String userId,
                                 String selectedPath,
                                 String sequencerName,
-                                boolean queryable,
                                 Throwable cause );
 
     /**
      * Signal that a property was added to a node.
-     * 
      * @param key the key of the node that was changed; may not be null
      * @param nodePrimaryType the primary type of the node; may not be null
      * @param nodeMixinTypes the mixin types of the node; may not be null
      * @param nodePath the path of the node that was changed
      * @param property the new property, with name and value(s); may not be null
-     * @param queryable true if this node is queryable, or false otherwise
      */
     void propertyAdded( NodeKey key,
                         Name nodePrimaryType,
                         Set<Name> nodeMixinTypes,
                         Path nodePath,
-                        Property property,
-                        boolean queryable );
+                        Property property );
 
     /**
      * Signal that a property was removed from a node.
-     * 
      * @param key the key of the node that was changed; may not be null
      * @param nodePrimaryType the primary type of the node; may not be null
      * @param nodeMixinTypes the mixin types of the node; may not be null
      * @param nodePath the path of the node that was changed
      * @param property the property that was removed, with name and value(s); may not be null
-     * @param queryable true if this node is queryable, or false otherwise
      */
     void propertyRemoved( NodeKey key,
                           Name nodePrimaryType,
                           Set<Name> nodeMixinTypes,
                           Path nodePath,
-                          Property property,
-                          boolean queryable );
+                          Property property );
 
     /**
      * Signal that a property was changed on a node.
-     * 
      * @param key the key of the node that was changed; may not be null
      * @param nodePrimaryType the primary type of the node; may not be null
      * @param nodeMixinTypes the mixin types of the node; may not be null
      * @param nodePath the path of the node that was changed
      * @param newProperty the new property, with name and value(s); may not be null
      * @param oldProperty the old property, with name and value(s); may not be null
-     * @param queryable true if this node is queryable, or false otherwise
      */
     void propertyChanged( NodeKey key,
                           Name nodePrimaryType,
                           Set<Name> nodeMixinTypes,
                           Path nodePath,
                           Property newProperty,
-                          Property oldProperty,
-                          boolean queryable );
+                          Property oldProperty );
 
     /**
      * Signal that the binary with the given key is not longer used by any properties.

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/change/NoOpChanges.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/change/NoOpChanges.java
@@ -54,8 +54,7 @@ public final class NoOpChanges implements Changes {
                              Path path,
                              Name primaryType,
                              Set<Name> mixinTypes,
-                             Map<Name, Property> properties,
-                             boolean queryable ) {
+                             Map<Name, Property> properties ) {
     }
 
     @Override
@@ -64,8 +63,7 @@ public final class NoOpChanges implements Changes {
                              Path path,
                              Name primaryType,
                              Set<Name> mixinTypes,
-                             boolean queryable, 
-                             Name parentPrimaryType, 
+                             Name parentPrimaryType,
                              Set<Name> parentMixinTypes ) {
     }
 
@@ -74,8 +72,7 @@ public final class NoOpChanges implements Changes {
                              Path newPath,
                              Segment oldName,
                              Name primaryType,
-                             Set<Name> mixinTypes,
-                             boolean queryable ) {
+                             Set<Name> mixinTypes ) {
     }
 
     @Override
@@ -85,8 +82,7 @@ public final class NoOpChanges implements Changes {
                            NodeKey newParent,
                            NodeKey oldParent,
                            Path newPath,
-                           Path oldPath,
-                           boolean queryable ) {
+                           Path oldPath ) {
     }
 
     @Override
@@ -96,16 +92,14 @@ public final class NoOpChanges implements Changes {
                                NodeKey parent,
                                Path newPath,
                                Path oldPath,
-                               Path reorderedBeforePath,
-                               boolean queryable ) {
+                               Path reorderedBeforePath ) {
     }
 
     @Override
     public void nodeChanged( NodeKey key,
                              Path path,
                              Name primaryType,
-                             Set<Name> mixinTypes,
-                             boolean queryable ) {
+                             Set<Name> mixinTypes ) {
     }
 
     @Override
@@ -118,8 +112,7 @@ public final class NoOpChanges implements Changes {
                                String outputPath,
                                String userId,
                                String selectedPath,
-                               String sequencerName,
-                               boolean queryable ) {
+                               String sequencerName ) {
     }
 
     @Override
@@ -131,7 +124,6 @@ public final class NoOpChanges implements Changes {
                                        String userId,
                                        String selectedPath,
                                        String sequencerName,
-                                       boolean queryable,
                                        Throwable cause ) {
     }
 
@@ -140,8 +132,7 @@ public final class NoOpChanges implements Changes {
                                Name nodePrimaryType,
                                Set<Name> nodeMixinTypes,
                                Path nodePath,
-                               Property property,
-                               boolean queryable ) {
+                               Property property ) {
     }
 
     @Override
@@ -149,8 +140,7 @@ public final class NoOpChanges implements Changes {
                                  Name nodePrimaryType,
                                  Set<Name> nodeMixinTypes,
                                  Path nodePath,
-                                 Property property,
-                                 boolean queryable ) {
+                                 Property property ) {
     }
 
     @Override
@@ -159,8 +149,7 @@ public final class NoOpChanges implements Changes {
                                  Set<Name> nodeMixinTypes,
                                  Path nodePath,
                                  Property newProperty,
-                                 Property oldProperty,
-                                 boolean queryable ) {
+                                 Property oldProperty ) {
     }
 
     @Override

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/change/NodeAdded.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/change/NodeAdded.java
@@ -40,9 +40,8 @@ public class NodeAdded extends AbstractNodeChange {
                       Path path,
                       Name primaryType,
                       Set<Name> mixinTypes,
-                      Map<Name, Property> properties,
-                      boolean queryable ) {
-        super(key, path, primaryType, mixinTypes, queryable);
+                      Map<Name, Property> properties ) {
+        super(key, path, primaryType, mixinTypes);
         this.parentKey = parentKey;
         assert this.parentKey != null;
         if (properties == null || properties.isEmpty()) {

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/change/NodeChanged.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/change/NodeChanged.java
@@ -30,9 +30,8 @@ public class NodeChanged extends AbstractNodeChange {
     public NodeChanged( NodeKey key,
                         Path path,
                         Name primaryType,
-                        Set<Name> mixinTypes,
-                        boolean queryable ) {
-        super(key, path, primaryType, mixinTypes, queryable);
+                        Set<Name> mixinTypes ) {
+        super(key, path, primaryType, mixinTypes);
     }
 
     @Override

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/change/NodeMoved.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/change/NodeMoved.java
@@ -37,9 +37,8 @@ public class NodeMoved extends AbstractNodeChange {
                       NodeKey oldParent,
                       NodeKey newParent,
                       Path newPath,
-                      Path oldPath,
-                      boolean queryable ) {
-        super(key, newPath, primaryType, mixinTypes, queryable);
+                      Path oldPath ) {
+        super(key, newPath, primaryType, mixinTypes);
         this.oldParent = oldParent;
         this.newParent = newParent;
         this.oldPath = oldPath;

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/change/NodeRemoved.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/change/NodeRemoved.java
@@ -36,10 +36,9 @@ public class NodeRemoved extends AbstractNodeChange {
                         Path path,
                         Name primaryType,
                         Set<Name> mixinTypes,
-                        boolean queryable, 
-                        Name parentPrimaryType, 
+                        Name parentPrimaryType,
                         Set<Name> parentMixinTypes ) {
-        super(key, path, primaryType, mixinTypes, queryable);
+        super(key, path, primaryType, mixinTypes);
         this.parentKey = parentKey;
         this.parentPrimaryType = parentPrimaryType;
         this.parentMixinTypes = parentMixinTypes;

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/change/NodeRenamed.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/change/NodeRenamed.java
@@ -34,9 +34,8 @@ public class NodeRenamed extends AbstractNodeChange {
                         Path newPath,
                         Segment oldSegment,
                         Name primaryType,
-                        Set<Name> mixinTypes,
-                        boolean queryable ) {
-        super(key, newPath, primaryType, mixinTypes, queryable);
+                        Set<Name> mixinTypes ) {
+        super(key, newPath, primaryType, mixinTypes);
         this.oldSegment = oldSegment;
         assert !this.oldSegment.equals(newPath.getLastSegment());
     }

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/change/NodeReordered.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/change/NodeReordered.java
@@ -39,9 +39,8 @@ public class NodeReordered extends AbstractNodeChange {
                           NodeKey parent,
                           Path newPath,
                           Path oldPath,
-                          Path reorderedBeforePath,
-                          boolean queryable ) {
-        super(key, newPath, primaryType, mixinTypes, queryable);
+                          Path reorderedBeforePath ) {
+        super(key, newPath, primaryType, mixinTypes);
         this.oldPath = oldPath;
         this.parent = parent;
         this.reorderedBeforePath = reorderedBeforePath;

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/change/NodeSequenced.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/change/NodeSequenced.java
@@ -41,9 +41,8 @@ public class NodeSequenced extends AbstractSequencingChange {
                           String outputPath,
                           String userId,
                           String selectedPath,
-                          String sequencerName,
-                          boolean queryable ) {
-        super(sequencedNodeKey, sequencedNodePath, sequencedNodePrimaryType, sequencedNodeMixinTypes, queryable, outputPath,
+                          String sequencerName ) {
+        super(sequencedNodeKey, sequencedNodePath, sequencedNodePrimaryType, sequencedNodeMixinTypes, outputPath,
               userId, selectedPath, sequencerName);
         assert outputNodeKey != null;
         assert outputNodePath != null;

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/change/NodeSequencingFailure.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/change/NodeSequencingFailure.java
@@ -42,9 +42,8 @@ public class NodeSequencingFailure extends AbstractSequencingChange {
                                   String userId,
                                   String selectedPath,
                                   String sequencerName,
-                                  boolean queryable,
                                   Throwable cause ) {
-        super(sequencedNodeKey, sequencedNodePath, sequencedNodePrimaryType, sequencedNodeMixinTypes, queryable, outputPath,
+        super(sequencedNodeKey, sequencedNodePath, sequencedNodePrimaryType, sequencedNodeMixinTypes, outputPath,
               userId, selectedPath, sequencerName);
         assert cause != null;
         this.cause = cause;

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/change/PropertyAdded.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/change/PropertyAdded.java
@@ -32,9 +32,8 @@ public class PropertyAdded extends AbstractPropertyChange {
                              Name nodePrimaryType,
                              Set<Name> nodeMixinTypes,
                              Path nodePath,
-                             Property property,
-                             boolean queryable ) {
-        super(key, nodePrimaryType, nodeMixinTypes, nodePath, property, queryable);
+                             Property property ) {
+        super(key, nodePrimaryType, nodeMixinTypes, nodePath, property);
     }
 
     @Override

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/change/PropertyChanged.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/change/PropertyChanged.java
@@ -35,9 +35,8 @@ public class PropertyChanged extends AbstractPropertyChange {
                                Set<Name> nodeMixinTypes,
                                Path nodePath,
                                Property newProperty,
-                               Property oldProperty,
-                               boolean queryable ) {
-        super(key, nodePrimaryType, nodeMixinTypes, nodePath, newProperty, queryable);
+                               Property oldProperty ) {
+        super(key, nodePrimaryType, nodeMixinTypes, nodePath, newProperty);
         this.oldProperty = oldProperty;
     }
 

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/change/PropertyRemoved.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/change/PropertyRemoved.java
@@ -32,9 +32,8 @@ public class PropertyRemoved extends AbstractPropertyChange {
                                Name nodePrimaryType,
                                Set<Name> nodeMixinTypes,
                                Path nodePath,
-                               Property property,
-                               boolean queryable ) {
-        super(key, nodePrimaryType, nodeMixinTypes, nodePath, property, queryable);
+                               Property property ) {
+        super(key, nodePrimaryType, nodeMixinTypes, nodePath, property);
     }
 
     @Override

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/change/RecordingChanges.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/change/RecordingChanges.java
@@ -107,9 +107,8 @@ public class RecordingChanges implements Changes, ChangeSet {
                              Path path,
                              Name primaryType,
                              Set<Name> mixinTypes,
-                             Map<Name, Property> properties,
-                             boolean queryable ) {
-        events.add(new NodeAdded(key, parentKey, path, filterName(primaryType), filterNameSet(mixinTypes), properties, queryable));
+                             Map<Name, Property> properties ) {
+        events.add(new NodeAdded(key, parentKey, path, filterName(primaryType), filterNameSet(mixinTypes), properties));
     }
 
     @Override
@@ -118,10 +117,9 @@ public class RecordingChanges implements Changes, ChangeSet {
                              Path path,
                              Name primaryType,
                              Set<Name> mixinTypes,
-                             boolean queryable, 
-                             Name parentPrimaryType, 
+                             Name parentPrimaryType,
                              Set<Name> parentMixinTypes ) {
-        events.add(new NodeRemoved(key, parentKey, path, filterName(primaryType), filterNameSet(mixinTypes), queryable, parentPrimaryType, 
+        events.add(new NodeRemoved(key, parentKey, path, filterName(primaryType), filterNameSet(mixinTypes), parentPrimaryType, 
                                    parentMixinTypes));
     }
 
@@ -130,9 +128,8 @@ public class RecordingChanges implements Changes, ChangeSet {
                              Path newPath,
                              Segment oldName,
                              Name primaryType,
-                             Set<Name> mixinTypes,
-                             boolean queryable ) {
-        events.add(new NodeRenamed(key, newPath, oldName, filterName(primaryType), filterNameSet(mixinTypes), queryable));
+                             Set<Name> mixinTypes ) {
+        events.add(new NodeRenamed(key, newPath, oldName, filterName(primaryType), filterNameSet(mixinTypes)));
     }
 
     @Override
@@ -142,10 +139,9 @@ public class RecordingChanges implements Changes, ChangeSet {
                            NodeKey newParent,
                            NodeKey oldParent,
                            Path newPath,
-                           Path oldPath,
-                           boolean queryable ) {
-        events.add(new NodeMoved(key, filterName(primaryType), filterNameSet(mixinTypes), newParent, oldParent, newPath, oldPath,
-                                 queryable));
+                           Path oldPath ) {
+        events.add(new NodeMoved(key, filterName(primaryType), filterNameSet(mixinTypes), newParent, oldParent, newPath, oldPath
+        ));
     }
 
     @Override
@@ -155,19 +151,17 @@ public class RecordingChanges implements Changes, ChangeSet {
                                NodeKey parent,
                                Path newPath,
                                Path oldPath,
-                               Path reorderedBeforePath,
-                               boolean queryable ) {
+                               Path reorderedBeforePath ) {
         events.add(new NodeReordered(key, filterName(primaryType), filterNameSet(mixinTypes), parent, newPath, oldPath,
-                                     reorderedBeforePath, queryable));
+                                     reorderedBeforePath));
     }
 
     @Override
     public void nodeChanged( NodeKey key,
                              Path path,
                              Name primaryType,
-                             Set<Name> mixinTypes,
-                             boolean queryable ) {
-        events.add(new NodeChanged(key, path, filterName(primaryType), filterNameSet(mixinTypes), queryable));
+                             Set<Name> mixinTypes ) {
+        events.add(new NodeChanged(key, path, filterName(primaryType), filterNameSet(mixinTypes)));
     }
 
     @Override
@@ -180,11 +174,10 @@ public class RecordingChanges implements Changes, ChangeSet {
                                String outputPath,
                                String userId,
                                String selectedPath,
-                               String sequencerName,
-                               boolean queryable ) {
+                               String sequencerName ) {
         events.add(new NodeSequenced(sequencedNodeKey, sequencedNodePath, filterName(sequencedNodePrimaryType),
                                      filterNameSet(sequencedNodeMixinTypes), outputNodeKey, outputNodePath, outputPath, userId,
-                                     selectedPath, sequencerName, queryable));
+                                     selectedPath, sequencerName));
     }
 
     @Override
@@ -196,11 +189,10 @@ public class RecordingChanges implements Changes, ChangeSet {
                                        String userId,
                                        String selectedPath,
                                        String sequencerName,
-                                       boolean queryable,
                                        Throwable cause ) {
         events.add(new NodeSequencingFailure(sequencedNodeKey, sequencedNodePath, filterName(sequencedNodePrimaryType),
                                              filterNameSet(sequencedNodeMixinTypes), outputPath, userId, selectedPath,
-                                             sequencerName, queryable, cause));
+                                             sequencerName, cause));
     }
 
     @Override
@@ -208,10 +200,9 @@ public class RecordingChanges implements Changes, ChangeSet {
                                Name nodePrimaryType,
                                Set<Name> nodeMixinTypes,
                                Path nodePath,
-                               Property property,
-                               boolean queryable ) {
-        events.add(new PropertyAdded(key, filterName(nodePrimaryType), filterNameSet(nodeMixinTypes), nodePath, property,
-                                     queryable));
+                               Property property ) {
+        events.add(new PropertyAdded(key, filterName(nodePrimaryType), filterNameSet(nodeMixinTypes), nodePath, property
+        ));
     }
 
     @Override
@@ -219,10 +210,9 @@ public class RecordingChanges implements Changes, ChangeSet {
                                  Name nodePrimaryType,
                                  Set<Name> nodeMixinTypes,
                                  Path nodePath,
-                                 Property property,
-                                 boolean queryable ) {
-        events.add(new PropertyRemoved(key, filterName(nodePrimaryType), filterNameSet(nodeMixinTypes), nodePath, property,
-                                       queryable));
+                                 Property property ) {
+        events.add(new PropertyRemoved(key, filterName(nodePrimaryType), filterNameSet(nodeMixinTypes), nodePath, property
+        ));
     }
 
     @Override
@@ -231,10 +221,9 @@ public class RecordingChanges implements Changes, ChangeSet {
                                  Set<Name> nodeMixinTypes,
                                  Path nodePath,
                                  Property newProperty,
-                                 Property oldProperty,
-                                 boolean queryable ) {
+                                 Property oldProperty ) {
         events.add(new PropertyChanged(key, filterName(nodePrimaryType), filterNameSet(nodeMixinTypes), nodePath, newProperty,
-                                       oldProperty, queryable));
+                                       oldProperty));
     }
 
     @Override

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/document/LazyCachedNode.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/document/LazyCachedNode.java
@@ -471,9 +471,9 @@ public class LazyCachedNode implements CachedNode, Serializable {
     }
 
     @Override
-    public boolean isQueryable( NodeCache cache ) {
+    public boolean isExcludedFromSearch( NodeCache cache ) {
         WorkspaceCache wsCache = workspaceCache(cache);
-        return wsCache.translator().isQueryable(document(wsCache));
+        return !wsCache.translator().isQueryable(document(wsCache));
     }
 
     @Override

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/document/SessionNode.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/document/SessionNode.java
@@ -100,7 +100,7 @@ public class SessionNode implements MutableCachedNode {
     private final AtomicReference<MutableChildReferences> appended = new AtomicReference<MutableChildReferences>();
     private final AtomicReference<MixinChanges> mixinChanges = new AtomicReference<MixinChanges>();
     private final AtomicReference<ReferrerChanges> referrerChanges = new AtomicReference<ReferrerChanges>();
-    private final AtomicReference<Boolean> isQueryable = new AtomicReference<Boolean>();
+    private final AtomicReference<Boolean> excludeFromSearch = new AtomicReference<Boolean>();
     private final boolean isNew;
     private volatile LockChange lockChange;
     private final AtomicReference<PermissionChanges> permissionChanges = new AtomicReference<>();
@@ -1405,19 +1405,18 @@ public class SessionNode implements MutableCachedNode {
     }
 
     @Override
-    public boolean isQueryable( NodeCache cache ) {
-        Boolean isQueryable = this.isQueryable.get();
-        if (isQueryable != null) {
-            return isQueryable;
+    public boolean isExcludedFromSearch( NodeCache cache ) {
+        Boolean isExcludedFromSearch = this.excludeFromSearch.get();
+        if (isExcludedFromSearch != null) {
+            return isExcludedFromSearch;
         }
         CachedNode persistedNode = nodeInWorkspace(session(cache));
         // if the node does not exist yet, it is queryable by default
-        return persistedNode == null || persistedNode.isQueryable(cache);
+        return persistedNode != null && persistedNode.isExcludedFromSearch(cache);
     }
 
-    @Override
-    public void setQueryable( boolean queryable ) {
-        this.isQueryable.set(queryable);
+    public void excludeFromSearch() {
+        this.excludeFromSearch.set(Boolean.TRUE);
     }
 
     @Override

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/federation/ConnectorChangeSetImpl.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/federation/ConnectorChangeSetImpl.java
@@ -95,14 +95,13 @@ public class ConnectorChangeSetImpl implements ConnectorChangeSet {
                              String path,
                              Name primaryType,
                              Set<Name> mixinTypes,
-                             Map<Name, Property> properties,
-                             boolean queryable ) {
+                             Map<Name, Property> properties ) {
         NodeKey key = nodeKey(docId);
         NodeKey parentKey = nodeKey(parentDocId);
         Path externalPath = pathMappings.getPathFactory().create(path);
         // This external path in the connector may be projected into *multiple* nodes in the same or different workspaces ...
         for (WorkspaceAndPath wsAndPath : pathMappings.resolveExternalPathToInternal(externalPath)) {
-            changesFor(wsAndPath).nodeCreated(key, parentKey, wsAndPath.getPath(), primaryType, mixinTypes, properties, queryable);
+            changesFor(wsAndPath).nodeCreated(key, parentKey, wsAndPath.getPath(), primaryType, mixinTypes, properties);
         }
     }
 
@@ -112,15 +111,14 @@ public class ConnectorChangeSetImpl implements ConnectorChangeSet {
                              String path,
                              Name primaryType,
                              Set<Name> mixinTypes,
-                             boolean queryable, 
-                             Name parentPrimaryType, 
+                             Name parentPrimaryType,
                              Set<Name> parentMixinTypes ) {
         NodeKey key = nodeKey(docId);
         NodeKey parentKey = nodeKey(parentDocId);
         Path externalPath = pathMappings.getPathFactory().create(path);
         // This external path in the connector may be projected into *multiple* nodes in the same or different workspaces ...
         for (WorkspaceAndPath wsAndPath : pathMappings.resolveExternalPathToInternal(externalPath)) {
-            changesFor(wsAndPath).nodeRemoved(key, parentKey, wsAndPath.getPath(), primaryType, mixinTypes, queryable, parentPrimaryType, 
+            changesFor(wsAndPath).nodeRemoved(key, parentKey, wsAndPath.getPath(), primaryType, mixinTypes, parentPrimaryType, 
                                               parentMixinTypes);
         }
         // Signal to the manager of the Connector instances that an external node was removed. If this external
@@ -135,8 +133,7 @@ public class ConnectorChangeSetImpl implements ConnectorChangeSet {
                            String newParentDocId,
                            String oldParentDocId,
                            String newPath,
-                           String oldPath,
-                           boolean queryable ) {
+                           String oldPath ) {
         NodeKey key = nodeKey(docId);
         NodeKey newParentKey = nodeKey(newParentDocId);
         NodeKey oldParentKey = nodeKey(oldParentDocId);
@@ -168,7 +165,7 @@ public class ConnectorChangeSetImpl implements ConnectorChangeSet {
             // There are only old locations, so treat as NODE_REMOVED.
             for (WorkspaceAndPath wsAndOldPath : oldWsAndPaths) {
                 changesFor(wsAndOldPath.getWorkspaceName()).nodeRemoved(key, oldParentKey, wsAndOldPath.getPath(), primaryType,
-                                                                        mixinTypes, queryable, null, null);
+                                                                        mixinTypes, null, null);
             }
             return;
         } else if (numOld == 0) {
@@ -177,7 +174,7 @@ public class ConnectorChangeSetImpl implements ConnectorChangeSet {
             Map<Name, Property> properties = Collections.emptyMap();
             for (WorkspaceAndPath wsAndNewPath : newWsAndPaths) {
                 changesFor(wsAndNewPath.getWorkspaceName()).nodeCreated(key, newParentKey, wsAndNewPath.getPath(), primaryType,
-                                                                        mixinTypes, properties, queryable);
+                                                                        mixinTypes, properties);
             }
             return;
         }
@@ -194,17 +191,17 @@ public class ConnectorChangeSetImpl implements ConnectorChangeSet {
             if (newWorkspace.equals(oldWorkspace)) {
                 // The workspaces are the same, so this is the case of a simple move
                 changesFor(newWorkspace).nodeMoved(key, primaryType, mixinTypes, newParentKey, oldParentKey,
-                                                   newWsAndPath.getPath(), oldWsAndPath.getPath(), queryable);
+                                                   newWsAndPath.getPath(), oldWsAndPath.getPath());
                 return;
             }
             // The workspace names don't match, so treat the old as a NODE_REMOVED ...
             changesFor(oldWsAndPath.getWorkspaceName()).nodeRemoved(key, oldParentKey, oldWsAndPath.getPath(), primaryType,
-                                                                    mixinTypes, queryable, null, null);
+                                                                    mixinTypes, null, null);
             // And the new as NODE_CREATED (in a separate workspace) ...
             // Note that we do not know the properties ...
             Map<Name, Property> properties = Collections.emptyMap();
             changesFor(newWsAndPath.getWorkspaceName()).nodeCreated(key, newParentKey, newWsAndPath.getPath(), primaryType,
-                                                                    mixinTypes, properties, queryable);
+                                                                    mixinTypes, properties);
             return;
         }
 
@@ -225,7 +222,7 @@ public class ConnectorChangeSetImpl implements ConnectorChangeSet {
                 if (newWorkspace.equals(oldWorkspace)) {
                     found = true;
                     changesFor(newWorkspace).nodeMoved(key, primaryType, mixinTypes, newParentKey, oldParentKey,
-                                                       wsAndNewPath.getPath(), wsAndOldPath.getPath(), queryable);
+                                                       wsAndNewPath.getPath(), wsAndOldPath.getPath());
                     oldWsAndPathsIter.remove(); // we don't want to deal with this WorkspaceAndPath as the 'from' of another move
                 }
             }
@@ -235,14 +232,14 @@ public class ConnectorChangeSetImpl implements ConnectorChangeSet {
                 // Note that we do not know the properties ...
                 Map<Name, Property> properties = Collections.emptyMap();
                 changesFor(wsAndNewPath).nodeCreated(key, newParentKey, wsAndNewPath.getPath(), primaryType, mixinTypes,
-                                                     properties, queryable);
+                                                     properties);
             }
         }
 
         // If there are any old paths left, we need to treat them as NODE_REMOVED ...
         for (WorkspaceAndPath oldWsAndPath : oldWsAndPaths) {
-            changesFor(oldWsAndPath).nodeRemoved(key, oldParentKey, oldWsAndPath.getPath(), primaryType, mixinTypes, queryable, 
-                    null, null);
+            changesFor(oldWsAndPath).nodeRemoved(key, oldParentKey, oldWsAndPath.getPath(), primaryType, mixinTypes,
+                                                 null, null);
         }
     }
 
@@ -253,8 +250,7 @@ public class ConnectorChangeSetImpl implements ConnectorChangeSet {
                                String parentDocId,
                                String newPath,
                                String oldNameSegment,
-                               String reorderedBeforeNameSegment,
-                               boolean queryable ) {
+                               String reorderedBeforeNameSegment ) {
         NodeKey key = nodeKey(docId);
         NodeKey parentKey = nodeKey(parentDocId);
         PathFactory pathFactory = pathMappings.getPathFactory();
@@ -266,7 +262,7 @@ public class ConnectorChangeSetImpl implements ConnectorChangeSet {
         // This external path in the connector may be projected into *multiple* nodes in the same or different workspaces ...
         for (WorkspaceAndPath wsAndPath : pathMappings.resolveExternalPathToInternal(newExternalPath)) {
             changesFor(wsAndPath).nodeReordered(key, primaryType, mixinTypes, parentKey, wsAndPath.getPath(), oldExternalPath,
-                                                reorderedBeforePath, queryable);
+                                                reorderedBeforePath);
         }
     }
 
@@ -275,13 +271,12 @@ public class ConnectorChangeSetImpl implements ConnectorChangeSet {
                                Name nodePrimaryType,
                                Set<Name> nodeMixinTypes,
                                String nodePath,
-                               Property property,
-                               boolean queryable ) {
+                               Property property ) {
         NodeKey key = nodeKey(docId);
         Path externalPath = pathMappings.getPathFactory().create(nodePath);
         // This external path in the connector may be projected into *multiple* nodes in the same or different workspaces ...
         for (WorkspaceAndPath wsAndPath : pathMappings.resolveExternalPathToInternal(externalPath)) {
-            changesFor(wsAndPath).propertyAdded(key, nodePrimaryType, nodeMixinTypes, wsAndPath.getPath(), property, queryable);
+            changesFor(wsAndPath).propertyAdded(key, nodePrimaryType, nodeMixinTypes, wsAndPath.getPath(), property);
         }
     }
 
@@ -290,13 +285,12 @@ public class ConnectorChangeSetImpl implements ConnectorChangeSet {
                                  Name nodePrimaryType,
                                  Set<Name> nodeMixinTypes,
                                  String nodePath,
-                                 Property property,
-                                 boolean queryable ) {
+                                 Property property ) {
         NodeKey key = nodeKey(docId);
         Path externalPath = pathMappings.getPathFactory().create(nodePath);
         // This external path in the connector may be projected into *multiple* nodes in the same or different workspaces ...
         for (WorkspaceAndPath wsAndPath : pathMappings.resolveExternalPathToInternal(externalPath)) {
-            changesFor(wsAndPath).propertyRemoved(key, nodePrimaryType, nodeMixinTypes, wsAndPath.getPath(), property, queryable);
+            changesFor(wsAndPath).propertyRemoved(key, nodePrimaryType, nodeMixinTypes, wsAndPath.getPath(), property);
         }
     }
 
@@ -306,14 +300,13 @@ public class ConnectorChangeSetImpl implements ConnectorChangeSet {
                                  Set<Name> nodeMixinTypes,
                                  String nodePath,
                                  Property oldProperty,
-                                 Property newProperty,
-                                 boolean queryable ) {
+                                 Property newProperty ) {
         NodeKey key = nodeKey(docId);
         Path externalPath = pathMappings.getPathFactory().create(nodePath);
         // This external path in the connector may be projected into *multiple* nodes in the same or different workspaces ...
         for (WorkspaceAndPath wsAndPath : pathMappings.resolveExternalPathToInternal(externalPath)) {
             changesFor(wsAndPath).propertyChanged(key, nodePrimaryType, nodeMixinTypes, wsAndPath.getPath(), newProperty,
-                                                  oldProperty, queryable);
+                                                  oldProperty);
         }
     }
 

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/index/local/IndexChangeAdapters.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/index/local/IndexChangeAdapters.java
@@ -278,8 +278,7 @@ public class IndexChangeAdapters {
                                 Path path,
                                 Name primaryType,
                                 Set<Name> mixinTypes,
-                                Properties properties,
-                                boolean queryable ) {
+                                Properties properties ) {
             if (path.isRoot() && includeRoot) {
                 index.add(nodeKey(key), convertRoot(path));
             } else {
@@ -317,8 +316,7 @@ public class IndexChangeAdapters {
                                  NodeKey oldParent,
                                  NodeKey newParent,
                                  Path newPath,
-                                 Path oldPath,
-                                 boolean queryable ) {
+                                 Path oldPath ) {
             String nodeKey = nodeKey(key);
             if (includeRoot) {
                 if (oldPath.isRoot()) index.remove(nodeKey);
@@ -335,8 +333,7 @@ public class IndexChangeAdapters {
                                    NodeKey parentKey,
                                    Path path,
                                    Name primaryType,
-                                   Set<Name> mixinTypes,
-                                   boolean queryable ) {
+                                   Set<Name> mixinTypes ) {
             if (includeRoot || path.isRoot()) {
                 index.remove(nodeKey(key));
             }
@@ -472,8 +469,7 @@ public class IndexChangeAdapters {
                                 Path path,
                                 Name primaryType,
                                 Set<Name> mixinTypes,
-                                Properties properties,
-                                boolean queryable ) {
+                                Properties properties ) {
             // Properties on new nodes are always represented as 'PropertyAdded' events, and handled via 'modifyProperties' ...
         }
 
@@ -520,8 +516,7 @@ public class IndexChangeAdapters {
                                    NodeKey parentKey,
                                    Path path,
                                    Name primaryType,
-                                   Set<Name> mixinTypes,
-                                   boolean queryable ) {
+                                   Set<Name> mixinTypes ) {
             removeValues(key);
         }
     }
@@ -618,8 +613,7 @@ public class IndexChangeAdapters {
                                 Path path,
                                 Name primaryType,
                                 Set<Name> mixinTypes,
-                                Properties properties,
-                                boolean queryable ) {
+                                Properties properties ) {
             addValue(key, primaryType);
         }
     }
@@ -638,8 +632,7 @@ public class IndexChangeAdapters {
                                 Path path,
                                 Name primaryType,
                                 Set<Name> mixinTypes,
-                                Properties properties,
-                                boolean queryable ) {
+                                Properties properties ) {
             if (mixinTypes != null && !mixinTypes.isEmpty()) {
                 for (Name mixinType : mixinTypes) {
                     addValue(key, mixinType);
@@ -798,8 +791,7 @@ public class IndexChangeAdapters {
                                 Path path,
                                 Name primaryType,
                                 Set<Name> mixinTypes,
-                                Properties properties,
-                                boolean queryable ) {
+                                Properties properties ) {
             addValue(key, primaryType);
             if (!mixinTypes.isEmpty()) {
                 for (Name mixinType : mixinTypes) {
@@ -831,8 +823,7 @@ public class IndexChangeAdapters {
                                    NodeKey parentKey,
                                    Path path,
                                    Name primaryType,
-                                   Set<Name> mixinTypes,
-                                   boolean queryable ) {
+                                   Set<Name> mixinTypes ) {
             removeValues(key);
         }
 

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/query/engine/QuerySources.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/query/engine/QuerySources.java
@@ -87,7 +87,8 @@ public class QuerySources {
                                               NodeCache cache ) {
                 // Include only queryable nodes ...
                 Name nodePrimaryType = node.getPrimaryType(cache);
-                return node.isQueryable(cache) && nodeTypes.isQueryable(nodePrimaryType);
+                Set<Name> mixinTypes = node.getMixinTypes(cache);
+                return !node.isExcludedFromSearch(cache) && nodeTypes.isQueryable(nodePrimaryType, mixinTypes);
             }
 
             @Override
@@ -98,7 +99,9 @@ public class QuerySources {
             @Override
             public boolean continueProcessingChildren( CachedNode node, NodeCache cache ) {
                 Name nodePrimaryType = node.getPrimaryType(cache);
-                return node.isQueryable(cache) && !nodeTypes.isQueryable(nodePrimaryType);
+                Set<Name> mixinTypes = node.getMixinTypes(cache);
+                return !node.isExcludedFromSearch(cache) && 
+                       !nodeTypes.isQueryable(nodePrimaryType, mixinTypes);
             }
         };
         if (!this.includeSystemContent) {
@@ -109,9 +112,10 @@ public class QuerySources {
                                                   NodeCache cache ) {
                     // Include only queryable nodes that are NOT in the system workspace ...
                     Name nodePrimaryType = node.getPrimaryType(cache);
-                    return node.isQueryable(cache) && 
+                    Set<Name> mixinTypes = node.getMixinTypes(cache);
+                    return !node.isExcludedFromSearch(cache) && 
                            !node.getKey().getWorkspaceKey().equals(systemWorkspaceKey) && 
-                           nodeTypes.isQueryable(nodePrimaryType);
+                           nodeTypes.isQueryable(nodePrimaryType, mixinTypes);
                 }
 
                 @Override
@@ -122,9 +126,10 @@ public class QuerySources {
                 @Override
                 public boolean continueProcessingChildren( CachedNode node, NodeCache cache ) {
                     Name nodePrimaryType = node.getPrimaryType(cache);
-                    return  node.isQueryable(cache) &&
+                    Set<Name> mixinTypes = node.getMixinTypes(cache);
+                    return  !node.isExcludedFromSearch(cache) &&
                             !node.getKey().getWorkspaceKey().equals(systemWorkspaceKey) && 
-                            !nodeTypes.isQueryable(nodePrimaryType);
+                            !nodeTypes.isQueryable(nodePrimaryType, mixinTypes);
                 }
             };
         } else {

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/spi/federation/ConnectorChangeSet.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/spi/federation/ConnectorChangeSet.java
@@ -56,22 +56,19 @@ public interface ConnectorChangeSet {
 
     /**
      * Signal that a new node resource was created.
-     * 
      * @param docId the connector's identifier for the new node; may not be null
      * @param parentDocId the connector's identifier for the parent of the new node; may not be null
      * @param path the path to the new node; may not be null
      * @param primaryType the primary type of the node; may not be null
      * @param mixinTypes the mixin types of the node; may not be null
      * @param properties the properties in the new node, or null if there are none
-     * @param queryable true if this node is queryable, or false otherwise
      */
     void nodeCreated( String docId,
                       String parentDocId,
                       String path,
                       Name primaryType,
                       Set<Name> mixinTypes,
-                      Map<Name, Property> properties,
-                      boolean queryable );
+                      Map<Name, Property> properties );
 
     /**
      * Signal that a node resource (and all descendants) was removed. Note that it is not common to fire an event for all nodes
@@ -82,7 +79,6 @@ public interface ConnectorChangeSet {
      * @param path the path to the removed node; may not be null
      * @param primaryType the primary type of the node; may not be null
      * @param mixinTypes the mixin types of the node; may not be null
-     * @param queryable true if this node is queryable, or false otherwise
      * @param parentPrimaryType the primary type of the parent node; may be null if the information is not available.
      * @param parentMixinTypes the mixin types of the parent node; may be null if the information is not available 
      */
@@ -91,8 +87,7 @@ public interface ConnectorChangeSet {
                       String path,
                       Name primaryType,
                       Set<Name> mixinTypes,
-                      boolean queryable, 
-                      Name parentPrimaryType, 
+                      Name parentPrimaryType,
                       Set<Name> parentMixinTypes );
 
     /**
@@ -105,7 +100,6 @@ public interface ConnectorChangeSet {
      * @param oldParentDocId the connector's identifier for the old parent for the node; may not be null
      * @param newPath the new path for the node after it has been moved; may not be null
      * @param oldPath the old path for the node before it was moved; may not be null
-     * @param queryable true if this node is queryable, or false otherwise
      */
     void nodeMoved( String docId,
                     Name primaryType,
@@ -113,12 +107,11 @@ public interface ConnectorChangeSet {
                     String newParentDocId,
                     String oldParentDocId,
                     String newPath,
-                    String oldPath,
-                    boolean queryable );
+                    String oldPath );
 
     /**
      * Signal that a node resource (and all descendants) was placed into a new location within the same parent.
-     * 
+     *
      * @param docId the connector's identifier for the node; may not be null
      * @param primaryType the primary type of the node; may not be null
      * @param mixinTypes the mixin types of the node; may not be null
@@ -127,7 +120,6 @@ public interface ConnectorChangeSet {
      * @param oldNameSegment the name segment (i.e., the name and if applicable the SNS index) for the node before it was
      *        reordered; may not be null
      * @param reorderedBeforeNameSegment the name segment of the node (in the same parent) before which the node was moved
-     * @param queryable true if this node is queryable, or false otherwise
      */
     void nodeReordered( String docId,
                         Name primaryType,
@@ -135,8 +127,7 @@ public interface ConnectorChangeSet {
                         String parentDocId,
                         String newPath,
                         String oldNameSegment,
-                        String reorderedBeforeNameSegment,
-                        boolean queryable );
+                        String reorderedBeforeNameSegment );
 
     /**
      * Signal that a property was added to a node resource.
@@ -146,14 +137,12 @@ public interface ConnectorChangeSet {
      * @param nodeMixinTypes the mixin types of the node; may not be null
      * @param nodePath the path of the node that was changed
      * @param property the new property, with name and value(s); may not be null
-     * @param queryable true if this node is queryable, or false otherwise
      */
     void propertyAdded( String docId,
                         Name nodePrimaryType,
                         Set<Name> nodeMixinTypes,
                         String nodePath,
-                        Property property,
-                        boolean queryable );
+                        Property property );
 
     /**
      * Signal that a property was removed from a node resource.
@@ -163,14 +152,12 @@ public interface ConnectorChangeSet {
      * @param nodeMixinTypes the mixin types of the node; may not be null
      * @param nodePath the path of the node that was changed
      * @param property the property that was removed, with name and value(s); may not be null
-     * @param queryable true if this node is queryable, or false otherwise
      */
     void propertyRemoved( String docId,
                           Name nodePrimaryType,
                           Set<Name> nodeMixinTypes,
                           String nodePath,
-                          Property property,
-                          boolean queryable );
+                          Property property );
 
     /**
      * Signal that a property resource was changed on a node resource.
@@ -181,15 +168,13 @@ public interface ConnectorChangeSet {
      * @param nodePath the path of the node that was changed
      * @param oldProperty the old property, with name and value(s); may be null
      * @param newProperty the new property, with name and value(s); may not be null
-     * @param queryable true if this node is queryable, or false otherwise
      */
     void propertyChanged( String docId,
                           Name nodePrimaryType,
                           Set<Name> nodeMixinTypes,
                           String nodePath,
                           Property oldProperty,
-                          Property newProperty,
-                          boolean queryable );
+                          Property newProperty );
 
     /**
      * Finish the construction of this change-set and make it available for publication into the repository. This also empties the

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/spi/index/provider/IndexProvider.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/spi/index/provider/IndexProvider.java
@@ -815,7 +815,7 @@ public abstract class IndexProvider {
                              Properties properties ) {
                 Collection<IndexChangeAdapter> adapters = adaptersByWorkspaceName.get(workspace);
                 if (adapters != null) {
-                    boolean queryable = nodeTypesSupplier.getNodeTypes().isQueryable(primaryType);
+                    boolean queryable = nodeTypesSupplier.getNodeTypes().isQueryable(primaryType, mixinTypes);
                     // There are adapters for this workspace ...
                     for (IndexChangeAdapter adapter : adaptersByWorkspaceName.get(workspace)) {
                         if (adapter != null) {
@@ -1022,7 +1022,7 @@ public abstract class IndexProvider {
                                      IndexDefinition newDefinition,
                                      NodeTypeMatcher matcher ) {
             this.managedIndex = managedIndex;
-            this.defn = defn;
+            this.defn = newDefinition;
             this.matcher.use(matcher);
         }
     }

--- a/modeshape-jcr/src/test/java/org/modeshape/connector/mock/MockConnectorWithChanges.java
+++ b/modeshape-jcr/src/test/java/org/modeshape/connector/mock/MockConnectorWithChanges.java
@@ -109,7 +109,7 @@ public class MockConnectorWithChanges extends MockConnector {
             newDocs.add(new DocInfo(writer.document(), newId, newPath));
             DocumentReader reader = readDocument(writer.document());
             changes.nodeCreated(newId, documentId, newPath, JcrNtLexicon.UNSTRUCTURED, Collections.<Name>emptySet(),
-                                reader.getProperties(), isQueryable());
+                                reader.getProperties());
 
             // And some children ...
             for (int i = 0; i != 3; ++i) {
@@ -126,7 +126,7 @@ public class MockConnectorWithChanges extends MockConnector {
                 newDocs.add(new DocInfo(childWriter.document(), childId, childPath));
                 DocumentReader childReader = readDocument(writer.document());
                 changes.nodeCreated(childId, newId, childPath, JcrNtLexicon.UNSTRUCTURED, Collections.<Name>emptySet(),
-                                    childReader.getProperties(), isQueryable());
+                                    childReader.getProperties());
             }
 
             for (DocInfo info : newDocs) {
@@ -186,7 +186,7 @@ public class MockConnectorWithChanges extends MockConnector {
             // Remove the document at '/doc{n}/generate-out/{name}' ...
             removeDocument(oldId);
             changes.nodeRemoved(oldId, documentId, oldPath, JcrNtLexicon.UNSTRUCTURED, Collections.<Name>emptySet(),
-                                isQueryable(), JcrNtLexicon.UNSTRUCTURED, Collections.<Name>emptySet());
+                                JcrNtLexicon.UNSTRUCTURED, Collections.<Name>emptySet());
 
             // Remove the child documents, but we don't need to fire events for the subnodes of a deleted node ...
             DocumentReader reader = readDocument(oldDoc);

--- a/modeshape-jcr/src/test/java/org/modeshape/jcr/AbstractIndexProviderTest.java
+++ b/modeshape-jcr/src/test/java/org/modeshape/jcr/AbstractIndexProviderTest.java
@@ -124,10 +124,10 @@ public abstract class AbstractIndexProviderTest extends SingleUseAbstractTest {
     }
 
     protected void registerNodeType( String typeName ) throws RepositoryException {
-        registerNodeType(typeName, true, "nt:unstructured");
+        registerNodeType(typeName, true, false, "nt:unstructured");
     }
     
-    protected void registerNodeType( String typeName, boolean queryable, String...declaredSuperTypes) throws RepositoryException {
+    protected void registerNodeType( String typeName, boolean queryable, boolean mixin, String...declaredSuperTypes) throws RepositoryException {
         NodeTypeManager mgr = session.getWorkspace().getNodeTypeManager();
 
         // Create a template for the node type ...
@@ -136,7 +136,7 @@ public abstract class AbstractIndexProviderTest extends SingleUseAbstractTest {
         type.setDeclaredSuperTypeNames(declaredSuperTypes);
         type.setAbstract(false);
         type.setOrderableChildNodes(true);
-        type.setMixin(false);
+        type.setMixin(mixin);
         type.setQueryable(queryable);
         mgr.registerNodeType(type, true);
     }

--- a/modeshape-jcr/src/test/resources/cnd/noquery.cnd
+++ b/modeshape-jcr/src/test/resources/cnd/noquery.cnd
@@ -9,4 +9,5 @@
 //------------------------------------------------------------------------------
 // N O D E T Y P E S
 //------------------------------------------------------------------------------
-[test:noQueryFolder] > nt:folder noquery 
+[test:noQueryFolder] > nt:folder noquery
+[test:noQueryMixin] mixin noquery


### PR DESCRIPTION
Also, updated the code to reflect the differences between the `noquery` types and the previously existing ModeShape `$queryable` document attribute which has a different semantic: the first are defined by the JCR spec while the second were introduced internally by ModeShape to avoid indexing entire branches in the system area. After that, their semantics was exposed to the connectors as well.