### PR TITLE
Support German Scharfes 'S' symbol when tokenising

### DIFF
--- a/modeshape-common/src/main/java/org/modeshape/common/text/TokenStream.java
+++ b/modeshape-common/src/main/java/org/modeshape/common/text/TokenStream.java
@@ -371,7 +371,6 @@ public class TokenStream {
     public static final int ANY_TYPE = Integer.MIN_VALUE;
 
     protected final String inputString;
-    protected final String inputUppercased;
     private final char[] inputContent;
     private final boolean caseSensitive;
     private final Tokenizer tokenizer;
@@ -402,7 +401,6 @@ public class TokenStream {
         this.inputString = content;
         this.inputContent = content.toCharArray();
         this.caseSensitive = caseSensitive;
-        this.inputUppercased = caseSensitive ? inputString : content.toUpperCase();
         this.tokenizer = tokenizer;
     }
 
@@ -1672,7 +1670,7 @@ public class TokenStream {
         }
 
         @Override
-        public final boolean matches( String expected ) {
+        public boolean matches(String expected) {
             return matchString().substring(startIndex, endIndex).equals(expected);
         }
 
@@ -1711,8 +1709,8 @@ public class TokenStream {
         }
 
         @Override
-        protected String matchString() {
-            return inputUppercased;
+        public boolean matches( String expected ) {
+            return matchString().substring(startIndex(), endIndex()).toUpperCase().equals(expected);
         }
 
         @Override

--- a/modeshape-common/src/test/java/org/modeshape/common/text/TokenStreamTest.java
+++ b/modeshape-common/src/test/java/org/modeshape/common/text/TokenStreamTest.java
@@ -20,6 +20,7 @@ import static org.junit.Assert.assertThat;
 import java.util.Arrays;
 import org.junit.Before;
 import org.junit.Test;
+import org.modeshape.common.FixFor;
 import org.modeshape.common.text.TokenStream.BasicTokenizer;
 import org.modeshape.common.text.TokenStream.Tokenizer;
 
@@ -122,6 +123,54 @@ public class TokenStreamTest {
         tokens.consume("SELECT");
         tokens.consume("ALL");
         tokens.consume("columns");
+    }
+
+    @FixFor( "MODE-2497" )
+    @Test
+    public void shouldHandleNonAsciiCharactersWhenCaseSensitive() {
+        content = "ü and";
+        makeCaseSensitive();
+        tokens.consume("ü");
+        tokens.consume("and");
+        assertThat(tokens.hasNext(), is(false));
+    }
+
+    @FixFor( "MODE-2497" )
+    @Test
+    public void shouldHandleßCharacterWhenCaseSensitive() {
+        content = "ß and";
+        makeCaseSensitive();
+        tokens.consume("ß");
+        tokens.consume("and");
+        assertThat(tokens.hasNext(), is(false));
+    }
+
+    @FixFor( "MODE-2497" )
+    @Test
+    public void shouldConsumeCaseInsensitiveStringInOriginalCase() {
+        makeCaseInsensitive();
+        String firstToken = tokens.consume();
+
+        assertThat(firstToken, is("Select"));
+    }
+
+    @FixFor( "MODE-2497" )
+    @Test
+    public void shouldMatchUpperCaseVersionOfßCharacterWhenCaseInsensitive() {
+        content = "ß";
+        makeCaseInsensitive();
+        tokens.consume("SS");
+        assertThat(tokens.hasNext(), is(false));
+    }
+
+    @FixFor( "MODE-2497" )
+    @Test
+    public void shouldHandleTokensAfterßCharacterWhenCaseInsensitive() {
+        content = "ß and";
+        makeCaseInsensitive();
+        tokens.consume(TokenStream.ANY_VALUE);
+        tokens.consume("AND");
+        assertThat(tokens.hasNext(), is(false));
     }
 
     @Test


### PR DESCRIPTION
This symbol is weird because the so-called 'capital' version (as determined by the JVM) is 'SS'. i.e. longer than the lower-case version. This sends the indexes out of kilter within the TokenStream class when using case insensitive tokenising.

The solution is to override the match method in the CaseInsensitiveToken to convert the current token to upper-case, rather than storing an upper-case version of the entire input string, which may not have the same indexes as the lower-case version.
(cherry picked from commit 9a8ac56)