### PR TITLE
MODE-2483 Allows custom authorization providers to be called for workspace based permissions

### DIFF
--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrSession.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrSession.java
@@ -1372,6 +1372,9 @@ public class JcrSession implements org.modeshape.jcr.api.Session {
                         hasPermission = acm.hasPermission(path, actions);
                     }
                     return hasPermission;
+                } else {
+                    return authorizer.hasPermission(context, repositoryName, repositoryName, workspaceName, null,
+                                                    actions);
                 }
             }
 
@@ -1387,6 +1390,8 @@ public class JcrSession implements org.modeshape.jcr.api.Session {
                         hasPermission = acm.hasPermission(path, actions);
                     }
                     return hasPermission;
+                } else {
+                    return authorizer.hasPermission(authorizerContext, null, actions);
                 }
             }
 
@@ -1767,11 +1772,13 @@ public class JcrSession implements org.modeshape.jcr.api.Session {
 
     @Override
     public synchronized void logout() {
+        // get the user id first, because calling terminate may cleanup the security context and loose this information
+        String userID = getUserID();
         terminate(true);
         try {
             RunningState running = repository.runningState();
             long lifetime = Math.abs(System.nanoTime() - this.nanosCreated);
-            Map<String, String> payload = Collections.singletonMap("userId", getUserID());
+            Map<String, String> payload = Collections.singletonMap("userId", userID);
             running.statistics().recordDuration(DurationMetric.SESSION_LIFETIME, lifetime, TimeUnit.NANOSECONDS, payload);
             running.statistics().decrement(ValueMetric.SESSION_COUNT);
             running.removeSession(this);

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/security/AuthorizationProvider.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/security/AuthorizationProvider.java
@@ -32,7 +32,7 @@ public interface AuthorizationProvider {
      * @param repositoryName the name of the repository containing the workspace content
      * @param repositorySourceName <i>This is no longer used and will always be the same as the repositoryName</i>
      * @param workspaceName the name of the workspace in which the path exists
-     * @param absPath the absolute path on which the actions are occurring
+     * @param absPath the absolute path on which the actions are occurring, or null if the permissions are at the workspace-level
      * @param actions the list of {@link ModeShapePermissions actions} to check
      * @return true if the subject has privilege to perform all of the named actions on the content at the supplied path in the
      *         given workspace within the repository, or false otherwise

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/security/SecurityContext.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/security/SecurityContext.java
@@ -44,8 +44,10 @@ public interface SecurityContext {
     /**
      * Returns whether the authenticated user has the given role.
      * 
-     * @param roleName the name of the role to check
+     * @param roleName the name of the role to check. The name of the role will always come from ModeShape and will be one of 
+     * ModeShape's built-in roles. 
      * @return true if the user has the role and is logged in; false otherwise
+     * @see org.modeshape.jcr.ModeShapeRoles
      */
     boolean hasRole( String roleName );
 


### PR DESCRIPTION
The previous code would circumvent custom providers altogether, meaning that right after `session.login` any custom provider had to have assigned ModeShape-specific roles to the authenticated user in order for the login to be successful.