### PR TITLE
Fix MODE-2490

### DIFF
--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/query/BufferManager.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/query/BufferManager.java
@@ -428,9 +428,14 @@ public class BufferManager implements Serializers, AutoCloseable {
         return null;
     }
 
+    @Override
+    public Serializer<?> nullSafeSerializerFor( Class<?> type ) {
+        return null;
+    }
+
     /**
      * Obtain a serializer for the given value type.
-     * 
+     *
      * @param type the type; may not be null
      * @return the serializer
      */
@@ -439,6 +444,21 @@ public class BufferManager implements Serializers, AutoCloseable {
             return ((TupleFactory<?>)type).getSerializer(this);
         }
         return serializers.serializerFor(type.getType());
+    }
+
+    /**
+     * Obtain serializer for the given value type that can handle null values. This is used in Tuples
+     * serialization. (See MODE-2490). Note: {@code type} must itself still not be null, but the values
+     * to be serialized <emph>can</emph> be null.
+     *
+     * @param type the type; may not be null
+     * @return the serializer
+     */
+    public Serializer<?> nullSafeSerializerFor( TypeFactory<?> type ) {
+        if (type instanceof TupleFactory) {
+            return ((TupleFactory<?>)type).getSerializer(this);
+        }
+        return serializers.nullSafeSerializerFor(type.getType());
     }
 
     /**

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/query/Tuples.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/query/Tuples.java
@@ -24,6 +24,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.Iterator;
+
 import org.infinispan.schematic.internal.HashCode;
 import org.mapdb.Serializer;
 import org.modeshape.common.util.ObjectUtil;
@@ -32,7 +33,7 @@ import org.modeshape.jcr.value.ValueFormatException;
 
 /**
  * A simple set of classes for working with tuples of data.
- * 
+ *
  * @author Randall Hauch (rhauch@redhat.com)
  */
 public class Tuples {
@@ -42,7 +43,7 @@ public class Tuples {
 
     /**
      * Create a tuple with the given two values.
-     * 
+     *
      * @param v1 the first value
      * @param v2 the second value
      * @return the tuple; never null
@@ -54,7 +55,7 @@ public class Tuples {
 
     /**
      * Create a tuple with the given three values.
-     * 
+     *
      * @param v1 the first value
      * @param v2 the second value
      * @param v3 the third value
@@ -68,7 +69,7 @@ public class Tuples {
 
     /**
      * Create a tuple with the given four values.
-     * 
+     *
      * @param v1 the first value
      * @param v2 the second value
      * @param v3 the third value
@@ -85,7 +86,7 @@ public class Tuples {
     /**
      * Create a tuple with the given values. Note that this always creates a n-ary tuple, so use {@link #tuple(Object, Object)},
      * {@link #tuple(Object, Object, Object)} or {@link #tuple(Object, Object, Object, Object)} for tuples smaller than 5.
-     * 
+     *
      * @param values the values
      * @return the tuple; never null
      */
@@ -95,7 +96,7 @@ public class Tuples {
 
     /**
      * Create a type factory for tuples of size 2.
-     * 
+     *
      * @param type1 the first type; may not be null
      * @param type2 the second type; may not be null
      * @return the type factory; never null
@@ -107,7 +108,7 @@ public class Tuples {
 
     /**
      * Create a type factory for tuples of size 3.
-     * 
+     *
      * @param type1 the first type; may not be null
      * @param type2 the second type; may not be null
      * @param type3 the third type; may not be null
@@ -121,7 +122,7 @@ public class Tuples {
 
     /**
      * Create a type factory for tuples of size 4.
-     * 
+     *
      * @param type1 the first type; may not be null
      * @param type2 the second type; may not be null
      * @param type3 the third type; may not be null
@@ -137,7 +138,7 @@ public class Tuples {
 
     /**
      * Create a type factory for n-ary tuples.
-     * 
+     *
      * @param types the collection of types for each slot in the tuple
      * @return the type factory; never null
      */
@@ -147,7 +148,7 @@ public class Tuples {
 
     /**
      * Create a type factory for uniform tuples.
-     * 
+     *
      * @param type the type of each/every slot in the tuples
      * @param tupleSize the size of the tuples
      * @return the type factory; never null
@@ -167,7 +168,7 @@ public class Tuples {
 
     /**
      * Create a {@link Serializer} for tuples of size 2.
-     * 
+     *
      * @param first the serializer for the first slot
      * @param second the serializer for the second slot
      * @return the serializer; never null
@@ -179,7 +180,7 @@ public class Tuples {
 
     /**
      * Create a {@link Serializer} for tuples of size 3.
-     * 
+     *
      * @param first the serializer for the first slot
      * @param second the serializer for the second slot
      * @param third the serializer for the third slot
@@ -193,7 +194,7 @@ public class Tuples {
 
     /**
      * Create a {@link Serializer} for tuples of size 4.
-     * 
+     *
      * @param first the serializer for the first slot
      * @param second the serializer for the second slot
      * @param third the serializer for the third slot
@@ -209,7 +210,7 @@ public class Tuples {
 
     /**
      * Create a {@link Serializer} for n-ary tuples
-     * 
+     *
      * @param serializers the serializers for each slot in the tuples
      * @return the serializer; never null
      */
@@ -219,7 +220,7 @@ public class Tuples {
 
     /**
      * Create a {@link Serializer} for uniform tuples.
-     * 
+     *
      * @param serializer the serializer of each/every slot in the tuples
      * @param tupleSize the size of the tuples
      * @return the type factory; never null
@@ -577,7 +578,7 @@ public class Tuples {
         }
     }
 
-    public static interface TupleFactory<T> {
+    public interface TupleFactory<T> {
         Serializer<T> getSerializer( BufferManager bufferMgr );
     }
 
@@ -638,8 +639,8 @@ public class Tuples {
 
         @Override
         public Serializer<Tuple2<T1, T2>> getSerializer( BufferManager bufferMgr ) {
-            Serializer<T1> ser1 = (Serializer<T1>)bufferMgr.serializerFor(type1);
-            Serializer<T2> ser2 = (Serializer<T2>)bufferMgr.serializerFor(type2);
+            Serializer<T1> ser1 = (Serializer<T1>)bufferMgr.nullSafeSerializerFor(type1);
+            Serializer<T2> ser2 = (Serializer<T2>)bufferMgr.nullSafeSerializerFor(type2);
             return new Tuple2Serializer<T1, T2>(ser1, ser2);
         }
 
@@ -727,9 +728,9 @@ public class Tuples {
 
         @Override
         public Serializer<Tuple3<T1, T2, T3>> getSerializer( BufferManager bufferMgr ) {
-            Serializer<T1> ser1 = (Serializer<T1>)bufferMgr.serializerFor(type1);
-            Serializer<T2> ser2 = (Serializer<T2>)bufferMgr.serializerFor(type2);
-            Serializer<T3> ser3 = (Serializer<T3>)bufferMgr.serializerFor(type3);
+            Serializer<T1> ser1 = (Serializer<T1>)bufferMgr.nullSafeSerializerFor(type1);
+            Serializer<T2> ser2 = (Serializer<T2>)bufferMgr.nullSafeSerializerFor(type2);
+            Serializer<T3> ser3 = (Serializer<T3>)bufferMgr.nullSafeSerializerFor(type3);
             return new Tuple3Serializer<T1, T2, T3>(ser1, ser2, ser3);
         }
 
@@ -823,10 +824,10 @@ public class Tuples {
 
         @Override
         public Serializer<Tuple4<T1, T2, T3, T4>> getSerializer( BufferManager bufferMgr ) {
-            Serializer<T1> ser1 = (Serializer<T1>)bufferMgr.serializerFor(type1);
-            Serializer<T2> ser2 = (Serializer<T2>)bufferMgr.serializerFor(type2);
-            Serializer<T3> ser3 = (Serializer<T3>)bufferMgr.serializerFor(type3);
-            Serializer<T4> ser4 = (Serializer<T4>)bufferMgr.serializerFor(type4);
+            Serializer<T1> ser1 = (Serializer<T1>)bufferMgr.nullSafeSerializerFor(type1);
+            Serializer<T2> ser2 = (Serializer<T2>)bufferMgr.nullSafeSerializerFor(type2);
+            Serializer<T3> ser3 = (Serializer<T3>)bufferMgr.nullSafeSerializerFor(type3);
+            Serializer<T4> ser4 = (Serializer<T4>)bufferMgr.nullSafeSerializerFor(type4);
             return new Tuple4Serializer<T1, T2, T3, T4>(ser1, ser2, ser3, ser4);
         }
 
@@ -916,7 +917,7 @@ public class Tuples {
         public Serializer<TupleN> getSerializer( BufferManager bufferMgr ) {
             Serializer<?>[] serializers = new Serializer<?>[types.length];
             for (int i = 0; i != types.length; ++i) {
-                serializers[i] = bufferMgr.serializerFor(types[i]);
+                serializers[i] = (Serializer<?>)bufferMgr.nullSafeSerializerFor(types[i]);
             }
             return new TupleNSerializer(serializers);
         }

--- a/modeshape-jcr/src/test/java/org/modeshape/jcr/JcrQueryManagerTest.java
+++ b/modeshape-jcr/src/test/java/org/modeshape/jcr/JcrQueryManagerTest.java
@@ -702,6 +702,14 @@ public class JcrQueryManagerTest extends MultiUseAbstractTest {
         validateQuery().rowCount(4).validate(query, query.execute());
     }
 
+    @FixFor("MODE-2490")
+    @Test
+    public void shouldOrderByTwoColumnsEvenIfNullable() throws RepositoryException {
+        String sql = "SELECT * FROM [car:Car] ORDER BY [car:maker] DESC NULLS FIRST, [car:msrp] ASC NULLS FIRST";
+        Query query = session.getWorkspace().getQueryManager().createQuery(sql, Query.JCR_SQL2);
+        validateQuery().rowCount(13).validate(query, query.execute());
+    }
+
     @FixFor( "MODE-2297" )
     @Test
     public void shouldExecuteQueryUsingSetOperationOfQueriesWithoutJoins() throws RepositoryException {


### PR DESCRIPTION
ORDER BY col1, col2 used to cause a NullPointerException whenever col1 or col2 were nullable and indeed did contain null values. This is because the row's col1 and col2 were being serialized as a tuple, and the serialization (correctly) assumed that since a tuple was created, the sort key was non-null. However serialization of the tuple was done by serializing each component, and they +can+ be null.

Therefore, the component serializers should use a null-safe wrapper around the original serializer, see their various getSerializer() implementations. The wrapper itself is in lines 585-615. Since I guess we don't always know what serializers we have, and some serializers also leave not enough wiggle room to accomodate NULLs without violating all kinds of contracts, we have to have (unfortunately) an extra sentinel boolean to indicate a null value (if set to false, lines 594-595 and 605).

The Tuples class holds a WeakHashMap to store the wrappers (line 617) so the same wrapper will be retrieved when requested multiple times. Perhaps there's a better way/place to store them; I am currently too unfamiliar with ModeShape to know. (Maybe inside the Serializers class?) By using a WeakHashMap I ensure that the wrappers will be removed whenever the bufferManager gets garbage-collected.

Whenever a null-safe serializer is requested, it is first retrieved from the WeakHashMap if available. If not, it is first checked whether the original serializer from the bufferManager is null-safe. If so, no wrapping is done and the original serializer is used.

Yours,
Jasper Stein (XebiaLabs)