### PR TITLE
MODE-2494 Adding check whether a child node join has been reversed du…

### DIFF
--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/query/engine/ScanningQueryEngine.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/query/engine/ScanningQueryEngine.java
@@ -666,11 +666,23 @@ public class ScanningQueryEngine implements org.modeshape.jcr.query.QueryEngine 
                             }
                         } else if (joinCondition instanceof ChildNodeJoinCondition) {
                             ChildNodeJoinCondition condition = (ChildNodeJoinCondition)joinCondition;
-                            assert leftColumns.getSelectorNames().contains(condition.getParentSelectorName());
-                            int leftIndex = leftColumns.getSelectorIndex(condition.getParentSelectorName());
-                            int rightIndex = rightColumns.getSelectorIndex(condition.getChildSelectorName());
-                            leftExtractor = RowExtractors.extractNodeKey(leftIndex, cache, types);
-                            rightExtractor = RowExtractors.extractParentNodeKey(rightIndex, cache, types);
+
+                            // check if the JOIN was not reversed by an optimization
+                            boolean joinReversed = !leftColumns.getSelectorNames().contains(condition.getParentSelectorName());
+
+                            if (joinReversed) {
+                                int leftIndex = leftColumns.getSelectorIndex(condition.getChildSelectorName());
+                                int rightIndex = rightColumns.getSelectorIndex(condition.getParentSelectorName());
+
+                                leftExtractor = RowExtractors.extractParentNodeKey(leftIndex, cache, types);
+                                rightExtractor = RowExtractors.extractNodeKey(rightIndex, cache, types);
+                            } else {
+                                int leftIndex = leftColumns.getSelectorIndex(condition.getParentSelectorName());
+                                int rightIndex = rightColumns.getSelectorIndex(condition.getChildSelectorName());
+
+                                leftExtractor = RowExtractors.extractNodeKey(leftIndex, cache, types);
+                                rightExtractor = RowExtractors.extractParentNodeKey(rightIndex, cache, types);
+                            }
                         } else if (joinCondition instanceof EquiJoinCondition) {
                             EquiJoinCondition condition = (EquiJoinCondition)joinCondition;
                             // check if the JOIN was not reversed by an optimization

--- a/modeshape-jcr/src/test/java/org/modeshape/jcr/JcrQueryManagerTest.java
+++ b/modeshape-jcr/src/test/java/org/modeshape/jcr/JcrQueryManagerTest.java
@@ -2642,6 +2642,56 @@ public class JcrQueryManagerTest extends MultiUseAbstractTest {
         validateQuery().rowCount(17).hasColumns("left.jcr:path").validate(query, result);
     }
 
+    @FixFor( "MODE-2494" )
+    @Test
+    public void shouldBeAbleToCreateAndExecuteJcrSql2QueryWithTwoLeftOuterJoinsOnIsChildNodeWithSubsequentIsChildNode() throws RepositoryException {
+        String sql = "SELECT parent.[jcr:path], child1.[jcr:name], desc.[jcr:name] FROM [nt:unstructured] AS parent " +
+                "LEFT OUTER JOIN [nt:unstructured] AS child1 ON ISCHILDNODE(child1,parent) " +
+                "INNER JOIN [nt:unstructured] AS desc on ISCHILDNODE(desc, child1) " +
+                "LEFT OUTER JOIN [nt:unstructured] AS child2 ON ISCHILDNODE(child2,parent) " +
+                "WHERE ISCHILDNODE(parent,'/') " +
+                "AND NAME(child2) = 'Hybrid' " +
+                "AND NAME(desc) LIKE 'Nissan%'";
+        Query query = session.getWorkspace().getQueryManager().createQuery(sql, Query.JCR_SQL2);
+        QueryResult result = query.execute();
+        validateQuery().rowCount(1).validate(query, result);
+    }
+
+    @FixFor( "MODE-2494" )
+    @Test
+    public void shouldBeAbleToCreateAndExecuteJcrSql2QueryWithTwoLeftOuterJoinsOnIsChildNodeWithSubsequentIsDescendantNode() throws RepositoryException {
+        String sql = "SELECT parent.[jcr:path], child1.[jcr:name], desc.[jcr:name] FROM [nt:unstructured] AS parent " +
+                "LEFT OUTER JOIN [nt:unstructured] AS child1 ON ISCHILDNODE(child1,parent) " +
+                "INNER JOIN [nt:unstructured] AS desc on ISDESCENDANTNODE(desc, child1) " +
+                "LEFT OUTER JOIN [nt:unstructured] AS child2 ON ISCHILDNODE(child2,parent) " +
+                "WHERE ISCHILDNODE(parent,'/') " +
+                "AND NAME(child2) = 'Hybrid' " +
+                "AND NAME(desc) LIKE 'Nissan%'";
+        Query query = session.getWorkspace().getQueryManager().createQuery(sql, Query.JCR_SQL2);
+        QueryResult result = query.execute();
+        validateQuery().rowCount(1).validate(query, result);
+    }
+
+    @FixFor( "MODE-2494" )
+    @Test
+    @Ignore("This is not fixed by the fix for MODE-2494, and points to a potentially deeper problem, " +
+            "possibly in ReplaceViews." +
+            "Note: this query has the same semantics as that in " +
+            "'shouldBeAbleToCreateAndExecuteJcrSql2QueryWithTwoLeftOuterJoinsOnIsChildNodeWithSubsequentIsDescendantNode' " +
+            "and should work exactly the same way.")
+    public void shouldBeAbleToCreateAndExecuteJcrSql2QueryWithTwoLeftOuterJoinsOnIsChildNodeWithSubsequentIsDescendantNodeOutOfOrder() throws RepositoryException {
+        String sql = "SELECT parent.[jcr:path], child1.[jcr:name], child2.[jcr:name], desc.[jcr:name] FROM [nt:unstructured] AS parent " +
+                "LEFT OUTER JOIN [nt:unstructured] AS child1 ON ISCHILDNODE(child1,parent) " +
+                "LEFT OUTER JOIN [nt:unstructured] AS child2 ON ISCHILDNODE(child2,parent) " +
+                "INNER JOIN [nt:unstructured] AS desc on ISDESCENDANTNODE(desc, child1) " +
+                "WHERE ISCHILDNODE(parent,'/') " +
+                "AND NAME(child2) = 'Hybrid' " +
+                "AND NAME(desc) LIKE 'Nissan%'";
+        Query query = session.getWorkspace().getQueryManager().createQuery(sql, Query.JCR_SQL2);
+        QueryResult result = query.execute();
+        validateQuery().rowCount(1).validate(query, result);
+    }
+
     @FixFor( "MODE-1750" )
     @Test
     public void shouldBeAbleToCreateAndExecuteJcrSql2QueryWithRightOuterJoinOnNullCondition() throws RepositoryException {


### PR DESCRIPTION
…ring query optimization, mirroring logic for SameNodeJoinCondition and EquiJoinCondition.

For some complex queries, such as:

SELECT parent.[jcr:path], child1.[jcr:name], desc.[jcr:name]
FROM [nt:unstructured] AS parent
LEFT OUTER JOIN [nt:unstructured] AS child1 ON ISCHILDNODE(child1,parent)
INNER JOIN [nt:unstructured] AS desc on ISCHILDNODE(desc, child1)
LEFT OUTER JOIN [nt:unstructured] AS child2 ON ISCHILDNODE(child2,parent)
WHERE ISCHILDNODE(parent,'/')
AND NAME(child2) = 'Hybrid'
AND NAME(desc) LIKE 'Nissan%'

the query optimizer reverses the left and right sides of the join, leading to an assertion error in ScanningQueryEngine.

This fix checks if the join has been reversed, and creates rowextractors for the opposite columns if this is the case.

Added three tests, two which are fixed by this change, and one which is still an issue, suggesting a deeper problem. For the remaining (Ignored) test, the exception is in the DescendantNodeJoinCondition code.
This seems less simple to resolve, and probably a true fix lies in ReplaceViews or somewhere similar.