### PR TITLE
MODE-2469 Added a "maxPoolSize" configuration attribute which allows the configuration of the sequencer's and text extractor's maximum number of threads. 

### DIFF
--- a/deploy/jbossas/modeshape-jbossas-subsystem/src/main/java/org/modeshape/jboss/subsystem/AddRepository.java
+++ b/deploy/jbossas/modeshape-jbossas-subsystem/src/main/java/org/modeshape/jboss/subsystem/AddRepository.java
@@ -176,6 +176,12 @@ public class AddRepository extends AbstractAddStepHandler {
         RepositoryService repositoryService = new RepositoryService(repositoryConfig, infinispanConfig, configRelativeTo);
         ServiceName repositoryServiceName = ModeShapeServiceNames.repositoryServiceName(repositoryName);
 
+        // Sequencing
+        parseSequencing(model, configDoc);
+
+        // Text Extraction
+        parseTextExtraction(model, configDoc);
+        
         // Journaling
         parseJournaling(repositoryService, context, model, configDoc);
 
@@ -291,6 +297,33 @@ public class AddRepository extends AbstractAddStepHandler {
         newControllers.add(binderBuilder.install());
         newControllers.add(binaryStorageBuilder.install());
         newControllers.add(monitorBuilder.install());
+    }
+
+    private void parseTextExtraction( ModelNode model, EditableDocument configDoc ) {
+        if (model.hasDefined(ModelKeys.TEXT_EXTRACTORS_THREAD_POOL_NAME)) {
+            EditableDocument extractors = configDoc.getOrCreateDocument(FieldName.TEXT_EXTRACTION);
+            String poolName = model.get(ModelKeys.TEXT_EXTRACTORS_THREAD_POOL_NAME).asString();
+            extractors.set(FieldName.THREAD_POOL, poolName);
+        }
+        if (model.hasDefined(ModelKeys.TEXT_EXTRACTORS_MAX_POOL_SIZE)) {
+            EditableDocument sequencing = configDoc.getOrCreateDocument(FieldName.TEXT_EXTRACTION);
+            int maxPoolSize = model.get(ModelKeys.TEXT_EXTRACTORS_MAX_POOL_SIZE).asInt();
+            sequencing.set(FieldName.MAX_POOL_SIZE, maxPoolSize);
+        }
+    }
+
+    private void parseSequencing( ModelNode model,
+                                  EditableDocument configDoc ) {
+        if (model.hasDefined(ModelKeys.SEQUENCERS_THREAD_POOL_NAME)) {
+            EditableDocument sequencing = configDoc.getOrCreateDocument(FieldName.SEQUENCING);
+            String sequencingThreadPool = model.get(ModelKeys.SEQUENCERS_THREAD_POOL_NAME).asString();
+            sequencing.set(FieldName.THREAD_POOL, sequencingThreadPool);
+        }            
+        if (model.hasDefined(ModelKeys.SEQUENCERS_MAX_POOL_SIZE)) {
+            EditableDocument sequencing = configDoc.getOrCreateDocument(FieldName.SEQUENCING);
+            int maxPoolSize = model.get(ModelKeys.SEQUENCERS_MAX_POOL_SIZE).asInt();
+            sequencing.set(FieldName.MAX_POOL_SIZE, maxPoolSize);
+        }            
     }
 
     private void parseSecurity( OperationContext context,

--- a/deploy/jbossas/modeshape-jbossas-subsystem/src/main/java/org/modeshape/jboss/subsystem/Attribute.java
+++ b/deploy/jbossas/modeshape-jbossas-subsystem/src/main/java/org/modeshape/jboss/subsystem/Attribute.java
@@ -79,11 +79,12 @@ public enum Attribute {
     JOURNAL_GC_INITIAL_TIME("journal-gc-initial-time"),
     JOURNAL_PATH("journal-path"),
     JOURNAL_RELATIVE_TO("journal-relative-to"),
-
     INDEX_KIND("kind"),
     SYNCHRONOUS("synchronous"),
     PROVIDER_NAME("provider-name"),
     NODE_TYPE("node-type"),
+    THREAD_POOL_NAME("thread-pool-name"),
+    MAX_POOL_SIZE("max-pool-size"),
     COLUMNS("columns");
 
     private final String name;

--- a/deploy/jbossas/modeshape-jbossas-subsystem/src/main/java/org/modeshape/jboss/subsystem/ModeShapeSubsystemXMLReader_2_1.java
+++ b/deploy/jbossas/modeshape-jbossas-subsystem/src/main/java/org/modeshape/jboss/subsystem/ModeShapeSubsystemXMLReader_2_1.java
@@ -248,7 +248,7 @@ public class ModeShapeSubsystemXMLReader_2_1 implements XMLStreamConstants, XMLE
 
                 // Sequencing ...
                 case SEQUENCERS:
-                    sequencers = parseSequencers(reader, address, repositoryName);
+                    sequencers = parseSequencers(reader, repository, address, repositoryName);
                     break;
 
                 // Index providers ...
@@ -268,7 +268,7 @@ public class ModeShapeSubsystemXMLReader_2_1 implements XMLStreamConstants, XMLE
 
                 // Text extracting ...
                 case TEXT_EXTRACTORS:
-                    textExtractors = parseTextExtracting(reader, repositoryName);
+                    textExtractors = parseTextExtracting(reader, repository, repositoryName);
                     break;
 
                 default:
@@ -770,9 +770,26 @@ public class ModeShapeSubsystemXMLReader_2_1 implements XMLStreamConstants, XMLE
     }
 
     private List<ModelNode> parseSequencers( final XMLExtendedStreamReader reader,
+                                             final ModelNode repository, 
                                              final ModelNode parentAddress,
                                              final String repositoryName ) throws XMLStreamException {
-        requireNoAttributes(reader);
+        if (reader.getAttributeCount() > 0) {
+            for (int i = 0; i < reader.getAttributeCount(); i++) {
+                String attrName = reader.getAttributeLocalName(i);
+                String attrValue = reader.getAttributeValue(i);
+                Attribute attribute = Attribute.forName(attrName);
+                switch (attribute) {
+                    case THREAD_POOL_NAME:
+                        ModelAttributes.SEQUENCER_THREAD_POOL_NAME.parseAndSetParameter(attrValue, repository, reader);
+                        break;
+                    case MAX_POOL_SIZE:
+                        ModelAttributes.SEQUENCER_MAX_POOL_SIZE.parseAndSetParameter(attrValue, repository, reader);
+                        break;
+                    default:
+                        throw ParseUtils.unexpectedAttribute(reader, i);
+                }
+            }
+        }
 
         List<ModelNode> sequencers = new ArrayList<ModelNode>();
         while (reader.hasNext() && reader.nextTag() != END_ELEMENT) {
@@ -1073,8 +1090,25 @@ public class ModeShapeSubsystemXMLReader_2_1 implements XMLStreamConstants, XMLE
     }
 
     private List<ModelNode> parseTextExtracting( final XMLExtendedStreamReader reader,
+                                                 final ModelNode repository, 
                                                  final String repositoryName ) throws XMLStreamException {
-        requireNoAttributes(reader);
+        if (reader.getAttributeCount() > 0) {
+            for (int i = 0; i < reader.getAttributeCount(); i++) {
+                String attrName = reader.getAttributeLocalName(i);
+                String attrValue = reader.getAttributeValue(i);
+                Attribute attribute = Attribute.forName(attrName);
+                switch (attribute) {
+                    case THREAD_POOL_NAME:
+                        ModelAttributes.TEXT_EXTRACTOR_THREAD_POOL_NAME.parseAndSetParameter(attrValue, repository, reader);
+                        break;
+                    case MAX_POOL_SIZE:
+                        ModelAttributes.TEXT_EXTRACTOR_MAX_POOL_SIZE.parseAndSetParameter(attrValue, repository, reader);
+                        break;
+                    default:
+                        throw ParseUtils.unexpectedAttribute(reader, i);
+                }
+            }
+        }
 
         List<ModelNode> extractors = new ArrayList<ModelNode>();
         while (reader.hasNext() && reader.nextTag() != END_ELEMENT) {

--- a/deploy/jbossas/modeshape-jbossas-subsystem/src/main/java/org/modeshape/jboss/subsystem/ModeShapeSubsystemXMLWriter.java
+++ b/deploy/jbossas/modeshape-jbossas-subsystem/src/main/java/org/modeshape/jboss/subsystem/ModeShapeSubsystemXMLWriter.java
@@ -338,7 +338,17 @@ public class ModeShapeSubsystemXMLWriter implements XMLStreamConstants, XMLEleme
                                   ModelNode repository ) throws XMLStreamException {
         if (has(repository, ModelKeys.SEQUENCER)) {
             writer.writeStartElement(Element.SEQUENCERS.getLocalName());
+            if (repository.hasDefined(ModelKeys.SEQUENCERS_THREAD_POOL_NAME)) {
+                writer.writeAttribute(Attribute.THREAD_POOL_NAME.getLocalName(), repository.get(
+                        ModelKeys.SEQUENCERS_THREAD_POOL_NAME).asString());
+            }
+            if (repository.hasDefined(ModelKeys.SEQUENCERS_MAX_POOL_SIZE)) {
+                writer.writeAttribute(Attribute.MAX_POOL_SIZE.getLocalName(), repository.get(ModelKeys.SEQUENCERS_MAX_POOL_SIZE)
+                                                                                        .asString());
+            }
+
             ModelNode sequencerNode = repository.get(ModelKeys.SEQUENCER);
+
             for (Property sequencer : sequencerNode.asPropertyList()) {
                 writer.writeStartElement(Element.SEQUENCER.getLocalName());
                 writer.writeAttribute(Attribute.NAME.getLocalName(), sequencer.getName());
@@ -477,6 +487,14 @@ public class ModeShapeSubsystemXMLWriter implements XMLStreamConstants, XMLEleme
                                       ModelNode repository ) throws XMLStreamException {
         if (has(repository, ModelKeys.TEXT_EXTRACTOR)) {
             writer.writeStartElement(Element.TEXT_EXTRACTORS.getLocalName());
+            if (repository.hasDefined(ModelKeys.TEXT_EXTRACTORS_THREAD_POOL_NAME)) {
+                writer.writeAttribute(Attribute.THREAD_POOL_NAME.getLocalName(), repository.get(
+                        ModelKeys.TEXT_EXTRACTORS_THREAD_POOL_NAME).asString());
+            }
+            if (repository.hasDefined(ModelKeys.TEXT_EXTRACTORS_MAX_POOL_SIZE)) {
+                writer.writeAttribute(Attribute.MAX_POOL_SIZE.getLocalName(), repository.get(ModelKeys.TEXT_EXTRACTORS_MAX_POOL_SIZE)
+                                                                                        .asString());
+            }
             for (Property extractor : repository.get(ModelKeys.TEXT_EXTRACTOR).asPropertyList()) {
                 writer.writeStartElement(Element.TEXT_EXTRACTOR.getLocalName());
                 writer.writeAttribute(Attribute.NAME.getLocalName(), extractor.getName());

--- a/deploy/jbossas/modeshape-jbossas-subsystem/src/main/java/org/modeshape/jboss/subsystem/ModelAttributes.java
+++ b/deploy/jbossas/modeshape-jbossas-subsystem/src/main/java/org/modeshape/jboss/subsystem/ModelAttributes.java
@@ -308,14 +308,6 @@ public class ModelAttributes {
                                                                                                                     .setFlags(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
                                                                                                                     .build();
 
-    public static final SimpleAttributeDefinition LOCK_CACHE_NAME = new MappedAttributeDefinitionBuilder(
-                                                                                                         ModelKeys.LOCK_CACHE_NAME,
-                                                                                                         ModelType.STRING).setXmlName(Attribute.LOCK_CACHE_NAME.getLocalName())
-                                                                                                                          .setAllowExpression(false)
-                                                                                                                          .setAllowNull(true)
-                                                                                                                          .setFlags(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
-                                                                                                                          .build();
-
     public static final SimpleAttributeDefinition METADATA_CACHE_NAME = new MappedAttributeDefinitionBuilder(
                                                                                                              ModelKeys.METADATA_CACHE_NAME,
                                                                                                              ModelType.STRING).setXmlName(Attribute.META_CACHE_NAME.getLocalName())
@@ -534,6 +526,31 @@ public class ModelAttributes {
                                                                                                                                                                      FieldName.SEQUENCERS,
                                                                                                                                                                      FieldName.CLASSNAME)
                                                                                                                               .build();
+    public static final SimpleAttributeDefinition SEQUENCER_THREAD_POOL_NAME = new MappedAttributeDefinitionBuilder(ModelKeys.SEQUENCERS_THREAD_POOL_NAME, 
+                                                                                                                    ModelType.STRING).setXmlName(Attribute.THREAD_POOL_NAME.getLocalName())
+                                                                                                                                     .setAllowExpression(false)
+                                                                                                                                     .setAllowNull(true)
+                                                                                                                                     .setFlags(AttributeAccess.Flag.RESTART_NONE)
+                                                                                                                                     .setDefaultValue(new ModelNode().set(RepositoryConfiguration.Default.SEQUENCING_POOL))
+                                                                                                                                     .setFieldPathInRepositoryConfiguration(
+                                                                                                                                             FieldName.SEQUENCING,
+                                                                                                                                             FieldName.SEQUENCERS,
+                                                                                                                                             FieldName.THREAD_POOL)
+                                                                                                                                     .build();
+    
+    public static final SimpleAttributeDefinition SEQUENCER_MAX_POOL_SIZE = new MappedAttributeDefinitionBuilder(ModelKeys.SEQUENCERS_MAX_POOL_SIZE, 
+                                                                                                                    ModelType.STRING).setXmlName(Attribute.MAX_POOL_SIZE.getLocalName())
+                                                                                                                                     .setAllowExpression(false)
+                                                                                                                                     .setAllowNull(true)
+                                                                                                                                     .setFlags(AttributeAccess.Flag.RESTART_NONE)
+                                                                                                                                     .setDefaultValue(new ModelNode().set(
+                                                                                                                                             RepositoryConfiguration.Default.SEQUENCING_MAX_POOL_SIZE))
+                                                                                                                                     .setFieldPathInRepositoryConfiguration(
+                                                                                                                                             FieldName.SEQUENCING,
+                                                                                                                                             FieldName.SEQUENCERS,
+                                                                                                                                             FieldName.MAX_POOL_SIZE)
+                                                                                                                                     .build();
+
     public static final SimpleAttributeDefinition STORE_NAME = new MappedAttributeDefinitionBuilder(ModelKeys.STORE_NAME,
                                                                                                     ModelType.STRING).setXmlName(Attribute.STORE_NAME.getLocalName())
                                                                                                                      .setAllowExpression(false)
@@ -562,6 +579,31 @@ public class ModelAttributes {
                                                                                                                                                                           FieldName.EXTRACTORS,
                                                                                                                                                                           FieldName.CLASSNAME)
                                                                                                                                    .build();
+    public static final SimpleAttributeDefinition TEXT_EXTRACTOR_THREAD_POOL_NAME = new MappedAttributeDefinitionBuilder(ModelKeys.TEXT_EXTRACTORS_THREAD_POOL_NAME,
+                                                                                                                    ModelType.STRING).setXmlName(Attribute.THREAD_POOL_NAME.getLocalName())
+                                                                                                                                     .setAllowExpression(false)
+                                                                                                                                     .setAllowNull(true)
+                                                                                                                                     .setFlags(AttributeAccess.Flag.RESTART_NONE)
+                                                                                                                                     .setDefaultValue(new ModelNode().set(RepositoryConfiguration.Default.TEXT_EXTRACTION_POOL))
+                                                                                                                                     .setFieldPathInRepositoryConfiguration(
+                                                                                                                                             FieldName.TEXT_EXTRACTION,
+                                                                                                                                             FieldName.EXTRACTORS,
+                                                                                                                                             FieldName.THREAD_POOL)
+                                                                                                                                     .build();
+
+    public static final SimpleAttributeDefinition TEXT_EXTRACTOR_MAX_POOL_SIZE = new MappedAttributeDefinitionBuilder(ModelKeys.TEXT_EXTRACTORS_MAX_POOL_SIZE,
+                                                                                                                 ModelType.STRING).setXmlName(Attribute.MAX_POOL_SIZE.getLocalName())
+                                                                                                                                  .setAllowExpression(false)
+                                                                                                                                  .setAllowNull(true)
+                                                                                                                                  .setFlags(AttributeAccess.Flag.RESTART_NONE)
+                                                                                                                                  .setDefaultValue(new ModelNode().set(
+                                                                                                                                          RepositoryConfiguration.Default.TEXT_EXTRACTION_MAX_POOL_SIZE))
+                                                                                                                                  .setFieldPathInRepositoryConfiguration(
+                                                                                                                                          FieldName.TEXT_EXTRACTION,
+                                                                                                                                          FieldName.EXTRACTORS,
+                                                                                                                                          FieldName.MAX_POOL_SIZE)
+                                                                                                                                  .build();
+
 
     public static final SimpleAttributeDefinition SECURITY_DOMAIN = new MappedAttributeDefinitionBuilder(
                                                                                                          ModelKeys.SECURITY_DOMAIN,
@@ -575,22 +617,6 @@ public class ModelAttributes {
                                                                                                                                                                  FieldName.JAAS,
                                                                                                                                                                  FieldName.JAAS_POLICY_NAME)
                                                                                                                           .build();
-
-    public static final SimpleAttributeDefinition SOURCE_PATH = new MappedAttributeDefinitionBuilder(ModelKeys.SOURCE_PATH,
-                                                                                                     ModelType.STRING).setXmlName(Attribute.SOURCE_PATH.getLocalName())
-                                                                                                                      .setAllowExpression(true)
-                                                                                                                      .setAllowNull(false)
-                                                                                                                      .setFlags(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
-                                                                                                                      .build();
-
-    public static final SimpleAttributeDefinition SOURCE_RELATIVE_TO = new MappedAttributeDefinitionBuilder(
-                                                                                                            ModelKeys.SOURCE_RELATIVE_TO,
-                                                                                                            ModelType.STRING).setXmlName(Attribute.SOURCE_RELATIVE_TO.getLocalName())
-                                                                                                                             .setAllowExpression(true)
-                                                                                                                             .setAllowNull(true)
-                                                                                                                             .setDefaultValue(new ModelNode().set(JBOSS_DATA_DIR_VARIABLE))
-                                                                                                                             .setFlags(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
-                                                                                                                             .build();
 
     public static final SimpleAttributeDefinition USE_ANONYMOUS_IF_AUTH_FAILED = new MappedAttributeDefinitionBuilder(
                                                                                                                       ModelKeys.USE_ANONYMOUS_IF_AUTH_FAILED,
@@ -683,7 +709,8 @@ public class ModelAttributes {
         GARBAGE_COLLECTION_INITIAL_TIME, GARBAGE_COLLECTION_INTERVAL, DOCUMENT_OPTIMIZATION_THREAD_POOL,
         DOCUMENT_OPTIMIZATION_INITIAL_TIME, DOCUMENT_OPTIMIZATION_INTERVAL, DOCUMENT_OPTIMIZATION_CHILD_COUNT_TARGET,
         DOCUMENT_OPTIMIZATION_CHILD_COUNT_TOLERANCE, JOURNAL_PATH, JOURNAL_RELATIVE_TO, MAX_DAYS_TO_KEEP_RECORDS,
-        JOURNAL_GC_INITIAL_TIME, JOURNAL_GC_THREAD_POOL, ASYNC_WRITES, JOURNALING};
+        JOURNAL_GC_INITIAL_TIME, JOURNAL_GC_THREAD_POOL, ASYNC_WRITES, JOURNALING, SEQUENCER_THREAD_POOL_NAME, SEQUENCER_MAX_POOL_SIZE, 
+        TEXT_EXTRACTOR_THREAD_POOL_NAME, TEXT_EXTRACTOR_MAX_POOL_SIZE};
 
     public static final AttributeDefinition[] FILE_BINARY_STORAGE_ATTRIBUTES = {MINIMUM_BINARY_SIZE, MINIMUM_STRING_SIZE, PATH,
         RELATIVE_TO, STORE_NAME};

--- a/deploy/jbossas/modeshape-jbossas-subsystem/src/main/java/org/modeshape/jboss/subsystem/ModelKeys.java
+++ b/deploy/jbossas/modeshape-jbossas-subsystem/src/main/java/org/modeshape/jboss/subsystem/ModelKeys.java
@@ -73,6 +73,10 @@ public class ModelKeys {
     static final String STORE_NAME = "store-name";
     static final String NESTED_STORES = "nested-stores";
     static final String USE_ANONYMOUS_IF_AUTH_FAILED = "use-anonymous-upon-failed-authentication";
+    static final String SEQUENCERS_THREAD_POOL_NAME = "sequencers-thread-pool-name";
+    static final String SEQUENCERS_MAX_POOL_SIZE = "sequencers-max-pool-size";
+    static final String TEXT_EXTRACTORS_THREAD_POOL_NAME = "text-extractors-thread-pool-name";
+    static final String TEXT_EXTRACTORS_MAX_POOL_SIZE = "text-extractors-max-pool-size";
 
     static final String AUTHENTICATOR = "authenticator";
     static final String AUTHENTICATOR_CLASSNAME = "classname";
@@ -85,7 +89,9 @@ public class ModelKeys {
     static final String CUSTOM_BINARY_STORAGE = "custom-binary-storage";
 
     static final String SEQUENCER = "sequencer";
+    static final String SEQUENCERS = "sequencers";
     static final String SOURCE = "source";
+    static final String EXTRACTORS = "text-extractors";
     static final String TEXT_EXTRACTOR = "text-extractor";
 
     static final String INDEX = "index";

--- a/deploy/jbossas/modeshape-jbossas-subsystem/src/main/resources/org/modeshape/jboss/subsystem/LocalDescriptions.properties
+++ b/deploy/jbossas/modeshape-jbossas-subsystem/src/main/resources/org/modeshape/jboss/subsystem/LocalDescriptions.properties
@@ -84,6 +84,8 @@ modeshape.repository.journal-gc-thread-pool = Name of the thread pool that shoul
 modeshape.repository.journal-gc-initial-time = The local time that the first garbage collection process should be run.
 
 # Sequencer
+modeshape.repository.sequencers-thread-pool-name = The name of the thread pool that generates sequencing threads
+modeshape.repository.sequencers-max-pool-size = The maximum size of the pool which spawns sequencing threads
 modeshape.repository.sequencer = ModeShape sequencer
 modeshape.repository.sequencer.add = Add ModeShape sequencer
 modeshape.repository.sequencer.remove = Remove ModeShape sequencer
@@ -142,6 +144,8 @@ modeshape.repository.source.properties.property = A name-value pair for the sour
 
 
 # Text extractor
+modeshape.repository.text-extractors-thread-pool-name = The name of the thread pool that generates sequencing threads
+modeshape.repository.text-extractors-max-pool-size = The maximum size of the pool which spawns sequencing threads
 modeshape.repository.text-extractor = ModeShape text extractor
 modeshape.repository.text-extractor.add = Add ModeShape text extractor
 modeshape.repository.text-extractor.remove = Remove ModeShape text extractor

--- a/deploy/jbossas/modeshape-jbossas-subsystem/src/main/resources/schema/modeshape_2_1.xsd
+++ b/deploy/jbossas/modeshape-jbossas-subsystem/src/main/resources/schema/modeshape_2_1.xsd
@@ -533,6 +533,16 @@
                 </xs:annotation>
             </xs:element>
         </xs:sequence>
+        <xs:attribute name="thread-pool-name" type="xs:string" use="optional" default="modeshape-sequencer">
+            <xs:annotation>
+                <xs:documentation>The name of the thread pool that generates sequencing threads.</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="max-pool-size" type="xs:integer" use="optional" default="10">
+            <xs:annotation>
+                <xs:documentation>The maximum number of sequencing threads that can be spawned at the same time</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
     </xs:complexType>
 
     <xs:complexType name="sequencer">
@@ -630,6 +640,16 @@
                 </xs:annotation>
             </xs:element>
         </xs:sequence>
+        <xs:attribute name="thread-pool-name" type="xs:string" use="optional" default="modeshape-text-extractor">
+            <xs:annotation>
+                <xs:documentation>The name of the thread pool that generates text extraction threads.</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="max-pool-size" type="xs:integer" use="optional" default="5">
+            <xs:annotation>
+                <xs:documentation>The maximum number of text extraction threads that can be spawned at the same time</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
     </xs:complexType>
 
     <xs:complexType name="text-extractor">

--- a/deploy/jbossas/modeshape-jbossas-subsystem/src/test/java/org/modeshape/jboss/subsystem/ModeShapeConfigurationTest.java
+++ b/deploy/jbossas/modeshape-jbossas-subsystem/src/test/java/org/modeshape/jboss/subsystem/ModeShapeConfigurationTest.java
@@ -271,6 +271,11 @@ public class ModeShapeConfigurationTest extends AbstractSubsystemBaseTest {
     public void testSequencingConfiguration() throws Exception {
         standardSubsystemTest("sequencing");
     }
+   
+    @Test
+    public void testTextExtractionConfiguration() throws Exception {
+        standardSubsystemTest("text-extraction");
+    }
 
     @Test
     public void testSchema() throws Exception {

--- a/deploy/jbossas/modeshape-jbossas-subsystem/src/test/resources/org/modeshape/jboss/subsystem/modeshape-sequencing-config.xml
+++ b/deploy/jbossas/modeshape-jbossas-subsystem/src/test/resources/org/modeshape/jboss/subsystem/modeshape-sequencing-config.xml
@@ -1,6 +1,6 @@
 <subsystem xmlns="urn:jboss:domain:modeshape:2.1">
     <repository name="sample">
-        <sequencers>
+        <sequencers max-pool-size="100" thread-pool-name="test-sequencer">
             <sequencer name="modeshape-sequencer-ddl1" classname="ddl"/>
             <sequencer name="modeshape-sequencer-java" classname="java" path-expression="//a/b" extra1="value1" extra2="2"/>
             <sequencer name="modeshape-sequencer-ddl2" classname="ddl">

--- a/deploy/jbossas/modeshape-jbossas-subsystem/src/test/resources/org/modeshape/jboss/subsystem/modeshape-text-extraction-config.xml
+++ b/deploy/jbossas/modeshape-jbossas-subsystem/src/test/resources/org/modeshape/jboss/subsystem/modeshape-text-extraction-config.xml
@@ -1,0 +1,9 @@
+<subsystem xmlns="urn:jboss:domain:modeshape:2.1">
+    <repository name="sample">
+        <text-extractors thread-pool-name="test-text-extractor" max-pool-size="2">
+            <text-extractor classname="tika" name="tika-extractor1"/>
+            <text-extractor
+                    classname="org.modeshape.extractor.tika.TikaTextExtractor" name="tika-extractor2"/>
+        </text-extractors>
+    </repository>
+</subsystem>

--- a/extractors/modeshape-extractor-tika/src/test/resources/repo-config.json
+++ b/extractors/modeshape-extractor-tika/src/test/resources/repo-config.json
@@ -6,6 +6,8 @@
         "allowCreation" : true
     },
     "textExtraction": {
+        "threadPool" : "test-text-extractors",
+        "maxPoolSize" : 5,
         "extractors" : {
             "tikaExtractor":{
                 "name" : "Tika content-based extractor",

--- a/integration/modeshape-jbossas-integration-tests/src/main/resources/kit/jboss-wf8/standalone/configuration/standalone-modeshape.xml
+++ b/integration/modeshape-jbossas-integration-tests/src/main/resources/kit/jboss-wf8/standalone/configuration/standalone-modeshape.xml
@@ -372,7 +372,7 @@
                 The sequencer names are unique identifiers within the configuration, and should not contain spaces.
                 Also, some of the sequencer configurations use the fully-qualified classname, while other use the
                 short alias (which only works for the sequencer provided by ModeShape). -->
-                <sequencers>
+                <sequencers max-pool-size="5" thread-pool-name="test-sequencer">
                     <sequencer name="delimited-text-sequencer" classname="org.modeshape.sequencer.text.DelimitedTextSequencer"
                                module="org.modeshape.sequencer.text" splitPattern=",">
                         <path-expression>/files(//*.csv[*])/jcr:content[@jcr:data] => /derived/text/delimited/$1
@@ -437,7 +437,7 @@
                     </sequencer>
                     <sequencer name="zip-sequencer-manual" classname="zip" module="org.modeshape.sequencer.zip"/>
                 </sequencers>
-                <text-extractors>
+                <text-extractors max-pool-size="5" thread-pool-name="test-text-extractor">
                     <text-extractor name="tika-extractor" classname="tika" module="org.modeshape.extractor.tika"/>
                 </text-extractors>
                 <file-binary-storage/>

--- a/modeshape-common/src/main/java/org/modeshape/common/util/ThreadPoolFactory.java
+++ b/modeshape-common/src/main/java/org/modeshape/common/util/ThreadPoolFactory.java
@@ -38,10 +38,11 @@ public interface ThreadPoolFactory {
      * return one if no thread pool exists with that name. When finished with the thread pool, it should be
      * {@link #releaseThreadPool released}.
      * 
+     * @param maxPoolSize the maximum number of threads that can be spawned by this pool.
      * @param name the name of the thread pool; may not be null
      * @return the thread pool executor; never null
      */
-    ExecutorService getCachedTreadPool( String name );
+    ExecutorService getCachedTreadPool( String name, int maxPoolSize );
 
     /**
      * Obtain a scheduled thread pool with the supplied name, or create and return one if no thread pool exists with that name.

--- a/modeshape-common/src/main/java/org/modeshape/common/util/ThreadPools.java
+++ b/modeshape-common/src/main/java/org/modeshape/common/util/ThreadPools.java
@@ -22,6 +22,8 @@ import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.SynchronousQueue;
+import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import org.modeshape.common.annotation.ThreadSafe;
 
@@ -42,8 +44,12 @@ public class ThreadPools implements ThreadPoolFactory {
     }
 
     @Override
-    public ExecutorService getCachedTreadPool( String name ) {
-        return getOrCreateNewPool(name, Executors.newCachedThreadPool(new NamedThreadFactory(name)));
+    public ExecutorService getCachedTreadPool( String name, int maxPoolSize ) {
+        NamedThreadFactory threadFactory = new NamedThreadFactory(name);
+        ExecutorService executorService = new ThreadPoolExecutor(0, maxPoolSize, 60L, TimeUnit.SECONDS, 
+                                                                 new SynchronousQueue<Runnable>(), 
+                                                                 threadFactory);
+        return getOrCreateNewPool(name, executorService);
     }
 
     @Override

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/ExecutionContext.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/ExecutionContext.java
@@ -393,8 +393,8 @@ public final class ExecutionContext implements ThreadPoolFactory, Cloneable, Nam
     }
 
     @Override
-    public ExecutorService getCachedTreadPool( String name ) {
-        return this.threadPools.getCachedTreadPool(name);
+    public ExecutorService getCachedTreadPool( String name, int maxPoolSize ) {
+        return this.threadPools.getCachedTreadPool(name, maxPoolSize);
     }
 
     @Override

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrRepository.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrRepository.java
@@ -1105,7 +1105,8 @@ public class JcrRepository implements org.modeshape.jcr.api.Repository {
                     this.internalWorkerContext = this.context.with(new InternalSecurityContext(INTERNAL_WORKER_USERNAME));
 
                     // Create clustering service and event bus
-                    this.changeDispatchingQueue = this.context().getCachedTreadPool("modeshape-event-dispatcher");
+                    this.changeDispatchingQueue = this.context().getCachedTreadPool("modeshape-event-dispatcher", 
+                                                                                    Integer.MAX_VALUE);
                     ChangeBus localBus = new RepositoryChangeBus(name(), changeDispatchingQueue);
                     this.changeBus = clusteringService != null ? new ClusteredChangeBus(localBus, clusteringService) : localBus;
                     this.changeBus.start();

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/RepositoryConfiguration.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/RepositoryConfiguration.java
@@ -462,56 +462,15 @@ public class RepositoryConfiguration {
         public static final String OPTIMIZATION_CHILD_COUNT_TOLERANCE = "childCountTolerance";
 
         /**
-         * The name for the field (under "sequencing" and "query") specifying the thread pool that should be used for sequencing.
-         * By default, all repository instances will use the same thread pool within the engine. To use a dedicated thread pool
-         * for a single repository, simply use a name that is unique from all other repositories.
+         * The name for the field (under "sequencing" and "textExtraction") specifying the thread pool that should be used for sequencing.
          */
         public static final String THREAD_POOL = "threadPool";
 
-        @Deprecated
-        public static final String REMOVE_DERIVED_CONTENT_WITH_ORIGINAL = "removeDerivedContentWithOriginal";
-
-        public static final String INDEXING_ANALYZER = "analyzer";
-        public static final String INDEXING_ANALYZER_CLASSPATH = "analyzerClasspath";
-        public static final String INDEXING_SIMILARITY = "similarity";
-        public static final String INDEXING_BATCH_SIZE = "batchSize";
-        public static final String INDEXING_INDEX_FORMAT = "indexFormat";
-        public static final String INDEXING_READER_STRATEGY = "readerStrategy";
-        public static final String INDEXING_MODE = "mode";
-        public static final String INDEXING_ASYNC_THREAD_POOL_SIZE = "asyncThreadPoolSize";
-        public static final String INDEXING_ASYNC_MAX_QUEUE_SIZE = "asyncMaxQueueSize";
-
-        public static final String INDEX_STORAGE_LOCATION = "location";
-        public static final String INDEX_STORAGE_SOURCE_LOCATION = "sourceLocation";
-        public static final String INDEX_STORAGE_LOCKING_STRATEGY = "lockingStrategy";
-        public static final String INDEX_STORAGE_FILE_SYSTEM_ACCESS_TYPE = "fileSystemAccessType";
-        public static final String INDEX_STORAGE_REFRESH_IN_SECONDS = "refreshInSeconds";
-        public static final String INDEX_STORAGE_COPY_BUFFER_SIZE_IN_MEGABYTES = "copyBufferSizeInMegabytes";
-        public static final String INDEX_STORAGE_RETRY_MARKER_LOOKUP = "retryMarkerLookup";
-        public static final String INDEX_STORAGE_RETRY_INITIALIZE_PERIOD_IN_SECONDS = "retryInitializePeriodInSeconds";
-
-        public static final String INDEXING_BACKEND_JMS_CONNECTION_FACTORY_JNDI_NAME = "connectionFactoryJndiName";
-        public static final String INDEXING_BACKEND_JMS_QUEUE_JNDI_NAME = "queueJndiName";
-        public static final String INDEXING_BACKEND_JGROUPS_CHANNEL_NAME = "channelName";
-        public static final String INDEXING_BACKEND_JGROUPS_CHANNEL_CONFIGURATION = "channelConfiguration";
-
         /**
-         * @deprecated use REBUILD_ON_STARTUP document
+         * The name of the field which allows the configuration of the maximum number of threads that can be spawned by a pool
          */
-        @Deprecated
-        public static final String REBUILD_UPON_STARTUP = "rebuildUponStartup";
-
-        /**
-         * @deprecated use REBUILD_ON_STARTUP document
-         */
-        @Deprecated
-        public static final String INDEXING_MODE_SYSTEM_CONTENT = "systemContentMode";
-
-        public static final String REBUILD_ON_STARTUP = "rebuildOnStartup";
-        public static final String REBUILD_WHEN = "when";
-        public static final String REBUILD_INCLUDE_SYSTEM_CONTENT = "includeSystemContent";
-        public static final String REBUILD_MODE = "mode";
-
+        public static final String MAX_POOL_SIZE = "maxPoolSize";
+        
         /**
          * The name of the journaling schema field.
          */
@@ -577,21 +536,13 @@ public class RepositoryConfiguration {
 
         public static final String ANONYMOUS_USERNAME = "<anonymous>";
 
-        public static final boolean QUERY_ENABLED = true;
-        public static final boolean FULL_TEXT_SEARCH_ENABLED = true;
-
         public static final boolean MONITORING_ENABLED = true;
 
-        @Deprecated
-        public static final boolean REMOVE_DERIVED_CONTENT_WITH_ORIGINAL = true;
-
         public static final String SEQUENCING_POOL = "modeshape-sequencer";
-        public static final String QUERY_THREAD_POOL = "modeshape-indexer";
+        public static final String TEXT_EXTRACTION_POOL = "modeshape-text-extractor";
         public static final String GARBAGE_COLLECTION_POOL = "modeshape-gc";
         public static final String OPTIMIZATION_POOL = "modeshape-opt";
         public static final String JOURNALING_POOL = "modeshape-journaling-gc";
-
-        public static final String CLUSTER_NAME = "ModeShape-JCR";
 
         public static final String GARBAGE_COLLECTION_INITIAL_TIME = "00:00";
         public static final int GARBAGE_COLLECTION_INTERVAL_IN_HOURS = 24;
@@ -608,6 +559,9 @@ public class RepositoryConfiguration {
         public static final String NODE_TYPE = "nt:base";
         public static final boolean SYNCHRONOUS = true;
         public static final String WORKSPACES = "*";
+
+        public static final int SEQUENCING_MAX_POOL_SIZE = 10;
+        public static final int TEXT_EXTRACTION_MAX_POOL_SIZE = 5;
     }
 
     public static final class FieldValue {
@@ -1944,8 +1898,18 @@ public class RepositoryConfiguration {
          * @return the thread pool name; never null
          */
         public String getThreadPoolName() {
-            return textExtracting.getString(FieldName.THREAD_POOL, "modeshape-text-extractor");
+            return textExtracting.getString(FieldName.THREAD_POOL, Default.TEXT_EXTRACTION_POOL);
         }
+
+        /**
+         * Get the maximum number of threads that can be spawned for sequencing at the same time
+         *
+         * @return the max number of threads
+         */
+        public int getMaxPoolSize() {
+            return textExtracting.getInteger(FieldName.MAX_POOL_SIZE, Default.TEXT_EXTRACTION_MAX_POOL_SIZE);
+        }
+
 
         /**
          * Get the ordered list of text extractors. All text extractors are configured with this list.
@@ -2136,25 +2100,21 @@ public class RepositoryConfiguration {
         }
 
         /**
-         * Determine whether the derived content originally produced by a sequencer upon sequencing some specific input should be
-         * removed if that input is updated and the sequencer re-run.
-         *
-         * @return true if the original derived content should be removed upon subsequent sequencing of the same input.
-         * @deprecated because it was never used
-         */
-        @Deprecated
-        public boolean removeDerivedContentWithOriginal() {
-            return sequencing.getBoolean(FieldName.REMOVE_DERIVED_CONTENT_WITH_ORIGINAL,
-                                         Default.REMOVE_DERIVED_CONTENT_WITH_ORIGINAL);
-        }
-
-        /**
          * Get the name of the thread pool that should be used for sequencing work.
          *
          * @return the thread pool name; never null
          */
         public String getThreadPoolName() {
             return sequencing.getString(FieldName.THREAD_POOL, Default.SEQUENCING_POOL);
+        }
+
+        /**
+         * Get the maximum number of threads that can be spawned for sequencing at the same time
+         * 
+         * @return the max number of threads
+         */
+        public int getMaxPoolSize() { 
+            return sequencing.getInteger(FieldName.MAX_POOL_SIZE, Default.SEQUENCING_MAX_POOL_SIZE);
         }
 
         /**

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/Sequencers.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/Sequencers.java
@@ -97,7 +97,8 @@ public class Sequencers implements ChangeSetListener {
                           RepositoryConfiguration config,
                           Iterable<String> workspaceNames ) {
         this.repository = repository;
-        this.components = config.getSequencing().getSequencers(repository.problems());
+        RepositoryConfiguration.Sequencing sequencing = config.getSequencing();
+        this.components = sequencing.getSequencers(repository.problems());
         this.systemWorkspaceKey = repository.repositoryCache().getSystemKey().getWorkspaceKey();
         if (components.isEmpty()) {
             this.processId = null;
@@ -110,8 +111,9 @@ public class Sequencers implements ChangeSetListener {
             this.initialized = true;
             this.sequencersByName = Collections.emptyMap();
         } else {
-            String threadPoolName = config.getSequencing().getThreadPoolName();
-            this.sequencingExecutor = repository.context().getCachedTreadPool(threadPoolName);
+            int maxThreadCount = sequencing.getMaxPoolSize();
+            String threadPoolName = sequencing.getThreadPoolName();
+            this.sequencingExecutor = repository.context().getCachedTreadPool(threadPoolName, maxThreadCount);
             this.workQueue = new SequencingWorkQueue();
             this.processId = repository.context().getProcessId();
             ExecutionContext context = this.repository.context();

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/TextExtractors.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/TextExtractors.java
@@ -58,8 +58,8 @@ public final class TextExtractors {
 
     protected TextExtractors( JcrRepository.RunningState repository,
                     RepositoryConfiguration.TextExtraction extracting ) {
-        this(repository.context().getCachedTreadPool(extracting.getThreadPoolName()), getConfiguredExtractors(repository,
-                                                                                                              extracting));
+        this(repository.context().getCachedTreadPool(extracting.getThreadPoolName(), extracting.getMaxPoolSize()), 
+             getConfiguredExtractors(repository, extracting));
     }
 
     protected void shutdown() {

--- a/modeshape-jcr/src/main/resources/org/modeshape/jcr/repository-config-schema.json
+++ b/modeshape-jcr/src/main/resources/org/modeshape/jcr/repository-config-schema.json
@@ -793,6 +793,11 @@
                     "default" : "modeshape-workers",
                     "description" : "Name of the thread pool that should be used for text extracting. Thread pools are named globally within a single ModeShape engine, and by default all repositories use the same thread pool for sequencing and indexing."
                 },
+                "maxPoolSize" : {
+                    "type" : "integer",
+                    "default" : 4,
+                    "description" : "The maximum number of threads that can be spawned at the same time to perform text extraction"
+                },
                 "extractors" : {
                     "type" : "object",
                     "description" : "The container for the list of configured text extractors",
@@ -841,6 +846,11 @@
                     "type" : "string",
                     "default" : "modeshape-workers",
                     "description" : "Name of the thread pool that should be used for sequencing. Thread pools are named globally within a single ModeShape engine, and by default all repositories use the same thread pool for sequencing and indexing."
+                },
+                "maxPoolSize" : {
+                    "type" : "integer",
+                    "default" : 10,
+                    "description" : "The maximum number of threads that can be spawned at the same time to perform sequencing"
                 },
                 "sequencers" : {
                     "type" : "object",

--- a/modeshape-jcr/src/test/resources/config/thorough-repo-config.json
+++ b/modeshape-jcr/src/test/resources/config/thorough-repo-config.json
@@ -63,6 +63,7 @@
     },
     "textExtraction": {
         "threadPool" : "test",
+        "maxPoolSize" : 10,
             "extractors" : {
                 "customExtractor": {
                     "name" : "MyFileType extractor",
@@ -76,6 +77,7 @@
     },
     "sequencing" : {
         "threadPool" : "modeshape-workers",
+        "maxPoolSize" : 100,
         "sequencers" : {
             "zipSequencer" : {
                 "classname" : "ZipSequencer",

--- a/modeshape-schematic/src/test/resources/json/schema/repository-config-schema.json
+++ b/modeshape-schematic/src/test/resources/json/schema/repository-config-schema.json
@@ -365,6 +365,11 @@
                             "default" : "modeshape-workers",
                             "description" : "Name of the thread pool that should be used for text extracting. Thread pools are named globally within a single ModeShape engine, and by default all repositories use the same thread pool for sequencing and indexing."
                         },
+                        "maxPoolSize" : {
+                            "type" : "integer",
+                            "default" : 4,
+                            "description" : "The maximum number of threads that can be spawned at the same time to perform text extraction"
+                        },
                         "extractors" : {
                             "type" : "object",
                             "description" : "The container for the list of configured text extractors",
@@ -872,6 +877,11 @@
                     "type" : "string",
                     "default" : "modeshape-workers",
                     "description" : "Name of the thread pool that should be used for sequencing. Thread pools are named globally within a single ModeShape engine, and by default all repositories use the same thread pool for sequencing and indexing."
+                },
+                "maxPoolSize" : {
+                    "type" : "integer",
+                    "default" : 10,
+                    "description" : "The maximum number of threads that can be spawned at the same time to perform text extraction"
                 },
                 "sequencers" : {
                     "type" : "object",

--- a/sequencers/modeshape-sequencer-images/src/test/resources/config/repo-config.json
+++ b/sequencers/modeshape-sequencer-images/src/test/resources/config/repo-config.json
@@ -1,6 +1,8 @@
 {
     "name" : "ImageSequencer Test Repository",
     "sequencing" : {
+        "maxPoolSize" : 4,
+        "threadPool" : "test-sequencer",
         "sequencers" : {
             "Images in separate location" : {
                 "classname" : "ImageSequencer",


### PR DESCRIPTION
Updated the AS kit to expose configuration attributes both for the names of the thread pools and the maximum size of the thread pool.