### PR TITLE
MODE-2159 Updates the index adapters SPI adding a property name for each add/remove operation

### DIFF
--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/index/local/LocalDuplicateIndex.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/index/local/LocalDuplicateIndex.java
@@ -85,6 +85,7 @@ final class LocalDuplicateIndex<T> extends LocalMapIndex<UniqueKey<T>, T> {
 
     @Override
     public void add( String nodeKey,
+                     String propertyName, 
                      T value ) {
         logger.trace("Adding node '{0}' to '{1}' index with value '{2}'", nodeKey, name, value);
         keysByValue.put(new UniqueKey<T>(value, counter.getAndIncrement()), nodeKey);
@@ -92,6 +93,7 @@ final class LocalDuplicateIndex<T> extends LocalMapIndex<UniqueKey<T>, T> {
 
     @Override
     public void remove( String nodeKey,
+                        String propertyName, 
                         T value ) {
         // Find all of the actual unique values for the given value ...
         UniqueKey<T> fromKey = new UniqueKey<T>(value, 0);

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/index/local/LocalIndex.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/index/local/LocalIndex.java
@@ -47,16 +47,16 @@ public abstract class LocalIndex<T> implements ProvidedIndex<T> {
     }
 
     @Override
-    public void add( String nodeKey, T[] values ) {
+    public void add( String nodeKey, String propertyName, T[] values ) {
         for (T value : values) {
-            add(nodeKey, value);
+            add(nodeKey, propertyName, value);
         }
     }
     
     @Override
-    public void remove( String nodeKey, T[] values ) {
+    public void remove( String nodeKey, String propertyName, T[] values ) {
         for (T value : values) {
-            remove(nodeKey, value);
+            remove(nodeKey, propertyName, value);
         }
     }
 

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/index/local/LocalIndexProvider.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/index/local/LocalIndexProvider.java
@@ -27,6 +27,7 @@ import org.modeshape.jcr.JcrI18n;
 import org.modeshape.jcr.NodeTypes;
 import org.modeshape.jcr.NodeTypes.Supplier;
 import org.modeshape.jcr.api.index.IndexDefinition;
+import org.modeshape.jcr.api.query.qom.ChildCount;
 import org.modeshape.jcr.api.query.qom.QueryObjectModelConstants;
 import org.modeshape.jcr.cache.change.ChangeSetAdapter.NodeTypePredicate;
 import org.modeshape.jcr.query.QueryContext;
@@ -225,6 +226,12 @@ public class LocalIndexProvider extends IndexProvider {
                     return false;
                 }
                 return super.indexAppliesTo(constraint);
+            }
+
+            @Override
+            protected boolean applies( ChildCount operand ) {
+                // this index can't handle this
+                return false;
             }
         };
     }

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/index/local/LocalMapIndex.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/index/local/LocalMapIndex.java
@@ -16,8 +16,8 @@
 
 package org.modeshape.jcr.index.local;
 
-import java.util.Collections;
 import java.util.Comparator;
+import java.util.List;
 import java.util.Map;
 import java.util.NavigableSet;
 import java.util.concurrent.ConcurrentMap;
@@ -119,9 +119,9 @@ abstract class LocalMapIndex<T, V> extends LocalIndex<V> {
     }
 
     @Override
-    public long estimateCardinality( Constraint constraint,
+    public long estimateCardinality( List<Constraint> andedConstraints,
                                      Map<String, Object> variables ) {
-        return Operations.createFilter(keysByValue, converter, Collections.singleton(constraint), variables).estimateCount();
+        return Operations.createFilter(keysByValue, converter, andedConstraints, variables).estimateCount();
     }
 
     @Override

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/index/local/LocalUniqueIndex.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/index/local/LocalUniqueIndex.java
@@ -76,6 +76,7 @@ class LocalUniqueIndex<T> extends LocalMapIndex<T, T> {
 
     @Override
     public void add( String nodeKey,
+                     String propertyName, 
                      T value ) {
         logger.trace("Adding node '{0}' to '{1}' index with value '{2}'", nodeKey, name, value);
         keysByValue.put(value, nodeKey);
@@ -83,6 +84,7 @@ class LocalUniqueIndex<T> extends LocalMapIndex<T, T> {
 
     @Override
     public void remove( String nodeKey,
+                        String propertyName, 
                         T value ) {
         // Find all of the T values (entry keys) for the given node key (entry values) ...
         for (T key : Fun.filter(valuesByKey, nodeKey)) {

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/spi/index/provider/Costable.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/spi/index/provider/Costable.java
@@ -16,6 +16,7 @@
 
 package org.modeshape.jcr.spi.index.provider;
 
+import java.util.List;
 import java.util.Map;
 import javax.jcr.query.qom.Constraint;
 
@@ -25,14 +26,15 @@ import javax.jcr.query.qom.Constraint;
  * @author Randall Hauch (rhauch@redhat.com)
  */
 public interface Costable {
+    
     /**
-     * Compute the cost applying the given constraint.
+     * Compute the cost applying the given constraints joined together conceptually using AND.
      *
-     * @param constraint the constraint; never null
+     * @param andedConstraints the constraints; never null
      * @param variables the bound variables for the query that is being costed; never null
      * @return the approximate number of records that will be returned
      */
-    long estimateCardinality( Constraint constraint,
+    long estimateCardinality( List<Constraint> andedConstraints,
                               Map<String, Object> variables );
 
     /**

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/spi/index/provider/DefaultManagedIndex.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/spi/index/provider/DefaultManagedIndex.java
@@ -15,6 +15,7 @@
  */
 package org.modeshape.jcr.spi.index.provider;
 
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
@@ -58,9 +59,9 @@ public final class DefaultManagedIndex implements ManagedIndex {
     }
 
     @Override
-    public long estimateCardinality( Constraint constraint,
+    public long estimateCardinality( List<Constraint> andedConstraints,
                                      Map<String, Object> variables ) {
-        return index.estimateCardinality(constraint, variables);
+        return index.estimateCardinality(andedConstraints, variables);
     }
 
     @Override

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/spi/index/provider/IndexUsage.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/spi/index/provider/IndexUsage.java
@@ -285,7 +285,7 @@ public class IndexUsage {
     }
 
     protected boolean applies( NodePath operand ) {
-        // This should apply to the 'jcr:name' pseudo-column on the index ...
+        // This should apply to the 'jcr:path' pseudo-column on the index ...
         return defn.appliesToProperty("jcr:path");
     }
 
@@ -319,7 +319,7 @@ public class IndexUsage {
     }
 
     protected boolean applies( FullTextSearch operand ) {
-        return true;
+        return defn.getKind() == IndexDefinition.IndexKind.TEXT;
     }
 
     protected final boolean matchesSelectorName( String selectorName ) {

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/spi/index/provider/ManagedIndexBuilder.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/spi/index/provider/ManagedIndexBuilder.java
@@ -58,10 +58,10 @@ public abstract class ManagedIndexBuilder {
     protected final String workspaceName;
 
     protected ManagedIndexBuilder( ExecutionContext context,
-                                 IndexDefinition defn,
-                                 String workspaceName,
-                                 NodeTypes.Supplier nodeTypesSupplier,
-                                 ChangeSetAdapter.NodeTypePredicate matcher ) {
+                                   IndexDefinition defn,
+                                   String workspaceName,
+                                   NodeTypes.Supplier nodeTypesSupplier,
+                                   ChangeSetAdapter.NodeTypePredicate matcher ) {
         this.context = context;
         this.workspaceName = workspaceName;
         this.defn = defn;

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/spi/index/provider/ProvidedIndex.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/spi/index/provider/ProvidedIndex.java
@@ -21,24 +21,33 @@ package org.modeshape.jcr.spi.index.provider;
  * 
  * @author Horia Chiorean (hchiorea@redhat.com)
  * @param <T> the type of the values handled by this index or {@link Object} in the case of multi-column indexes.
+ * @since 4.5
  */
 public interface ProvidedIndex<T> extends Filter, Costable, Reindexable, Lifecycle {
-    
+
     /**
      * Adds a single value to this index for the given node.
-     * 
+     *
      * @param nodeKey a {@link org.modeshape.jcr.cache.NodeKey} instance, never {@code null}
-     * @param value an Object instance, never {@code null} 
+     * @param propertyName the name for which the value is removed, never {@code null} but certain providers
+     * may ignore the value. Most of the times this is the real JCR property name, but for some index types (e.g. node types
+     * index) this may be something else (e.g. the name of the index)
+     * @param value an Object instance, never {@code null}
      */
-    void add( String nodeKey, T value );
+    void add( String nodeKey, String propertyName, T value );
 
     /**
      * Adds multiple values to the index for the given node.
      *
      * @param nodeKey a {@link org.modeshape.jcr.cache.NodeKey} instance, never {@code null}
+     * @param propertyName the name for which the value is removed, never {@code null} but certain providers
+     * may ignore the value. Most of the times this is the real JCR property name, but for some index types (e.g. node types
+     * index) this may be something else (e.g. the name of the index)
      * @param values an array of values, never {@code null} or empty
      */
-    void add( String nodeKey, T[] values);
+    void add( String nodeKey, 
+              String propertyName, 
+              T[] values );
 
     /**
      * Removes the given node from the index.
@@ -48,21 +57,28 @@ public interface ProvidedIndex<T> extends Filter, Costable, Reindexable, Lifecyc
     void remove( String nodeKey );
 
     /**
-     * Removes a value for the given node from the index. 
-     * 
+     * Removes a value for the given node from the index.
+     *
      * @param nodeKey a {@link org.modeshape.jcr.cache.NodeKey} instance, never {@code null}
+     * @param propertyName the name for which the value is removed, never {@code null} but certain providers
+     * may ignore the value. Most of the times this is the real JCR property name, but for some index types (e.g. node types
+     * index) this may be something else (e.g. the name of the index)
      * @param value the value to remove from the index for this node, never {@code null}
      */
     void remove( String nodeKey,
+                 String propertyName, 
                  T value );
 
     /**
      * Removes multiple values from the index for the given node.
      *
      * @param nodeKey a {@link org.modeshape.jcr.cache.NodeKey} instance, never {@code null}
+     * @param propertyName the name for which the value is removed, never {@code null} but certain providers
+     * may ignore the value. Most of the times this is the real JCR property name, but for some index types (e.g. node types
+     * index) this may be something else (e.g. the name of the index)
      * @param values the values to remove, never {@code null} or empty
      */
-    void remove( String nodeKey, T[] values );
+    void remove( String nodeKey, String propertyName, T[] values );
 
     /**
      * Commits any potential changes made by the add/remove/update operations to this index.

--- a/modeshape-jcr/src/test/java/org/modeshape/jcr/index/local/AbstractLocalIndexTest.java
+++ b/modeshape-jcr/src/test/java/org/modeshape/jcr/index/local/AbstractLocalIndexTest.java
@@ -67,28 +67,28 @@ public abstract class AbstractLocalIndexTest {
     protected void loadLongIndex( LocalUniqueIndex<Long> index,
                                   int numValues ) {
         for (int i = 1; i <= numValues; ++i) {
-            index.add(key(i), (long)(i * 10));
+            index.add(key(i), "test", (long)(i * 10));
         }
     }
 
     protected void loadStringIndex( LocalUniqueIndex<String> index,
                                     int numValues ) {
         for (int i = 1; i <= numValues; ++i) {
-            index.add(key(i), "" + (i * 10));
+            index.add(key(i), "test", "" + (i * 10));
         }
     }
 
     protected void loadLongIndexWithNoDuplicates( LocalDuplicateIndex<Long> index,
                                                   int numValues ) {
         for (int i = 1; i <= numValues; ++i) {
-            index.add(key(i), (long)(i * 10));
+            index.add(key(i), "test", (long)(i * 10));
         }
     }
 
     protected void loadStringIndexWithNoDuplicates( LocalDuplicateIndex<String> index,
                                                     int numValues ) {
         for (int i = 1; i <= numValues; ++i) {
-            index.add(key(i), "" + (i * 10));
+            index.add(key(i), "test", "" + (i * 10));
         }
     }
 

--- a/modeshape-jcr/src/test/java/org/modeshape/jcr/index/local/LocalDuplicateIndexTest.java
+++ b/modeshape-jcr/src/test/java/org/modeshape/jcr/index/local/LocalDuplicateIndexTest.java
@@ -135,12 +135,12 @@ public class LocalDuplicateIndexTest extends AbstractLocalIndexTest {
         assertThat(index.estimateTotalCount(), is(9L));
 
         // Remove a value and key pair that's in the index, and verify they are indeed gone ...
-        index.remove(key(3), 30L);
+        index.remove(key(3), null, 30L);
         assertNoMatch(index, Operator.EQUAL_TO, 30L);
         assertThat(index.estimateTotalCount(), is(8L));
 
-        // Try to remove a non-existant value-key pair, and verify nothing is removed ...
-        index.remove(key(3), 3000L);
+        // Try to remove a non-existent value-key pair, and verify nothing is removed ...
+        index.remove(key(3), null, 3000L);
         assertNoMatch(index, Operator.EQUAL_TO, 30L);
         assertThat(index.estimateTotalCount(), is(8L));
     }

--- a/modeshape-jcr/src/test/java/org/modeshape/jcr/index/local/LocalUniqueIndexTest.java
+++ b/modeshape-jcr/src/test/java/org/modeshape/jcr/index/local/LocalUniqueIndexTest.java
@@ -134,12 +134,12 @@ public class LocalUniqueIndexTest extends AbstractLocalIndexTest {
         assertThat(index.estimateTotalCount(), is(9L));
 
         // Remove a value and key pair that's in the index, and verify they are indeed gone ...
-        index.remove(key(3), 30L);
+        index.remove(key(3), null, 30L);
         assertNoMatch(index, Operator.EQUAL_TO, 30L);
         assertThat(index.estimateTotalCount(), is(8L));
 
         // Try to remove a non-existant value-key pair, and verify nothing is removed ...
-        index.remove(key(3), 3000L);
+        index.remove(key(3), null, 3000L);
         assertNoMatch(index, Operator.EQUAL_TO, 30L);
         assertThat(index.estimateTotalCount(), is(8L));
     }


### PR DESCRIPTION
Index providers are free to ignore the property if their logic does not require it (for example the Local Index provider) but other (e.g. Lucene) are interested in the property name so they can add it to the indexing information. 

Also, this PR changes the default index planning logic adding the ability for Index Providers to process multiple constraints, not just one like the `LocalIndexProvider` did.