### PR TITLE
MODE-2502 Adds retrying logic when a node cannot locate its parent self-reference

### DIFF
--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/document/WorkspaceCache.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/document/WorkspaceCache.java
@@ -220,6 +220,10 @@ public class WorkspaceCache implements DocumentCache {
             this.nodesByKey.remove(nodeKey);
         }
     }
+    
+    final void purge(NodeKey key) {
+        this.nodesByKey.remove(key);
+    }
 
     @Override
     public NodeKey getRootKey() {


### PR DESCRIPTION
The code will now attempt to retry loading the parent and its references after removing it from the workspace cache first. This ensures that a "fresh" copy of the parent is always loaded from the persistent store.