### PR TITLE
MODE-2478 Updates ISPN to 7.2.4.Final

### DIFF
--- a/boms/modeshape-bom-embedded/pom.xml
+++ b/boms/modeshape-bom-embedded/pom.xml
@@ -50,7 +50,7 @@
 
     <properties>
         <jcr.version>2.0</jcr.version>
-        <infinispan.version>7.2.3.Final</infinispan.version>
+        <infinispan.version>7.2.4.Final</infinispan.version>
         <jgroups.version>3.6.2.Final</jgroups.version>
         <c3p0.version>0.9.5</c3p0.version>  <!-- same as the one used by Infinispan's JDBC cache store -->
         <picketbox.version>4.0.21.Final</picketbox.version>

--- a/modeshape-parent/pom.xml
+++ b/modeshape-parent/pom.xml
@@ -242,7 +242,7 @@
         <atomikos.version>3.8.0</atomikos.version>
         <picketbox.version>4.0.21.Final</picketbox.version>
 
-        <infinispan.version>7.2.3.Final</infinispan.version>
+        <infinispan.version>7.2.4.Final</infinispan.version>
         <infinispan.module.slot>ispn-7.2</infinispan.module.slot>
         <!--Make sure the jgroups version is the same as the one used by ISPN -->
         <jgroups.version>3.6.2.Final</jgroups.version>


### PR DESCRIPTION
This fixes the problem of the marshalling artifact which is now contained in the ISPN AS artifact.