### PR TITLE
MODE-2481 Added some more optimization to the ChildReferences implementations

### DIFF
--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrSession.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrSession.java
@@ -24,6 +24,7 @@ import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
@@ -60,8 +61,6 @@ import javax.jcr.version.Version;
 import javax.jcr.version.VersionException;
 import javax.jcr.version.VersionIterator;
 import org.infinispan.schematic.SchematicEntry;
-import org.modeshape.common.collection.LinkedListMultimap;
-import org.modeshape.common.collection.Multimap;
 import org.modeshape.common.i18n.I18n;
 import org.modeshape.common.logging.Logger;
 import org.modeshape.common.text.TextDecoder;
@@ -2349,78 +2348,99 @@ public class JcrSession implements org.modeshape.jcr.api.Session {
             MutableCachedNode.NodeChanges changes = modifiedNode.getNodeChanges();
             Map<NodeKey, Name> appendedChildren = changes.appendedChildren();
             Map<NodeKey, Name> renamedChildren = changes.renamedChildren();
+            if (appendedChildren.isEmpty() && renamedChildren.isEmpty()) {
+                // no appended or renamed children so nothing more to compute
+                return;
+            }
             Set<NodeKey> removedChildren = changes.removedChildren();
-            if (!appendedChildren.isEmpty() || !renamedChildren.isEmpty()) {
+            Map<Name, List<NodeKey>> appendedOrRenamedChildrenByName = new HashMap<>();
 
-                Multimap<Name, NodeKey> appendedOrRenamedChildrenByName = LinkedListMultimap.create();
+            if (!appendedChildren.isEmpty()) {
                 for (Map.Entry<NodeKey, Name> appended : appendedChildren.entrySet()) {
-                    appendedOrRenamedChildrenByName.put(appended.getValue(), appended.getKey());
+                    Name name = appended.getValue();
+                    NodeKey key = appended.getKey();
+                    List<NodeKey> childKeys = appendedOrRenamedChildrenByName.get(name);
+                    if (childKeys == null) {
+                        childKeys = new ArrayList<>();
+                        appendedOrRenamedChildrenByName.put(name, childKeys);
+                    }
+                    childKeys.add(key);
                 }
+            }
+            
+            if (!renamedChildren.isEmpty()) {
                 for (Map.Entry<NodeKey, Name> renamed : renamedChildren.entrySet()) {
-                    appendedOrRenamedChildrenByName.put(renamed.getValue(), renamed.getKey());
+                    Name name = renamed.getValue();
+                    NodeKey key = renamed.getKey();
+                    List<NodeKey> childKeys = appendedOrRenamedChildrenByName.get(name);
+                    if (childKeys == null) {
+                        childKeys = new ArrayList<>();
+                        appendedOrRenamedChildrenByName.put(name, childKeys);
+                    }
+                    childKeys.add(key);
+                }
+            }
+
+            assert !appendedOrRenamedChildrenByName.isEmpty();
+
+            // look at the information that was already persisted to determine whether some other thread has already
+            // created a child with the same name
+            CachedNode persistentNode = persistentNodeCache.getNode(modifiedNode.getKey());
+            final ChildReferences persistedChildReferences = persistentNode.getChildReferences(persistentNodeCache);
+            final SiblingCounter siblingCounter = SiblingCounter.create(persistedChildReferences);
+
+            // process appended/renamed children
+            for (Name childName : appendedOrRenamedChildrenByName.keySet()) {
+                int existingChildrenWithSameName = persistedChildReferences.getChildCount(childName);
+                if (existingChildrenWithSameName == 0) {
+                    continue;
+                }
+                if (existingChildrenWithSameName == 1) {
+                    // See if the existing same-name sibling is removed ...
+                    NodeKey persistedChildKey = persistedChildReferences.getChild(childName).getKey();
+                    if (removedChildren.contains(persistedChildKey)) {
+                        // the sole existing child with this name is being removed, so we can ignore it ...
+                        // existingChildrenWithSameName = 0;
+                        continue;
+                    }
                 }
 
-                assert appendedOrRenamedChildrenByName.isEmpty() == false;
+                // There is at least one persisted child with the same name, and we're adding a new child
+                // or renaming an existing child to this name. Therefore, we have to find a child node definition
+                // that allows SNS. Look for one ignoring the child node type (this is faster than finding the
+                // child node primary types) ...
+                NodeDefinitionSet childDefns = nodeTypeCapabilities.findChildNodeDefinitions(primaryType, mixinTypes);
+                JcrNodeDefinition childNodeDefinition = childDefns.findBestDefinitionForChild(childName, null, true,
+                                                                                              siblingCounter);
+                if (childNodeDefinition != null) {
+                    // found the one child node definition that applies, so it's okay ...
+                    continue;
+                }
 
-                // look at the information that was already persisted to determine whether some other thread has already
-                // created a child with the same name
-                CachedNode persistentNode = persistentNodeCache.getNode(modifiedNode.getKey());
-                final ChildReferences persistedChildReferences = persistentNode.getChildReferences(persistentNodeCache);
-                final SiblingCounter siblingCounter = SiblingCounter.create(persistedChildReferences);
+                // We were NOT able to find a definition that allows SNS for this name, but we need to make sure that
+                // the node that already exists (persisted) isn't the one that's being changed
+                NodeKey persistedChildKey = persistedChildReferences.getChild(childName).getKey();
+                if (appendedChildren.containsKey(persistedChildKey) || renamedChildren.containsKey(persistedChildKey)) {
+                    // The persisted node is being changed, so it's okay ...
+                    continue;
+                }
 
-                // process appended/renamed children
-                for (Name childName : appendedOrRenamedChildrenByName.keySet()) {
-                    int existingChildrenWithSameName = persistedChildReferences.getChildCount(childName);
-                    if (existingChildrenWithSameName == 0) {
-                        continue;
-                    }
-                    if (existingChildrenWithSameName == 1) {
-                        // See if the existing same-name sibling is removed ...
-                        NodeKey persistedChildKey = persistedChildReferences.getChild(childName).getKey();
-                        if (removedChildren.contains(persistedChildKey)) {
-                            // the sole existing child with this name is being removed, so we can ignore it ...
-                            // existingChildrenWithSameName = 0;
-                            continue;
-                        }
-                    }
-
-                    // There is at least one persisted child with the same name, and we're adding a new child
-                    // or renaming an existing child to this name. Therefore, we have to find a child node definition
-                    // that allows SNS. Look for one ignoring the child node type (this is faster than finding the
-                    // child node primary types) ...
-                    NodeDefinitionSet childDefns = nodeTypeCapabilities.findChildNodeDefinitions(primaryType, mixinTypes);
-                    JcrNodeDefinition childNodeDefinition = childDefns.findBestDefinitionForChild(childName, null, true,
-                                                                                                  siblingCounter);
-                    if (childNodeDefinition != null) {
-                        // found the one child node definition that applies, so it's okay ...
-                        continue;
-                    }
-
-                    // We were NOT able to find a definition that allows SNS for this name, but we need to make sure that
-                    // the node that already exists (persisted) isn't the one that's being changed
-                    NodeKey persistedChildKey = persistedChildReferences.getChild(childName).getKey();
-                    if (appendedChildren.containsKey(persistedChildKey) || renamedChildren.containsKey(persistedChildKey)) {
-                        // The persisted node is being changed, so it's okay ...
-                        continue;
-                    }
-
-                    // We still were NOT able to find a definition that allows SNS for this name WITHOUT considering the
-                    // specific child node type. This likely means there is either 0 or more than 1 (possibly residual)
-                    // child node definitions. We need to find all of the added/renamed child nodes and use their specific
-                    // primary types. The first to fail will result in an exception ...
-                    final SessionCache session = cache();
-                    for (NodeKey appendedOrRenamedKey : appendedOrRenamedChildrenByName.get(childName)) {
-                        MutableCachedNode appendedOrRenamedChild = session.mutable(appendedOrRenamedKey);
-                        if (appendedOrRenamedChild == null) continue;
-                        Name childPrimaryType = appendedOrRenamedChild.getPrimaryType(session);
-                        childDefns = nodeTypeCapabilities.findChildNodeDefinitions(primaryType, mixinTypes);
-                        childNodeDefinition = childDefns.findBestDefinitionForChild(childName, childPrimaryType, true,
-                                                                                    siblingCounter);
-                        if (childNodeDefinition == null) {
-                            // Could not find a valid child node definition that allows SNS given the child's primary type and
-                            // name plus the parent's primary type and mixin types.
-                            throw new ItemExistsException(JcrI18n.noSnsDefinitionForNode.text(childName, workspaceName()));
-                        }
+                // We still were NOT able to find a definition that allows SNS for this name WITHOUT considering the
+                // specific child node type. This likely means there is either 0 or more than 1 (possibly residual)
+                // child node definitions. We need to find all of the added/renamed child nodes and use their specific
+                // primary types. The first to fail will result in an exception ...
+                final SessionCache session = cache();
+                for (NodeKey appendedOrRenamedKey : appendedOrRenamedChildrenByName.get(childName)) {
+                    MutableCachedNode appendedOrRenamedChild = session.mutable(appendedOrRenamedKey);
+                    if (appendedOrRenamedChild == null) { continue; }
+                    Name childPrimaryType = appendedOrRenamedChild.getPrimaryType(session);
+                    childDefns = nodeTypeCapabilities.findChildNodeDefinitions(primaryType, mixinTypes);
+                    childNodeDefinition = childDefns.findBestDefinitionForChild(childName, childPrimaryType, true,
+                                                                                siblingCounter);
+                    if (childNodeDefinition == null) {
+                        // Could not find a valid child node definition that allows SNS given the child's primary type and
+                        // name plus the parent's primary type and mixin types.
+                        throw new ItemExistsException(JcrI18n.noSnsDefinitionForNode.text(childName, workspaceName()));
                     }
                 }
             }

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/NodeTypes.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/NodeTypes.java
@@ -286,7 +286,7 @@ public class NodeTypes {
                         // fullDefined = false;
                     }
                     if (childDefn.allowsSameNameSiblings()) {
-                        if (childDefn.isResidual() && !childDefn.hasRequiredPrimaryTypes()) {
+                        if (childDefn.isResidual()) {
                             allowsResidualWithSameNameSiblings = true;
                         }
                     } else {
@@ -575,11 +575,22 @@ public class NodeTypes {
         return false;
     }
 
-    public boolean disallowsSameNameSiblings( Name primaryType,
-                                              Set<Name> mixinTypes ) {
-        if (!nodeTypeNamesThatAllowSameNameSiblings.contains(primaryType)) return true;
-        for (Name mixinType : mixinTypes) {
-            if (!nodeTypeNamesThatAllowSameNameSiblings.contains(mixinType)) return true;
+    /**
+     * Determine if either the primary type or any of the mixin types allows SNS.
+     *
+     * @param primaryType the primary type name; may not be null
+     * @param mixinTypes the mixin type names; may be null or empty
+     * @return {@code true} if either the primary type or any of the mixin types allows SNS. If neither allow SNS,
+     * this will return {@code false}
+     */
+    public boolean allowsNameSiblings( Name primaryType,
+                                       Set<Name> mixinTypes ) {
+        if (nodeTypeNamesThatAllowSameNameSiblings.contains(primaryType)) return true;
+        if (mixinTypes != null && !mixinTypes.isEmpty()) {
+            for (Name mixinType : mixinTypes) {
+                if (nodeTypeNamesThatAllowSameNameSiblings.contains(mixinType))
+                    return true;
+            }
         }
         return false;
     }

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/ChildReferences.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/ChildReferences.java
@@ -199,6 +199,12 @@ public interface ChildReferences extends Iterable<ChildReference> {
     Iterator<ChildReference> iterator( Context context,
                                        Collection<?> namePatterns,
                                        NamespaceRegistry registry );
+    /**
+     * Determine if the child references instance should support SNS or not.
+     * 
+     * @return {@code true} if the child reference instance supports SNS
+     */
+    boolean allowsSNS();
 
     /**
      * Get the keys for all of the children. The resulting iterator is lazy where possible, but it may be an expensive call if
@@ -354,7 +360,7 @@ public interface ChildReferences extends Iterable<ChildReference> {
      * with the same names, since it always returns '1' for the SNS index.
      */
     public static final class NoContext implements Context {
-        protected static final Context INSTANCE = new NoContext();
+        public static final Context INSTANCE = new NoContext();
 
         private NoContext() {
         }

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/RepositoryEnvironment.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/RepositoryEnvironment.java
@@ -15,13 +15,14 @@
  */
 package org.modeshape.jcr.cache;
 
+import org.modeshape.jcr.NodeTypes;
 import org.modeshape.jcr.cache.document.TransactionalWorkspaceCaches;
 import org.modeshape.jcr.txn.Transactions;
 
 /**
  * Interface which exposes global repository subsystems/configuration to running sessions.
  */
-public interface SessionEnvironment {
+public interface RepositoryEnvironment {
 
     /**
      * Get the interface for working with transactions.
@@ -43,4 +44,12 @@ public interface SessionEnvironment {
      * @return either a {@link String} or {@code null} if no journal is configured.
      */
     String journalId();
+
+    /**
+     * Returns the {@link NodeTypes} instance for this repository.
+     *
+     * @return a {@link NodeTypes} instance or {@code null} if no such information is available yet (e.g. the node types have not
+     * been initialized yet).
+     */
+    NodeTypes nodeTypes();
 }

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/SessionCache.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/SessionCache.java
@@ -18,6 +18,7 @@ package org.modeshape.jcr.cache;
 import java.util.Set;
 import org.modeshape.jcr.ExecutionContext;
 import org.modeshape.jcr.api.value.DateTime;
+import org.modeshape.jcr.cache.document.WorkspaceCache;
 
 /**
  * 
@@ -46,7 +47,7 @@ public interface SessionCache extends NodeCache {
 
     /**
      * The definition of a callback that can be implemented and passed to {@link SessionCache#save(SessionCache, PreSave)} and
-     * {@link SessionCache#save(Set, SessionCache, PreSave)}, allowing the caller to recieve a hook where they can interrogate
+     * {@link SessionCache#save(Set, SessionCache, PreSave)}, allowing the caller to receive a hook where they can interrogate
      * each of the changed nodes and perform additional logic prior to the actual persisting of the changes. Note that
      * implementations are free to make additional modifications to the supplied nodes, and even create additional nodes or change
      * persistent but unchanged nodes, as long as these operations are done within the same calling thread.
@@ -188,7 +189,7 @@ public interface SessionCache extends NodeCache {
      * 
      * @return the workspace cache; never null
      */
-    public NodeCache getWorkspace();
+    public WorkspaceCache getWorkspace();
 
     /**
      * Get a mutable form of the node with the supplied key. If this session already has a mutable node in its cache, that

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/SessionCacheWrapper.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/SessionCacheWrapper.java
@@ -18,6 +18,7 @@ package org.modeshape.jcr.cache;
 import java.util.Iterator;
 import java.util.Set;
 import org.modeshape.jcr.ExecutionContext;
+import org.modeshape.jcr.cache.document.WorkspaceCache;
 
 /**
  * A {@link SessionCache} implementation that wraps another and is suitable to extend and overwrite only those methods that are
@@ -121,7 +122,7 @@ public class SessionCacheWrapper implements SessionCache {
     }
 
     @Override
-    public NodeCache getWorkspace() {
+    public WorkspaceCache getWorkspace() {
         return delegate.getWorkspace();
     }
 

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/document/AbstractChildReferences.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/document/AbstractChildReferences.java
@@ -42,28 +42,28 @@ public abstract class AbstractChildReferences implements ChildReferences {
 
     @Override
     public ChildReference getChild( Name name ) {
-        return getChild(name, 1, new BasicContext());
+        return getChild(name, 1, defaultContext());
     }
 
     @Override
     public ChildReference getChild( Segment segment ) {
-        return getChild(segment.getName(), segment.getIndex(), new BasicContext());
+        return getChild(segment.getName(), segment.getIndex(), defaultContext());
     }
 
     @Override
     public ChildReference getChild( Name name,
                                     int snsIndex ) {
-        return getChild(name, snsIndex, new BasicContext());
+        return getChild(name, snsIndex, defaultContext());
     }
 
     @Override
     public Iterator<ChildReference> iterator( Name name ) {
-        return iterator(name, new BasicContext());
+        return iterator(name, defaultContext());
     }
 
     @Override
     public Iterator<ChildReference> iterator() {
-        return iterator(new BasicContext());
+        return iterator(defaultContext());
     }
 
     @Override
@@ -181,7 +181,7 @@ public abstract class AbstractChildReferences implements ChildReferences {
     public Iterator<ChildReference> iterator( Collection<?> namePatterns,
                                               final NamespaceRegistry registry ) {
         //we don't care about SNSs here
-        return iterator(new BasicContext(), namePatterns, registry);
+        return iterator(defaultContext(), namePatterns, registry);
     }
 
     @Override
@@ -205,6 +205,10 @@ public abstract class AbstractChildReferences implements ChildReferences {
     @Override
     public String toString() {
         return toString(new StringBuilder()).toString();
+    }   
+    
+    protected Context defaultContext() {
+        return allowsSNS() ? new BasicContext() : NoContext.INSTANCE;
     }
 
     public abstract StringBuilder toString( StringBuilder sb );

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/document/DocumentTranslator.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/document/DocumentTranslator.java
@@ -46,11 +46,13 @@ import org.modeshape.common.text.TextEncoder;
 import org.modeshape.common.util.StringUtil;
 import org.modeshape.jcr.ExecutionContext;
 import org.modeshape.jcr.JcrLexicon;
+import org.modeshape.jcr.NodeTypes;
 import org.modeshape.jcr.api.value.DateTime;
 import org.modeshape.jcr.cache.CachedNode.ReferenceType;
 import org.modeshape.jcr.cache.ChildReference;
 import org.modeshape.jcr.cache.ChildReferences;
 import org.modeshape.jcr.cache.NodeKey;
+import org.modeshape.jcr.cache.RepositoryEnvironment;
 import org.modeshape.jcr.cache.document.SessionNode.ChangedAdditionalParents;
 import org.modeshape.jcr.cache.document.SessionNode.ChangedChildren;
 import org.modeshape.jcr.cache.document.SessionNode.Insertions;
@@ -336,7 +338,8 @@ public class DocumentTranslator implements DocumentConstants {
     }
 
     public Name getPrimaryType( Document document ) {
-        return names.create(getProperty(document, JcrLexicon.PRIMARY_TYPE).getFirstValue());
+        Property primaryType = getProperty(document, JcrLexicon.PRIMARY_TYPE);
+        return primaryType != null ? names.create(primaryType.getFirstValue()) : null;
     }
 
     public String getPrimaryTypeName( Document document ) {
@@ -870,32 +873,46 @@ public class DocumentTranslator implements DocumentConstants {
         if (!hasChildren && !hasFederatedSegments) {
             return ImmutableChildReferences.EMPTY_CHILD_REFERENCES;
         }
-        ChildReferences internalChildRefs = hasChildren ? ImmutableChildReferences.create(this, document, CHILDREN) : ImmutableChildReferences.EMPTY_CHILD_REFERENCES;
+        
+        Name primaryType = getPrimaryType(document);
+        Set<Name> mixinTypes = getMixinTypes(document);
+        NodeTypes nodeTypes = getNodeTypes(cache);
+        boolean allowsSNS = nodeTypes == null || nodeTypes.allowsNameSiblings(primaryType, mixinTypes);
+        ChildReferences internalChildRefs = hasChildren ? ImmutableChildReferences.create(this, document, CHILDREN, allowsSNS) : ImmutableChildReferences.EMPTY_CHILD_REFERENCES;
         ChildReferences externalChildRefs = hasFederatedSegments ? ImmutableChildReferences.create(this, document,
-                                                                                                   FEDERATED_SEGMENTS) : ImmutableChildReferences.EMPTY_CHILD_REFERENCES;
+                                                                                                   FEDERATED_SEGMENTS, allowsSNS) : ImmutableChildReferences.EMPTY_CHILD_REFERENCES;
 
         // Now look at the 'childrenInfo' document for info about the next block of children ...
         ChildReferencesInfo info = getChildReferencesInfo(document);
         if (!hasChildren) {
-            return ImmutableChildReferences.create(externalChildRefs, info, cache);
+            return ImmutableChildReferences.create(externalChildRefs, info, cache, allowsSNS);
         } else if (!hasFederatedSegments) {
-            return ImmutableChildReferences.create(internalChildRefs, info, cache);
+            return ImmutableChildReferences.create(internalChildRefs, info, cache, allowsSNS);
         } else {
-            return ImmutableChildReferences.create(internalChildRefs, info, externalChildRefs, cache);
+            return ImmutableChildReferences.create(internalChildRefs, info, externalChildRefs, cache, allowsSNS);
         }
+    }
+
+    protected NodeTypes getNodeTypes( WorkspaceCache cache ) {
+        RepositoryEnvironment repositoryEnvironment = cache.repositoryEnvironment();
+        if (repositoryEnvironment == null) {
+            return null;
+        }
+        return repositoryEnvironment.nodeTypes();
     }
 
     /**
      * Reads the children of the given block and returns a {@link ChildReferences} instance.
      * 
      * @param block a {@code non-null} {@link Document} representing a block of children
+     * @param allowsSNS {@code true} if the child references instance should be SNS aware, {@code false} otherwise
      * @return a {@code non-null} child references instance
      */
-    public ChildReferences getChildReferencesFromBlock( Document block ) {
+    protected ChildReferences getChildReferencesFromBlock( Document block, boolean allowsSNS ) {
         if (!block.containsField(CHILDREN)) {
             return ImmutableChildReferences.EMPTY_CHILD_REFERENCES;
         }
-        return ImmutableChildReferences.create(this, block, CHILDREN);
+        return ImmutableChildReferences.create(this, block, CHILDREN, allowsSNS);
     }
 
     public ChildReferencesInfo getChildReferencesInfo( Document document ) {

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/document/ImmutableChildReferences.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/document/ImmutableChildReferences.java
@@ -17,9 +17,11 @@ package org.modeshape.jcr.cache.document;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
@@ -27,8 +29,6 @@ import java.util.Set;
 import org.infinispan.schematic.document.Document;
 import org.modeshape.common.annotation.Immutable;
 import org.modeshape.common.collection.EmptyIterator;
-import org.modeshape.common.collection.LinkedListMultimap;
-import org.modeshape.common.collection.ListMultimap;
 import org.modeshape.jcr.cache.ChildReference;
 import org.modeshape.jcr.cache.ChildReferences;
 import org.modeshape.jcr.cache.DocumentNotFoundException;
@@ -192,30 +192,27 @@ public class ImmutableChildReferences {
     @Immutable
     protected static final class Medium extends AbstractChildReferences {
 
-        private final ListMultimap<Name, ChildReference> childReferences;
         private final Map<NodeKey, ChildReference> childReferencesByKey;
+        private final Map<Name, List<NodeKey>> childKeysByName;
 
         protected Medium( DocumentTranslator documentTranslator,
                           Document document,
                           String childrenFieldName ) {
-            this.childReferences = LinkedListMultimap.create();
-            this.childReferencesByKey = new HashMap<NodeKey, ChildReference>();
+            this.childKeysByName = new HashMap<>();
+            this.childReferencesByKey = new LinkedHashMap<>();
 
             final List<?> documentArray = document.getArray(childrenFieldName);
-            if (documentArray == null) {
+            if (documentArray == null || documentArray.isEmpty()) {
                 return;
             }
-            int size = documentArray.size();
-            List<ChildReference> childrenReferences = new ArrayList<ChildReference>(size);
             for (Object value : documentArray) {
-                ChildReference childReference = documentTranslator.childReferenceFrom(value);
-                if (childReference != null) {
-                    childrenReferences.add(childReference);
+                ChildReference ref = documentTranslator.childReferenceFrom(value);
+                if (ref == null) {
+                    continue;
                 }
-            }
-            for (ChildReference ref : childrenReferences) {
                 Name refName = ref.getName();
-                ChildReference old = this.childReferencesByKey.get(ref.getKey());
+                NodeKey refKey = ref.getKey();
+                ChildReference old = this.childReferencesByKey.get(refKey);
                 if (old != null && old.getName().equals(ref.getName())) {
                     // We already have this key/name pair, so we don't need to add it again ...
                     continue;
@@ -225,11 +222,18 @@ public class ImmutableChildReferences {
                 // more than once in its parent's list of child nodes). See MODE-2120.
 
                 // we can precompute the SNS index up front
-                int currentSNS = this.childReferences.get(refName).size();
+                List<NodeKey> keysWithName = this.childKeysByName.get(refName);
+                int currentSNS = keysWithName != null ? this.childKeysByName.get(refName).size() : 0;
                 ChildReference refWithSNS = ref.with(currentSNS + 1);
-                this.childReferencesByKey.put(ref.getKey(), refWithSNS);
-                this.childReferences.put(ref.getName(), refWithSNS);
+                this.childReferencesByKey.put(refKey, refWithSNS); 
+               
+                if (keysWithName == null) {
+                    keysWithName = new ArrayList<>();
+                    this.childKeysByName.put(refName, keysWithName);
+                }
+                keysWithName.add(refKey);
             }
+           
         }
 
         @Override
@@ -239,7 +243,8 @@ public class ImmutableChildReferences {
 
         @Override
         public int getChildCount( Name name ) {
-            return childReferences.get(name).size();
+            List<NodeKey> nodeKeys = childKeysByName.get(name);
+            return nodeKeys != null ? nodeKeys.size() : 0;
         }
 
         @Override
@@ -259,17 +264,21 @@ public class ImmutableChildReferences {
                 }
             }
 
-            List<ChildReference> childrenWithSameName = this.childReferences.get(name);
+            List<NodeKey> childrenWithSameName = this.childKeysByName.get(name);
             if (changes == null) {
+                if (childrenWithSameName == null) {
+                    return null;
+                }
                 // there are no changes, so we can take advantage of the fact that we precomputed the SNS indexes up front...
                 if (snsIndex > childrenWithSameName.size()) {
                     return null;
                 }
-                return childrenWithSameName.get(snsIndex - 1);
+                NodeKey childKey = childrenWithSameName.get(snsIndex - 1);
+                return childReferencesByKey.get(childKey);
             }
             // there are changes, so there is some extra processing to be done...
 
-            if (childrenWithSameName.isEmpty() && !includeRenames) {
+            if (childrenWithSameName == null && !includeRenames) {
                 // This segment contains no nodes with the supplied name ...
                 if (insertions == null) {
                     // and no nodes with this name were inserted ...
@@ -300,7 +309,8 @@ public class ImmutableChildReferences {
             }
 
             // We have at least one SNS in this list (and still potentially some removals) ...
-            for (ChildReference childWithSameName : childrenWithSameName) {
+            for (NodeKey key : childrenWithSameName) {
+                ChildReference childWithSameName = childReferencesByKey.get(key);
                 if (changes.isRemoved(childWithSameName)) {
                     continue;
                 }
@@ -392,13 +402,33 @@ public class ImmutableChildReferences {
         @Override
         public Iterator<ChildReference> iterator( Name name ) {
             // the child references should already have the correct SNS precomputed
-            return childReferences.get(name).iterator();
+            List<NodeKey> childKeys = childKeysByName.get(name);
+            if (childKeys == null || childKeys.isEmpty()) {
+                return Collections.emptyIterator();
+            }
+            final Iterator<NodeKey> childKeysIterator = childKeys.iterator();
+            return new Iterator<ChildReference>() {
+                @Override
+                public boolean hasNext() {
+                    return childKeysIterator.hasNext();
+                }
+
+                @Override
+                public ChildReference next() {
+                    return childReferencesByKey.get(childKeysIterator.next());
+                }
+
+                @Override
+                public void remove() {
+                    throw new UnsupportedOperationException();
+                }
+            };
         }
 
         @Override
         public Iterator<ChildReference> iterator() {
             // the child references should already have the correct SNS precomputed
-            return childReferences.values().iterator();
+            return childReferencesByKey.values().iterator();
         }
 
         @Override
@@ -429,7 +459,7 @@ public class ImmutableChildReferences {
 
         @Override
         public StringBuilder toString( StringBuilder sb ) {
-            Iterator<ChildReference> iter = childReferences.values().iterator();
+            Iterator<ChildReference> iter = childReferencesByKey.values().iterator();
             if (iter.hasNext()) {
                 sb.append(iter.next());
                 while (iter.hasNext()) {

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/document/ReadOnlySessionCache.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/document/ReadOnlySessionCache.java
@@ -22,8 +22,8 @@ import org.modeshape.common.logging.Logger;
 import org.modeshape.jcr.ExecutionContext;
 import org.modeshape.jcr.cache.CachedNode;
 import org.modeshape.jcr.cache.NodeKey;
+import org.modeshape.jcr.cache.RepositoryEnvironment;
 import org.modeshape.jcr.cache.SessionCache;
-import org.modeshape.jcr.cache.SessionEnvironment;
 
 /**
  * A read-only {@link SessionCache} implementation.
@@ -35,8 +35,8 @@ public class ReadOnlySessionCache extends AbstractSessionCache {
 
     public ReadOnlySessionCache( ExecutionContext context,
                                  WorkspaceCache workspaceCache,
-                                 SessionEnvironment sessionContext ) {
-        super(context, workspaceCache, sessionContext);
+                                 RepositoryEnvironment repositoryEnvironment ) {
+        super(context, workspaceCache, repositoryEnvironment);
     }
 
     @Override

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/document/SessionChildReferences.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/document/SessionChildReferences.java
@@ -119,7 +119,9 @@ public class SessionChildReferences extends AbstractChildReferences {
 
     @Override
     public boolean hasChild( NodeKey key ) {
-        return getChild(key, new BasicContext()) != null;
+        return persisted.hasChild(key) ||
+               (appended != null && appended.hasChild(key)) ||
+               (changedChildren != null && changedChildren.inserted(key) != null);
     }
 
     @Override

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/document/SessionChildReferences.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/document/SessionChildReferences.java
@@ -41,13 +41,16 @@ public class SessionChildReferences extends AbstractChildReferences {
     private final ChildReferences persisted;
     private final MutableChildReferences appended;
     private final SessionNode.ChangedChildren changedChildren;
+    private final boolean allowsSNS;
 
     public SessionChildReferences( ChildReferences persisted,
                                    MutableChildReferences appended,
-                                   SessionNode.ChangedChildren changedChildren ) {
+                                   SessionNode.ChangedChildren changedChildren,
+                                   boolean allowsSNS) {
         this.persisted = persisted != null ? persisted : ImmutableChildReferences.EMPTY_CHILD_REFERENCES;
         this.appended = appended;
         this.changedChildren = changedChildren;
+        this.allowsSNS = allowsSNS;
     }
 
     @Override
@@ -94,7 +97,10 @@ public class SessionChildReferences extends AbstractChildReferences {
     public ChildReference getChild( Name name,
                                     int snsIndex,
                                     Context context ) {
-        if (changedChildren != null) context = new WithChanges(context, changedChildren);
+        if (!allowsSNS && snsIndex > 1) {
+            return null;
+        }
+        if (changedChildren != null && !changedChildren.isEmpty()) context = new WithChanges(context, changedChildren);
         // First look in the delegate references ...
         ChildReference ref = persisted.getChild(name, snsIndex, context);
         if (ref == null) {
@@ -126,13 +132,13 @@ public class SessionChildReferences extends AbstractChildReferences {
 
     @Override
     public ChildReference getChild( NodeKey key ) {
-        return getChild(key, new BasicContext());
+        return getChild(key, defaultContext());
     }
 
     @Override
     public ChildReference getChild( NodeKey key,
                                     Context context ) {
-        if (changedChildren != null) context = new WithChanges(context, changedChildren);
+        if (changedChildren != null && !changedChildren.isEmpty()) context = new WithChanges(context, changedChildren);
         // First look in the delegate references ...
         // Note that we don't know the name of the child yet, so we'll have to come back
         // to the persisted node after we know the name ...
@@ -150,7 +156,7 @@ public class SessionChildReferences extends AbstractChildReferences {
                         // when looking in the persisted node above. So adjust the SNS index ...
 
                         int numSnsInRemoved = 0;
-                        if (changedChildren != null) {
+                        if (changedChildren != null && !changedChildren.isEmpty()) {
                             Set<NodeKey> removals = changedChildren.getRemovals();
                             //we need to take into account that the same node might be removed (in case of an reorder to the end)
                             if (removals.contains(key)) {
@@ -179,7 +185,7 @@ public class SessionChildReferences extends AbstractChildReferences {
     @Override
     public Iterator<ChildReference> iterator( Name name,
                                               Context context ) {
-        if (changedChildren != null) context = new WithChanges(context, changedChildren);
+        if (changedChildren != null && !changedChildren.isEmpty()) context = new WithChanges(context, changedChildren);
         return createIterator(name, context);
     }
 
@@ -198,7 +204,7 @@ public class SessionChildReferences extends AbstractChildReferences {
 
     @Override
     public Iterator<ChildReference> iterator( Context context ) {
-        if (changedChildren != null) context = new WithChanges(context, changedChildren);
+        if (changedChildren != null && !changedChildren.isEmpty()) context = new WithChanges(context, changedChildren);
         return createIterator(context);
     }
 
@@ -238,5 +244,10 @@ public class SessionChildReferences extends AbstractChildReferences {
             }
         }
         return sb;
+    }
+
+    @Override
+    public boolean allowsSNS() {
+        return allowsSNS;
     }
 }

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/document/WorkspaceCache.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/document/WorkspaceCache.java
@@ -31,6 +31,7 @@ import org.modeshape.jcr.cache.CachedNode;
 import org.modeshape.jcr.cache.ChildReference;
 import org.modeshape.jcr.cache.NodeCache;
 import org.modeshape.jcr.cache.NodeKey;
+import org.modeshape.jcr.cache.RepositoryEnvironment;
 import org.modeshape.jcr.cache.WorkspaceNotFoundException;
 import org.modeshape.jcr.cache.change.ChangeSet;
 import org.modeshape.jcr.cache.change.ChangeSetListener;
@@ -62,6 +63,7 @@ public class WorkspaceCache implements DocumentCache {
     private final ChangeBus changeBus;
     private final ChangeSetListener systemChangeNotifier;
     private final ChangeSetListener nonSystemChangeNotifier;
+    private final RepositoryEnvironment repositoryEnvironment;
     private volatile boolean closed = false;
 
     public WorkspaceCache( ExecutionContext context,
@@ -72,7 +74,8 @@ public class WorkspaceCache implements DocumentCache {
                            DocumentTranslator translator,
                            NodeKey rootKey,
                            ConcurrentMap<NodeKey, CachedNode> cache,
-                           ChangeBus changeBus ) {
+                           ChangeBus changeBus,
+                           RepositoryEnvironment repositoryEnvironment) {
         assert context != null;
         assert repositoryKey != null;
         assert workspaceName != null;
@@ -94,6 +97,7 @@ public class WorkspaceCache implements DocumentCache {
         this.pathFactory = context.getValueFactories().getPathFactory();
         this.nameFactory = context.getValueFactories().getNameFactory();
         this.nodesByKey = cache;
+        this.repositoryEnvironment = repositoryEnvironment;
         if (systemWorkspace != null) {
             // This is not the system workspace, so we have to listen both asynchronously and synchronously ...
             this.systemChangeNotifier = new SystemChangeNotifier(systemWorkspace.getWorkspaceName());
@@ -121,6 +125,7 @@ public class WorkspaceCache implements DocumentCache {
         this.sourceKey = original.sourceKey;
         this.pathFactory = original.pathFactory;
         this.nameFactory = original.nameFactory;
+        this.repositoryEnvironment = original.repositoryEnvironment;
         this.nodesByKey = cache;
         this.systemChangeNotifier = null;
         this.nonSystemChangeNotifier = null;
@@ -172,6 +177,10 @@ public class WorkspaceCache implements DocumentCache {
 
     final DocumentStore documentStore() {
         return documentStore;
+    }
+    
+    final RepositoryEnvironment repositoryEnvironment() {
+        return repositoryEnvironment;
     }
 
     final Document documentFor( String key ) {

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/document/WritableSessionCache.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/document/WritableSessionCache.java
@@ -66,8 +66,8 @@ import org.modeshape.jcr.cache.NodeKey;
 import org.modeshape.jcr.cache.NodeNotFoundException;
 import org.modeshape.jcr.cache.PathCache;
 import org.modeshape.jcr.cache.ReferentialIntegrityException;
+import org.modeshape.jcr.cache.RepositoryEnvironment;
 import org.modeshape.jcr.cache.SessionCache;
-import org.modeshape.jcr.cache.SessionEnvironment;
 import org.modeshape.jcr.cache.WrappedException;
 import org.modeshape.jcr.cache.change.ChangeSet;
 import org.modeshape.jcr.cache.change.RecordingChanges;
@@ -123,16 +123,16 @@ public class WritableSessionCache extends AbstractSessionCache {
      *
      * @param context the execution context; may not be null
      * @param workspaceCache the (shared) workspace cache; may not be null
-     * @param sessionContext the context for the session; may not be null
+     * @param repositoryEnvironment the context for the session; may not be null
      */
     public WritableSessionCache( ExecutionContext context,
                                  WorkspaceCache workspaceCache,
-                                 SessionEnvironment sessionContext ) {
-        super(context, workspaceCache, sessionContext);
+                                 RepositoryEnvironment repositoryEnvironment ) {
+        super(context, workspaceCache, repositoryEnvironment);
         this.changedNodes = new HashMap<NodeKey, SessionNode>();
         this.changedNodesInOrder = new LinkedHashSet<NodeKey>();
         this.referrerChangesForRemovedNodes = new HashMap<NodeKey, ReferrerChanges>();
-        this.txns = sessionContext.getTransactions();
+        this.txns = repositoryEnvironment.getTransactions();
     }
 
     protected final void assertInSession( SessionNode node ) {

--- a/modeshape-jcr/src/test/java/org/modeshape/jcr/cache/document/AbstractSessionCacheTest.java
+++ b/modeshape-jcr/src/test/java/org/modeshape/jcr/cache/document/AbstractSessionCacheTest.java
@@ -21,12 +21,13 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import javax.transaction.TransactionManager;
 import org.modeshape.jcr.ExecutionContext;
+import org.modeshape.jcr.NodeTypes;
 import org.modeshape.jcr.bus.RepositoryChangeBus;
 import org.modeshape.jcr.cache.CachedNode;
 import org.modeshape.jcr.cache.NodeCache;
 import org.modeshape.jcr.cache.NodeKey;
+import org.modeshape.jcr.cache.RepositoryEnvironment;
 import org.modeshape.jcr.cache.SessionCache;
-import org.modeshape.jcr.cache.SessionEnvironment;
 import org.modeshape.jcr.cache.change.PrintingChangeSetListener;
 import org.modeshape.jcr.txn.NoClientTransactions;
 import org.modeshape.jcr.txn.Transactions;
@@ -54,9 +55,9 @@ public abstract class AbstractSessionCacheTest extends AbstractNodeCacheTest {
         DocumentStore documentStore = new LocalDocumentStore(schematicDb);
         DocumentTranslator translator = new DocumentTranslator(context, documentStore, 100L);
         workspaceCache = new WorkspaceCache(context, "repo", "ws", null, documentStore, translator, ROOT_KEY_WS1, nodeCache,
-                                            changeBus);
+                                            changeBus, null);
         loadJsonDocuments(resource(resourceNameForWorkspaceContentDocument()));
-        SessionEnvironment sessionEnv = createSessionContext();
+        RepositoryEnvironment sessionEnv = createRepositoryEnvironment();
         session1 = createSessionCache(context, workspaceCache, sessionEnv);
         session2 = createSessionCache(context, workspaceCache, sessionEnv);
         return session1;
@@ -70,11 +71,11 @@ public abstract class AbstractSessionCacheTest extends AbstractNodeCacheTest {
 
     protected abstract SessionCache createSessionCache( ExecutionContext context,
                                                         WorkspaceCache cache,
-                                                        SessionEnvironment sessionEnv );
+                                                        RepositoryEnvironment sessionEnv );
 
-    protected SessionEnvironment createSessionContext() {
+    protected RepositoryEnvironment createRepositoryEnvironment() {
         final TransactionManager txnMgr = txnManager();
-        return new SessionEnvironment() {
+        return new RepositoryEnvironment() {
             private final Transactions transactions = new NoClientTransactions(txnMgr);
             private final TransactionalWorkspaceCaches transactionalWorkspaceCacheFactory = new TransactionalWorkspaceCaches(
                                                                                                                              transactions);
@@ -93,6 +94,11 @@ public abstract class AbstractSessionCacheTest extends AbstractNodeCacheTest {
             public String journalId() {
                 return null;
             }
+
+            @Override
+            public NodeTypes nodeTypes() {
+                return null;
+            }
         };
     }
 
@@ -101,8 +107,6 @@ public abstract class AbstractSessionCacheTest extends AbstractNodeCacheTest {
     }
 
     /**
-     * {@inheritDoc}
-     * 
      * @see org.modeshape.jcr.cache.document.AbstractNodeCacheTest#print(boolean)
      */
     @Override

--- a/modeshape-jcr/src/test/java/org/modeshape/jcr/cache/document/DocumentOptimizerTest.java
+++ b/modeshape-jcr/src/test/java/org/modeshape/jcr/cache/document/DocumentOptimizerTest.java
@@ -31,8 +31,8 @@ import org.modeshape.jcr.ExecutionContext;
 import org.modeshape.jcr.cache.ChildReference;
 import org.modeshape.jcr.cache.MutableCachedNode;
 import org.modeshape.jcr.cache.NodeKey;
+import org.modeshape.jcr.cache.RepositoryEnvironment;
 import org.modeshape.jcr.cache.SessionCache;
-import org.modeshape.jcr.cache.SessionEnvironment;
 import org.modeshape.jcr.value.Name;
 import org.modeshape.jcr.value.Path.Segment;
 
@@ -50,8 +50,8 @@ public class DocumentOptimizerTest extends AbstractSessionCacheTest {
     @Override
     protected SessionCache createSessionCache( ExecutionContext context,
                                                WorkspaceCache cache,
-                                               SessionEnvironment sessionEnv ) {
-        return new WritableSessionCache(context, workspaceCache, sessionEnv);
+                                               RepositoryEnvironment repositoryEnvironment ) {
+        return new WritableSessionCache(context, workspaceCache, repositoryEnvironment);
     }
 
     @Test

--- a/modeshape-jcr/src/test/java/org/modeshape/jcr/cache/document/ReadOnlySessionCacheTest.java
+++ b/modeshape-jcr/src/test/java/org/modeshape/jcr/cache/document/ReadOnlySessionCacheTest.java
@@ -16,8 +16,8 @@
 package org.modeshape.jcr.cache.document;
 
 import org.modeshape.jcr.ExecutionContext;
+import org.modeshape.jcr.cache.RepositoryEnvironment;
 import org.modeshape.jcr.cache.SessionCache;
-import org.modeshape.jcr.cache.SessionEnvironment;
 
 /**
  * Tests that operate against a {@link ReadOnlySessionCache}.
@@ -27,7 +27,7 @@ public class ReadOnlySessionCacheTest extends AbstractSessionCacheTest {
     @Override
     protected SessionCache createSessionCache( ExecutionContext context,
                                                WorkspaceCache cache,
-                                               SessionEnvironment sessionEnv ) {
-        return new ReadOnlySessionCache(context, workspaceCache, sessionEnv);
+                                               RepositoryEnvironment repositoryEnvironment ) {
+        return new ReadOnlySessionCache(context, workspaceCache, repositoryEnvironment);
     }
 }

--- a/modeshape-jcr/src/test/java/org/modeshape/jcr/cache/document/WorkspaceCacheTest.java
+++ b/modeshape-jcr/src/test/java/org/modeshape/jcr/cache/document/WorkspaceCacheTest.java
@@ -37,7 +37,7 @@ public class WorkspaceCacheTest extends AbstractNodeCacheTest {
         DocumentStore documentStore = new LocalDocumentStore(schematicDb);
         DocumentTranslator translator = new DocumentTranslator(context, documentStore, 100L);
         WorkspaceCache workspaceCache = new WorkspaceCache(context, "repo", "ws", null, documentStore, translator, ROOT_KEY_WS1,
-                                                           nodeCache, changeBus);
+                                                           nodeCache, changeBus,  null);
         loadJsonDocuments(resource(resourceNameForWorkspaceContentDocument()));
         return workspaceCache;
     }

--- a/modeshape-jcr/src/test/java/org/modeshape/jcr/cache/document/WritableSessionCacheTest.java
+++ b/modeshape-jcr/src/test/java/org/modeshape/jcr/cache/document/WritableSessionCacheTest.java
@@ -29,8 +29,8 @@ import org.modeshape.jcr.ExecutionContext;
 import org.modeshape.jcr.cache.CachedNode;
 import org.modeshape.jcr.cache.MutableCachedNode;
 import org.modeshape.jcr.cache.NodeKey;
+import org.modeshape.jcr.cache.RepositoryEnvironment;
 import org.modeshape.jcr.cache.SessionCache;
-import org.modeshape.jcr.cache.SessionEnvironment;
 
 /**
  * Tests that operate against a {@link WritableSessionCache}. Each test method starts with a clean slate of content
@@ -49,8 +49,8 @@ public class WritableSessionCacheTest extends AbstractSessionCacheTest {
     @Override
     protected SessionCache createSessionCache( ExecutionContext context,
                                                WorkspaceCache cache,
-                                               SessionEnvironment sessionEnv ) {
-        return new WritableSessionCache(context, workspaceCache, sessionEnv);
+                                               RepositoryEnvironment repositoryEnvironment ) {
+        return new WritableSessionCache(context, workspaceCache, repositoryEnvironment);
     }
 
     @Test

--- a/modeshape-jcr/src/test/java/org/modeshape/jcr/query/AbstractNodeSequenceTest.java
+++ b/modeshape-jcr/src/test/java/org/modeshape/jcr/query/AbstractNodeSequenceTest.java
@@ -55,7 +55,7 @@ public class AbstractNodeSequenceTest extends AbstractNodeCacheTest {
         DocumentStore documentStore = new LocalDocumentStore(schematicDb);
         DocumentTranslator translator = new DocumentTranslator(context, documentStore, 100L);
         WorkspaceCache workspaceCache = new WorkspaceCache(context, "repo", "ws", null, documentStore, translator, ROOT_KEY_WS1,
-                                                           nodeCache, changeBus);
+                                                           nodeCache, changeBus, null);
         loadJsonDocuments(resource(resourceNameForWorkspaceContentDocument()));
         return workspaceCache;
     }


### PR DESCRIPTION
The optimizations are in 2 different areas:
* the data structures being used to hold the node information - ModeShape's `MultiMap` family is heavyweight compared to the standard JDK `Maps` and doesn't require it being used in this case
* passed SNS information down to the `ChildReferences` implementations, allowing further optimizations in the way SNS indexes are computed in certain cases as well as the `Context` instance being used.