### PR TITLE
MODE-2495 Fixes how user transactions are handled

### DIFF
--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/txn/NoClientTransactions.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/txn/NoClientTransactions.java
@@ -50,14 +50,15 @@ public final class NoClientTransactions extends Transactions {
 
     @Override
     public synchronized Transaction begin() throws NotSupportedException, SystemException {
-        if (ACTIVE_TRANSACTION.get() == null) {
+        NestableThreadLocalTransaction tx = ACTIVE_TRANSACTION.get();
+        if (tx == null) {
             // Start a transaction ...
             txnMgr.begin();
             if (logger.isTraceEnabled()) {
                 logger.trace("Begin transaction {0}", currentTransactionId());
             }
-            ACTIVE_TRANSACTION.set(new NestableThreadLocalTransaction(txnMgr, ACTIVE_TRANSACTION));
+            tx = new NestableThreadLocalTransaction(txnMgr, ACTIVE_TRANSACTION);
         }
-        return ACTIVE_TRANSACTION.get().begin();
+        return tx.begin();
     }
 }


### PR DESCRIPTION
The previous code made the incorrect assumption that a user transaction is "confined" to the thread that started it. This is obviously not the case, since the same transaction can be suspended & resumed subsequently off different threads.