### PR TITLE
MODE-2496 Makes sure custom authentication providers in the AS kit are added first in the list

### DIFF
--- a/integration/modeshape-jbossas-integration-tests/src/main/java/org/modeshape/test/integration/CustomAuthenticationProvider.java
+++ b/integration/modeshape-jbossas-integration-tests/src/main/java/org/modeshape/test/integration/CustomAuthenticationProvider.java
@@ -1,0 +1,61 @@
+/*
+ * ModeShape (http://www.modeshape.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.modeshape.test.integration;
+
+import java.util.Map;
+import javax.jcr.Credentials;
+import org.modeshape.jcr.ExecutionContext;
+import org.modeshape.jcr.security.AuthenticationProvider;
+import org.modeshape.jcr.security.SecurityContext;
+
+/**
+ * A simple {@link AuthenticationProvider} implementation used for Arquillian testing.
+ * 
+ * @author Horia Chiorean (hchiorea@redhat.com)
+ */
+public final class CustomAuthenticationProvider implements AuthenticationProvider, SecurityContext {
+
+    private String username;
+
+    public void setUsername( String username ) {
+        this.username = username;
+    }
+
+    @Override
+    public ExecutionContext authenticate( Credentials credentials, String repositoryName, String workspaceName,
+                                          ExecutionContext repositoryContext, Map<String, Object> sessionAttributes ) {
+        return repositoryContext.with(this);
+    }
+
+    @Override
+    public boolean isAnonymous() {
+        return false;
+    }
+
+    @Override
+    public String getUserName() {
+        return username;
+    }
+
+    @Override
+    public boolean hasRole( String roleName ) {
+        return true;
+    }
+
+    @Override
+    public void logout() {
+    }
+}

--- a/integration/modeshape-jbossas-integration-tests/src/main/resources/kit/jboss-wf9/standalone/configuration/standalone-modeshape.xml
+++ b/integration/modeshape-jbossas-integration-tests/src/main/resources/kit/jboss-wf9/standalone/configuration/standalone-modeshape.xml
@@ -516,6 +516,13 @@
                         document-optimization-initial-time="02:00"
                         document-optimization-interval="24"
                         document-optimization-thread-pool="modeshape-opt"/>
+            <repository name="customAuthenticatorRepository" cache-config="modeshape/infinispan-test-caches.xml" cache-name="anonymousRepository">
+                <authenticators>
+                    <authenticator classname="org.modeshape.test.integration.CustomAuthenticationProvider" 
+                                   module="deployment.security-test.war"
+                                   username="arquillian"/>
+                </authenticators>
+            </repository>
 
             <!--These should be deployed after the repositories, because they use servlet context listeners to load all repositories-->
             <webapp name="modeshape-cmis.war"/>


### PR DESCRIPTION
This essentially makes sure that any custom providers will take precedence over the default (built-in) security providers which interface with the AS's security domain.