### PR TITLE
MODE-2159 Adds support for storing indexes in Lucene

### DIFF
--- a/boms/modeshape-bom-embedded/pom.xml
+++ b/boms/modeshape-bom-embedded/pom.xml
@@ -80,6 +80,7 @@
         <poi.version>3.11-beta2</poi.version>
         <jcommander.version>1.5</jcommander.version>
         <wsdl4j.version>1.6.2</wsdl4j.version>
+        <version.org.apache.lucene>5.3.1</version.org.apache.lucene>
         <!-- ***************** -->
         <!-- Repository Deployment URLs -->
         <!-- ***************** -->
@@ -241,6 +242,11 @@
             <dependency>
                 <groupId>org.modeshape</groupId>
                 <artifactId>modeshape-extractor-tika</artifactId>
+                <version>${project.version}</version>
+            </dependency> 
+            <dependency>
+                <groupId>org.modeshape</groupId>
+                <artifactId>modeshape-lucene-index-provider</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
@@ -610,6 +616,27 @@
                 <artifactId>cassandra-driver-core</artifactId>
                 <version>${cassandra-cql-driver}</version>
                 <scope>provided</scope>
+            </dependency>
+            
+            <!-- 
+                Index providers
+            -->
+
+            <!-- Lucene Index Provider -->
+            <dependency>
+                <groupId>org.apache.lucene</groupId>
+                <artifactId>lucene-core</artifactId>
+                <version>${version.org.apache.lucene}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.lucene</groupId>
+                <artifactId>lucene-analyzers-common</artifactId>
+                <version>${version.org.apache.lucene}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.lucene</groupId>
+                <artifactId>lucene-queryparser</artifactId>
+                <version>${version.org.apache.lucene}</version>
             </dependency>
 
             <!--

--- a/index-providers/modeshape-lucene-index-provider/pom.xml
+++ b/index-providers/modeshape-lucene-index-provider/pom.xml
@@ -1,0 +1,31 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.modeshape</groupId>
+        <artifactId>modeshape-index-providers</artifactId>
+        <version>4.5-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+    <!-- The groupId and version values are inherited from parent -->
+    <artifactId>modeshape-lucene-index-provider</artifactId>
+    <packaging>jar</packaging>
+    <name>ModeShape Lucene Index Provider</name>
+    <description>ModeShape index provider that uses the Apache Lucene library</description>
+    <url>http://www.modeshape.org</url>
+
+	<dependencies>
+        <dependency>
+            <groupId>org.apache.lucene</groupId>
+            <artifactId>lucene-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.lucene</groupId>
+            <artifactId>lucene-analyzers-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.lucene</groupId>
+            <artifactId>lucene-queryparser</artifactId>
+        </dependency>
+    </dependencies>      
+</project>

--- a/index-providers/modeshape-lucene-index-provider/pom.xml
+++ b/index-providers/modeshape-lucene-index-provider/pom.xml
@@ -27,5 +27,13 @@
             <groupId>org.apache.lucene</groupId>
             <artifactId>lucene-queryparser</artifactId>
         </dependency>
+        <!-- 
+            Required to text FTS on binary properties...
+        -->
+        <dependency>
+            <groupId>org.modeshape</groupId>
+            <artifactId>modeshape-extractor-tika</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>      
 </project>

--- a/index-providers/modeshape-lucene-index-provider/src/main/java/org/modeshape/jcr/index/lucene/FieldUtil.java
+++ b/index-providers/modeshape-lucene-index-provider/src/main/java/org/modeshape/jcr/index/lucene/FieldUtil.java
@@ -13,30 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-/*
- * ModeShape (http://www.modeshape.org)
- * See the COPYRIGHT.txt file distributed with this work for information
- * regarding copyright ownership.  Some portions may be licensed
- * to Red Hat, Inc. under one or more contributor license agreements.
- * See the AUTHORS.txt file in the distribution for a full listing of 
- * individual contributors.
- *
- * ModeShape is free software. Unless otherwise indicated, all code in ModeShape
- * is licensed to you under the terms of the GNU Lesser General Public License as
- * published by the Free Software Foundation; either version 2.1 of
- * the License, or (at your option) any later version.
- * 
- * ModeShape is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this software; if not, write to the Free
- * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
- * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
- */
 package org.modeshape.jcr.index.lucene;
 
 import java.math.BigDecimal;

--- a/index-providers/modeshape-lucene-index-provider/src/main/java/org/modeshape/jcr/index/lucene/FieldUtil.java
+++ b/index-providers/modeshape-lucene-index-provider/src/main/java/org/modeshape/jcr/index/lucene/FieldUtil.java
@@ -1,0 +1,349 @@
+/*
+ * ModeShape (http://www.modeshape.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * ModeShape (http://www.modeshape.org)
+ * See the COPYRIGHT.txt file distributed with this work for information
+ * regarding copyright ownership.  Some portions may be licensed
+ * to Red Hat, Inc. under one or more contributor license agreements.
+ * See the AUTHORS.txt file in the distribution for a full listing of 
+ * individual contributors.
+ *
+ * ModeShape is free software. Unless otherwise indicated, all code in ModeShape
+ * is licensed to you under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ * 
+ * ModeShape is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.modeshape.jcr.index.lucene;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import org.apache.lucene.document.Field;
+import org.apache.lucene.document.StringField;
+import org.apache.lucene.index.Term;
+import org.apache.lucene.search.TermQuery;
+import org.apache.lucene.util.BytesRef;
+
+/**
+ * Utility for working with Lucene field values.
+ * 
+ * @since 4.5
+ */
+public class FieldUtil {
+
+    protected static final String ID = ":id:";
+    protected static final String LENGTH_PREFIX = ":len:";
+
+    /**
+     * Creates the name of the Lucene document field which will store the length of a property.
+     *
+     * @param propertyName the name of the property; may not be null
+     * @return the name of the length field; never {@code null}
+     */
+    public static String lengthField(String propertyName){
+        return LENGTH_PREFIX + propertyName;
+    }
+
+    protected static Field idField( String key ) {
+        // the ids are always stored in the document in their bytes format because Lucene performs better with those
+        return new StringField(ID, new BytesRef(key), Field.Store.YES);
+    }
+
+    protected static TermQuery idQuery( String key ) {
+        return new TermQuery(idTerm(key));
+    }
+
+    protected static Term idTerm( String key ) {
+        return new Term(ID, new BytesRef(key));
+    }
+
+
+    /**
+     * Creates a canonical string representation of the supplied {@link BigDecimal} value, whereby all string representations are
+     * lexicographically sortable. This makes it possible to store the wide range of values that can be represented by BigDecimal,
+     * while still enabling sorting and range queries.
+     * <p>
+     * This canonical form represents all decimal values using a prescribed format, which is based upon <a
+     * href="http://www.mail-archive.com/java-user@lucene.apache.org/msg23632.html">Steven Rowe's suggestion</a> but with
+     * modifications to handle variable-length exponents (per his suggestion in the last sentence), use spaces between fields on
+     * where required (for minimal length), and utilize an optimized (e.g., shorter) form when the value is '0' or the exponent is
+     * '0'. Thus, this format contains only digits (e.g., '0'..'9') and the '-' and 'A' characters.
+     * 
+     * <pre>
+     *     &lt;significand-sign>&lt;exponent-sign>&lt;exponent-length> &lt;exponent>&lt;significand>
+     * </pre>
+     * 
+     * where:
+     * <ul>
+     * <li>the <b>significand</b> is the part of the number containing the significant figures, and is a (big) integer value
+     * obtained from the BigDecimal using {@link BigDecimal#unscaledValue()};</li>
+     * <li>the <b>exponent</b> is the integer used to define the number of factors of 10 that are applied to the significand,
+     * obtained by computing <code>value.precision() - value.scale() - 1</code>;</li>
+     * </ul>
+     * Thus the fields are defined as:
+     * <ul>
+     * <li>the <code>&lt;significand-sign></code> is '-' if the significand is negative, '0' if equal to zero, or '1' if positive;
+     * </li>
+     * <li>the <code>&lt;exponent-sign></code> is '-' if the exponent is negative, '0' if equal to zero, or '1' if positive; if
+     * '0', then the <code>&lt;exponent-length></code> and <code>&lt;exponent></code> fields are not written;</li>
+     * <li>the <code>&lt;exponent-length></code> is the postive value representing the length of the <code>&lt;exponent></code>,
+     * and is not included when the <code>&lt;exponent-sign></code> is '0';</li>
+     * <li>the <code>&lt;exponent></code> is the integer used to define the number of factors of 10 that are applied to the
+     * significand, obtained by computing <code>value.precision() - value.scale() - 1</code>;</li>
+     * <li>the <code>&lt;significand></code> is the part of the number containing the significant figures, and is a (big) integer
+     * value obtained from the BigDecimal using {@link BigDecimal#unscaledValue()};</li>
+     * </ul>
+     * In the case of a negative exponent, the <code>&lt;exponent-length></code> field is negated such that each digit is replaced
+     * with <code>(base - digit - 1)</code>.
+     * </p>
+     * <p>
+     * In the case of a negative significand, the <code>&lt;significand></code> field is negated such that each digit is replaced
+     * with <code>(base - digit - 1)</code> and appended by 'A' (which is greater than all other digits) to ensure that
+     * significands with greater precision are ordered before those that share significand prefixes but have lesser precision. In
+     * this case, the <code>&lt;exponent-length></code> and <code>&lt;exponent></code> parts are also negated (unless they already
+     * are).
+     * </p>
+     * <p>
+     * Thus, the format for a negative BigDecimal value becomes:
+     * 
+     * <pre>
+     *     -&lt;reversed-exponent-sign>&lt;negated-exponent-length> &lt;negated-exponent>&lt;significand>&lt;sentinel>
+     * </pre>
+     * 
+     * where the <code>&lt;sentinel></code> is always 'A'. Note that the exponent length field is also negated.
+     * </p>
+     * <h3>Examples</h3>
+     * <p>
+     * Here are several examples that show BigDecimal values and their corresponding canonical string representation:
+     * 
+     * <pre>
+     *    +5.E-3     => 1-8 65
+     *    +1.E-2     => 1-8 71
+     *    +1.0E-2    => 1-8 71
+     *    +1.0000E-2 => 1-8 71
+     *    +1.1E-2    => 1-8 711
+     *    +1.11E-2   => 1-8 7111
+     *    +1.2E-2    => 1-8 712
+     *    +5.E-2     => 1-8 75
+     *    +7.3E+2    => 111 273
+     *    +7.4E+2    => 111 274
+     *    +7.45E+2   => 111 2745
+     *    +8.7654E+3 => 111 387654
+     * </pre>
+     * 
+     * Here is how a BigDecimal value of {@link BigDecimal#ZERO zero} is represented:
+     * 
+     * <pre>
+     *     0.0E0     => 0
+     * </pre>
+     * 
+     * BigDecimal values with an exponent of '0' are represented as follows:
+     * 
+     * <pre>
+     *    +1.2E0     => 1012
+     *    -1.2E0     => -087A
+     * </pre>
+     * 
+     * And here are some negative value examples:
+     * 
+     * <pre>
+     *    -8.7654E+3 => --8 612345A
+     *    -7.45E+2   => --8 7254A
+     *    -7.4E+2    => --8 725A
+     *    -7.3E+2    => --8 726A
+     *    -5.E-2     => -18 24A
+     *    -1.2E-2    => -18 287A
+     *    -1.11E-2   => -18 2888A
+     *    -1.1E-2    => -18 288A
+     *    -1.0000E-2 => -18 28A
+     *    -1.0E-2    => -18 28A
+     *    -1.E-2     => -18 28A
+     *    -5.E-3     => -18 34A
+     *    -5.E-4     => -18 44A
+     * </pre>
+     * 
+     * </p>
+     * <p>
+     * This canonical form is valid for all values of {@link BigDecimal}.
+     * </p>
+     * 
+     * @param value the value to be converted into its canonical form; may not be null
+     * @return the canonical string representation; never null or empty
+     * @see #stringToDecimal(String)
+     */
+    public static String decimalToString( BigDecimal value ) {
+        StringBuilder sb = new StringBuilder();
+        boolean negate = false;
+        // <sigificand-sign> field
+        switch (value.signum()) {
+            case -1:
+                sb.append('-');
+                negate = true;
+                break;
+            case 1:
+                sb.append('1');
+                break;
+            default:
+                return "0";
+        }
+
+        // <exponent-sign>, <exponent-length> and <exponent> fields
+        long exponent = value.precision() - value.scale() - 1;
+        if (exponent == 0) {
+            sb.append('0');
+        } else {
+            if (negate) exponent = -exponent;
+            String exponentField = String.valueOf(Math.abs(exponent));
+            int length = exponentField.length();
+            char sign = exponent > 0 ? '1' : '-';
+            if (exponent < 0) exponentField = negate(exponentField);
+            // <exponent-length>
+            String lengthField = String.valueOf(length);
+            if (negate || exponent < 0) lengthField = negate(lengthField);
+            sb.append(sign).append(lengthField).append(' ').append(exponentField);
+        }
+
+        // <significand>
+        if (negate) value = value.negate();
+        StringBuilder significand = new StringBuilder(value.unscaledValue().toString());
+        removeTralingZeros(significand);
+
+        // Append the significand (and the sentinel character)...
+        sb.append(negate ? negate(significand).append('A') : significand);
+
+        return sb.toString();
+    }
+
+    /**
+     * Converts the canonical string representation of a {@link BigDecimal} value into the object form.
+     * <p>
+     * See {@link #decimalToString(BigDecimal)} to documentation of the canonical form.
+     * </p>
+     * 
+     * @param value the canonical string representation; may not be null or empty
+     * @return the BigDecimal representation; never null
+     * @see #decimalToString(BigDecimal)
+     */
+    public static BigDecimal stringToDecimal( String value ) {
+        assert value != null;
+        assert value.length() != 0;
+        if ("0".equals(value)) return BigDecimal.ZERO;
+
+        boolean negate = false;
+        if (value.charAt(0) == '-') {
+            // Negative, so remove the trailing sentinel ...
+            assert value.charAt(value.length() - 1) == 'A';
+            value = value.substring(0, value.length() - 1);
+            negate = true;
+        }
+
+        // <exponent-sign>, <exponent-length> and <exponent> fields
+        long exponent = 0L;
+        boolean negateExponent = false;
+        int endIndex = 0;
+        switch (value.charAt(1)) {
+            case '0':
+                value = value.substring(2);
+                break;
+            case '-':
+                negateExponent = true;
+                // $FALL-THROUGH$
+            case '1':
+            default:
+                // Read in the <exponent-length>
+                int indexOfSpace = value.indexOf(' ', 2);
+                String expLengthField = value.substring(2, indexOfSpace);
+                if (negate || negateExponent) expLengthField = negate(expLengthField);
+                int lengthOfExponent = Integer.parseInt(expLengthField);
+                // Read in the <exponent> (after the space) ...
+                int startIndex = indexOfSpace + 1;
+                endIndex = startIndex + lengthOfExponent;
+                String exponentField = value.substring(startIndex, endIndex);
+                exponent = Long.parseLong(negateExponent ? negate(exponentField) : exponentField);
+                if (negate) negateExponent = !negateExponent;
+                if (negateExponent) exponent = -exponent;
+                value = value.substring(endIndex);
+        }
+
+        // <significand>
+        if (negate) {
+            value = negate(value);
+        }
+        BigInteger significand = new BigInteger(value);
+        int scale = (int)(value.length() - exponent - 1);
+
+        // Now create the result ...
+        return new BigDecimal(negate ? significand.negate() : significand, scale);
+    }
+
+    /**
+     * Compute the "negated" string, which replaces the digits (0 becomes 9, 1 becomes 8, ... and 9 becomes 0).
+     * 
+     * @param value the input string; may not be null
+     * @return the negated string; never null
+     * @see #negate(StringBuilder)
+     */
+    protected static String negate( String value ) {
+        return negate(new StringBuilder(value)).toString();
+    }
+
+    /**
+     * Compute the "negated" string, which replaces the digits (0 becomes 9, 1 becomes 8, ... and 9 becomes 0).
+     * 
+     * @param value the input string; may not be null
+     * @return the negated string; never null
+     * @see #negate(String)
+     */
+    protected static StringBuilder negate( StringBuilder value ) {
+        for (int i = 0, len = value.length(); i != len; ++i) {
+            char c = value.charAt(i);
+            if (c == ' ' || c == '-') continue;
+            value.setCharAt(i, (char)('9' - c + '0'));
+        }
+        return value;
+    }
+
+    /**
+     * Utility to remove the trailing 0's.
+     * 
+     * @param sb the input string builder; may not be null
+     */
+    protected static void removeTralingZeros( StringBuilder sb ) {
+        int endIndex = sb.length();
+        if (endIndex > 0) {
+            --endIndex;
+            int index = endIndex;
+            while (sb.charAt(index) == '0') {
+                --index;
+            }
+            if (index < endIndex) sb.delete(index + 1, endIndex + 1);
+        }
+    }
+
+    /* Prevent instantiation */
+    private FieldUtil() {
+    }
+}

--- a/index-providers/modeshape-lucene-index-provider/src/main/java/org/modeshape/jcr/index/lucene/LuceneConfig.java
+++ b/index-providers/modeshape-lucene-index-provider/src/main/java/org/modeshape/jcr/index/lucene/LuceneConfig.java
@@ -1,0 +1,199 @@
+/*
+ * ModeShape (http://www.modeshape.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.modeshape.jcr.index.lucene;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
+import org.apache.lucene.analysis.Analyzer;
+import org.apache.lucene.analysis.standard.StandardAnalyzer;
+import org.apache.lucene.codecs.Codec;
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.index.IndexWriterConfig;
+import org.apache.lucene.search.SearcherManager;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.store.FSDirectory;
+import org.apache.lucene.store.LockFactory;
+import org.apache.lucene.store.MMapDirectory;
+import org.apache.lucene.store.NIOFSDirectory;
+import org.apache.lucene.store.NativeFSLockFactory;
+import org.apache.lucene.store.NoLockFactory;
+import org.apache.lucene.store.RAMDirectory;
+import org.apache.lucene.store.SimpleFSDirectory;
+import org.apache.lucene.store.SimpleFSLockFactory;
+import org.modeshape.common.util.CheckArg;
+import org.modeshape.common.util.Reflection;
+import org.modeshape.common.util.StringUtil;
+import org.modeshape.jcr.Environment;
+
+/**
+ * Holder of various Lucene configuration options.
+ * 
+ * @author Horia Chiorean (hchiorea@redhat.com)
+ * @since  4.5
+ */
+public final class LuceneConfig {
+
+    protected static final String LAST_SUCCESSFUL_COMMIT_TIME = "last_commit_time";
+
+    private final LockFactory lockFactory;
+    private final String directoryClass;
+    private final Analyzer analyzer;
+    private final Codec codec;
+    private final String basePath;   
+    private final AtomicLong lastSuccessfulCommitTime;
+    
+    protected static LuceneConfig inMemory() {
+        return new LuceneConfig(null, null, null, null, null, null);
+    }
+
+    protected static LuceneConfig onDisk(String baseDir) {
+        return new LuceneConfig(baseDir, null, null, null, null, null);
+    }
+    
+    protected LuceneConfig(String baseDir, String lockFactoryClass, String directoryClass, String analyzerClass,
+                           String codecName, Environment environment) {
+        this.directoryClass = directoryClass;
+        this.lockFactory = lockFactory(lockFactoryClass);
+        this.analyzer = analyzer(analyzerClass, environment);
+        this.codec = codec(codecName);
+        this.basePath = baseDir;
+        this.lastSuccessfulCommitTime = new AtomicLong(-1);
+    }
+    
+    protected IndexWriter newWriter( String indexName ) {
+        CheckArg.isNotNull(indexName, "indexName");
+        try {
+            Directory directory = directory(directoryClass, indexName);
+            IndexWriter indexWriter = new IndexWriter(directory, newIndexWriterConfig());
+            if (!DirectoryReader.indexExists(directory)) {
+                indexWriter.commit();
+            } else {
+                readLatestCommitTime(indexWriter);
+            }
+            return indexWriter;
+        } catch (IOException e) {
+            throw new LuceneIndexException("Cannot create index writer", e);
+        }
+    }
+   
+    private IndexWriterConfig newIndexWriterConfig() {
+        IndexWriterConfig writerConfig = new IndexWriterConfig(analyzer);
+        writerConfig.setCommitOnClose(true);
+        writerConfig.setCodec(codec);
+        return writerConfig;
+    }
+    
+    protected SearcherManager searchManager( IndexWriter writer ) {
+        try {
+            return new SearcherManager(writer, true, null);
+        } catch (IOException e) {
+            throw new LuceneIndexException("Cannot create index writer", e);
+        }
+    }
+    
+    protected long lastSuccessfulCommitTime() {
+        return lastSuccessfulCommitTime.get();
+    }
+    
+    protected int refreshTimeSeconds() {
+        return 30;
+    }
+
+    /**
+     * Returns the analyzer configured for Lucene.
+     * 
+     * @return a {@link Analyzer} instance; never null
+     */
+    public Analyzer getAnalyzer() {
+        return analyzer;
+    }
+    
+    private void readLatestCommitTime( IndexWriter writer ) {
+        Map<String, String> commitData = writer.getCommitData();
+        String timestampString = commitData.get(LAST_SUCCESSFUL_COMMIT_TIME);
+        if (timestampString == null) {
+            return;
+        }
+        long timestamp = Long.valueOf(timestampString);
+        long currentTs = lastSuccessfulCommitTime.get();
+        if (timestamp > currentTs) {
+            lastSuccessfulCommitTime.compareAndSet(currentTs, timestamp);
+        }
+    }
+
+    private Codec codec(String name) {
+        return StringUtil.isBlank(name) ? Codec.getDefault() : Codec.forName(name);
+    }
+
+    private LockFactory lockFactory(String lockFactoryClass) {
+        if (StringUtil.isBlank(lockFactoryClass)) {
+            return null; 
+        }
+        switch (lockFactoryClass) {
+            case "org.apache.lucene.store.NativeFSLockFactory" : {
+                return NativeFSLockFactory.INSTANCE;
+            }
+            case "org.apache.lucene.store.NoLockFactory" : {
+                return NoLockFactory.INSTANCE;                
+            }
+            case "org.apache.lucene.store.SimpleFSLockFactory" : {
+                return SimpleFSLockFactory.INSTANCE;
+            }
+            default:
+                throw new IllegalArgumentException("Unknown lock factory implementation: " + lockFactoryClass);
+        }
+    }
+
+    private Analyzer analyzer(String analyzerClass, Environment environment) {
+        if (StringUtil.isBlank(analyzerClass)) {
+            return new StandardAnalyzer();    
+        } else {
+            return Reflection.getInstance(analyzerClass, environment.getClassLoader(getClass().getClassLoader()));
+        }
+    }
+
+    private Directory directory(String directoryClass, String indexName) throws IOException {
+        boolean useLockFactory = lockFactory != null;
+        if (StringUtil.isBlank(basePath)) {
+            return useLockFactory ?  new RAMDirectory(lockFactory) : new RAMDirectory();
+        }
+        Path path = Paths.get(basePath, indexName);
+        if (StringUtil.isBlank(directoryClass)) {             
+            return useLockFactory ? FSDirectory.open(path, lockFactory) : FSDirectory.open(path); 
+        }
+        switch (directoryClass) {
+            case "org.apache.lucene.store.RAMDirectory" : {
+                return useLockFactory ? new RAMDirectory(lockFactory) : new RAMDirectory();
+            }
+            case "org.apache.lucene.store.MMapDirectory" : {
+                return useLockFactory ? new MMapDirectory(path, lockFactory) : new MMapDirectory(path);
+            }
+            case "org.apache.lucene.store.NIOFSDirectory" : {
+                return useLockFactory ? new NIOFSDirectory(path, lockFactory) : new NIOFSDirectory(path);
+            }
+            case "org.apache.lucene.store.SimpleFSDirectory" : {
+                return useLockFactory ? new SimpleFSDirectory(path, lockFactory) : new SimpleFSDirectory(path);
+            }
+            default: {
+                throw new IllegalArgumentException("Unknown Lucene directory: " + directoryClass);
+            }
+        }
+    }
+}

--- a/index-providers/modeshape-lucene-index-provider/src/main/java/org/modeshape/jcr/index/lucene/LuceneConfig.java
+++ b/index-providers/modeshape-lucene-index-provider/src/main/java/org/modeshape/jcr/index/lucene/LuceneConfig.java
@@ -37,6 +37,8 @@ import org.apache.lucene.store.NoLockFactory;
 import org.apache.lucene.store.RAMDirectory;
 import org.apache.lucene.store.SimpleFSDirectory;
 import org.apache.lucene.store.SimpleFSLockFactory;
+import org.modeshape.common.annotation.Immutable;
+import org.modeshape.common.annotation.ThreadSafe;
 import org.modeshape.common.util.CheckArg;
 import org.modeshape.common.util.Reflection;
 import org.modeshape.common.util.StringUtil;
@@ -48,6 +50,8 @@ import org.modeshape.jcr.Environment;
  * @author Horia Chiorean (hchiorea@redhat.com)
  * @since  4.5
  */
+@Immutable
+@ThreadSafe
 public final class LuceneConfig {
 
     protected static final String LAST_SUCCESSFUL_COMMIT_TIME = "last_commit_time";
@@ -77,10 +81,11 @@ public final class LuceneConfig {
         this.lastSuccessfulCommitTime = new AtomicLong(-1);
     }
     
-    protected IndexWriter newWriter( String indexName ) {
+    protected IndexWriter newWriter( String workspaceName, String indexName ) {
         CheckArg.isNotNull(indexName, "indexName");
+        CheckArg.isNotNull(workspaceName, "workspaceName");
         try {
-            Directory directory = directory(directoryClass, indexName);
+            Directory directory = directory(directoryClass, workspaceName, indexName);
             IndexWriter indexWriter = new IndexWriter(directory, newIndexWriterConfig());
             if (!DirectoryReader.indexExists(directory)) {
                 indexWriter.commit();
@@ -169,12 +174,12 @@ public final class LuceneConfig {
         }
     }
 
-    private Directory directory(String directoryClass, String indexName) throws IOException {
+    private Directory directory( String directoryClass, String workspaceName, String indexName ) throws IOException {
         boolean useLockFactory = lockFactory != null;
         if (StringUtil.isBlank(basePath)) {
             return useLockFactory ?  new RAMDirectory(lockFactory) : new RAMDirectory();
         }
-        Path path = Paths.get(basePath, indexName);
+        Path path = Paths.get(basePath, workspaceName, indexName);
         if (StringUtil.isBlank(directoryClass)) {             
             return useLockFactory ? FSDirectory.open(path, lockFactory) : FSDirectory.open(path); 
         }

--- a/index-providers/modeshape-lucene-index-provider/src/main/java/org/modeshape/jcr/index/lucene/LuceneIndex.java
+++ b/index-providers/modeshape-lucene-index-provider/src/main/java/org/modeshape/jcr/index/lucene/LuceneIndex.java
@@ -1,0 +1,298 @@
+/*
+ * ModeShape (http://www.modeshape.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.modeshape.jcr.index.lucene;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import javax.jcr.Binary;
+import javax.jcr.RepositoryException;
+import javax.jcr.query.qom.Constraint;
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.DoubleField;
+import org.apache.lucene.document.Field;
+import org.apache.lucene.document.IntField;
+import org.apache.lucene.document.LongField;
+import org.apache.lucene.document.StringField;
+import org.apache.lucene.index.IndexWriter;
+import org.modeshape.common.annotation.Immutable;
+import org.modeshape.common.annotation.ThreadSafe;
+import org.modeshape.common.logging.Logger;
+import org.modeshape.common.util.CheckArg;
+import org.modeshape.jcr.ExecutionContext;
+import org.modeshape.jcr.api.value.DateTime;
+import org.modeshape.jcr.index.lucene.query.LuceneQueryFactory;
+import org.modeshape.jcr.spi.index.IndexConstraints;
+import org.modeshape.jcr.spi.index.provider.ProvidedIndex;
+import org.modeshape.jcr.value.PropertyType;
+import org.modeshape.jcr.value.StringFactory;
+
+/**
+ * Bases class for indexes stored in Lucene
+ * 
+ * @author Horia Chiorean (hchiorea@redhat.com)
+ * @since 4.5
+ */
+@ThreadSafe
+@Immutable
+public abstract class LuceneIndex implements ProvidedIndex<Object> {
+
+    protected final Logger logger = Logger.getLogger(getClass());
+    protected final String name;
+    protected final ExecutionContext context;
+    protected final IndexWriter writer;
+    protected final Map<String, PropertyType> propertyTypesByName;
+    protected final LuceneConfig config;
+    protected final StringFactory stringFactory;
+    protected final Searcher searcher;
+   
+    protected LuceneIndex( String name, 
+                           LuceneConfig config, 
+                           Map<String, PropertyType> propertyTypesByName, 
+                           ExecutionContext context ) {
+        assert !propertyTypesByName.isEmpty();
+        this.propertyTypesByName = propertyTypesByName;                
+        this.name = name;
+        this.context = context;
+        this.stringFactory = context.getValueFactories().getStringFactory();
+        this.config = config;
+        this.writer = config.newWriter(name);
+        this.searcher = new Searcher(config, writer, name);
+    }
+
+    @Override
+    public void add( String nodeKey, String propertyName, Object value ) {
+        add(nodeKey, propertyName, new Object[]{value});      
+    }
+
+    @Override
+    public void remove( String nodeKey ) {
+        CheckArg.isNotNull(nodeKey, "nodeKey");
+        try {
+            // mark the nodekey as removed
+            writer.deleteDocuments(FieldUtil.idTerm(nodeKey));
+        } catch (IOException e) {
+            throw new LuceneIndexException(e);
+        }
+    }
+
+    @Override
+    public void remove( String nodeKey, String propertyName, Object value ) {
+        // we don't really care about the value...
+        remove(nodeKey, propertyName);
+    }
+
+    @Override
+    public void remove( String nodeKey, String propertyName, Object[] values ) {
+        // we don't really care about the values...
+        remove(nodeKey, propertyName);
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public long estimateCardinality( List<Constraint> andedConstraints, Map<String, Object> variables ) {
+        try {
+            return searcher.estimateCardinality(andedConstraints, queryFactory(variables));
+        } catch (IOException e) {
+            throw new LuceneIndexException(e);
+        }
+    }
+
+    @Override
+    public long estimateTotalCount() {
+        return writer.numDocs();
+    }
+
+    @Override
+    public Results filter( IndexConstraints constraints ) {
+        return searcher.filter(constraints.getConstraints(), queryFactory(constraints.getVariables()));
+    }
+
+    @Override
+    public boolean requiresReindexing() {
+        return writer.numDocs() <= 0;
+    }
+
+    public void commit() {
+        if (!writer.hasUncommittedChanges()) {
+            return;
+        }
+        try {
+            Map<String, String> oldData = writer.getCommitData();
+            Map<String, String> newData = new HashMap<>(oldData);
+            preCommit(newData);
+            writer.setCommitData(newData);
+            writer.commit();
+            postCommit();
+        } catch (IOException e) {
+            throw new LuceneIndexException("Cannot commit index writer", e);
+        }
+    }
+
+    protected void postCommit() {
+        //nothing by default     
+    }
+
+    protected void preCommit(Map<String, String> commitData) {
+        commitData.put(LuceneConfig.LAST_SUCCESSFUL_COMMIT_TIME, String.valueOf(System.currentTimeMillis()));
+    }
+
+    public void shutdown( boolean destroyed ) {
+        if (destroyed) {
+            clearAllData();
+        }
+        try {
+            searcher.close();
+            writer.close();
+        } catch (IOException e) {
+            throw new LuceneIndexException("Cannot shutdown lucene index", e);
+        }
+    }
+
+    public void clearAllData() {
+        try {
+            writer.deleteAll();
+            writer.commit();
+        } catch (IOException e) {
+            throw new LuceneIndexException("Cannot remove all documents from the index");
+        }
+    }
+    
+    protected void addProperty( String nodeKey, Document document, String property, Object... values ) {
+        if (values != null && values.length > 0) {
+            // add the new fields for the given values to the document
+            List<Field> fields = valuesToFields(property, values);
+            for (Field field : fields) {
+                document.add(field);
+            }
+        }
+        // always add the ID (which in the case of an update is removed first)
+        document.add(FieldUtil.idField(nodeKey));
+    }
+    
+    protected abstract void remove(final String nodeKey, final String propertyName);
+    
+    protected abstract LuceneQueryFactory queryFactory( Map<String, Object> variables );
+    
+    protected List<Field> valuesToFields( String propertyName, Object... values ) {
+        assert values.length > 0;
+        PropertyType type = propertyTypesByName.get(propertyName);
+        assert type != null;
+        List<Field> fields = new ArrayList<>(); 
+        for (Object value : values) {
+            switch (type) {
+                case NAME:
+                case PATH:    
+                case REFERENCE:
+                case SIMPLEREFERENCE:
+                case WEAKREFERENCE:
+                case URI:
+                case STRING: {
+                    addStringField(propertyName, stringFactory.create(value), fields);
+                    break;
+                }
+                case BOOLEAN: {
+                    addBooleanField(propertyName, (Boolean)value, fields);
+                    break;
+                }
+                case BINARY: {
+                    // don't cast to anything, because depending on the index type this may be a string or a binary 
+                    addBinaryField(propertyName, value, fields);
+                    break;
+                }
+                case DATE: {
+                    addDateField(propertyName, ((DateTime)value), fields);
+                    break;
+                }
+                case DECIMAL: {
+                    addDecimalField(propertyName,(BigDecimal) value, fields);
+                    break;
+                }
+                case DOUBLE: {
+                    addDoubleField(propertyName, (Double) value, fields);
+                    break;
+                }
+                case LONG: {
+                    addLongField(propertyName, (Long) value, fields);
+                    break;    
+                }
+                default:
+                    throw new LuceneIndexException("Unsupported property type: " + type);
+            }
+        }
+        return fields;
+    }
+    
+    protected void addStringField( String propertyName, String value, List<Field> fields ) {
+        fields.add(new StringField(propertyName, value, Field.Store.YES));
+        fields.add(new LongField(FieldUtil.lengthField(propertyName), value.length(), Field.Store.YES));
+    }
+
+    protected void addBooleanField( String propertyName, Boolean value, List<Field> fields ) {
+        String valueString = stringFactory.create(value);
+        int intValue = value ? 1 : 0;
+        fields.add(new IntField(propertyName, intValue, Field.Store.YES));
+        // add the length
+        fields.add(new LongField(FieldUtil.lengthField(propertyName), valueString.length(), Field.Store.YES));
+    } 
+    
+    protected void addDateField( String propertyName, DateTime value, List<Field> fields ) {
+        // dates are stored as millis
+        fields.add(new LongField(propertyName, value.getMilliseconds(), Field.Store.YES));
+        // add the length
+        String valueString = stringFactory.create(value);
+        fields.add(new LongField(FieldUtil.lengthField(propertyName), valueString.length(), Field.Store.YES));
+    }
+    
+    protected void addBinaryField( String propertyName, Object value, List<Field> fields ) {
+        // only the length is indexed for binary values by default....
+        try {
+            Binary binary = (Binary) value;
+            fields.add(new LongField(FieldUtil.lengthField(propertyName), binary.getSize(), Field.Store.YES));
+        } catch (RepositoryException e) {
+            throw new LuceneIndexException(e);
+        }
+    }
+
+    protected void addDecimalField( String propertyName, BigDecimal value, List<Field> fields ) {
+        // big decimals are stored as string, because Lucene doesn't support these natively...
+        String stringValue = FieldUtil.decimalToString(value);
+        fields.add(new StringField(propertyName, stringValue, Field.Store.YES));
+        // add the length using the JCR string format
+        fields.add(new LongField(FieldUtil.lengthField(propertyName), stringFactory.create(value).length(), Field.Store.YES));
+    }
+
+    protected void addDoubleField( String propertyName, Double value, List<Field> fields ) {
+        fields.add(new DoubleField(propertyName, value, Field.Store.YES));
+        // add the length
+        String valueString = stringFactory.create(value);
+        fields.add(new LongField(FieldUtil.lengthField(propertyName), valueString.length(), Field.Store.YES));
+    }
+    
+    protected void addLongField( String propertyName, Long value, List<Field> fields ) {
+        fields.add(new LongField(propertyName, value.longValue(), Field.Store.YES));
+        // add the length
+        String valueString = stringFactory.create(value);
+        fields.add(new LongField(FieldUtil.lengthField(propertyName), valueString.length(), Field.Store.YES));
+    }
+}

--- a/index-providers/modeshape-lucene-index-provider/src/main/java/org/modeshape/jcr/index/lucene/LuceneIndex.java
+++ b/index-providers/modeshape-lucene-index-provider/src/main/java/org/modeshape/jcr/index/lucene/LuceneIndex.java
@@ -62,9 +62,10 @@ public abstract class LuceneIndex implements ProvidedIndex<Object> {
     protected final StringFactory stringFactory;
     protected final Searcher searcher;
    
-    protected LuceneIndex( String name, 
-                           LuceneConfig config, 
-                           Map<String, PropertyType> propertyTypesByName, 
+    protected LuceneIndex( String name,
+                           String workspaceName, 
+                           LuceneConfig config,
+                           Map<String, PropertyType> propertyTypesByName,
                            ExecutionContext context ) {
         assert !propertyTypesByName.isEmpty();
         this.propertyTypesByName = propertyTypesByName;                
@@ -72,7 +73,7 @@ public abstract class LuceneIndex implements ProvidedIndex<Object> {
         this.context = context;
         this.stringFactory = context.getValueFactories().getStringFactory();
         this.config = config;
-        this.writer = config.newWriter(name);
+        this.writer = config.newWriter(workspaceName, name);
         this.searcher = new Searcher(config, writer, name);
     }
 
@@ -125,7 +126,7 @@ public abstract class LuceneIndex implements ProvidedIndex<Object> {
 
     @Override
     public Results filter( IndexConstraints constraints ) {
-        return searcher.filter(constraints.getConstraints(), queryFactory(constraints.getVariables()));
+        return searcher.filter(constraints, queryFactory(constraints.getVariables()));
     }
 
     @Override

--- a/index-providers/modeshape-lucene-index-provider/src/main/java/org/modeshape/jcr/index/lucene/LuceneIndexException.java
+++ b/index-providers/modeshape-lucene-index-provider/src/main/java/org/modeshape/jcr/index/lucene/LuceneIndexException.java
@@ -1,0 +1,65 @@
+/*
+ * ModeShape (http://www.modeshape.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.modeshape.jcr.index.lucene;
+
+
+/**
+ * Exception used when a problem occurs in a Lucene index.
+ * 
+ * @author Horia Chiorean (hchiorea@redhat.com)
+ * @since 4.5
+ */
+public class LuceneIndexException extends RuntimeException {
+
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * Constructs a new instance of this class with <code>null</code> as its detail message.
+     */
+    public LuceneIndexException() {
+    }
+
+    /**
+     * Constructs a new instance of this class with the specified detail message.
+     * 
+     * @param message the detail message. The detail message is saved for later retrieval by the {@link #getMessage()} method.
+     */
+    public LuceneIndexException( String message ) {
+        super(message);
+    }
+
+    /**
+     * Constructs a new instance of this class with the specified root cause.
+     * 
+     * @param rootCause root failure cause
+     */
+    public LuceneIndexException( Throwable rootCause ) {
+        super(rootCause);
+    }
+
+    /**
+     * Constructs a new instance of this class with the specified detail message and root cause.
+     * 
+     * @param message the detail message. The detail message is saved for later retrieval by the {@link #getMessage()} method.
+     * @param rootCause root failure cause
+     */
+    public LuceneIndexException( String message,
+                                 Throwable rootCause ) {
+        super(message, rootCause);
+    }
+
+}

--- a/index-providers/modeshape-lucene-index-provider/src/main/java/org/modeshape/jcr/index/lucene/LuceneIndexProvider.java
+++ b/index-providers/modeshape-lucene-index-provider/src/main/java/org/modeshape/jcr/index/lucene/LuceneIndexProvider.java
@@ -1,0 +1,148 @@
+/*
+ * ModeShape (http://www.modeshape.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.modeshape.jcr.index.lucene;
+
+import java.io.File;
+import java.nio.file.Paths;
+import javax.jcr.RepositoryException;
+import javax.jcr.query.qom.DynamicOperand;
+import org.modeshape.common.collection.Problems;
+import org.modeshape.jcr.ExecutionContext;
+import org.modeshape.jcr.NodeTypes;
+import org.modeshape.jcr.api.index.IndexDefinition;
+import org.modeshape.jcr.api.query.qom.ChildCount;
+import org.modeshape.jcr.cache.change.ChangeSetAdapter;
+import org.modeshape.jcr.query.QueryContext;
+import org.modeshape.jcr.query.model.FullTextSearch;
+import org.modeshape.jcr.spi.index.IndexCostCalculator;
+import org.modeshape.jcr.spi.index.provider.IndexProvider;
+import org.modeshape.jcr.spi.index.provider.IndexUsage;
+import org.modeshape.jcr.spi.index.provider.ManagedIndexBuilder;
+
+/**
+ * {@link org.modeshape.jcr.spi.index.provider.IndexProvider} implementation which uses the Apache Lucene library.
+ * 
+ * @author Horia Chiorean (hchiorea@redhat.com)
+ * @since 4.5
+ */
+public class LuceneIndexProvider extends IndexProvider {
+
+    /**
+     * The cost estimate for this index; this is the same as the local index atm 
+     */
+    private static final int COST_ESTIMATE = IndexCostCalculator.Costs.LOCAL;
+    
+    /**
+     * The directory in which the indexes are to be stored. This can to be set, or the {@link #path} and {@link #relativeTo}
+     * need to be set. If neither of those properties are present, the provider will store the indexes in RAM.
+     */
+    private String directory;
+    
+    /**
+     * The path in which the indexes are to be stored, relative to {@link #relativeTo}. These can be set, or the
+     * {@link #directory} can to be set.
+     */
+    private String path;
+    
+    /**
+     * The directory relative to which the {@link #path} specifies where the indexes are to be stored. These can be
+     * set, or {@link #directory} can be set.
+     */
+    private String relativeTo;
+
+    /**
+     * A number of properties which allow advanced lucene configuration. Each of them is optional and will default to Lucene
+     * defaults
+     */
+    private String lockFactoryClass;
+    private String directoryClass;
+    private String analyzerClass;
+    private String codecName;
+    
+    private LuceneConfig luceneConfig;
+    
+    @Override
+    protected void doInitialize() throws RepositoryException {
+        String baseDir = baseDir(); 
+        this.luceneConfig = new LuceneConfig(baseDir, lockFactoryClass, directoryClass, analyzerClass, codecName, environment());
+    }
+
+    private String baseDir() throws RepositoryException {
+        if (directory == null && relativeTo != null && path != null) {
+            // Try to set the directory using relativeTo and path ...
+            try {
+                File rel = new File(relativeTo);
+                File dir = Paths.get(rel.toURI()).resolve(path).toFile();
+                directory = dir.getAbsolutePath();
+            } catch (RuntimeException e) {
+                throw new RepositoryException(e);
+            }
+        }
+        if (directory == null) {
+            logger().debug("The lucene index provider '{0}' for repository '{1}' will be held in memory", getName(), getRepositoryName());
+            return null;
+        } else {
+            logger().debug("Initializing the lucene index provider '{0}' in repository '{1}' at: {2}", getName(), getRepositoryName(),
+                           directory);
+            return directory;
+        }
+    }
+
+    @Override
+    public void validateProposedIndex( ExecutionContext context, 
+                                       IndexDefinition defn, 
+                                       NodeTypes.Supplier nodeTypesSupplier,
+                                       Problems problems ) {
+        LuceneManagedIndexBuilder.validate(defn, problems);
+    }
+
+    @Override
+    protected int getCostEstimate() {
+        return COST_ESTIMATE;
+    }
+
+    @Override
+    public Long getLatestIndexUpdateTime() {
+        return luceneConfig.lastSuccessfulCommitTime();
+    }
+
+    @Override
+    protected ManagedIndexBuilder getIndexBuilder( IndexDefinition defn, String workspaceName,
+                                                   NodeTypes.Supplier nodeTypesSupplier,
+                                                   ChangeSetAdapter.NodeTypePredicate matcher ) {
+        return new LuceneManagedIndexBuilder(context(), defn, workspaceName, nodeTypesSupplier, matcher, luceneConfig);
+    }
+
+    @Override
+    protected IndexUsage evaluateUsage( QueryContext context, IndexCostCalculator calculator, final IndexDefinition defn ) {
+        return new IndexUsage(context, calculator, defn) {
+            @Override
+            protected boolean applies( ChildCount operand ) {
+                // nothing to do about this...
+                return false;
+            }
+            
+            @Override
+            protected boolean applies( DynamicOperand operand ) {
+                if (IndexDefinition.IndexKind.TEXT == defn.getKind() && !(operand instanceof FullTextSearch)) {
+                    // text indexes can ONLY apply to FTS operands...
+                    return false;
+                }
+                return super.applies(operand);
+            }
+        };
+    }
+}

--- a/index-providers/modeshape-lucene-index-provider/src/main/java/org/modeshape/jcr/index/lucene/LuceneIndexProviderI18n.java
+++ b/index-providers/modeshape-lucene-index-provider/src/main/java/org/modeshape/jcr/index/lucene/LuceneIndexProviderI18n.java
@@ -1,0 +1,45 @@
+/*
+ * ModeShape (http://www.modeshape.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.modeshape.jcr.index.lucene;
+
+import org.modeshape.common.i18n.I18n;
+
+/**
+ * I18n constants for the Lucene index provider.
+ * 
+ * @author Horia Chiorean (hchiorea@redhat.com)
+ * @since 4.5
+ */
+public final class LuceneIndexProviderI18n {
+    
+    public static I18n warnErrorWhileClosingSearcher;      
+    public static I18n multiColumnTextIndexesNotSupported;      
+    public static I18n invalidColumnType; 
+    public static I18n invalidOperatorForPropertyType;
+    public static I18n invalidOperatorForOperand;
+
+    private LuceneIndexProviderI18n() {
+    }
+
+    static {
+        try {
+            I18n.initialize(LuceneIndexProviderI18n.class);
+        } catch (final Exception err) {
+            // CHECKSTYLE IGNORE check FOR NEXT 1 LINES
+            System.err.println(err);
+        }
+    }
+}

--- a/index-providers/modeshape-lucene-index-provider/src/main/java/org/modeshape/jcr/index/lucene/LuceneManagedIndexBuilder.java
+++ b/index-providers/modeshape-lucene-index-provider/src/main/java/org/modeshape/jcr/index/lucene/LuceneManagedIndexBuilder.java
@@ -1,0 +1,164 @@
+/*
+ * ModeShape (http://www.modeshape.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.modeshape.jcr.index.lucene;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.modeshape.common.annotation.Immutable;
+import org.modeshape.common.collection.Problems;
+import org.modeshape.common.collection.SimpleProblems;
+import org.modeshape.jcr.ExecutionContext;
+import org.modeshape.jcr.NodeTypes;
+import org.modeshape.jcr.api.index.IndexColumnDefinition;
+import org.modeshape.jcr.api.index.IndexDefinition;
+import org.modeshape.jcr.cache.change.ChangeSetAdapter;
+import org.modeshape.jcr.spi.index.provider.ManagedIndexBuilder;
+import org.modeshape.jcr.spi.index.provider.ProvidedIndex;
+import org.modeshape.jcr.value.PropertyType;
+
+/**
+ * {@link ManagedIndexBuilder} extension which builds different types of Lucene indexes.
+ * 
+ * @author Horia Chiorean (hchiorea@redhat.com)
+ * @since 4.5
+ */
+@Immutable
+public class LuceneManagedIndexBuilder extends ManagedIndexBuilder {
+    
+    private final LuceneConfig luceneConfig;
+
+    protected LuceneManagedIndexBuilder( ExecutionContext context,
+                                         IndexDefinition defn,
+                                         String workspaceName,
+                                         NodeTypes.Supplier nodeTypesSupplier,
+                                         ChangeSetAdapter.NodeTypePredicate matcher,
+                                         LuceneConfig luceneConfig ) {
+        super(context, defn, workspaceName, nodeTypesSupplier, matcher);
+        assert luceneConfig != null;
+        this.luceneConfig = luceneConfig;
+    }
+    
+    private Map<String, PropertyType> propertyTypesByName(IndexDefinition defn) {
+        int size = defn.size();
+        Map<String, PropertyType> result = new HashMap<>(size);
+        for (int i = 0; i < size; i++) {
+            IndexColumnDefinition columnDef = defn.getColumnDefinition(i);
+            PropertyType propertyType = PropertyType.valueFor(columnDef.getColumnType());
+            String propertyName = columnDef.getPropertyName();
+            if (isPrimaryTypeIndex(columnDef, propertyType) || 
+                isMixinTypesIndex(columnDef, propertyType) ||
+                isNodeNameIndex(columnDef, propertyType)) {
+                // we know all these will be send by the adapters as names...
+                result.put(propertyName, PropertyType.NAME);
+            } else if (isNodeLocalNameIndex(columnDef, propertyType)) {
+                // we know this will be a string...
+                result.put(propertyName, PropertyType.STRING);
+            } else if (isNodeDepthIndex(columnDef, propertyType)) {
+                // we know this will be a long
+                result.put(propertyName, PropertyType.LONG);
+            } else if (isNodePathIndex(columnDef, propertyType)) {
+                // we know this will be a path
+                result.put(propertyName, PropertyType.PATH);
+            } else {
+                // just add as is
+                result.put(propertyName, propertyType);
+            }             
+        }    
+        return result;
+    }
+    
+    protected static void validate(IndexDefinition definition, Problems problems) {
+        IndexDefinition.IndexKind kind = definition.getKind();
+        boolean isTextIndex = kind == IndexDefinition.IndexKind.TEXT;
+        if (isTextIndex && definition.size() > 1){
+            problems.addError(LuceneIndexProviderI18n.multiColumnTextIndexesNotSupported, definition.getName());    
+        }
+        for (int i = 0; i < definition.size(); i++) {
+            IndexColumnDefinition columnDef = definition.getColumnDefinition(i);
+            PropertyType propertyType = PropertyType.valueFor(columnDef.getColumnType());
+            switch (propertyType) {
+                case OBJECT: {
+                    problems.addError(LuceneIndexProviderI18n.invalidColumnType, propertyType, columnDef.getPropertyName(),
+                                      definition.getName());
+                    continue;                    
+                }
+                case BINARY: {
+                    if (!isTextIndex) {
+                        problems.addError(LuceneIndexProviderI18n.invalidColumnType, propertyType, columnDef.getPropertyName(),
+                                          definition.getName());
+
+                    }
+                }
+            }
+        }
+    }
+
+    @Override
+    protected ProvidedIndex<?> buildMultiValueIndex( ExecutionContext context, 
+                                                     IndexDefinition defn, 
+                                                     String workspaceName,
+                                                     NodeTypes.Supplier nodeTypesSupplier,
+                                                     ChangeSetAdapter.NodeTypePredicate matcher ) {
+        validate(defn);
+        return defn.size() > 1 ? 
+               new MultiColumnIndex(defn.getName(), luceneConfig, propertyTypesByName(defn), context) :
+               new SingleColumnIndex(defn.getName(), luceneConfig, propertyTypesByName(defn), context);
+    }
+    
+    @Override
+    protected ProvidedIndex<?> buildUniqueValueIndex( ExecutionContext context, IndexDefinition defn, String workspaceName,
+                                                      NodeTypes.Supplier nodeTypesSupplier,
+                                                      ChangeSetAdapter.NodeTypePredicate matcher ) {
+        validate(defn);
+        return defn.size() > 1 ?
+               new MultiColumnIndex(defn.getName(), luceneConfig, propertyTypesByName(defn), context) :
+               new SingleColumnIndex(defn.getName(), luceneConfig, propertyTypesByName(defn), context);
+    }
+
+    @Override
+    protected ProvidedIndex<?> buildEnumeratedIndex( ExecutionContext context, IndexDefinition defn, String workspaceName,
+                                                     NodeTypes.Supplier nodeTypesSupplier,
+                                                     ChangeSetAdapter.NodeTypePredicate matcher ) {
+        validate(defn);
+        return defn.size() > 1 ?
+               new MultiColumnIndex(defn.getName(), luceneConfig, propertyTypesByName(defn), context) :
+               new SingleColumnIndex(defn.getName(), luceneConfig, propertyTypesByName(defn), context);
+    }
+
+    @Override
+    protected ProvidedIndex<?> buildTextIndex( ExecutionContext context, IndexDefinition defn, String workspaceName,
+                                               NodeTypes.Supplier nodeTypesSupplier,
+                                               ChangeSetAdapter.NodeTypePredicate matcher ) {
+        validate(defn);
+        return new TextIndex(defn.getName(), luceneConfig, propertyTypesByName(defn), context);
+    }
+
+    @Override
+    protected ProvidedIndex<?> buildNodeTypeIndex( ExecutionContext context, IndexDefinition defn, String workspaceName,
+                                                   NodeTypes.Supplier nodeTypesSupplier,
+                                                   ChangeSetAdapter.NodeTypePredicate matcher ) {
+        assert defn.size() == 1; //should've been validated by the super class
+        return new SingleColumnIndex(defn.getName(), luceneConfig, propertyTypesByName(defn), context);
+    }
+
+    private void validate( IndexDefinition defn ) {
+        SimpleProblems problems = new SimpleProblems();
+        validate(defn, problems);
+        if (problems.hasErrors()) {
+            throw new LuceneIndexException(problems.toString());
+        }
+    }
+}

--- a/index-providers/modeshape-lucene-index-provider/src/main/java/org/modeshape/jcr/index/lucene/LuceneManagedIndexBuilder.java
+++ b/index-providers/modeshape-lucene-index-provider/src/main/java/org/modeshape/jcr/index/lucene/LuceneManagedIndexBuilder.java
@@ -114,8 +114,8 @@ public class LuceneManagedIndexBuilder extends ManagedIndexBuilder {
                                                      ChangeSetAdapter.NodeTypePredicate matcher ) {
         validate(defn);
         return defn.size() > 1 ? 
-               new MultiColumnIndex(defn.getName(), luceneConfig, propertyTypesByName(defn), context) :
-               new SingleColumnIndex(defn.getName(), luceneConfig, propertyTypesByName(defn), context);
+               new MultiColumnIndex(defn.getName(), workspaceName, luceneConfig, propertyTypesByName(defn), context) :
+               new SingleColumnIndex(defn.getName(), workspaceName, luceneConfig, propertyTypesByName(defn), context);
     }
     
     @Override
@@ -124,8 +124,8 @@ public class LuceneManagedIndexBuilder extends ManagedIndexBuilder {
                                                       ChangeSetAdapter.NodeTypePredicate matcher ) {
         validate(defn);
         return defn.size() > 1 ?
-               new MultiColumnIndex(defn.getName(), luceneConfig, propertyTypesByName(defn), context) :
-               new SingleColumnIndex(defn.getName(), luceneConfig, propertyTypesByName(defn), context);
+               new MultiColumnIndex(defn.getName(), workspaceName, luceneConfig, propertyTypesByName(defn), context) :
+               new SingleColumnIndex(defn.getName(), workspaceName, luceneConfig, propertyTypesByName(defn), context);
     }
 
     @Override
@@ -134,8 +134,8 @@ public class LuceneManagedIndexBuilder extends ManagedIndexBuilder {
                                                      ChangeSetAdapter.NodeTypePredicate matcher ) {
         validate(defn);
         return defn.size() > 1 ?
-               new MultiColumnIndex(defn.getName(), luceneConfig, propertyTypesByName(defn), context) :
-               new SingleColumnIndex(defn.getName(), luceneConfig, propertyTypesByName(defn), context);
+               new MultiColumnIndex(defn.getName(), workspaceName, luceneConfig, propertyTypesByName(defn), context) :
+               new SingleColumnIndex(defn.getName(), workspaceName, luceneConfig, propertyTypesByName(defn), context);
     }
 
     @Override
@@ -143,7 +143,7 @@ public class LuceneManagedIndexBuilder extends ManagedIndexBuilder {
                                                NodeTypes.Supplier nodeTypesSupplier,
                                                ChangeSetAdapter.NodeTypePredicate matcher ) {
         validate(defn);
-        return new TextIndex(defn.getName(), luceneConfig, propertyTypesByName(defn), context);
+        return new TextIndex(defn.getName(), workspaceName, luceneConfig, propertyTypesByName(defn), context);
     }
 
     @Override
@@ -151,7 +151,7 @@ public class LuceneManagedIndexBuilder extends ManagedIndexBuilder {
                                                    NodeTypes.Supplier nodeTypesSupplier,
                                                    ChangeSetAdapter.NodeTypePredicate matcher ) {
         assert defn.size() == 1; //should've been validated by the super class
-        return new SingleColumnIndex(defn.getName(), luceneConfig, propertyTypesByName(defn), context);
+        return new SingleColumnIndex(defn.getName(), workspaceName, luceneConfig, propertyTypesByName(defn), context);
     }
 
     private void validate( IndexDefinition defn ) {

--- a/index-providers/modeshape-lucene-index-provider/src/main/java/org/modeshape/jcr/index/lucene/MultiColumnIndex.java
+++ b/index-providers/modeshape-lucene-index-provider/src/main/java/org/modeshape/jcr/index/lucene/MultiColumnIndex.java
@@ -36,6 +36,7 @@ import org.modeshape.jcr.value.PropertyType;
  * Whenever possible, prefer the {@link SingleColumnIndex} implementation to this one. 
  * </p>
  * @author Horia Chiorean (hchiorea@redhat.com)
+ * @since 4.5
  */
 @ThreadSafe
 @Immutable
@@ -44,10 +45,11 @@ class MultiColumnIndex extends LuceneIndex {
     private final DocumentIdCache cache;
     
     protected MultiColumnIndex( String name,
+                                String workspaceName, 
                                 LuceneConfig config,
                                 Map<String, PropertyType> propertyTypesByName,
                                 ExecutionContext context ) {
-        super(name, config, propertyTypesByName, context);
+        super(name, workspaceName, config, propertyTypesByName, context);
         // we keep track of the node keys which are added/removed in the commit data
         // this is an optimization to avoid searching for a document each time an update or partial remove is performed
         this.cache = new DocumentIdCache();
@@ -130,7 +132,9 @@ class MultiColumnIndex extends LuceneIndex {
     @Override
     public void remove( String nodeKey ) {
         super.remove(nodeKey);
-        cache.remove(nodeKey);
+        if (documentExists(nodeKey)) {
+            cache.remove(nodeKey);
+        }
     }
 
     private boolean documentExists( String nodeKey ) {

--- a/index-providers/modeshape-lucene-index-provider/src/main/java/org/modeshape/jcr/index/lucene/MultiColumnIndex.java
+++ b/index-providers/modeshape-lucene-index-provider/src/main/java/org/modeshape/jcr/index/lucene/MultiColumnIndex.java
@@ -1,0 +1,201 @@
+/*
+ * ModeShape (http://www.modeshape.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.modeshape.jcr.index.lucene;
+
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Set;
+import org.apache.lucene.document.Document;
+import org.apache.lucene.index.IndexableField;
+import org.modeshape.common.annotation.Immutable;
+import org.modeshape.common.annotation.ThreadSafe;
+import org.modeshape.common.util.CheckArg;
+import org.modeshape.jcr.ExecutionContext;
+import org.modeshape.jcr.index.lucene.query.LuceneQueryFactory;
+import org.modeshape.jcr.value.PropertyType;
+
+/**
+ * Lucene index which supports multiple heterogeneous columns for any given document. This is more complicated and performs 
+ * worse in some cases than {@link SingleColumnIndex} because Lucene doesn't support updates, so this index has to deal with merging fields.
+ * <p>
+ * Whenever possible, prefer the {@link SingleColumnIndex} implementation to this one. 
+ * </p>
+ * @author Horia Chiorean (hchiorea@redhat.com)
+ */
+@ThreadSafe
+@Immutable
+class MultiColumnIndex extends LuceneIndex {
+
+    private final DocumentIdCache cache;
+    
+    protected MultiColumnIndex( String name,
+                                LuceneConfig config,
+                                Map<String, PropertyType> propertyTypesByName,
+                                ExecutionContext context ) {
+        super(name, config, propertyTypesByName, context);
+        // we keep track of the node keys which are added/removed in the commit data
+        // this is an optimization to avoid searching for a document each time an update or partial remove is performed
+        this.cache = new DocumentIdCache();
+    }
+
+    @Override
+    public void add( final String nodeKey, final String propertyName, final Object[] values ) {
+        CheckArg.isNotNull(nodeKey, "nodeKey");
+        CheckArg.isNotNull(propertyName, "propertyName");
+        CheckArg.isNotNull(values, "values");
+       
+        try {
+            // first look at the cache and commit data to check if a document exists or not with this key. If a document does not
+            // exist, this operation will be a lot faster. Otherwise the document needs to be loaded which is costly....
+            // THIS IS A COSTLY OPERATION...
+            if (documentExists(nodeKey)) {
+                // we're updating an existing document
+                logger.debug("Updating the property '{0}' of document '{1}' in the Lucene index '{2}' with the values '{3}'", values,
+                             propertyName, nodeKey, name, values);
+
+                Document document = searcher.loadDocumentById(nodeKey);
+                // remove the old values for the property from the document
+                removeProperty(propertyName, document);
+                // add the new values 
+                addProperty(nodeKey, document, propertyName, values);
+                writer.updateDocument(FieldUtil.idTerm(nodeKey), document);
+            } else {
+                // we're creating the document for the first time...
+                logger.debug("Adding the document '{0}' in the Lucene Index '{1}' with the property '{2}' and values '{3}",
+                             nodeKey, name, propertyName, values);                 
+                Document document = new Document();
+                addProperty(nodeKey, document, propertyName, values);
+                writer.addDocument(document);
+                // mark the node key as added
+                cache.add(nodeKey);
+            }
+        } catch (IOException e) {
+            throw new LuceneIndexException(e);
+        }
+    }
+   
+    @Override
+    protected void preCommit( Map<String, String> commitData ) {
+        super.preCommit(commitData);
+        cache.updateCommmitData(commitData);
+    }
+
+    @Override
+    protected void remove(final String nodeKey, final String propertyName) {
+        CheckArg.isNotNull(nodeKey, "nodeKey");
+        CheckArg.isNotNull(propertyName, "propertyName");
+       
+        if (!documentExists(nodeKey)) {
+            // no document found so nothing to do
+            return;
+        }
+        try {
+            Document document = searcher.loadDocumentById(nodeKey);
+            removeProperty(propertyName, document);
+            if (document.getFields().isEmpty()) {
+                // there are no more fields, so remove the entire document....
+                writer.deleteDocuments(FieldUtil.idTerm(nodeKey));
+                // mark the node key as removed
+                cache.remove(nodeKey);
+            } else {
+                // update the document after adding back the ID (which was removed during removeProperty)
+                document.add(FieldUtil.idField(nodeKey));
+                writer.updateDocument(FieldUtil.idTerm(nodeKey), document);
+            }
+        } catch (IOException e) {
+            throw new LuceneIndexException(e);
+        }
+    }
+
+    @Override
+    protected LuceneQueryFactory queryFactory( Map<String, Object> variables ) {
+        return LuceneQueryFactory.forMultiColumnIndex(context.getValueFactories(), variables, propertyTypesByName);
+    }
+
+    @Override
+    public void remove( String nodeKey ) {
+        super.remove(nodeKey);
+        cache.remove(nodeKey);
+    }
+
+    private boolean documentExists( String nodeKey ) {
+        return cache.hasNode(nodeKey) || writer.getCommitData().containsKey(nodeKey);
+    }
+    
+    private void removeProperty( String propertyName, Document document ) {
+        Iterator<IndexableField> fieldIterator = document.iterator();
+        while (fieldIterator.hasNext()) {
+            IndexableField field = fieldIterator.next();
+            String name = field.name();
+            if (name.equals(propertyName)) {
+                // there can be multiple properties with the same name (multivalued) so we need to call remove for each one
+                fieldIterator.remove();
+            } else if (FieldUtil.ID.equals(name)) {
+                // for some inexplicable reason (Lucene bug ??) this has to be removed and readded with each update 
+                fieldIterator.remove();
+            }
+        }
+    }
+
+    /**
+     * A simple holder which tracks for each index writer session the document keys which exist in the index
+     * and then writes this information in the commit data. This avoids the document searching required when updating the column
+     * of an existing document.
+     */
+    private class DocumentIdCache {
+        private final Set<String> removed;
+        private final Set<String> added;
+
+        private DocumentIdCache() {
+            this.removed = new HashSet<>();
+            this.added = new HashSet<>();
+        }
+
+        protected synchronized boolean hasNode(String nodeKey) {
+            return added.contains(nodeKey) || removed.contains(nodeKey);
+        }
+
+        protected synchronized void add(String nodeKey) {
+            this.removed.remove(nodeKey);
+            this.added.add(nodeKey);
+        }
+
+        protected synchronized void remove(String nodeKey) {
+            this.added.remove(nodeKey);
+            this.removed.add(nodeKey);
+        }
+
+        protected synchronized void clear() {
+            this.added.clear();
+            this.removed.clear();
+        }
+
+        protected synchronized void updateCommmitData(Map<String, String> commitData) {
+            if (!removed.isEmpty()) {
+                for (String key : removed) {
+                    commitData.remove(key);
+                }
+            }
+            if (!added.isEmpty()) {
+                for (String key : added) {
+                    commitData.put(key, "");
+                }
+            }
+        }
+    }
+}

--- a/index-providers/modeshape-lucene-index-provider/src/main/java/org/modeshape/jcr/index/lucene/Searcher.java
+++ b/index-providers/modeshape-lucene-index-provider/src/main/java/org/modeshape/jcr/index/lucene/Searcher.java
@@ -1,0 +1,337 @@
+/*
+ * ModeShape (http://www.modeshape.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.modeshape.jcr.index.lucene;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import javax.jcr.query.qom.Constraint;
+import org.apache.lucene.document.Document;
+import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.index.LeafReader;
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.search.BooleanClause;
+import org.apache.lucene.search.BooleanQuery;
+import org.apache.lucene.search.CachingWrapperQuery;
+import org.apache.lucene.search.CollectionTerminatedException;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.LRUQueryCache;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.QueryCache;
+import org.apache.lucene.search.QueryCachingPolicy;
+import org.apache.lucene.search.Scorer;
+import org.apache.lucene.search.SearcherManager;
+import org.apache.lucene.search.SimpleCollector;
+import org.apache.lucene.search.TotalHitCountCollector;
+import org.modeshape.common.annotation.Immutable;
+import org.modeshape.common.annotation.ThreadSafe;
+import org.modeshape.common.logging.Logger;
+import org.modeshape.common.util.NamedThreadFactory;
+import org.modeshape.jcr.cache.NodeKey;
+import org.modeshape.jcr.index.lucene.query.LuceneQueryFactory;
+import org.modeshape.jcr.spi.index.ResultWriter;
+import org.modeshape.jcr.spi.index.provider.Filter;
+
+/**
+ * Class which handles the actual Lucene searching for the {@link LuceneIndexProvider}
+ * 
+ * @author Horia Chiorean (hchiorea@redhat.com)
+ * @since 4.5
+ */
+@Immutable
+@ThreadSafe
+public class Searcher {
+    
+    private static final Logger LOGGER = Logger.getLogger(Searcher.class);
+    
+    private final SearcherManager searchManager;
+    private final ScheduledExecutorService searchManagerRefreshService;
+    private final ScheduledFuture<?> searchManagerRefreshResult;
+    private final QueryCache queryCache;
+
+    protected Searcher( LuceneConfig config, IndexWriter writer, String name ) {
+        this.searchManager = config.searchManager(writer);
+        this.queryCache = new LRUQueryCache(200, 50);
+        this.searchManagerRefreshService = Executors.newScheduledThreadPool(1, new NamedThreadFactory(
+                name + "-lucene-search-manager-refresher"));
+        this.searchManagerRefreshResult = this.searchManagerRefreshService.scheduleWithFixedDelay(new SearchManagerRefresher(),
+                                                                                                  0,
+                                                                                                  config.refreshTimeSeconds(),
+                                                                                                  TimeUnit.SECONDS);
+    }
+    
+    protected void close() {
+        try {
+            searchManagerRefreshResult.cancel(true);
+            searchManagerRefreshService.shutdown();
+            searchManager.close();
+        } catch (IOException e) {
+            LOGGER.warn(e, LuceneIndexProviderI18n.warnErrorWhileClosingSearcher);
+        }
+    }
+    
+    protected Filter.Results filter( Collection<Constraint> andedConstraints, LuceneQueryFactory queryFactory) {
+        Query query = createQueryFromConstraints(andedConstraints, queryFactory);
+        return new LuceneResults(query, queryFactory.scoreDocuments());
+    }
+    
+    protected long estimateCardinality( final List<Constraint> andedConstraints, final LuceneQueryFactory queryFactory ) throws IOException {
+        assert !andedConstraints.isEmpty();
+        return search(new Searchable<Long>() {
+            @Override
+            public Long search( IndexSearcher searcher ) throws IOException {
+                Query query = createQueryFromConstraints(andedConstraints, queryFactory);
+                TotalHitCountCollector results = new TotalHitCountCollector();
+                searcher.search(query, results);
+                return (long)results.getTotalHits();
+            }
+        }, false, true);
+    }
+    
+    protected Document loadDocumentById(final String id) throws IOException {
+        // this is a potentially costly operation
+        return search(new Searchable<Document>() {
+            @Override
+            public Document search( IndexSearcher searcher ) throws IOException {
+                DocumentByIdCollector collector = new DocumentByIdCollector();
+                searcher.search(FieldUtil.idQuery(id), collector);
+                return collector.document();
+            }
+        }, false, true);
+    }
+
+    private Query createQueryFromConstraints( Collection<Constraint> andedConstraints, LuceneQueryFactory queryFactory ) {
+        if (andedConstraints.size() == 1) {
+            return queryFactory.createQuery(andedConstraints.iterator().next());
+        } else {
+            BooleanQuery.Builder builder = new BooleanQuery.Builder();
+            builder.setDisableCoord(true);
+            for (Constraint constraint : andedConstraints) {
+                builder.add(queryFactory.createQuery(constraint), BooleanClause.Occur.MUST);
+            }
+            return builder.build();
+        }
+    }
+
+    protected void refreshSearchManager(boolean async)  {
+        try {
+            if (!async) {
+                searchManager.maybeRefreshBlocking();
+            } else if (!searchManager.maybeRefresh()){
+                LOGGER.debug("Attempted to perform a search manager refresh, but another thread is already doing this.");
+            }
+        } catch (IOException e) {
+            LOGGER.warn(e, LuceneIndexProviderI18n.warnErrorWhileClosingSearcher);
+        }
+    }
+
+    protected <T> T search(Searchable<T> searchable, boolean useScoring, boolean refreshReader) {
+        if (refreshReader) {
+            refreshSearchManager(false);
+        }
+        IndexSearcher searcher = null;
+        try {
+            try {
+                searcher = searchManager.acquire();
+                if (!useScoring) {
+                    searcher.setQueryCache(queryCache);
+                }
+                return searchable.search(searcher);
+            } finally {
+                if (searcher != null) {
+                    searchManager.release(searcher);
+                }
+            }
+        } catch (IOException e) {
+            throw new LuceneIndexException(e);
+        }
+    }
+
+    private class LuceneResults implements Filter.Results {
+        
+        private final Query query;
+        private final boolean scoreDocuments;
+        
+        private int currentBatch;
+        private boolean runQuery;
+        private List<Float> scores;
+        private List<NodeKey> ids;
+        private int size;
+
+        protected LuceneResults( Query query, boolean scoreDocuments ) {
+            this.scoreDocuments = scoreDocuments;
+            this.query = scoreDocuments ? query : new CachingWrapperQuery(query, QueryCachingPolicy.ALWAYS_CACHE);
+            this.currentBatch = 0;
+            this.runQuery = true;
+            this.scores = new ArrayList<>();
+            this.ids = new ArrayList<>();
+        }
+
+        @Override
+        public boolean getNextBatch( final ResultWriter writer, final int batchSize ) {
+            if (runQuery) {
+                search(new Searchable<Void>() {
+                    @Override
+                    public Void search( IndexSearcher searcher ) throws IOException {
+                        IdsCollector collector = new IdsCollector(scoreDocuments);
+                        searcher.search(query, collector);
+                        for (Map.Entry<NodeKey, Float> entry : collector.getScoresById().entrySet()) {
+                            ids.add(entry.getKey());
+                            scores.add(entry.getValue());
+                        }
+                        size = ids.size();
+                        runQuery = false;
+                        return null;
+                    }
+                }, scoreDocuments, true);
+            }
+
+            int startPosition = currentBatch * batchSize;
+            int endPosition = Math.min(size, startPosition + batchSize);
+            for (int i = startPosition; i < endPosition; i++) {
+                writer.add(ids.get(i), scores.get(i));
+            }
+            ++currentBatch;
+            return endPosition < size;
+        }
+
+        @Override
+        public void close() {
+            scores.clear();
+            ids.clear();
+        }
+
+        @Override
+        public String toString() {
+            final StringBuilder sb = new StringBuilder(query.toString());
+            sb.append("=").append("[");
+            for (int i = 0; i < size; i++) {
+                sb.append("(").append(ids.get(i)).append(", ").append(scores.get(i)).append(")");
+                if (i < size - 1) {
+                    sb.append(", ");
+                }
+            }
+            sb.append(']');
+            return sb.toString();
+        }
+    }
+    
+    private static class IdsCollector extends SimpleCollector {
+        // the implicit score that will be used when no explicit scoring is requested
+        private static final float IMPLICIT_SCORE = 1.0f;
+        
+        // a set which contains the ID field which is the only field we want to load
+        private static final Set<String> ID_FIELD_SET = Collections.singleton(FieldUtil.ID);
+        
+        private final boolean useScore;
+        private final Map<NodeKey, Float> scoresById;
+
+        private LeafReader currentReader;
+        private Scorer scorer;
+
+        protected IdsCollector( boolean useScore ) {
+            this.useScore = useScore;
+            this.scoresById = new LinkedHashMap<>();
+        }
+
+        @Override
+        protected void doSetNextReader( LeafReaderContext context ) throws IOException {
+            currentReader = context.reader();
+        }
+
+        @Override
+        public void setScorer( Scorer scorer ) throws IOException {
+            if (useScore) {
+                this.scorer = scorer;
+            }
+        }
+
+        @Override
+        public void collect( int doc ) throws IOException {
+            // this is a valid document which we have to load...
+            Document document = currentReader.document(doc, ID_FIELD_SET);
+            if (document == null) {
+                return;
+            }
+            String id = document.getBinaryValue(FieldUtil.ID).utf8ToString();
+            Float score = useScore ? scorer.score() : IMPLICIT_SCORE;
+            scoresById.put(new NodeKey(id), score);
+        }
+        
+
+        @Override
+        public boolean needsScores() {
+            return useScore;
+        }
+
+        protected Map<NodeKey, Float> getScoresById() {
+            return scoresById;
+        }
+    }
+    
+    protected interface Searchable<T> {
+        T search(IndexSearcher searcher) throws IOException;
+    }
+    
+    protected class SearchManagerRefresher implements Runnable {
+        @Override
+        public void run() {
+            refreshSearchManager(true);
+        }
+    }
+
+    private static class DocumentByIdCollector extends SimpleCollector {
+
+        private LeafReader currentReader;
+        private Document document;
+
+        @Override
+        public void collect( int doc ) throws IOException {
+            if (document == null) {
+                document = currentReader.document(doc);
+            } else {
+                throw new CollectionTerminatedException();
+            }
+        }
+
+        @Override
+        protected void doSetNextReader( LeafReaderContext context ) throws IOException {
+            if (document != null) {
+                // we already found our do, so terminate
+                throw new CollectionTerminatedException();
+            }
+            currentReader = context.reader();
+        }
+
+        @Override
+        public boolean needsScores() {
+            return false;
+        }
+
+        protected Document document() {
+            return document;
+        }
+    }
+}

--- a/index-providers/modeshape-lucene-index-provider/src/main/java/org/modeshape/jcr/index/lucene/SingleColumnIndex.java
+++ b/index-providers/modeshape-lucene-index-provider/src/main/java/org/modeshape/jcr/index/lucene/SingleColumnIndex.java
@@ -36,10 +36,12 @@ import org.modeshape.jcr.value.PropertyType;
 @ThreadSafe
 class SingleColumnIndex extends LuceneIndex {
     
-    protected SingleColumnIndex( String name, LuceneConfig config,
+    protected SingleColumnIndex( String name, 
+                                 String workspaceName, 
+                                 LuceneConfig config,
                                  Map<String, PropertyType> propertyTypesByName,
                                  ExecutionContext context ) {
-        super(name, config, propertyTypesByName, context);
+        super(name, workspaceName, config, propertyTypesByName, context);
     }
 
     @Override

--- a/index-providers/modeshape-lucene-index-provider/src/main/java/org/modeshape/jcr/index/lucene/SingleColumnIndex.java
+++ b/index-providers/modeshape-lucene-index-provider/src/main/java/org/modeshape/jcr/index/lucene/SingleColumnIndex.java
@@ -1,0 +1,79 @@
+/*
+ * ModeShape (http://www.modeshape.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.modeshape.jcr.index.lucene;
+
+import java.io.IOException;
+import java.util.Map;
+import org.apache.lucene.document.Document;
+import org.modeshape.common.annotation.Immutable;
+import org.modeshape.common.annotation.ThreadSafe;
+import org.modeshape.common.util.CheckArg;
+import org.modeshape.jcr.ExecutionContext;
+import org.modeshape.jcr.index.lucene.query.LuceneQueryFactory;
+import org.modeshape.jcr.value.PropertyType;
+
+/**
+ * Lucene index which only supports a single column. This should perform better in most cases than {@link MultiColumnIndex}
+ * because there is no real document updating. Each document is removed and then added with new fields.
+ * 
+ * @author Horia Chiorean (hchiorea@redhat.com)
+ * @since 4.5
+ */
+@Immutable
+@ThreadSafe
+class SingleColumnIndex extends LuceneIndex {
+    
+    protected SingleColumnIndex( String name, LuceneConfig config,
+                                 Map<String, PropertyType> propertyTypesByName,
+                                 ExecutionContext context ) {
+        super(name, config, propertyTypesByName, context);
+    }
+
+    @Override
+    public void add( String nodeKey, String propertyName, Object[] values ) {
+        CheckArg.isNotNull(nodeKey, "nodeKey");
+        CheckArg.isNotNull(propertyName, "propertyName");
+        CheckArg.isNotNull(values, "values");
+
+        try {
+            Document document = new Document();
+            addProperty(nodeKey, document, propertyName, values);
+            // since multiple columns are not possible we'll just update the entire document
+            // which means removing the old one and creating a new one (which is what Lucene does anyway)
+            logger.debug("Adding the document '{0}' in the Lucene Index '{1}' with the property '{2}' and values '{3}",
+                         nodeKey, name, propertyName, values);
+            writer.updateDocument(FieldUtil.idTerm(nodeKey), document);
+        } catch (IOException e) {
+            throw new LuceneIndexException(e);
+        }
+    }
+
+    @Override
+    protected void remove( String nodeKey, String propertyName ) {
+        // simply remove the document with this key, since if this method was called, `propertyName` is already tracked by this index
+        // and there's can't be more than 1 column
+        try {
+            writer.deleteDocuments(FieldUtil.idTerm(nodeKey));
+        } catch (IOException e) {
+            throw new LuceneIndexException(e);
+        }
+    }
+
+    @Override
+    protected LuceneQueryFactory queryFactory( Map<String, Object> variables ) {
+        return LuceneQueryFactory.forSingleColumnIndex(context.getValueFactories(), variables, propertyTypesByName);
+    }
+}

--- a/index-providers/modeshape-lucene-index-provider/src/main/java/org/modeshape/jcr/index/lucene/TextIndex.java
+++ b/index-providers/modeshape-lucene-index-provider/src/main/java/org/modeshape/jcr/index/lucene/TextIndex.java
@@ -1,0 +1,92 @@
+/*
+ * ModeShape (http://www.modeshape.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.modeshape.jcr.index.lucene;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Map;
+import org.apache.lucene.document.Field;
+import org.apache.lucene.document.TextField;
+import org.modeshape.common.annotation.Immutable;
+import org.modeshape.common.annotation.ThreadSafe;
+import org.modeshape.jcr.ExecutionContext;
+import org.modeshape.jcr.api.value.DateTime;
+import org.modeshape.jcr.index.lucene.query.LuceneQueryFactory;
+import org.modeshape.jcr.value.PropertyType;
+
+/**
+ * Lucene index which stores strings or binary values that can then be used for FTS. 
+ * <p>
+ * This type of index is only used for full text searching and will not store any other information. This types of indexes 
+ * only work with certain property names, i.e. they cannot be used for storing the full text information of multiple (*) properties
+ * of a node.
+ * </p> 
+ *
+ * @author Horia Chiorean (hchiorea@redhat.com)
+ * @since 4.5
+ */
+@Immutable
+@ThreadSafe
+class TextIndex extends SingleColumnIndex {
+    
+    protected TextIndex( String name, LuceneConfig config,
+                         Map<String, PropertyType> propertyTypesByName,
+                         ExecutionContext context ) {
+        super(name, config, propertyTypesByName, context);
+    }
+
+    @Override
+    protected LuceneQueryFactory queryFactory( Map<String, Object> variables ) {
+        return LuceneQueryFactory.forTextIndex(context.getValueFactories(), variables, propertyTypesByName, config);
+    }
+
+    @Override
+    protected void addStringField( String propertyName, String value, List<Field> fields ) {
+        // never store the actual field
+        fields.add(new TextField(propertyName, value, Field.Store.NO));
+    }
+
+    @Override
+    protected void addBooleanField( String propertyName, Boolean value, List<Field> fields ) {
+        // not supported 
+    }
+
+    @Override
+    protected void addDateField( String propertyName, DateTime value, List<Field> fields ) {
+        // not supported
+    }
+
+    @Override
+    protected void addBinaryField( String propertyName, Object value, List<Field> fields ) {
+        String valueString = value instanceof String ? (String)value : stringFactory.create(value); 
+        fields.add(new TextField(propertyName, valueString, Field.Store.NO));
+    }
+
+    @Override
+    protected void addDecimalField( String propertyName, BigDecimal value, List<Field> fields ) {
+        // not supported
+    }
+
+    @Override
+    protected void addDoubleField( String propertyName, Double value, List<Field> fields ) {
+        // not supported
+    }
+
+    @Override
+    protected void addLongField( String propertyName, Long value, List<Field> fields ) {
+        // not supported
+    }
+}

--- a/index-providers/modeshape-lucene-index-provider/src/main/java/org/modeshape/jcr/index/lucene/TextIndex.java
+++ b/index-providers/modeshape-lucene-index-provider/src/main/java/org/modeshape/jcr/index/lucene/TextIndex.java
@@ -30,9 +30,7 @@ import org.modeshape.jcr.value.PropertyType;
 /**
  * Lucene index which stores strings or binary values that can then be used for FTS. 
  * <p>
- * This type of index is only used for full text searching and will not store any other information. This types of indexes 
- * only work with certain property names, i.e. they cannot be used for storing the full text information of multiple (*) properties
- * of a node.
+ * This type of index is only used for full text searching and will not store any other information.
  * </p> 
  *
  * @author Horia Chiorean (hchiorea@redhat.com)
@@ -42,10 +40,12 @@ import org.modeshape.jcr.value.PropertyType;
 @ThreadSafe
 class TextIndex extends SingleColumnIndex {
     
-    protected TextIndex( String name, LuceneConfig config,
+    protected TextIndex( String name, 
+                         String workspaceName, 
+                         LuceneConfig config,
                          Map<String, PropertyType> propertyTypesByName,
                          ExecutionContext context ) {
-        super(name, config, propertyTypesByName, context);
+        super(name, workspaceName, config, propertyTypesByName, context);
     }
 
     @Override

--- a/index-providers/modeshape-lucene-index-provider/src/main/java/org/modeshape/jcr/index/lucene/query/CaseOperations.java
+++ b/index-providers/modeshape-lucene-index-provider/src/main/java/org/modeshape/jcr/index/lucene/query/CaseOperations.java
@@ -1,0 +1,93 @@
+/*
+ * ModeShape (http://www.modeshape.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.modeshape.jcr.index.lucene.query;
+
+import org.modeshape.common.annotation.Immutable;
+
+/**
+ * A set of functions that can be used to operate upon the case of a string stored in the indexes before being evaluated against
+ * criteria from a query.
+ */
+@Immutable
+public class CaseOperations {
+
+    /**
+     * A function that can be used to operate upon the case of a string stored in the indexes before being evaluated against
+     * criteria from a query.
+     */
+    public static interface CaseOperation {
+
+        /**
+         * Perform the operation.
+         * 
+         * @param input the input string; never null
+         * @return the output string; never null
+         */
+        String execute( String input );
+    }
+
+    /**
+     * The CaseOperation instance that leaves as is the string used within the indexes before being evaluated.
+     */
+    public static final CaseOperation AS_IS = NoOperation.INSTANCE;
+
+    /**
+     * The CaseOperation instance that lowercases the string used within the indexes before being evaluated.
+     */
+    public static final CaseOperation LOWERCASE = LowercaseOperation.INSTANCE;
+
+    /**
+     * The CaseOperation instance that uppercases the string used within the indexes before being evaluated.
+     */
+    public static final CaseOperation UPPERCASE = UppercaseOperation.INSTANCE;
+
+    private final static class NoOperation implements CaseOperation {
+        protected static final CaseOperation INSTANCE = new NoOperation();
+
+        private NoOperation() {
+        }
+
+        @Override
+        public String execute( String input ) {
+            return input;
+        }
+    }
+
+    private final static class UppercaseOperation implements CaseOperation {
+        protected static final CaseOperation INSTANCE = new UppercaseOperation();
+
+        private UppercaseOperation() {
+        }
+
+        @Override
+        public String execute( String input ) {
+            return input.toUpperCase();
+        }
+    }
+
+    private final static class LowercaseOperation implements CaseOperation {
+        protected static final CaseOperation INSTANCE = new LowercaseOperation();
+
+        private LowercaseOperation() {
+        }
+
+        @Override
+        public String execute( String input ) {
+            return input.toLowerCase();
+        }
+    }
+
+}

--- a/index-providers/modeshape-lucene-index-provider/src/main/java/org/modeshape/jcr/index/lucene/query/CompareNameQuery.java
+++ b/index-providers/modeshape-lucene-index-provider/src/main/java/org/modeshape/jcr/index/lucene/query/CompareNameQuery.java
@@ -1,0 +1,215 @@
+/*
+ * ModeShape (http://www.modeshape.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.modeshape.jcr.index.lucene.query;
+
+import javax.jcr.query.qom.Comparison;
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.Weight;
+import org.modeshape.jcr.index.lucene.query.CaseOperations.CaseOperation;
+import org.modeshape.jcr.value.Name;
+import org.modeshape.jcr.value.ValueComparators;
+import org.modeshape.jcr.value.ValueFactories;
+import org.modeshape.jcr.value.ValueFactory;
+
+/**
+ * A Lucene {@link Query} implementation that is used to apply a {@link Comparison} constraint against the name of nodes. This
+ * query implementation works by using the weight and {@link Weight#scorer(LeafReaderContext)}  scorer} of the wrapped
+ * query to score (and return) only those documents that correspond to nodes with Names that satisfy the constraint.
+ */
+public class CompareNameQuery extends CompareQuery<Name> {
+
+    protected static final Evaluator<Name> EQUAL_TO = new Evaluator<Name>() {
+        @Override
+        public boolean satisfiesConstraint( Name nodeValue,
+                                            Name constraintValue ) {
+            return ValueComparators.NAME_COMPARATOR.compare(nodeValue, constraintValue) == 0;
+        }
+
+        @Override
+        public String toString() {
+            return " = ";
+        }
+    };
+    protected static final Evaluator<Name> IS_LESS_THAN = new Evaluator<Name>() {
+        @Override
+        public boolean satisfiesConstraint( Name nodeValue,
+                                            Name constraintValue ) {
+            return ValueComparators.NAME_COMPARATOR.compare(nodeValue, constraintValue) < 0;
+        }
+
+        @Override
+        public String toString() {
+            return " < ";
+        }
+    };
+    protected static final Evaluator<Name> IS_LESS_THAN_OR_EQUAL_TO = new Evaluator<Name>() {
+        @Override
+        public boolean satisfiesConstraint( Name nodeValue,
+                                            Name constraintValue ) {
+            return ValueComparators.NAME_COMPARATOR.compare(nodeValue, constraintValue) <= 0;
+        }
+
+        @Override
+        public String toString() {
+            return " <= ";
+        }
+    };
+    protected static final Evaluator<Name> IS_GREATER_THAN = new Evaluator<Name>() {
+        @Override
+        public boolean satisfiesConstraint( Name nodeValue,
+                                            Name constraintValue ) {
+            return ValueComparators.NAME_COMPARATOR.compare(nodeValue, constraintValue) > 0;
+        }
+
+        @Override
+        public String toString() {
+            return " > ";
+        }
+    };
+    protected static final Evaluator<Name> IS_GREATER_THAN_OR_EQUAL_TO = new Evaluator<Name>() {
+        @Override
+        public boolean satisfiesConstraint( Name nodeValue,
+                                            Name constraintValue ) {
+            return ValueComparators.NAME_COMPARATOR.compare(nodeValue, constraintValue) >= 0;
+        }
+
+        @Override
+        public String toString() {
+            return " >= ";
+        }
+    };
+    
+    /**
+     * Construct a {@link Query} implementation that scores documents such that the node represented by the document has a name
+     * that is greater than the supplied constraint name.
+     *
+     * @param constraintValue the constraint value; may not be null
+     * @param fieldName the name of the document field containing the name value; may not be null
+     * @param factories the value factories that can be used during the scoring; may not be null
+     * @param caseOperation the operation that should be performed on the indexed values before the constraint value is being
+     * evaluated; may not be null
+     * @return the query; never null
+     */
+    public static Query createQueryForNodesWithNameEqualTo( Name constraintValue,
+                                                            String fieldName,
+                                                            ValueFactories factories,
+                                                            CaseOperation caseOperation ) {
+        return new CompareNameQuery(fieldName, constraintValue, factories.getNameFactory(), factories.getStringFactory(),
+                                    EQUAL_TO, caseOperation);
+    }
+
+    /**
+     * Construct a {@link Query} implementation that scores documents such that the node represented by the document has a name
+     * that is greater than the supplied constraint name.
+     *
+     * @param constraintValue the constraint value; may not be null
+     * @param localNameField the name of the document field containing the local name value; may not be null
+     * @param factories the value factories that can be used during the scoring; may not be null
+     * @param caseOperation the operation that should be performed on the indexed values before the constraint value is being
+     * evaluated; may not be null
+     * @return the query; never null
+     */
+    public static CompareNameQuery createQueryForNodesWithNameGreaterThan( Name constraintValue,
+                                                                           String localNameField,
+                                                                           ValueFactories factories,
+                                                                           CaseOperation caseOperation ) {
+        return new CompareNameQuery(localNameField, constraintValue, factories.getNameFactory(),
+                                    factories.getStringFactory(), IS_GREATER_THAN, caseOperation);
+    }
+
+    /**
+     * Construct a {@link Query} implementation that scores documents such that the node represented by the document has a name
+     * that is greater than or equal to the supplied constraint name.
+     *
+     * @param constraintValue the constraint value; may not be null
+     * @param localNameField the name of the document field containing the local name value; may not be null
+     * @param factories the value factories that can be used during the scoring; may not be null
+     * @param caseOperation the operation that should be performed on the indexed values before the constraint value is being
+     * evaluated; may not be null
+     * @return the query; never null
+     */
+    public static CompareNameQuery createQueryForNodesWithNameGreaterThanOrEqualTo( Name constraintValue,
+                                                                                    String localNameField,
+                                                                                    ValueFactories factories,
+                                                                                    CaseOperation caseOperation ) {
+        return new CompareNameQuery(localNameField, constraintValue, factories.getNameFactory(),
+                                    factories.getStringFactory(), IS_GREATER_THAN_OR_EQUAL_TO, caseOperation);
+    }
+
+    /**
+     * Construct a {@link Query} implementation that scores documents such that the node represented by the document has a name
+     * that is less than the supplied constraint name.
+     *
+     * @param constraintValue the constraint value; may not be null
+     * @param localNameField the name of the document field containing the local name value; may not be null
+     * @param factories the value factories that can be used during the scoring; may not be null
+     * @param caseOperation the operation that should be performed on the indexed values before the constraint value is being
+     * evaluated; may not be null
+     * @return the query; never null
+     */
+    public static CompareNameQuery createQueryForNodesWithNameLessThan( Name constraintValue,
+                                                                        String localNameField,
+                                                                        ValueFactories factories,
+                                                                        CaseOperation caseOperation ) {
+        return new CompareNameQuery(localNameField, constraintValue, factories.getNameFactory(),
+                                    factories.getStringFactory(), IS_LESS_THAN, caseOperation);
+    }
+
+    /**
+     * Construct a {@link Query} implementation that scores documents such that the node represented by the document has a name
+     * that is less than or equal to the supplied constraint name.
+     *
+     * @param constraintValue the constraint value; may not be null
+     * @param localNameField the name of the document field containing the local name value; may not be null
+     * @param factories the value factories that can be used during the scoring; may not be null
+     * @param caseOperation the operation that should be performed on the indexed values before the constraint value is being
+     * evaluated; may not be null
+     * @return the query; never null
+     */
+    public static CompareNameQuery createQueryForNodesWithNameLessThanOrEqualTo( Name constraintValue,
+                                                                                 String localNameField,
+                                                                                 ValueFactories factories,
+                                                                                 CaseOperation caseOperation ) {
+        return new CompareNameQuery(localNameField, constraintValue, factories.getNameFactory(),
+                                    factories.getStringFactory(), IS_LESS_THAN_OR_EQUAL_TO, caseOperation);
+    }
+
+
+    /**
+     * Construct a {@link Query} implementation that scores nodes according to the supplied comparator.
+     *
+     * @param field the name of the document field containing the local name value; may not be null
+     * @param constraintValue the constraint path; may not be null
+     * @param nameFactory the value factory used during scoring; may not be null
+     * @param evaluator the {@link Evaluator} implementation that returns whether the node path satisfies the
+     * constraint; may not be null
+     * @param caseOperation the operation that should be performed on the indexed values before the constraint value is being
+     */
+    protected CompareNameQuery( final String field,
+                                Name constraintValue,
+                                ValueFactory<Name> nameFactory,
+                                ValueFactory<String> stringFactory,
+                                Evaluator<Name> evaluator,
+                                CaseOperation caseOperation ) {
+        super(field, constraintValue, nameFactory, stringFactory, evaluator, caseOperation);
+    }
+
+    @Override
+    public Query clone() {
+        return new CompareNameQuery(field(), constraintValue, valueTypeFactory, stringFactory, evaluator, caseOperation);
+    }
+}

--- a/index-providers/modeshape-lucene-index-provider/src/main/java/org/modeshape/jcr/index/lucene/query/ComparePathQuery.java
+++ b/index-providers/modeshape-lucene-index-provider/src/main/java/org/modeshape/jcr/index/lucene/query/ComparePathQuery.java
@@ -1,0 +1,189 @@
+/*
+ * ModeShape (http://www.modeshape.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.modeshape.jcr.index.lucene.query;
+
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.Weight;
+import org.modeshape.common.annotation.Immutable;
+import org.modeshape.jcr.index.lucene.query.CaseOperations.CaseOperation;
+import org.modeshape.jcr.value.Path;
+import org.modeshape.jcr.value.ValueComparators;
+import org.modeshape.jcr.value.ValueFactories;
+import org.modeshape.jcr.value.ValueFactory;
+
+/**
+ * A Lucene {@link Query} implementation that is used to apply a {@link javax.jcr.query.qom.Comparison} constraint against the
+ * Path of nodes. This query implementation works by using the weight and {@link Weight#scorer(LeafReaderContext)} 
+ * scorer} of the wrapped query to score (and return) only those documents that correspond to nodes with Paths that satisfy the
+ * constraint.
+ */
+@Immutable
+public class ComparePathQuery extends CompareQuery<Path> {
+
+    protected static final Evaluator<Path> PATH_IS_LESS_THAN = new Evaluator<Path>() {
+
+        @Override
+        public boolean satisfiesConstraint( Path nodePath,
+                                            Path constraintPath ) {
+            return ValueComparators.PATH_COMPARATOR.compare(nodePath, constraintPath) < 0;
+        }
+
+        @Override
+        public String toString() {
+            return " < ";
+        }
+    };
+    protected static final Evaluator<Path> PATH_IS_LESS_THAN_OR_EQUAL_TO = new Evaluator<Path>() {
+        @Override
+        public boolean satisfiesConstraint( Path nodePath,
+                                            Path constraintPath ) {
+            return ValueComparators.PATH_COMPARATOR.compare(nodePath, constraintPath) <= 0;
+        }
+
+        @Override
+        public String toString() {
+            return " <= ";
+        }
+    };
+    protected static final Evaluator<Path> PATH_IS_GREATER_THAN = new Evaluator<Path>() {
+        @Override
+        public boolean satisfiesConstraint( Path nodePath,
+                                            Path constraintPath ) {
+            return ValueComparators.PATH_COMPARATOR.compare(nodePath, constraintPath) > 0;
+        }
+
+        @Override
+        public String toString() {
+            return " > ";
+        }
+    };
+    protected static final Evaluator<Path> PATH_IS_GREATER_THAN_OR_EQUAL_TO = new Evaluator<Path>() {
+        @Override
+        public boolean satisfiesConstraint( Path nodePath,
+                                            Path constraintPath ) {
+            return ValueComparators.PATH_COMPARATOR.compare(nodePath, constraintPath) >= 0;
+        }
+
+        @Override
+        public String toString() {
+            return " >= ";
+        }
+    };
+
+    /**
+     * Construct a {@link Query} implementation that scores documents such that the node represented by the document has a path
+     * that is greater than the supplied constraint path.
+     * 
+     * @param constraintPath the constraint path; may not be null
+     * @param fieldName the name of the document field containing the path value; may not be null
+     * @param factories the value factories that can be used during the scoring; may not be null
+     * @param caseOperation the operation that should be performed on the indexed values before the constraint value is being
+     *        evaluated; may not be null
+     * @return the path query; never null
+     */
+    public static ComparePathQuery createQueryForNodesWithPathGreaterThan( Path constraintPath,
+                                                                           String fieldName,
+                                                                           ValueFactories factories,
+                                                                           CaseOperation caseOperation ) {
+        return new ComparePathQuery(fieldName, constraintPath, factories.getPathFactory(), factories.getStringFactory(),
+                                    PATH_IS_GREATER_THAN, caseOperation);
+    }
+
+    /**
+     * Construct a {@link Query} implementation that scores documents such that the node represented by the document has a path
+     * that is greater than or equal to the supplied constraint path.
+     * 
+     * @param constraintPath the constraint path; may not be null
+     * @param fieldName the name of the document field containing the path value; may not be null
+     * @param factories the value factories that can be used during the scoring; may not be null
+     * @param caseOperation the operation that should be performed on the indexed values before the constraint value is being
+     *        evaluated; may not be null
+     * @return the path query; never null
+     */
+    public static ComparePathQuery createQueryForNodesWithPathGreaterThanOrEqualTo( Path constraintPath,
+                                                                                    String fieldName,
+                                                                                    ValueFactories factories,
+                                                                                    CaseOperation caseOperation ) {
+        return new ComparePathQuery(fieldName, constraintPath, factories.getPathFactory(), factories.getStringFactory(),
+                                    PATH_IS_GREATER_THAN_OR_EQUAL_TO, caseOperation);
+    }
+
+    /**
+     * Construct a {@link Query} implementation that scores documents such that the node represented by the document has a path
+     * that is less than the supplied constraint path.
+     * 
+     * @param constraintPath the constraint path; may not be null
+     * @param fieldName the name of the document field containing the path value; may not be null
+     * @param factories the value factories that can be used during the scoring; may not be null
+     * @param caseOperation the operation that should be performed on the indexed values before the constraint value is being
+     *        evaluated; may not be null
+     * @return the path query; never null
+     */
+    public static ComparePathQuery createQueryForNodesWithPathLessThan( Path constraintPath,
+                                                                        String fieldName,
+                                                                        ValueFactories factories,
+                                                                        CaseOperation caseOperation ) {
+        return new ComparePathQuery(fieldName, constraintPath, factories.getPathFactory(), factories.getStringFactory(),
+                                    PATH_IS_LESS_THAN, caseOperation);
+    }
+
+    /**
+     * Construct a {@link Query} implementation that scores documents such that the node represented by the document has a path
+     * that is less than or equal to the supplied constraint path.
+     * 
+     * @param constraintPath the constraint path; may not be null
+     * @param fieldName the name of the document field containing the path value; may not be null
+     * @param factories the value factories that can be used during the scoring; may not be null
+     * @param caseOperation the operation that should be performed on the indexed values before the constraint value is being
+     *        evaluated; may not be null
+     * @return the path query; never null
+     */
+    public static ComparePathQuery createQueryForNodesWithPathLessThanOrEqualTo( Path constraintPath,
+                                                                                 String fieldName,
+                                                                                 ValueFactories factories,
+                                                                                 CaseOperation caseOperation ) {
+        return new ComparePathQuery(fieldName, constraintPath, factories.getPathFactory(), factories.getStringFactory(),
+                                    PATH_IS_LESS_THAN_OR_EQUAL_TO, caseOperation);
+    }
+
+    /**
+     * Construct a {@link Query} implementation that scores nodes according to the supplied comparator.
+     * 
+     * @param fieldName the name of the document field containing the path value; may not be null
+     * @param constraintPath the constraint path; may not be null
+     * @param pathFactory the value factory that can be used during the scoring; may not be null
+     * @param stringFactory the string factory that can be used during the scoring; may not be null
+     * @param evaluator the {@link CompareQuery.Evaluator} implementation that returns whether the node path satisfies the
+     *        constraint; may not be null
+     * @param caseOperation the operation that should be performed on the indexed values before the constraint value is being
+     *        evaluated; may not be null
+     */
+    protected ComparePathQuery( String fieldName,
+                                Path constraintPath,
+                                ValueFactory<Path> pathFactory,
+                                ValueFactory<String> stringFactory,
+                                Evaluator<Path> evaluator,
+                                CaseOperation caseOperation ) {
+        super(fieldName, constraintPath, pathFactory, stringFactory, evaluator, caseOperation);
+    }
+
+
+    @Override
+    public Query clone() {
+        return new ComparePathQuery(field(), constraintValue, valueTypeFactory, stringFactory, evaluator, caseOperation);
+    }
+}

--- a/index-providers/modeshape-lucene-index-provider/src/main/java/org/modeshape/jcr/index/lucene/query/CompareQuery.java
+++ b/index-providers/modeshape-lucene-index-provider/src/main/java/org/modeshape/jcr/index/lucene/query/CompareQuery.java
@@ -1,0 +1,93 @@
+/*
+ * ModeShape (http://www.modeshape.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.modeshape.jcr.index.lucene.query;
+
+import javax.jcr.query.qom.Comparison;
+import org.apache.lucene.document.Document;
+import org.apache.lucene.search.Query;
+import org.modeshape.common.annotation.Immutable;
+import org.modeshape.jcr.index.lucene.query.CaseOperations.CaseOperation;
+import org.modeshape.jcr.value.ValueFactory;
+
+/**
+ * A Lucene {@link Query} implementation that is used to apply a {@link Comparison} constraint against the indexed nodes. 
+ * <p> 
+ * This should only be used when the data stored in the indexes for {@code ValueType} is a {@link String}.
+ * </p> 
+ * 
+ * @param <ValueType> the actual value type used by the query
+ */
+@SuppressWarnings( "deprecation" )
+@Immutable
+public abstract class CompareQuery<ValueType> extends ConstantScoreWeightQuery {
+
+    protected static interface Evaluator<ValueType> {
+        boolean satisfiesConstraint( ValueType nodeValue,
+                                     ValueType constraintValue );
+    }
+
+    /**
+     * The operand that is being negated by this query.
+     */
+    protected final ValueType constraintValue;
+    protected final Evaluator<ValueType> evaluator;
+    protected final ValueFactory<ValueType> valueTypeFactory;
+    protected final ValueFactory<String> stringFactory;
+    protected final CaseOperation caseOperation;
+    
+    /**
+     * Construct a {@link Query} implementation that scores nodes according to the supplied comparator.
+     * 
+     * @param fieldName the name of the document field containing the value; may not be null
+     * @param constraintValue the constraint value; may not be null
+     * @param valueTypeFactory the value factory that can be used during the scoring; may not be null
+     * @param stringFactory the string factory that can be used during the scoring; may not be null
+     * @param evaluator the {@link Evaluator} implementation that returns whether the node value satisfies the constraint; may not
+     *        be null
+     * @param caseOperation the operation that should be performed on the indexed values before the constraint value is being
+     *        evaluated; may not be null
+     */
+    protected CompareQuery( final String fieldName,
+                            ValueType constraintValue,
+                            ValueFactory<ValueType> valueTypeFactory,
+                            ValueFactory<String> stringFactory,
+                            Evaluator<ValueType> evaluator,
+                            CaseOperation caseOperation) {
+        super(fieldName);
+        this.constraintValue = constraintValue;
+        this.valueTypeFactory = valueTypeFactory;
+        this.stringFactory = stringFactory;
+        this.caseOperation = caseOperation;
+        this.evaluator = evaluator;
+        assert this.constraintValue != null;
+        assert this.evaluator != null;
+        assert this.caseOperation != null;
+        
+    }
+
+    @Override
+    protected boolean isValid( Document document ) {
+        String valueAsString = document.get(field());
+        ValueType value = valueAsString != null ? valueTypeFactory.create(caseOperation.execute(valueAsString)) : null;
+        return evaluator.satisfiesConstraint(value, constraintValue);
+    }
+  
+    @Override
+    public String toString( String field ) {
+        return "(" + field() + evaluator.toString()
+               + (stringFactory != null ? stringFactory.create(constraintValue) : constraintValue.toString()) + ")";
+    }
+}

--- a/index-providers/modeshape-lucene-index-provider/src/main/java/org/modeshape/jcr/index/lucene/query/CompareStringQuery.java
+++ b/index-providers/modeshape-lucene-index-provider/src/main/java/org/modeshape/jcr/index/lucene/query/CompareStringQuery.java
@@ -1,0 +1,321 @@
+/*
+ * ModeShape (http://www.modeshape.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.modeshape.jcr.index.lucene.query;
+
+import java.text.CharacterIterator;
+import java.text.StringCharacterIterator;
+import java.util.regex.Pattern;
+import javax.jcr.query.qom.Comparison;
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.index.Term;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.RegexpQuery;
+import org.apache.lucene.search.Weight;
+import org.apache.lucene.search.WildcardQuery;
+import org.modeshape.common.annotation.Immutable;
+import org.modeshape.jcr.index.lucene.query.CaseOperations.CaseOperation;
+import org.modeshape.jcr.value.ValueComparators;
+import org.modeshape.jcr.value.ValueFactories;
+import org.modeshape.jcr.value.ValueFactory;
+
+/**
+ * A Lucene {@link Query} implementation that is used to apply a {@link Comparison} constraint against a string field. This query
+ * implementation works by using the weight and {@link Weight#scorer(LeafReaderContext)}  scorer} of the wrapped query
+ * to score (and return) only those documents with string fields that satisfy the constraint.
+ */
+@Immutable
+public class CompareStringQuery extends CompareQuery<String> {
+
+    protected static final Evaluator<String> EQUAL_TO = new Evaluator<String>() {
+        @Override
+        public boolean satisfiesConstraint( String nodeValue,
+                                            String constraintValue ) {
+            return constraintValue.equals(nodeValue);
+        }
+
+        @Override
+        public String toString() {
+            return "=";
+        }
+    };
+    protected static final Evaluator<String> IS_LESS_THAN = new Evaluator<String>() {
+        @Override
+        public boolean satisfiesConstraint( String nodeValue,
+                                            String constraintValue ) {
+            return ValueComparators.STRING_COMPARATOR.compare(nodeValue, constraintValue) < 0;
+        }
+
+        @Override
+        public String toString() {
+            return "<";
+        }
+    };
+    protected static final Evaluator<String> IS_LESS_THAN_OR_EQUAL_TO = new Evaluator<String>() {
+        @Override
+        public boolean satisfiesConstraint( String nodeValue,
+                                            String constraintValue ) {
+            return ValueComparators.STRING_COMPARATOR.compare(nodeValue, constraintValue) <= 0;
+        }
+
+        @Override
+        public String toString() {
+            return "<=";
+        }
+    };
+    protected static final Evaluator<String> IS_GREATER_THAN = new Evaluator<String>() {
+        @Override
+        public boolean satisfiesConstraint( String nodeValue,
+                                            String constraintValue ) {
+            return ValueComparators.STRING_COMPARATOR.compare(nodeValue, constraintValue) > 0;
+        }
+
+        @Override
+        public String toString() {
+            return ">";
+        }
+    };
+    protected static final Evaluator<String> IS_GREATER_THAN_OR_EQUAL_TO = new Evaluator<String>() {
+        @Override
+        public boolean satisfiesConstraint( String nodeValue,
+                                            String constraintValue ) {
+            return ValueComparators.STRING_COMPARATOR.compare(nodeValue, constraintValue) >= 0;
+        }
+
+        @Override
+        public String toString() {
+            return ">=";
+        }
+    };
+
+    /**
+     * Construct a {@link Query} implementation that scores documents with a string field value that is equal to the supplied
+     * constraint value.
+     *
+     * @param constraintValue the constraint value; may not be null
+     * @param fieldName the name of the document field containing the value; may not be null
+     * @param factories the value factories that can be used during the scoring; may not be null
+     * @param caseOperation the operation that should be performed on the indexed values before the constraint value is being
+     * evaluated; may not be null
+     * @return the query; never null
+     */
+    public static Query createQueryForNodesWithFieldEqualTo( String constraintValue,
+                                                             String fieldName,
+                                                             ValueFactories factories,
+                                                             CaseOperation caseOperation ) {      
+        return new CompareStringQuery(fieldName, constraintValue, factories.getStringFactory(), factories.getStringFactory(),
+                                      EQUAL_TO, caseOperation);
+    }
+
+    /**
+     * Construct a {@link Query} implementation that scores documents with a string field value that is greater than the supplied
+     * constraint value.
+     * 
+     * @param constraintValue the constraint value; may not be null
+     * @param fieldName the name of the document field containing the value; may not be null
+     * @param factories the value factories that can be used during the scoring; may not be null
+     * @param caseOperation the operation that should be performed on the indexed values before the constraint value is being
+     *        evaluated; may not be null
+     * @return the query; never null
+     */
+    public static CompareStringQuery createQueryForNodesWithFieldGreaterThan( String constraintValue,
+                                                                              String fieldName,
+                                                                              ValueFactories factories,
+                                                                              CaseOperation caseOperation ) {
+        return new CompareStringQuery(fieldName, constraintValue, factories.getStringFactory(), factories.getStringFactory(),
+                                      IS_GREATER_THAN, caseOperation);
+    }
+
+    /**
+     * Construct a {@link Query} implementation that scores documents with a string field value that is greater than or equal to
+     * the supplied constraint value.
+     * 
+     * @param constraintValue the constraint value; may not be null
+     * @param fieldName the name of the document field containing the value; may not be null
+     * @param factories the value factories that can be used during the scoring; may not be null
+     * @param caseOperation the operation that should be performed on the indexed values before the constraint value is being
+     *        evaluated; may not be null
+     * @return the query; never null
+     */
+    public static CompareStringQuery createQueryForNodesWithFieldGreaterThanOrEqualTo( String constraintValue,
+                                                                                       String fieldName,
+                                                                                       ValueFactories factories,
+                                                                                       CaseOperation caseOperation ) {
+        return new CompareStringQuery(fieldName, constraintValue, factories.getStringFactory(), factories.getStringFactory(),
+                                      IS_GREATER_THAN_OR_EQUAL_TO, caseOperation);
+    }
+
+    /**
+     * Construct a {@link Query} implementation that scores documents with a string field value that is less than the supplied
+     * constraint value.
+     * 
+     * @param constraintValue the constraint value; may not be null
+     * @param fieldName the name of the document field containing the value; may not be null
+     * @param factories the value factories that can be used during the scoring; may not be null
+     * @param caseOperation the operation that should be performed on the indexed values before the constraint value is being
+     *        evaluated; may not be null
+     * @return the query; never null
+     */
+    public static CompareStringQuery createQueryForNodesWithFieldLessThan( String constraintValue,
+                                                                           String fieldName,
+                                                                           ValueFactories factories,
+                                                                           CaseOperation caseOperation ) {
+        return new CompareStringQuery(fieldName, constraintValue, factories.getStringFactory(), factories.getStringFactory(),
+                                      IS_LESS_THAN, caseOperation);
+    }
+
+    /**
+     * Construct a {@link Query} implementation that scores documents with a string field value that is less than or equal to the
+     * supplied constraint value.
+     * 
+     * @param constraintValue the constraint value; may not be null
+     * @param fieldName the name of the document field containing the value; may not be null
+     * @param factories the value factories that can be used during the scoring; may not be null
+     * @param caseOperation the operation that should be performed on the indexed values before the constraint value is being
+     *        evaluated; may not be null
+     * @return the query; never null
+     */
+    public static CompareStringQuery createQueryForNodesWithFieldLessThanOrEqualTo( String constraintValue,
+                                                                                    String fieldName,
+                                                                                    ValueFactories factories,
+                                                                                    CaseOperation caseOperation ) {
+        return new CompareStringQuery(fieldName, constraintValue, factories.getStringFactory(), factories.getStringFactory(),
+                                      IS_LESS_THAN_OR_EQUAL_TO, caseOperation);
+    }
+
+    protected static boolean hasWildcardCharacters( String expression ) {
+        CharacterIterator iter = new StringCharacterIterator(expression);
+        boolean skipNext = false;
+        for (char c = iter.first(); c != CharacterIterator.DONE; c = iter.next()) {
+            if (skipNext) {
+                skipNext = false;
+                continue;
+            }
+            if (c == '*' || c == '?' || c == '%' || c == '_') return true;
+            if (c == '\\') skipNext = true;
+        }
+        return false;
+    }
+
+    /**
+     * Construct a {@link Query} implementation that scores documents with a string field value that is LIKE the supplied
+     * constraint value, where the LIKE expression contains the SQL wildcard characters '%' and '_' or the regular expression
+     * wildcard characters '*' and '?'.
+     * 
+     * @param likeExpression the LIKE expression; may not be null
+     * @param fieldName the name of the document field containing the value; may not be null
+     * @param factories the value factories that can be used during the scoring; may not be null
+     * @param caseOperation the operation that should be performed on the indexed values before the constraint value is being
+     *        evaluated; may not be null
+     * @return the query; never null
+     */
+    public static Query createQueryForNodesWithFieldLike( String likeExpression,
+                                                          String fieldName,
+                                                          ValueFactories factories,
+                                                          CaseOperation caseOperation ) {
+        assert likeExpression != null;
+        assert likeExpression.length() > 0;
+
+        if (!hasWildcardCharacters(likeExpression)) {
+            // This is not a like expression, so just do an equals ...
+            return createQueryForNodesWithFieldEqualTo(likeExpression, fieldName, factories, caseOperation);
+        }
+        if (caseOperation == CaseOperations.AS_IS) {
+            // We can just do a normal Wildcard or RegEx query ...
+
+            // '%' matches 0 or more characters
+            // '_' matches any single character
+            // '\x' matches 'x'
+            // all other characters match themselves
+
+            // Wildcard queries are a better match, but they can be slow and should not be used
+            // if the first character of the expression is a '%' or '_' or '*' or '?' ...
+            char firstChar = likeExpression.charAt(0);
+            if (firstChar != '%' && firstChar != '_' && firstChar != '*' && firstChar != '?') {
+                // Create a wildcard query ...
+                String expression = toWildcardExpression(likeExpression);
+                return new WildcardQuery(new Term(fieldName, expression));
+            }
+        }
+        // Create a regex query (which will be done using the correct case) ...
+        String regex = toRegularExpression(likeExpression);
+        RegexpQuery query = new RegexpQuery(new Term(fieldName, regex));
+        int flags = Pattern.UNICODE_CASE;
+        if (caseOperation != CaseOperations.AS_IS) {
+            // if we're searching either for the UPPERCASE or LOWERCASE of something, use Case Insensitive matching
+            // even though it could produce false positive
+            flags = flags | Pattern.CASE_INSENSITIVE;
+        } 
+        return query;
+    }
+
+    /**
+     * Convert the JCR like expression to a Lucene wildcard expression. The JCR like expression uses '%' to match 0 or more
+     * characters, '_' to match any single character, '\x' to match the 'x' character, and all other characters to match
+     * themselves.
+     * 
+     * @param likeExpression the like expression; may not be null
+     * @return the expression that can be used with a WildcardQuery; never null
+     */
+    protected static String toWildcardExpression( String likeExpression ) {
+        return likeExpression.replace('%', '*').replace('_', '?').replaceAll("\\\\(.)", "$1");
+    }
+
+    /**
+     * Convert the JCR like expression to a regular expression. The JCR like expression uses '%' to match 0 or more characters,
+     * '_' to match any single character, '\x' to match the 'x' character, and all other characters to match themselves. Note that
+     * if any regex metacharacters appear in the like expression, they will be escaped within the resulting regular expression.
+     * 
+     * @param likeExpression the like expression; may not be null
+     * @return the expression that can be used with a WildcardQuery; never null
+     */
+    public static String toRegularExpression( String likeExpression ) {
+        // Replace all '\x' with 'x' ...
+        String result = likeExpression.replaceAll("\\\\(.)", "$1");
+        // Escape characters used as metacharacters in regular expressions, including
+        // '[', '^', '\', '$', '.', '|', '+', '(', and ')'
+        // But leave '?' and '*'
+        result = result.replaceAll("([$.|+()\\[\\\\^\\\\\\\\])", "\\\\$1");
+        // Replace '%'->'[.]*' and '_'->'[.]
+        // (order of these calls is important!)
+        result = result.replace("*", ".*").replace("?", ".");
+        result = result.replace("%", ".*").replace("_", ".");
+        return result;
+    }
+
+    /**
+     * Construct a {@link Query} implementation that scores nodes according to the supplied comparator.
+     * 
+     * @param fieldName the name of the document field containing the value; may not be null
+     * @param constraintValue the constraint value; may not be null
+     * @param valueFactory the value factory that can be used during the scoring; may not be null
+     * @param stringFactory the string factory that can be used during the scoring; may not be null
+     * @param evaluator the {@link CompareQuery.Evaluator} implementation that returns whether the node path satisfies the
+     *        constraint; may not be null
+     */
+    protected CompareStringQuery( String fieldName,
+                                  String constraintValue,
+                                  ValueFactory<String> valueFactory,
+                                  ValueFactory<String> stringFactory,
+                                  Evaluator<String> evaluator,
+                                  CaseOperation caseOperation ) {
+        super(fieldName, constraintValue, valueFactory, stringFactory, evaluator, caseOperation);
+    }
+
+    @Override
+    public Query clone() {
+        return new CompareStringQuery(field(), constraintValue, valueTypeFactory, stringFactory, evaluator, caseOperation);
+    }
+}

--- a/index-providers/modeshape-lucene-index-provider/src/main/java/org/modeshape/jcr/index/lucene/query/ConstantScoreWeightQuery.java
+++ b/index-providers/modeshape-lucene-index-provider/src/main/java/org/modeshape/jcr/index/lucene/query/ConstantScoreWeightQuery.java
@@ -18,6 +18,7 @@ package org.modeshape.jcr.index.lucene.query;
 import java.io.IOException;
 import java.util.Collections;
 import org.apache.lucene.document.Document;
+import org.apache.lucene.index.IndexableField;
 import org.apache.lucene.index.LeafReader;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.search.ConstantScoreWeight;
@@ -102,11 +103,15 @@ public abstract class ConstantScoreWeightQuery extends Query {
                     return Scorer.NO_MORE_DOCS;
                 }
                 Document document = leafReader.document(docId, Collections.singleton(field));
-                if (document == null || document.getField(field) == null) {
+                if (document == null) {
+                    continue;
+                }
+                IndexableField[] fields = document.getFields(field);
+                if (fields == null || fields.length == 0) {
                     // the document doesn't have the field...
                     continue;
                 }
-                if (isValid(document)) {
+                if (areValid(fields)) {
                     return docId;
                 }
             } while (true);
@@ -136,13 +141,10 @@ public abstract class ConstantScoreWeightQuery extends Query {
     }
 
     /**
-     * Checks if the given document is a valid document for a particular query or not. When this method is called can safely 
-     * assume that {@link #field} is present on the document.
-     *
-     * @param document a {@link Document} instance which was loaded by the scorer for the current field. Subclasses can rely on
-     * the fact that this document has a value for {@link #field}
-     * @return {@code true} if the document instance is valid and should be returned by the query or {@code false} meaning it 
-     * should be rejected.
+     * Checks if the given fields are valid for the document matched by a particular query or not.
+     * @param fields a {@link IndexableField} array instance which was loaded by the scorer for the current field; never {@code null}
+     * and never empty.
+     * @return {@code true} if the array of fields is valid and document should be returned by the query or {@code false} if not.
      */
-    protected abstract boolean isValid( Document document );
+    protected abstract boolean areValid( IndexableField... fields );
 }

--- a/index-providers/modeshape-lucene-index-provider/src/main/java/org/modeshape/jcr/index/lucene/query/ConstantScoreWeightQuery.java
+++ b/index-providers/modeshape-lucene-index-provider/src/main/java/org/modeshape/jcr/index/lucene/query/ConstantScoreWeightQuery.java
@@ -1,0 +1,148 @@
+/*
+ * ModeShape (http://www.modeshape.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.modeshape.jcr.index.lucene.query;
+
+import java.io.IOException;
+import java.util.Collections;
+import org.apache.lucene.document.Document;
+import org.apache.lucene.index.LeafReader;
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.search.ConstantScoreWeight;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.Scorer;
+import org.apache.lucene.search.Weight;
+import org.modeshape.common.annotation.Immutable;
+import org.modeshape.common.util.CheckArg;
+
+/**
+ * Base class for ModeShape-specific Lucene queries, which always use a constant weight and score of 1.0f for the documents.
+ * 
+ * @author Horia Chiorean (hchiorea@redhat.com)
+ * @since 4.5
+ */
+@Immutable
+public abstract class ConstantScoreWeightQuery extends Query {
+    
+    private final String field;
+
+    protected ConstantScoreWeightQuery( String field ) {
+        CheckArg.isNotNull(field, "field");
+        this.field = field;
+    }
+    
+    protected String field() {
+        return field;
+    }
+
+    @Override
+    public Weight createWeight(IndexSearcher searcher, boolean needsScores) throws IOException {
+        return new ConstantWeight(this);
+    }
+    
+    protected class ConstantWeight extends ConstantScoreWeight {
+        private ConstantWeight( Query query ) {
+            super(query);
+        }
+
+        @Override
+        public Scorer scorer( LeafReaderContext context ) throws IOException {
+            return new ConstantWeightScorer(context, this);
+        }
+    }
+
+    protected class ConstantWeightScorer extends Scorer {
+        private int docId = -1;
+        private final int maxDocId;
+        private final LeafReader leafReader;
+
+        public ConstantWeightScorer( LeafReaderContext readerContext, Weight weight ) {
+            // We don't care which Similarity we have, because we don't use it. So get the default.
+            super(weight);
+            this.leafReader = readerContext.reader();
+            assert this.leafReader != null;
+            this.maxDocId = this.leafReader.maxDoc();
+        }
+
+        @Override
+        public int freq() throws IOException {
+            return 1;
+        }
+
+        @Override
+        public long cost() {
+            return maxDocId;
+        }
+
+
+        @Override
+        public int docID() {
+            return docId;
+        }
+
+        @Override
+        public int nextDoc() throws IOException {
+            do {
+                ++docId;
+                if (docId == maxDocId) {
+                    docId = Scorer.NO_MORE_DOCS;
+                    return Scorer.NO_MORE_DOCS;
+                }
+                Document document = leafReader.document(docId, Collections.singleton(field));
+                if (document == null || document.getField(field) == null) {
+                    // the document doesn't have the field...
+                    continue;
+                }
+                if (isValid(document)) {
+                    return docId;
+                }
+            } while (true);
+        }
+
+        @Override
+        public int advance( int target ) throws IOException {
+            if (target == Scorer.NO_MORE_DOCS) {
+                return target;
+            }
+            while (true) {
+                int doc = nextDoc();
+                if (doc >= target) return doc;
+            }
+        }
+
+        /**
+         * This method always returns a score of 1.0 for the current document, since all the documents which satisfy the constraint
+         * are considered equal
+         *
+         * @see org.apache.lucene.search.Scorer#score()
+         */
+        @Override
+        public float score() {
+            return 1.0f;
+        }
+    }
+
+    /**
+     * Checks if the given document is a valid document for a particular query or not. When this method is called can safely 
+     * assume that {@link #field} is present on the document.
+     *
+     * @param document a {@link Document} instance which was loaded by the scorer for the current field. Subclasses can rely on
+     * the fact that this document has a value for {@link #field}
+     * @return {@code true} if the document instance is valid and should be returned by the query or {@code false} meaning it 
+     * should be rejected.
+     */
+    protected abstract boolean isValid( Document document );
+}

--- a/index-providers/modeshape-lucene-index-provider/src/main/java/org/modeshape/jcr/index/lucene/query/FieldExistsQuery.java
+++ b/index-providers/modeshape-lucene-index-provider/src/main/java/org/modeshape/jcr/index/lucene/query/FieldExistsQuery.java
@@ -15,7 +15,7 @@
  */
 package org.modeshape.jcr.index.lucene.query;
 
-import org.apache.lucene.document.Document;
+import org.apache.lucene.index.IndexableField;
 import org.apache.lucene.search.Query;
 import org.modeshape.common.annotation.Immutable;
 
@@ -38,8 +38,8 @@ public class FieldExistsQuery extends ConstantScoreWeightQuery {
     }
 
     @Override
-    protected boolean isValid( Document document ) {
-        // always valid, since the base class will only call this for a document which actually has the field...
+    protected boolean areValid( IndexableField... fields ) {
+        // always valid, since the base class will only call this for a document which actually has the fields...
         return true;
     }
 

--- a/index-providers/modeshape-lucene-index-provider/src/main/java/org/modeshape/jcr/index/lucene/query/FieldExistsQuery.java
+++ b/index-providers/modeshape-lucene-index-provider/src/main/java/org/modeshape/jcr/index/lucene/query/FieldExistsQuery.java
@@ -1,0 +1,50 @@
+/*
+ * ModeShape (http://www.modeshape.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.modeshape.jcr.index.lucene.query;
+
+import org.apache.lucene.document.Document;
+import org.apache.lucene.search.Query;
+import org.modeshape.common.annotation.Immutable;
+
+/**
+ * Lucene query which returns the documents that have any value for a given field.
+ * 
+ * @author Horia Chiorean (hchiorea@redhat.com)
+ * @since 4.5
+ */
+@Immutable
+public class FieldExistsQuery extends ConstantScoreWeightQuery {
+    
+    protected FieldExistsQuery( String field ) {
+        super(field);
+    }
+
+    @Override
+    public String toString( String field ) {
+        return "(FIELD " + field + " EXISTS)";
+    }
+
+    @Override
+    protected boolean isValid( Document document ) {
+        // always valid, since the base class will only call this for a document which actually has the field...
+        return true;
+    }
+
+    @Override
+    public Query clone() {
+        return new FieldExistsQuery(field());
+    }
+}

--- a/index-providers/modeshape-lucene-index-provider/src/main/java/org/modeshape/jcr/index/lucene/query/LuceneQueryFactory.java
+++ b/index-providers/modeshape-lucene-index-provider/src/main/java/org/modeshape/jcr/index/lucene/query/LuceneQueryFactory.java
@@ -1,0 +1,1091 @@
+/*
+ * ModeShape (http://www.modeshape.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.modeshape.jcr.index.lucene.query;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Pattern;
+import javax.jcr.RepositoryException;
+import javax.jcr.Value;
+import javax.jcr.query.qom.Constraint;
+import javax.jcr.query.qom.DynamicOperand;
+import javax.jcr.query.qom.Length;
+import javax.jcr.query.qom.LowerCase;
+import javax.jcr.query.qom.NodeLocalName;
+import javax.jcr.query.qom.NodeName;
+import javax.jcr.query.qom.Not;
+import javax.jcr.query.qom.PropertyExistence;
+import javax.jcr.query.qom.PropertyValue;
+import javax.jcr.query.qom.StaticOperand;
+import javax.jcr.query.qom.UpperCase;
+import org.apache.lucene.analysis.Analyzer;
+import org.apache.lucene.analysis.TokenStream;
+import org.apache.lucene.analysis.tokenattributes.CharTermAttribute;
+import org.apache.lucene.index.Term;
+import org.apache.lucene.queryparser.classic.ParseException;
+import org.apache.lucene.queryparser.classic.QueryParser;
+import org.apache.lucene.search.BooleanClause.Occur;
+import org.apache.lucene.search.BooleanQuery;
+import org.apache.lucene.search.MatchAllDocsQuery;
+import org.apache.lucene.search.MatchNoDocsQuery;
+import org.apache.lucene.search.NumericRangeQuery;
+import org.apache.lucene.search.PhraseQuery;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.RegexpQuery;
+import org.modeshape.common.annotation.Immutable;
+import org.modeshape.common.annotation.ThreadSafe;
+import org.modeshape.jcr.JcrI18n;
+import org.modeshape.jcr.JcrLexicon;
+import org.modeshape.jcr.ModeShapeLexicon;
+import org.modeshape.jcr.api.query.qom.Between;
+import org.modeshape.jcr.api.query.qom.NodeDepth;
+import org.modeshape.jcr.api.query.qom.NodePath;
+import org.modeshape.jcr.api.query.qom.Operator;
+import org.modeshape.jcr.index.lucene.FieldUtil;
+import org.modeshape.jcr.index.lucene.LuceneConfig;
+import org.modeshape.jcr.index.lucene.LuceneIndexException;
+import org.modeshape.jcr.index.lucene.LuceneIndexProviderI18n;
+import org.modeshape.jcr.index.lucene.query.CaseOperations.CaseOperation;
+import org.modeshape.jcr.query.model.And;
+import org.modeshape.jcr.query.model.BindVariableName;
+import org.modeshape.jcr.query.model.Comparison;
+import org.modeshape.jcr.query.model.FullTextSearch;
+import org.modeshape.jcr.query.model.Literal;
+import org.modeshape.jcr.query.model.Or;
+import org.modeshape.jcr.query.model.ReferenceValue;
+import org.modeshape.jcr.query.model.Relike;
+import org.modeshape.jcr.query.model.SetCriteria;
+import org.modeshape.jcr.value.Name;
+import org.modeshape.jcr.value.NameFactory;
+import org.modeshape.jcr.value.Path;
+import org.modeshape.jcr.value.PathFactory;
+import org.modeshape.jcr.value.PropertyType;
+import org.modeshape.jcr.value.StringFactory;
+import org.modeshape.jcr.value.ValueFactories;
+
+/**
+ * The factory that creates a Lucene {@link Query} object from a Query Object Model {@link Constraint} object.
+ * 
+ * @since 4.5
+ */
+@ThreadSafe
+@Immutable
+public class LuceneQueryFactory {
+
+    protected final PathFactory pathFactory;
+    protected final NameFactory nameFactory;
+    protected final StringFactory stringFactory;
+    protected final Map<String, Object> variables;
+    protected final ValueFactories factories;
+    protected final Map<String, PropertyType> propertyTypesByName;
+
+    private LuceneQueryFactory( ValueFactories factories,
+                                Map<String, Object> variables,
+                                Map<String, PropertyType> propertyTypesByName ) {
+        assert factories != null;
+        this.factories = factories;
+        this.pathFactory = factories.getPathFactory();
+        this.nameFactory = factories.getNameFactory();
+        this.stringFactory = factories.getStringFactory();
+
+        this.variables = variables != null ? variables : Collections.<String, Object>emptyMap();
+        assert propertyTypesByName != null;
+        this.propertyTypesByName = propertyTypesByName;
+    }
+
+    /**
+     * Creates a new query factory which can be used to produce Lucene queries for {@link org.modeshape.jcr.index.lucene.MultiColumnIndex}
+     * indexes.
+     *
+     * @param factories a {@link ValueFactories} instance; may not be null
+     * @param variables a {@link Map(String, Object)} instance which contains the query variables for a particular query; may be {@code null}
+     * @param propertyTypesByName a {@link Map(String, PropertyType)} representing the columns and their types for the index definition
+     * for which the query should be created; may not be null.
+     * @return a {@link LuceneQueryFactory} instance, never {@code null}
+     */
+    public static LuceneQueryFactory forMultiColumnIndex(ValueFactories factories,
+                                                         Map<String, Object> variables,
+                                                         Map<String, PropertyType> propertyTypesByName) {
+        return new LuceneQueryFactory(factories, variables, propertyTypesByName);
+    }
+
+    /**
+     * Creates a new query factory which can be used to produce Lucene queries for {@link org.modeshape.jcr.index.lucene.SingleColumnIndex}
+     * indexes.
+     *
+     * @param factories a {@link ValueFactories} instance; may not be null
+     * @param variables a {@link Map(String, Object)} instance which contains the query variables for a particular query; may be {@code null}
+     * @param propertyTypesByName a {@link Map(String, PropertyType)} representing the columns and their types for the index definition
+     * for which the query should be created; may not be null.
+     * @return a {@link LuceneQueryFactory} instance, never {@code null}
+     */
+    public static LuceneQueryFactory forSingleColumnIndex( ValueFactories factories,
+                                                           Map<String, Object> variables,
+                                                           Map<String, PropertyType> propertyTypesByName ) {
+        return new SingleColumnQueryFactory(factories, variables, propertyTypesByName);
+    }
+
+    /**
+     * Creates a new query factory which can be used to produce Lucene queries for {@link org.modeshape.jcr.index.lucene.TextIndex}
+     * indexes.
+     *
+     * @param factories a {@link ValueFactories} instance; may not be null
+     * @param variables a {@link Map(String, Object)} instance which contains the query variables for a particular query; may be {@code null}
+     * @param propertyTypesByName a {@link Map(String, PropertyType)} representing the columns and their types for the index definition
+     * for which the query should be created; may not be null.
+     * @param config a {@link LuceneConfig} instance required to get various information for FTS (e.g. configured analyzer); may
+     * not be null
+     * @return a {@link LuceneQueryFactory} instance, never {@code null}
+     */
+    public static LuceneQueryFactory forTextIndex( ValueFactories factories,
+                                                   Map<String, Object> variables,
+                                                   Map<String, PropertyType> propertyTypesByName,
+                                                   LuceneConfig config ) {
+        return new TextQueryFactory(factories, variables, propertyTypesByName, config);
+    }
+
+    /**
+     * Create a Lucene {@link Query} that represents the supplied Query Object Model {@link Constraint}.
+     *
+     * @param constraint the QOM constraint; never null
+     * @return the corresponding Query object; never null
+     */
+    public Query createQuery( Constraint constraint ) {
+        if (constraint instanceof And) {
+            return createQuery((And)constraint);
+        }
+        if (constraint instanceof Or) {
+            return createQuery((Or)constraint);
+        }
+        if (constraint instanceof Not) {
+            return createQuery((Not)constraint);
+        }
+        if (constraint instanceof SetCriteria) {
+            return createQuery((SetCriteria)constraint);
+        }
+        if (constraint instanceof PropertyExistence) {
+            return createQuery((PropertyExistence)constraint);
+        }
+        if (constraint instanceof Between) {
+            return createQuery((Between)constraint);
+        }
+        if (constraint instanceof Relike) {
+            return createQuery((Relike)constraint);
+        }
+        if (constraint instanceof Comparison) {
+            return createQuery((Comparison)constraint);
+        }
+        if (constraint instanceof FullTextSearch) {
+            return createQuery((FullTextSearch)constraint);
+        }
+        // Should not get here ...
+        throw new LuceneIndexException(
+                "Unexpected Constraint instance: class=" + (constraint != null ? constraint.getClass() : "null")
+                + " and instance=" + constraint);
+    }
+
+    /**
+     * Checks if for the query produced by this factory scores are expected or not for matching documents.
+     * 
+     * @return {@code true} if scores are expected to matching documents, {@code false} otherwise
+     */
+    public boolean scoreDocuments() {
+        return false;
+    }
+
+    protected Query createQuery( FullTextSearch constraint ) {
+        throw new UnsupportedOperationException("Only text indexes support FTS constraints...");     
+    }
+
+    protected Query createQuery( Comparison comparison ) {
+        return createQuery(comparison.getOperand1(), comparison.operator(), comparison.getOperand2(), null);
+    }
+
+    protected Query createQuery( Not not ) {
+        return not(createQuery(not.getConstraint()));
+    }
+
+    protected Query createQuery( Relike relike ) {
+        StaticOperand op1 = relike.getOperand1();
+        PropertyValue op2 = relike.getOperand2();
+
+        Object relikeValue = getSingleValueFromStaticOperand(op1);
+        assert relikeValue != null;
+        String fieldName = op2.getPropertyName();
+        return new RelikeQuery(fieldName, relikeValue.toString());
+    }
+
+    protected Query createQuery( Between between ) {
+        DynamicOperand operand = between.getOperand();
+        
+        StaticOperand lower = between.getLowerBound();
+        StaticOperand upper = between.getUpperBound();
+
+        boolean upperBoundIncluded = between.isUpperBoundIncluded();
+        boolean lowerBoundIncluded = between.isLowerBoundIncluded();
+
+        // Handle the static operands ...
+        Object lowerValue = getSingleValueFromStaticOperand(lower);
+        Object upperValue = getSingleValueFromStaticOperand(upper);
+        assert lowerValue != null;
+        assert upperValue != null;
+
+        // Only in the case of a PropertyValue and Depth will we need to do something special ...
+        if (operand instanceof NodeDepth) {
+            return createRangeQuery(depthField(), lowerValue, upperValue, lowerBoundIncluded, upperBoundIncluded);
+        } else if (operand instanceof PropertyValue) {
+            String field = ((PropertyValue) operand).getPropertyName();
+            PropertyType lowerType = PropertyType.discoverType(lowerValue);
+            PropertyType upperType = PropertyType.discoverType(upperValue);
+            if (upperType == lowerType) {
+                switch (upperType) {
+                    case DATE:
+                    case LONG:
+                    case DOUBLE:
+                    case DECIMAL:
+                        return createRangeQuery(field, lowerValue, upperValue, lowerBoundIncluded, upperBoundIncluded);
+                                                
+                    default:
+                        // continue on and handle as boolean query ...
+                }
+            }
+        }
+
+        // Otherwise, just create a boolean query ...
+        Operator lowerOp = lowerBoundIncluded ? Operator.GREATER_THAN_OR_EQUAL_TO : Operator.GREATER_THAN;
+        Operator upperOp = upperBoundIncluded ? Operator.LESS_THAN_OR_EQUAL_TO : Operator.LESS_THAN;
+        Query lowerQuery = createQuery(operand, lowerOp, lower, null);
+        Query upperQuery = createQuery(operand, upperOp, upper, null);
+        return booleanQuery(lowerQuery, Occur.MUST, upperQuery, Occur.MUST);
+    }
+
+    protected Query createRangeQuery( String field, Object lowerValue, Object upperValue, boolean includesLower,
+                                      boolean includesUpper ) {
+        PropertyType type = null;
+        PropertyType lowerType = PropertyType.discoverType(lowerValue);
+        PropertyType upperType = PropertyType.discoverType(upperValue);
+        if (lowerType != upperType) {
+            // the types of the bounds don't match, so nothing can be done
+            return new MatchNoDocsQuery();
+        } else {
+            type = lowerType;
+        }
+      
+        switch (type) {
+            case DATE:
+                long lowerDate = factories.getLongFactory().create(lowerValue);
+                long upperDate = factories.getLongFactory().create(upperValue);
+                return NumericRangeQuery.newLongRange(field, lowerDate, upperDate, includesLower, includesUpper);
+            case LONG:
+                long lowerLong = factories.getLongFactory().create(lowerValue);
+                long upperLong = factories.getLongFactory().create(upperValue);
+                return NumericRangeQuery.newLongRange(field, lowerLong, upperLong, includesLower, includesUpper);
+            case DOUBLE:
+                double lowerDouble = factories.getDoubleFactory().create(lowerValue);
+                double upperDouble = factories.getDoubleFactory().create(upperValue);
+                return NumericRangeQuery.newDoubleRange(field, lowerDouble, upperDouble, includesLower, includesUpper);
+            case BOOLEAN:
+                int lowerInt = factories.getBooleanFactory().create(lowerValue) ? 1 : 0;
+                int upperInt = factories.getBooleanFactory().create(upperValue) ? 1 : 0;
+                return NumericRangeQuery.newIntRange(field, lowerInt, upperInt, includesLower, includesUpper);
+            case DECIMAL:
+                BigDecimal lowerDecimal = factories.getDecimalFactory().create(lowerValue);
+                BigDecimal upperDecimal = factories.getDecimalFactory().create(upperValue);
+                CaseOperation caseOp = CaseOperations.AS_IS; // decimals are stored the same way regardless
+                String lsv = FieldUtil.decimalToString(lowerDecimal);
+                String usv = FieldUtil.decimalToString(upperDecimal);
+                Query lower = null;
+                if (includesLower) {
+                    lower = CompareStringQuery.createQueryForNodesWithFieldGreaterThanOrEqualTo(lsv, field, factories, caseOp);
+                } else {
+                    lower = CompareStringQuery.createQueryForNodesWithFieldGreaterThan(lsv, field, factories, caseOp);
+                }
+                Query upper = null;
+                if (includesUpper) {
+                    upper = CompareStringQuery.createQueryForNodesWithFieldLessThanOrEqualTo(usv, field, factories, caseOp);
+                } else {
+                    upper = CompareStringQuery.createQueryForNodesWithFieldLessThan(usv, field, factories, caseOp);
+                }
+                return booleanQuery(lower, Occur.MUST, upper, Occur.MUST);
+            case OBJECT:
+            case URI:
+            case PATH:
+            case NAME:
+            case STRING:
+            case REFERENCE:
+            case WEAKREFERENCE:
+            case SIMPLEREFERENCE:
+            case BINARY:
+                throw new LuceneIndexException("Unsupported type for range query:" + type);
+        }
+        return new MatchNoDocsQuery();
+    }
+
+
+    protected Query createQuery( SetCriteria setCriteria ) {
+        DynamicOperand left = setCriteria.leftOperand();
+        int numRightOperands = setCriteria.rightOperands().size();
+        assert numRightOperands > 0;
+        if (numRightOperands == 1) {
+            StaticOperand rightOperand = setCriteria.rightOperands().iterator().next();
+            if (rightOperand instanceof Literal) {
+                return createQuery(left, Operator.EQUAL_TO, setCriteria.rightOperands().iterator().next(), null);
+            }
+        }
+        BooleanQuery.Builder builder = new BooleanQuery.Builder();
+        builder.setDisableCoord(true);
+        for (StaticOperand right : setCriteria.rightOperands()) {
+            if (right instanceof BindVariableName) {
+                // This single value is a variable name, which may evaluate to a single value or multiple values ...
+                BindVariableName var = (BindVariableName)right;
+                Object value = variables.get(var.getBindVariableName());
+                if (value == null) {
+                    throw new LuceneIndexException(JcrI18n.missingVariableValue.text(var.getBindVariableName()));
+                }
+                if (value instanceof Iterable<?>) {
+                    for (Object resolvedValue : (Iterable<?>)value) {
+                        if (resolvedValue == null) { continue; }
+                        if (resolvedValue instanceof Object[]) {
+                            // The row has multiple values (e.g., a multi-valued property) ...
+                            for (Object val : (Object[])resolvedValue) {
+                                addQueryForSetConstraint(builder, left, val);
+                            }
+                        } else {
+                            addQueryForSetConstraint(builder, left, resolvedValue);
+                        }
+                    }
+                }
+            } else {
+                Query rightQuery = createQuery(left, Operator.EQUAL_TO, right, null);
+                builder.add(rightQuery, Occur.SHOULD);
+            }
+        }
+        return builder.build();
+    }
+
+    private Query createQuery( Or or ) {
+        Query leftQuery = createQuery(or.left());
+        Query rightQuery = createQuery(or.right());
+        if (leftQuery == null) {
+            return rightQuery != null ? rightQuery : null;
+        } else if (rightQuery == null) {
+            return leftQuery;
+        }
+        return booleanQuery(leftQuery, Occur.SHOULD, rightQuery, Occur.SHOULD);
+    }
+
+    protected Query createQuery( And and )  {
+        Query leftQuery = createQuery(and.left());
+        Query rightQuery = createQuery(and.right());
+        if (leftQuery == null || rightQuery == null) { return null; }
+        return booleanQuery(leftQuery, Occur.MUST, rightQuery, Occur.MUST);
+    }
+
+    protected Query createQuery( PropertyExistence propertyExistence ) {
+        String field = propertyExistence.getPropertyName();
+        assert propertyTypesByName.containsKey(field); //or this index should not have been planned in the first place...
+        return new FieldExistsQuery(field);
+    }
+
+    private void addQueryForSetConstraint( BooleanQuery.Builder setQueryBuilder, DynamicOperand left, Object resolvedValue ) {
+        StaticOperand elementInRight = resolvedValue instanceof Literal ? (Literal)resolvedValue : new Literal(resolvedValue);
+        Query rightQuery = createQuery(left, Operator.EQUAL_TO, elementInRight, null);
+        setQueryBuilder.add(rightQuery, Occur.SHOULD);
+    }
+
+    protected Query createQuery( DynamicOperand left,
+                                 Operator operator,
+                                 StaticOperand right,
+                                 CaseOperation caseOperation ) {
+        // Handle the static operand ...
+        Object value = getSingleValueFromStaticOperand(right);
+        assert value != null;
+
+        // Address the dynamic operand ...
+       if (left instanceof PropertyValue) {
+            return createPropertyValueQuery((PropertyValue)left, operator, value, caseOperation);
+        } else if (left instanceof ReferenceValue) {
+            return createReferenceValueQuery((ReferenceValue)left, operator, value);
+        } else if (left instanceof Length) {
+            return createLengthQuery((Length)left, operator, value);
+        } else if (left instanceof LowerCase) {
+            LowerCase lowercase = (LowerCase)left;
+            if (caseOperation == null) { caseOperation = CaseOperations.LOWERCASE; }
+            return createQuery(lowercase.getOperand(), operator, right, caseOperation);
+        } else if (left instanceof UpperCase) {
+            UpperCase uppercase = (UpperCase)left;
+            if (caseOperation == null) { caseOperation = CaseOperations.UPPERCASE; }
+            return createQuery(uppercase.getOperand(), operator, right, caseOperation);
+        } else if (left instanceof NodeDepth) {
+            // this only applies to mode:depth
+            return longFieldQuery(depthField(), operator, value);
+        } else if (left instanceof NodePath) {
+            // this only applies to jcr:path
+            String field = stringFactory.create(JcrLexicon.PATH);
+            return pathFieldQuery(field, operator, value, caseOperation);
+        } else if (left instanceof NodeName) {
+            // this only applies to jcr:name
+            String field = stringFactory.create(JcrLexicon.NAME);
+            return nameFieldQuery(field, operator, value, caseOperation);
+        } else if (left instanceof NodeLocalName) {
+            // this only applies to mode:localName
+            String field = stringFactory.create(ModeShapeLexicon.LOCALNAME);
+            return stringFieldQuery(field, operator, value, caseOperation);
+        }
+
+        throw new LuceneIndexException("Unexpected DynamicOperand instance: class=" + (left != null ? left.getClass() : "null")
+                                       + " and instance=" + left);
+    }
+
+    private String depthField() {
+        return stringFactory.create(ModeShapeLexicon.DEPTH);
+    }
+    
+    protected Object getSingleValueFromStaticOperand( StaticOperand operand ) {
+        Object value = null;
+        if (operand instanceof Literal) {
+            Literal literal = (Literal)operand;
+            value = literal.value();
+        } else if (operand instanceof BindVariableName) {
+            BindVariableName variable = (BindVariableName)operand;
+            String variableName = variable.getBindVariableName();
+            value = variables.get(variableName);
+            if (value instanceof Iterable<?>) {
+                // We can only return one value ...
+                Iterator<?> iter = ((Iterable<?>)value).iterator();
+                if (iter.hasNext()) { return iter.next(); }
+                value = null;
+            }
+            if (value == null) {
+                throw new LuceneIndexException(JcrI18n.missingVariableValue.text(variableName));
+            }
+        } else {
+            throw new IllegalArgumentException("Unknown operand type:" + operand);
+        }
+        return value;
+    }
+    
+    protected BooleanQuery not( Query notted ) {
+        BooleanQuery.Builder builder = new BooleanQuery.Builder();
+        builder.setDisableCoord(true);
+        // We need at least some positive match, so get all docs ...
+        builder.add(new MatchAllDocsQuery(), Occur.SHOULD);
+        // Now apply the original query being 'NOT-ed' as a MUST_NOT occurrence ...
+        builder.add(notted, Occur.MUST_NOT);
+        return builder.build();
+    }
+
+    protected Query createPropertyValueQuery( PropertyValue propertyValue,
+                                              Operator operator,
+                                              Object value,
+                                              CaseOperation caseOperation ) {
+        if (caseOperation == null) {
+            caseOperation = CaseOperations.AS_IS;
+        }
+
+        if (operator == Operator.LIKE) {
+            String stringValue = stringFactory.create(value);
+            if (!stringValue.contains("%") && !stringValue.contains("_") && !stringValue.contains("\\")) {
+                // The value is not a LIKE literal, so we can treat it as an '=' operator ...
+                operator = Operator.EQUAL_TO;
+            }
+        }
+
+        String propertyName = propertyValue.getPropertyName();
+        PropertyType valueType = propertyTypesByName.get(propertyName);
+
+        switch (valueType) {
+            case REFERENCE:
+            case WEAKREFERENCE:
+            case SIMPLEREFERENCE:
+                return stringFieldQuery(propertyName, operator, value, CaseOperations.AS_IS);
+            case URI:
+            case STRING:
+                return stringFieldQuery(propertyName, operator, value, caseOperation);
+            case PATH:
+                return pathFieldQuery(propertyName, operator, value, caseOperation);
+            case NAME:
+                return nameFieldQuery(propertyName, operator, value, caseOperation);
+            case DECIMAL:
+                return decimalFieldQuery(propertyName, operator, value, caseOperation);
+            case DATE:
+                return dateFieldQuery(propertyName, operator, value);
+            case LONG:
+                return longFieldQuery(propertyName, operator, value);
+            case BOOLEAN:
+                return booleanFieldQuery(propertyName, operator, value);
+            case DOUBLE:
+                return doubleFieldQuery(propertyName, operator, value);
+            case BINARY:
+            case OBJECT:
+            default:
+                throw new IllegalArgumentException("Unsupported value type:" + valueType);
+        }
+    }
+
+    protected Query stringFieldQuery( String field, Operator operator, Object value, CaseOperation caseOperation ) {
+        String stringValue = stringFactory.create(value);
+        switch (operator) {
+            case EQUAL_TO:
+                return CompareStringQuery.createQueryForNodesWithFieldEqualTo(stringValue, field, factories, caseOperation);
+            case NOT_EQUAL_TO:
+                Query query = CompareStringQuery.createQueryForNodesWithFieldEqualTo(stringValue, field, factories,
+                                                                                     caseOperation);
+                return not(query);
+            case GREATER_THAN:
+                return CompareStringQuery.createQueryForNodesWithFieldGreaterThan(stringValue, field, factories, caseOperation);
+            case GREATER_THAN_OR_EQUAL_TO:
+                return CompareStringQuery.createQueryForNodesWithFieldGreaterThanOrEqualTo(stringValue, field, factories,
+                                                                                           caseOperation);
+            case LESS_THAN:
+                return CompareStringQuery.createQueryForNodesWithFieldLessThan(stringValue, field, factories, caseOperation);
+            case LESS_THAN_OR_EQUAL_TO:
+                return CompareStringQuery.createQueryForNodesWithFieldLessThanOrEqualTo(stringValue, field, factories,
+                                                                                        caseOperation);
+            case LIKE:
+                return CompareStringQuery.createQueryForNodesWithFieldLike(stringValue, field, factories, caseOperation);
+            default:
+                throw new IllegalArgumentException("Unknown operator:" + operator);
+        }
+    }
+
+    protected Query decimalFieldQuery( String field, Operator operator, Object value, CaseOperation caseOperation ) {
+        String decimalString = null;
+        if (operator != Operator.LIKE) {
+            // Decimal values are stored in a special lexicographically sortable form, so we have to
+            // convert the value to this ...
+            BigDecimal decimalValue = factories.getDecimalFactory().create(value);
+            decimalString = FieldUtil.decimalToString(decimalValue);                                       
+        } else {
+            // search for LIKE as a regular string expression
+            decimalString = stringFactory.create(value);
+        }
+        
+        return stringFieldQuery(field, operator, decimalString, caseOperation);
+    }
+
+    protected Query booleanFieldQuery( String field, Operator operator, Object value ) {
+        Boolean booleanValue = factories.getBooleanFactory().create(value);
+        
+        if (booleanValue) {
+            switch (operator) {
+                case EQUAL_TO:
+                    return NumericRangeQuery.newIntRange(field, 0, 1, false, true);
+                case NOT_EQUAL_TO:
+                    return NumericRangeQuery.newIntRange(field, 0, 1, true, false);
+                case GREATER_THAN_OR_EQUAL_TO:
+                    return NumericRangeQuery.newIntRange(field, 1, 1, true, true);
+                case LESS_THAN_OR_EQUAL_TO:
+                    return NumericRangeQuery.newIntRange(field, 0, 1, true, true);
+                case GREATER_THAN:
+                    // Can't be greater than 'true', per JCR spec
+                    return new MatchNoDocsQuery();
+                case LESS_THAN:
+                    // 'false' is less than 'true' ...
+                    return NumericRangeQuery.newIntRange(field, 0, 0, true, true);
+                case LIKE:
+                    // This is not supported
+                    throw new LuceneIndexException(LuceneIndexProviderI18n.invalidOperatorForPropertyType.text(Operator.LIKE,
+                                                                                                               PropertyType.BOOLEAN));
+                default:
+                    throw new IllegalArgumentException("Unknown operator:" + operator);
+
+            }
+        } else {
+            switch (operator) {
+                case EQUAL_TO:
+                    return NumericRangeQuery.newIntRange(field, 0, 1, true, false);
+                case NOT_EQUAL_TO:
+                    return NumericRangeQuery.newIntRange(field, 0, 1, false, true);
+                case GREATER_THAN_OR_EQUAL_TO:
+                    return NumericRangeQuery.newIntRange(field, 0, 1, true, true);
+                case LESS_THAN_OR_EQUAL_TO:
+                    return NumericRangeQuery.newIntRange(field, 0, 0, true, true);
+                case GREATER_THAN:
+                    // 'true' is greater than 'false' ...
+                    return NumericRangeQuery.newIntRange(field, 1, 1, true, true);
+                case LESS_THAN:
+                    // Can't be less than 'false', per JCR spec
+                    return new MatchNoDocsQuery();
+                case LIKE:
+                    // This is not supported
+                    throw new LuceneIndexException(LuceneIndexProviderI18n.invalidOperatorForPropertyType.text(Operator.LIKE,
+                                                                                                               PropertyType.BOOLEAN));
+                default:
+                    throw new IllegalArgumentException("Unknown operator:" + operator);
+            }
+        }
+    }
+
+    protected Query longFieldQuery( String field, Operator operator, Object value ) {
+        Long longMinimum = Long.MIN_VALUE;
+        Long longMaximum = Long.MAX_VALUE;
+        long longValue = factories.getLongFactory().create(value);
+        switch (operator) {
+            case EQUAL_TO:
+                if (longValue < longMinimum || longValue > longMaximum) { return new MatchNoDocsQuery(); }
+                return NumericRangeQuery.newLongRange(field, longValue, longValue, true, true);
+            case NOT_EQUAL_TO:
+                if (longValue < longMinimum || longValue > longMaximum) { return new MatchAllDocsQuery(); }
+                Query lowerRange = NumericRangeQuery.newLongRange(field, longMinimum, longValue, true, false);
+                Query upperRange = NumericRangeQuery.newLongRange(field, longValue, longMaximum, false, true);
+                return booleanQuery(lowerRange, Occur.SHOULD, upperRange, Occur.SHOULD);
+            case GREATER_THAN:
+                if (longValue > longMaximum) { return new MatchNoDocsQuery(); }
+                return NumericRangeQuery.newLongRange(field, longValue, longMaximum, false, true);
+            case GREATER_THAN_OR_EQUAL_TO:
+                if (longValue > longMaximum) { return new MatchNoDocsQuery(); }
+                return NumericRangeQuery.newLongRange(field, longValue, longMaximum, true, true);
+            case LESS_THAN:
+                if (longValue < longMinimum) { return new MatchNoDocsQuery(); }
+                return NumericRangeQuery.newLongRange(field, longMinimum, longValue, true, false);
+            case LESS_THAN_OR_EQUAL_TO:
+                if (longValue < longMinimum) { return new MatchNoDocsQuery(); }
+                return NumericRangeQuery.newLongRange(field, longMinimum, longValue, true, true);
+            case LIKE:
+                throw new LuceneIndexException(LuceneIndexProviderI18n.invalidOperatorForPropertyType.text(operator, PropertyType.LONG));
+            default:
+                throw new IllegalArgumentException("Unknown operator:" + operator);
+        }
+    }
+
+    protected Query doubleFieldQuery( String field, Operator operator, Object value ) {
+        double doubleValue = factories.getDoubleFactory().create(value);
+        Double doubleMinimum = Double.MIN_VALUE;
+        Double doubleMaximum = Double.MAX_VALUE;
+        switch (operator) {
+            case EQUAL_TO:
+                if (doubleValue < doubleMinimum || doubleValue > doubleMaximum) { return new MatchNoDocsQuery(); }
+                return NumericRangeQuery.newDoubleRange(field, doubleValue, doubleValue, true, true);
+            case NOT_EQUAL_TO:
+                if (doubleValue < doubleMinimum || doubleValue > doubleMaximum) { return new MatchAllDocsQuery(); }
+                Query lowerRange = NumericRangeQuery.newDoubleRange(field, doubleMinimum, doubleValue, true,
+                                                                    false);
+                Query upperRange = NumericRangeQuery.newDoubleRange(field, doubleValue, doubleMaximum, false,
+                                                                    true);
+                return booleanQuery(lowerRange, Occur.SHOULD, upperRange, Occur.SHOULD);
+            case GREATER_THAN:
+                if (doubleValue > doubleMaximum) { return new MatchNoDocsQuery(); }
+                return NumericRangeQuery.newDoubleRange(field, doubleValue, doubleMaximum, false, true);
+            case GREATER_THAN_OR_EQUAL_TO:
+                if (doubleValue > doubleMaximum) { return new MatchNoDocsQuery(); }
+                return NumericRangeQuery.newDoubleRange(field, doubleValue, doubleMaximum, true, true);
+            case LESS_THAN:
+                if (doubleValue < doubleMinimum) { return new MatchNoDocsQuery(); }
+                return NumericRangeQuery.newDoubleRange(field, doubleMinimum, doubleValue, true, false);
+            case LESS_THAN_OR_EQUAL_TO:
+                if (doubleValue < doubleMinimum) { return new MatchNoDocsQuery(); }
+                return NumericRangeQuery.newDoubleRange(field, doubleMinimum, doubleValue, true, true);
+            case LIKE:
+                // should never happen (the double conversion should've failed)
+                assert false;
+            default:
+                throw new IllegalArgumentException("Unknown operator:" + operator);
+        }
+    }
+
+    protected Query dateFieldQuery( String field, Operator operator, Object value ) {
+        Long longMinimum = Long.MIN_VALUE;
+        Long longMaximum = Long.MAX_VALUE;
+        long millis = factories.getDateFactory().create(value).getMilliseconds();
+        switch (operator) {
+            case EQUAL_TO:
+                if (millis < longMinimum || millis > longMaximum) { return new MatchNoDocsQuery(); }
+                return NumericRangeQuery.newLongRange(field, millis, millis, true, true);
+            case NOT_EQUAL_TO:
+                if (millis < longMinimum || millis > longMaximum) { return new MatchAllDocsQuery(); }
+                Query lowerRange = NumericRangeQuery.newLongRange(field, longMinimum, millis, true, false);
+                Query upperRange = NumericRangeQuery.newLongRange(field, millis, longMaximum, false, true);
+                return booleanQuery(lowerRange, Occur.SHOULD, upperRange, Occur.SHOULD);
+            case GREATER_THAN:
+                if (millis > longMaximum) { return new MatchNoDocsQuery(); }
+                return NumericRangeQuery.newLongRange(field, millis, longMaximum, false, true);
+            case GREATER_THAN_OR_EQUAL_TO:
+                if (millis > longMaximum) { return new MatchNoDocsQuery(); }
+                return NumericRangeQuery.newLongRange(field, millis, longMaximum, true, true);
+            case LESS_THAN:
+                if (millis < longMinimum) { return new MatchNoDocsQuery(); }
+                return NumericRangeQuery.newLongRange(field, longMinimum, millis, true, false);
+            case LESS_THAN_OR_EQUAL_TO:
+                if (millis < longMinimum) { return new MatchNoDocsQuery(); }
+                return NumericRangeQuery.newLongRange(field, longMinimum, millis, true, true);
+            case LIKE:
+                // should never happen (the millis conversion should've failed)
+                assert false;
+            default:
+                throw new IllegalArgumentException("Unknown operator:" + operator);
+        }
+    }
+
+    protected Query createReferenceValueQuery( ReferenceValue referenceValue, Operator operator, Object value ) {
+        String field = referenceValue.getPropertyName();
+        if (field != null) {
+            return stringFieldQuery(field, operator, value, CaseOperations.AS_IS);    
+        }
+
+        // we are being asked to query for all the references fields that apply to this index, so we need to collect them first
+        List<String> referenceFields = collectReferenceFieldNames(referenceValue);
+        assert !referenceFields.isEmpty(); // this can't be empty because this index was called in the first place....
+        if (referenceFields.size() == 1) {
+            return stringFieldQuery(referenceFields.get(0), operator, value, CaseOperations.AS_IS);
+        } else {
+            BooleanQuery.Builder builder = new BooleanQuery.Builder();
+            builder.setDisableCoord(true);
+            for (String fieldName : referenceFields) {
+                Query fieldQuery = stringFieldQuery(fieldName, operator, value, CaseOperations.AS_IS);
+                builder.add(fieldQuery, Occur.SHOULD);
+            }
+            return builder.build();
+        }
+    }
+
+    protected List<String> collectReferenceFieldNames( ReferenceValue referenceValue ) {
+        List<String> result = new ArrayList<>();
+        boolean includeWeakReferences = referenceValue.includesWeakReferences();
+        boolean includeSimpleReferences = referenceValue.includeSimpleReferences();
+        for (Map.Entry<String, PropertyType> propertyEntry : propertyTypesByName.entrySet()) {
+            PropertyType propertyType = propertyEntry.getValue();
+            switch (propertyType) {
+                case WEAKREFERENCE: {
+                    if (includeWeakReferences) {
+                        result.add(propertyEntry.getKey());
+                    }
+                    break;
+                }
+                case SIMPLEREFERENCE: {
+                    if (includeSimpleReferences) {
+                        result.add(propertyEntry.getKey());
+                    }
+                    break;
+                }
+                case REFERENCE: {
+                    result.add(propertyEntry.getKey());
+                    break;
+                }
+            }
+        }
+        return result;
+    }
+    
+    protected Query createLengthQuery( Length propertyLength, Operator operator, Object value ) {
+        assert propertyLength != null;
+        assert value != null;
+        long length = factories.getLongFactory().create(value);
+        if (length <= 0L) {
+            return new MatchNoDocsQuery();
+        }
+        String field = FieldUtil.lengthField(propertyLength.getPropertyValue().getPropertyName());
+        switch (operator) {
+            case EQUAL_TO:
+                return NumericRangeQuery.newLongRange(field, length, length, true, true);
+            case NOT_EQUAL_TO:
+                Query upper = NumericRangeQuery.newLongRange(field, length, Long.MAX_VALUE, false, false);
+                Query lower = NumericRangeQuery.newLongRange(field, 0L, length, true, false);
+                return booleanQuery(upper, Occur.SHOULD, lower, Occur.SHOULD);
+            case GREATER_THAN:
+                return NumericRangeQuery.newLongRange(field, length, Long.MAX_VALUE, false, false);
+            case GREATER_THAN_OR_EQUAL_TO:
+                return NumericRangeQuery.newLongRange(field, length, Long.MAX_VALUE, true, false);
+            case LESS_THAN:
+                return NumericRangeQuery.newLongRange(field, 0L, length, true, false);
+            case LESS_THAN_OR_EQUAL_TO:
+                return NumericRangeQuery.newLongRange(field, 0L, length, true, true);
+            case LIKE:
+                // This is not allowed ...
+                throw new LuceneIndexException(LuceneIndexProviderI18n.invalidOperatorForOperand.text(operator, propertyLength));
+            default: {
+                throw new IllegalArgumentException("Unknown operator:" + operator);
+            }
+        }
+    }
+
+    protected Query pathFieldQuery( String field, Operator operator, Object value, CaseOperation caseOperation ) {
+        Path path = null;
+        if (operator != Operator.LIKE) {
+            path = !(value instanceof Path) ? pathFactory.create(value) : (Path)value;
+        }
+        if (caseOperation == null) {
+            caseOperation = CaseOperations.AS_IS;
+        }
+        switch (operator) {
+            case EQUAL_TO:
+                return CompareStringQuery.createQueryForNodesWithFieldEqualTo(stringFactory.create(path), field, factories, caseOperation);
+            case NOT_EQUAL_TO:
+                return not(CompareStringQuery.createQueryForNodesWithFieldEqualTo(stringFactory.create(path), field,
+                                                                                  factories, caseOperation));
+            case LIKE:
+                String likeExpression = stringFactory.create(value);
+                if (likeExpression.contains("[%]")) {
+                    // We can't use '[%]' because we only want to match digits,
+                    // so handle this using a regex ...
+                    String regex = likeExpression;
+                    regex = regex.replace("[%]", "[\\d+]");
+                    regex = regex.replace("[", "\\[");
+                    regex = regex.replace("*", ".*").replace("?", ".");
+                    regex = regex.replace("%", ".*").replace("_", ".");
+                    // Now create a regex query ...
+                    int flags = caseOperation == CaseOperations.AS_IS ? 0 : Pattern.CASE_INSENSITIVE;
+                    return new RegexpQuery(new Term(field, regex), flags);
+                } else {
+                    return CompareStringQuery.createQueryForNodesWithFieldLike(likeExpression, field, factories, caseOperation);
+                }
+            case GREATER_THAN:
+                return ComparePathQuery.createQueryForNodesWithPathGreaterThan(path, field, factories, caseOperation);
+            case GREATER_THAN_OR_EQUAL_TO:
+                return ComparePathQuery.createQueryForNodesWithPathGreaterThanOrEqualTo(path, field, factories, caseOperation);
+            case LESS_THAN:
+                return ComparePathQuery.createQueryForNodesWithPathLessThan(path, field, factories, caseOperation);
+            case LESS_THAN_OR_EQUAL_TO:
+                return ComparePathQuery.createQueryForNodesWithPathLessThanOrEqualTo(path, field, factories, caseOperation);
+            default: {
+                throw new IllegalArgumentException("Unknown operator:" + operator);
+            }
+        }
+    }
+
+    protected Query nameFieldQuery( String field, Operator operator, Object value, CaseOperation caseOperation ) {
+        Name name = null;
+        if (operator != Operator.LIKE) {
+            name = !(value instanceof Name) ? factories.getNameFactory().create(value) : (Name)value;
+        }
+        if (caseOperation == null) {
+            caseOperation = CaseOperations.AS_IS;
+        }
+        switch (operator) {
+            case EQUAL_TO:
+                return CompareNameQuery.createQueryForNodesWithNameEqualTo(name, field, factories, caseOperation);
+            case NOT_EQUAL_TO:
+                Query equalToQuery = CompareNameQuery.createQueryForNodesWithNameEqualTo(name, field, factories, caseOperation);
+                return not(equalToQuery);
+            case GREATER_THAN:
+                return CompareNameQuery.createQueryForNodesWithNameGreaterThan(name, field, factories, caseOperation);
+            case GREATER_THAN_OR_EQUAL_TO:
+                return CompareNameQuery.createQueryForNodesWithNameGreaterThanOrEqualTo(name, field, factories, caseOperation);
+            case LESS_THAN:
+                return CompareNameQuery.createQueryForNodesWithNameLessThan(name, field, factories, caseOperation);
+            case LESS_THAN_OR_EQUAL_TO:
+                return CompareNameQuery.createQueryForNodesWithNameLessThanOrEqualTo(name, field, factories, caseOperation);
+            case LIKE:
+                // we can only process the value as a string...
+                String likeExpression = stringFactory.create(value);
+                return CompareStringQuery.createQueryForNodesWithFieldLike(likeExpression, field, factories, caseOperation);
+            default:
+                throw new IllegalArgumentException("Unknown operator:" + operator);
+        }
+    }
+
+    protected BooleanQuery booleanQuery( Query leftQuery, Occur leftOccur, Query rightQuery, Occur rightOccur ) {
+        BooleanQuery.Builder builder = new BooleanQuery.Builder();
+        builder.setDisableCoord(true);
+        builder.add(leftQuery, leftOccur);
+        builder.add(rightQuery, rightOccur);
+        return builder.build();
+    }
+    
+    protected static class SingleColumnQueryFactory extends LuceneQueryFactory {
+        private SingleColumnQueryFactory( ValueFactories factories, Map<String, Object> variables,
+                                         Map<String, PropertyType> propertyTypesByName ) {
+            super(factories, variables, propertyTypesByName);
+        }
+
+        @Override
+        protected Query createQuery( PropertyExistence propertyExistence ) {
+            // since there can be only one property per indexed document, the fact that this was called means it applies to all the
+            // documents of the stored index
+            return new MatchAllDocsQuery();
+        }
+
+        @Override
+        protected List<String> collectReferenceFieldNames( ReferenceValue referenceValue ) {
+            // there should be just one column for these types of indexes and that column should already have the reference value
+            assert propertyTypesByName.size() == 1;
+            return Collections.singletonList(propertyName());
+        }
+
+        protected String propertyName() {
+            // these indexes can only apply to 1 single property
+            return propertyTypesByName.keySet().iterator().next();
+        }
+    }
+    
+    protected static class TextQueryFactory extends SingleColumnQueryFactory {
+        private static final PhraseQuery EMPTY_PHRASE_QUERY = new PhraseQuery.Builder().build();
+
+        private final Analyzer analyzer;
+        
+        private TextQueryFactory( ValueFactories factories,
+                                  Map<String, Object> variables,
+                                  Map<String, PropertyType> propertyTypesByName,
+                                  LuceneConfig config) {
+            super(factories, variables, propertyTypesByName);
+            this.analyzer = config.getAnalyzer();
+        }
+
+        @Override
+        public boolean scoreDocuments() {
+            return true;
+        }
+
+        @Override
+        protected Query createQuery( FullTextSearch search ) {
+            String propertyName = search.getPropertyName();
+            if (propertyName == null) {
+                // the search if for * (all properties) so this query should be done for the current index's property
+                propertyName = propertyName();
+            }
+            StaticOperand expression = search.getFullTextSearchExpression();
+            Object value = getSingleValueFromStaticOperand(expression);
+            try {
+                String valueString = value instanceof Value ? ((Value) value).getString() : stringFactory.create(value);
+                search = search.withFullTextExpression(valueString);
+                return createQuery(propertyName, search.getTerm());
+            } catch (RepositoryException e) {
+                throw new LuceneIndexException(e);
+            }
+        }
+        
+        protected Query createQuery( String fieldName, FullTextSearch.Term term ) {
+            assert fieldName != null;
+            if (term instanceof FullTextSearch.Conjunction) {
+                return createConjunctionQuery(fieldName, (FullTextSearch.Conjunction)term);
+            }
+            if (term instanceof FullTextSearch.Disjunction) {
+                return createDisjunctionQuery(fieldName, (FullTextSearch.Disjunction)term);
+            }
+            if (term instanceof FullTextSearch.SimpleTerm) {
+                return createSimpleTermQuery(fieldName, (FullTextSearch.SimpleTerm)term);
+            }
+            if (term instanceof FullTextSearch.NegationTerm) {
+                return createNegationTermQuery(fieldName, (FullTextSearch.NegationTerm)term);
+            }
+            throw new IllegalArgumentException("Unknown term instance:" + term);
+        }
+
+        private Query createNegationTermQuery( String fieldName, FullTextSearch.NegationTerm negation ) {
+            BooleanQuery.Builder builder = new BooleanQuery.Builder();
+            builder.setDisableCoord(true);
+            Query subQuery = createQuery(fieldName, negation.getNegatedTerm());
+            if (!EMPTY_PHRASE_QUERY.equals(subQuery)) {
+                builder.add(subQuery, Occur.MUST_NOT);
+                // need to add at least a positive match
+                builder.add(new MatchAllDocsQuery(), Occur.FILTER);
+                return builder.build();
+            }  else {
+                return new MatchAllDocsQuery(); 
+            }
+        }
+
+        private Query createSimpleTermQuery( String fieldName, FullTextSearch.SimpleTerm simple ) {
+            try {
+                if (simple.containsWildcards()) {
+                    return createWildcardQuery(fieldName, simple);
+                }
+                PhraseQuery.Builder builder = new PhraseQuery.Builder();
+                builder.setSlop(0); // terms must be adjacent
+                String expression = simple.getValue();
+                // Run the expression through the Lucene analyzer to extract the terms ...
+                try (TokenStream stream = analyzer.tokenStream(fieldName, expression)) {
+                    stream.reset();
+                    CharTermAttribute termAttribute = stream.addAttribute(CharTermAttribute.class);
+                    while (stream.incrementToken()) {
+                        // The term attribute object has been modified to contain the next term ...
+                        String analyzedTerm = termAttribute.toString();
+                        builder.add(new Term(fieldName, analyzedTerm));
+                    }
+                    stream.end();
+                }
+                return builder.build();
+            } catch (Exception e) {
+                throw new LuceneIndexException(e);
+            }
+        }
+
+        private Query createDisjunctionQuery( String fieldName, FullTextSearch.Disjunction disjunction ) {
+            BooleanQuery.Builder builder = new BooleanQuery.Builder();
+            builder.setDisableCoord(true);
+            boolean atLeastOnePositiveClause = false;
+            for (FullTextSearch.Term nested : disjunction) {
+                if (nested instanceof FullTextSearch.NegationTerm) {
+                    //Lucene does not have a SHOULD_NOT and MUST_NOT is too strong for disjunctions...
+                } else {
+                    Query subQuery = createQuery(fieldName, nested);
+                    if (!EMPTY_PHRASE_QUERY.equals(subQuery)) {
+                        atLeastOnePositiveClause = true;
+                        builder.add(subQuery, Occur.SHOULD);
+                    }
+                }
+            }
+            if (!atLeastOnePositiveClause) {
+                // there are only MUST_NOT terms so we should add one positive for this to work
+                builder.add(new MatchAllDocsQuery(), Occur.FILTER);
+            }
+            return builder.build();
+        }
+
+        private Query createConjunctionQuery( String fieldName, FullTextSearch.Conjunction conjunction ) {
+            BooleanQuery.Builder builder = new BooleanQuery.Builder();
+            builder.setDisableCoord(true);
+            boolean atLeastOnePositiveClause = false;
+            for (FullTextSearch.Term nested : conjunction) {
+                if (nested instanceof FullTextSearch.NegationTerm) {
+                    Query subQuery = createQuery(fieldName, ((FullTextSearch.NegationTerm)nested).getNegatedTerm());
+                    if (!EMPTY_PHRASE_QUERY.equals(subQuery)) {
+                        builder.add(subQuery, Occur.MUST_NOT);
+                    }
+                } else {
+                    Query subQuery = createQuery(fieldName, nested);
+                    if (!EMPTY_PHRASE_QUERY.equals(subQuery)) {
+                        atLeastOnePositiveClause = true;
+                        builder.add(subQuery, Occur.MUST);
+                    }
+                }
+            }
+            if (!atLeastOnePositiveClause) {
+                // there are only MUST_NOT terms so we should add one positive for this to work
+                builder.add(new MatchAllDocsQuery(), Occur.FILTER);
+            }
+            return builder.build();
+        }
+
+        private Query createWildcardQuery( final String fieldName, FullTextSearch.SimpleTerm simple ) throws ParseException {
+            // Use the standard parser, but instead of wildcard queries (which don't work with leading
+            // wildcards) we should use our like queries (which often use RegexQuery where applicable) ...
+            
+            //as an alternative, for leading wildcards one could call parser.setAllowLeadingWildcard(true);
+            //and use the default Lucene query parser
+            QueryParser parser = new QueryParser(fieldName, analyzer) {
+                @Override
+                protected Query getWildcardQuery( String field, String termStr ) {
+                    return CompareStringQuery.createQueryForNodesWithFieldLike(termStr.toLowerCase(), fieldName, factories,
+                                                                               CaseOperations.AS_IS);
+                }
+            };
+
+            String expression = simple.getValue();
+            // The ComplexPhraseQueryParser only understands the '?' and '*' as being wildcards ...
+            expression = expression.replaceAll("(?<![\\\\])_", "?");
+            expression = expression.replaceAll("(?<![\\\\])%", "*");
+            // // Replace any '-' between tokens, except when preceded or followed by a digit, '*', or '?' ...
+            expression = expression.replaceAll("((?<![\\d*?]))[-]((?![\\d*?]))", "$1 $2");
+            // Then use the parser ...
+            return parser.parse(expression);
+        }
+    }
+}

--- a/index-providers/modeshape-lucene-index-provider/src/main/java/org/modeshape/jcr/index/lucene/query/RelikeQuery.java
+++ b/index-providers/modeshape-lucene-index-provider/src/main/java/org/modeshape/jcr/index/lucene/query/RelikeQuery.java
@@ -1,0 +1,142 @@
+/*
+ * ModeShape (http://www.modeshape.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.modeshape.jcr.index.lucene.query;
+
+import java.text.CharacterIterator;
+import java.text.StringCharacterIterator;
+import java.util.regex.Pattern;
+import org.apache.lucene.document.Document;
+import org.apache.lucene.search.Query;
+import org.modeshape.common.annotation.Immutable;
+
+/**
+ * A Lucene {@link Query} implementation that matches some value by document property as like pattern.
+ * 
+ * @since 4.5
+ */
+@Immutable
+public class RelikeQuery extends ConstantScoreWeightQuery {
+
+    private final String relikeValue;
+    
+    protected RelikeQuery( String field, String relikeValue ) {
+        super(field);
+        this.relikeValue = relikeValue;
+    }
+
+    @Override
+    protected boolean isValid( Document document ) {
+        String value = document.getField(field()).stringValue();
+        return like(relikeValue, value);
+    }
+    
+    public String toString( String field ) {
+        final StringBuilder sb = new StringBuilder();
+        return sb.append(field).append(" RELIKE ").append(relikeValue).toString();
+    }
+
+    @Override
+    public Query clone() {
+        return new RelikeQuery(field(), relikeValue);
+    }
+    
+    private static boolean like( String value, String pattern ) {
+        CompareType cmpType = getCompareType(pattern);
+        switch (cmpType) {
+            case EQ: {
+                return value.equals(pattern);
+            }
+            case ENDS_WITH: {
+                return value.endsWith(pattern.substring(1));
+            }
+            case STARTS_WITH: {
+                return value.startsWith(pattern.substring(0, pattern.length() - 1));
+            }
+            case REGEXP:
+            default: {
+                Pattern p = Pattern.compile(toRegularExpression(pattern));
+                return p.matcher(value).matches();
+            }
+        }
+    }
+
+    private enum CompareType {
+        EQ,
+        STARTS_WITH,
+        ENDS_WITH,
+        REGEXP;
+    }
+    
+    /**
+     * Determine the compare type given the expression. This method returns:
+     * <ul>
+     * <li>CompareType.EQ if expression does not contains '_' or '%';</li>
+     * <li>CompareType.ENDS_WITH if expression has only one '%' at start and does not contains '_';</li>
+     * <li>CompareType.STARTS_WITH if expression has only one '%' at end and does not contains '_';</li>
+     * <li>CompareType.REGEXP otherwise</li>
+     * </ul>
+     * 
+     * @param expression the expression for which the {@link CompareType} is to be found
+     * @return the compare type; never null;
+     */
+    private static CompareType getCompareType( String expression ) {
+        CompareType result = CompareType.EQ;
+
+        CharacterIterator iter = new StringCharacterIterator(expression);
+        final int fistIndex = 0;
+        final int lastIndex = expression.length() - 1;
+        boolean skipNext = false;
+        for (char c = iter.first(); c != CharacterIterator.DONE; c = iter.next()) {
+            if (skipNext) {
+                skipNext = false;
+                continue;
+            }
+            if (c == '_') {
+                return CompareType.REGEXP;
+            }
+            if (c == '%') {
+                if (result != CompareType.EQ) {
+                    // pattern like '%abcdfe%' -> only regexp can handle this;
+                    return CompareType.REGEXP;
+                }
+
+                int index = iter.getIndex();
+                if (index == fistIndex) {
+                    result = CompareType.ENDS_WITH;
+                } else if (index == lastIndex) {
+                    result = CompareType.STARTS_WITH;
+                } else {
+                    return CompareType.REGEXP;
+                }
+            }
+
+            if (c == '\\') skipNext = true;
+        }
+
+        return result;
+    }
+
+    private static String toRegularExpression( String likeExpression ) {
+        // Replace all '\x' with 'x' ...
+        String result = likeExpression.replaceAll("\\\\(.)", "$1");
+        // Escape characters used as metacharacters in regular expressions, including
+        // '[', '^', '\', '$', '.', '|', '+', '*', '?', '(', and ')'
+        result = result.replaceAll("([$.|+()\\*\\?\\[\\\\^\\\\\\\\])", "\\\\$1");
+        // Replace '%'->'[.]*' and '_'->'[.]
+        result = result.replace("%", ".*").replace("_", ".");
+        return result;
+    }
+}

--- a/index-providers/modeshape-lucene-index-provider/src/main/java/org/modeshape/jcr/index/lucene/query/RelikeQuery.java
+++ b/index-providers/modeshape-lucene-index-provider/src/main/java/org/modeshape/jcr/index/lucene/query/RelikeQuery.java
@@ -18,7 +18,7 @@ package org.modeshape.jcr.index.lucene.query;
 import java.text.CharacterIterator;
 import java.text.StringCharacterIterator;
 import java.util.regex.Pattern;
-import org.apache.lucene.document.Document;
+import org.apache.lucene.index.IndexableField;
 import org.apache.lucene.search.Query;
 import org.modeshape.common.annotation.Immutable;
 
@@ -38,9 +38,15 @@ public class RelikeQuery extends ConstantScoreWeightQuery {
     }
 
     @Override
-    protected boolean isValid( Document document ) {
-        String value = document.getField(field()).stringValue();
-        return like(relikeValue, value);
+    protected boolean areValid( IndexableField... fields ) {
+        for (IndexableField field : fields) {
+            String value = field.stringValue();
+            if (value != null && like(relikeValue, value)) {
+                // if at least one value matches, return true
+                return true;
+            }
+        }
+        return false;
     }
     
     public String toString( String field ) {

--- a/index-providers/modeshape-lucene-index-provider/src/main/resources/org/modeshape/jcr/index/lucene/LuceneIndexProviderI18n.properties
+++ b/index-providers/modeshape-lucene-index-provider/src/main/resources/org/modeshape/jcr/index/lucene/LuceneIndexProviderI18n.properties
@@ -1,0 +1,20 @@
+#
+# ModeShape (http://www.modeshape.org)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+multiColumnTextIndexesNotSupported = The Lucene Text index '{0}' does not support multiple columns
+invalidColumnType = The type '{0}' for the column '{1}' of index '{2}' is not a valid type for Lucene indexes.
+warnErrorWhileClosingSearcher = Unexpected error while closing the Lucene Index Searcher.
+invalidOperatorForPropertyType = The operator '{0}' is not a valid operator for properties of type '{1}'
+invalidOperatorForOperand = The operator '{0}' is not a valid operator for the '{1}' operand

--- a/index-providers/modeshape-lucene-index-provider/src/test/java/org/modeshape/jcr/index/lucene/AbstractIndexPersistenceTest.java
+++ b/index-providers/modeshape-lucene-index-provider/src/test/java/org/modeshape/jcr/index/lucene/AbstractIndexPersistenceTest.java
@@ -1,0 +1,158 @@
+/*
+ * ModeShape (http://www.modeshape.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.modeshape.jcr.index.lucene;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+import java.util.UUID;
+import org.junit.After;
+import org.junit.Before;
+import org.modeshape.common.util.FileUtil;
+import org.modeshape.jcr.ExecutionContext;
+import org.modeshape.jcr.cache.NodeKey;
+import org.modeshape.jcr.value.PropertyType;
+import org.modeshape.jcr.value.basic.JodaDateTime;
+
+/**
+ * Base class for testing the CRUD operations on Lucene indexes.
+ *
+ * @author Horia Chiorean (hchiorea@redhat.com)
+ */
+public abstract class AbstractIndexPersistenceTest {
+
+    private static final Random RANDOM = new Random();
+
+    protected ExecutionContext context;
+    protected LuceneConfig config;
+    protected LuceneIndex index;
+    
+    protected abstract LuceneIndex createIndex( String name );
+
+    @Before
+    public void setUp() throws Exception {
+        String dir = "target/lucene-index-test";
+        FileUtil.delete(dir);
+        config = LuceneConfig.onDisk(dir);
+        context = new ExecutionContext();
+        index = defaultIndex();
+    }
+
+    protected LuceneIndex defaultIndex() {
+        return createIndex("default");
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        index.shutdown(false);
+    }
+  
+    protected String addMultiplePropertiesToSameNode( LuceneIndex index, String nodeKey, int valuesPerProperty, PropertyType type) {
+        List<Object> values = new ArrayList<>();
+        IndexedProperty property = newProperty(type);
+        String propertyName = property.getName();
+        for (int i = 0; i < valuesPerProperty; i++) {
+            values.add(property.getValue());
+            property = newProperty(type);
+        }
+        index.add(nodeKey, propertyName, values.toArray());
+        return propertyName;
+    }
+    
+    protected IndexedProperty newProperty(PropertyType type) {
+        String rnd = UUID.randomUUID().toString().replace("\\-", "_");
+        switch (type) {
+            case STRING: {
+                return new IndexedProperty(type, PropertiesTestUtil.STRING_PROP, "string#" + rnd);                
+            }
+            case BINARY: {
+                return new IndexedProperty(type, PropertiesTestUtil.BINARY_PROP, context.getValueFactories().getBinaryFactory().create(rnd));                
+            }
+            case NAME: {
+                return new IndexedProperty(type, PropertiesTestUtil.NAME_PROP, context.getValueFactories().getNameFactory().create("jcr:" + rnd));
+            }
+            case PATH: {
+                return new IndexedProperty(type, PropertiesTestUtil.PATH_PROP, context.getValueFactories().getPathFactory().create("/a/b/" + rnd));                
+            }
+            case BOOLEAN: {
+                Boolean value = RANDOM.nextInt(2) == 1 ? Boolean.TRUE : Boolean.FALSE;
+                return new IndexedProperty(type, PropertiesTestUtil.BOOLEAN_PROP, value);
+            }
+            case DATE: {
+                return new IndexedProperty(type, PropertiesTestUtil.DATE_PROP, new JodaDateTime(System.currentTimeMillis()));
+            }
+            case DECIMAL: {
+                return new IndexedProperty(type, PropertiesTestUtil.DECIMAL_PROP, BigDecimal.valueOf(RANDOM.nextDouble()));
+            }
+            case DOUBLE: {
+                return new IndexedProperty(type, PropertiesTestUtil.DOUBLE_PROP, RANDOM.nextDouble());
+            }
+            case LONG: {
+                return new IndexedProperty(type, PropertiesTestUtil.LONG_PROP, RANDOM.nextLong());
+            }
+            case REFERENCE: {
+                return new IndexedProperty(type, PropertiesTestUtil.REF_PROP, context.getValueFactories().getReferenceFactory().create(new NodeKey(rnd), false));
+            }
+            case WEAKREFERENCE:  {
+                return new IndexedProperty(type, PropertiesTestUtil.WEAK_REF_PROP, context.getValueFactories().getReferenceFactory().create(new NodeKey(rnd), false));
+            }
+            case SIMPLEREFERENCE: {
+                return new IndexedProperty(type, PropertiesTestUtil.SIMPLE_REF_PROP, context.getValueFactories().getReferenceFactory().create(new NodeKey(rnd), false));
+            }
+            case URI: {
+                return new IndexedProperty(type, PropertiesTestUtil.URI_PROP, "http://" + rnd);
+            }
+            default: {
+                throw new IllegalArgumentException("Unknown property type:" + type);
+            }
+        }
+    }
+    
+    protected static class IndexedProperty {
+        private final PropertyType type;
+        private final String name;
+        private final Object value;
+
+        protected IndexedProperty( PropertyType type, String name, Object value ) {
+            this.type = type;
+            this.name = name;
+            this.value = value;
+        }
+
+        protected PropertyType getType() {
+            return type;
+        }
+
+        protected String getName() {
+            return name;
+        }
+
+        protected Object getValue() {
+            return value;
+        }
+
+        @Override
+        public String toString() {
+            final StringBuilder sb = new StringBuilder("IndexedProperty{");
+            sb.append("type=").append(type);
+            sb.append(", name='").append(name).append('\'');
+            sb.append(", value=").append(value);
+            sb.append('}');
+            return sb.toString();
+        }
+    }
+}

--- a/index-providers/modeshape-lucene-index-provider/src/test/java/org/modeshape/jcr/index/lucene/AbstractLuceneIndexSearchTest.java
+++ b/index-providers/modeshape-lucene-index-provider/src/test/java/org/modeshape/jcr/index/lucene/AbstractLuceneIndexSearchTest.java
@@ -1,0 +1,269 @@
+/*
+ * ModeShape (http://www.modeshape.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.modeshape.jcr.index.lucene;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+import static org.modeshape.jcr.api.query.qom.Operator.EQUAL_TO;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import javax.jcr.query.qom.JoinCondition;
+import org.junit.After;
+import org.junit.Before;
+import org.modeshape.common.util.FileUtil;
+import org.modeshape.jcr.ExecutionContext;
+import org.modeshape.jcr.api.query.qom.Operator;
+import org.modeshape.jcr.cache.NodeKey;
+import org.modeshape.jcr.query.model.And;
+import org.modeshape.jcr.query.model.Between;
+import org.modeshape.jcr.query.model.Comparison;
+import org.modeshape.jcr.query.model.Constraint;
+import org.modeshape.jcr.query.model.FullTextSearch;
+import org.modeshape.jcr.query.model.Length;
+import org.modeshape.jcr.query.model.Literal;
+import org.modeshape.jcr.query.model.LowerCase;
+import org.modeshape.jcr.query.model.Not;
+import org.modeshape.jcr.query.model.Or;
+import org.modeshape.jcr.query.model.PropertyExistence;
+import org.modeshape.jcr.query.model.PropertyValue;
+import org.modeshape.jcr.query.model.ReferenceValue;
+import org.modeshape.jcr.query.model.Relike;
+import org.modeshape.jcr.query.model.SelectorName;
+import org.modeshape.jcr.query.model.SetCriteria;
+import org.modeshape.jcr.query.model.StaticOperand;
+import org.modeshape.jcr.query.model.UpperCase;
+import org.modeshape.jcr.spi.index.ResultWriter;
+import org.modeshape.jcr.spi.index.provider.Filter;
+import org.modeshape.jcr.value.ValueFactories;
+
+/**
+ * Base class for testing the search behavior on the various types of Lucene indexes.
+ * 
+ * @author Horia Chiorean (hchiorea@redhat.com)
+ */
+public abstract class AbstractLuceneIndexSearchTest {
+
+    protected static final SelectorName SELECTOR = new SelectorName("node");
+    
+    protected ExecutionContext context;
+    protected LuceneConfig config;
+    protected LuceneIndex index;
+    protected ValueFactories valueFactories;
+
+    protected abstract LuceneIndex createIndex( String name );
+
+    @Before
+    public void setUp() throws Exception {
+        String dir = "target/lucene-index-search-test";
+        FileUtil.delete(dir);
+        config = LuceneConfig.onDisk(dir);
+        context = new ExecutionContext();
+        valueFactories = context.getValueFactories();
+        index = createIndex("default");
+    }
+    
+    @After
+    public void tearDown() throws Exception {
+        index.shutdown(false);
+    }
+
+    protected void assertLengthComparisonConstraint( String propertyName, String expectedNodeKey, int expectedLength ) {
+        Constraint constraint = length(propertyName, EQUAL_TO, expectedLength);
+        validateCardinality(constraint, 1);
+        validateFilterResults(constraint, 1, false, expectedNodeKey);
+    }
+
+    protected void validateCardinality(Constraint constraint, long expected) {
+        long actualValue = index.estimateCardinality(Collections.<javax.jcr.query.qom.Constraint>singletonList(constraint), Collections.<String, Object>emptyMap());
+        assertEquals("Incorrect returned cardinality:", expected, actualValue);
+    }
+
+    protected void validateFilterResults(Constraint constraint, int batchSize, boolean expectRealScore, String...expectedKeys) {
+        Filter.Results results = index.filter(new TestIndexConstraints(constraint));
+        BatchCollector collector = new BatchCollector();
+        while (true) {
+            if (!results.getNextBatch(collector, batchSize)) {
+                break;
+            }
+        }
+        Map<String, Float> actualResults = collector.actualResults();
+        assertEquals("Incorrect number of results:", expectedKeys.length, actualResults.size());
+        for (String expectedKey : actualResults.keySet()) {
+            Float score = actualResults.get(expectedKey);
+            if (score == null) {
+                fail("Expected key: " + expectedKey + " not found among results: " + actualResults.keySet());
+            }
+            if (expectRealScore && score == 1.0f) {
+                fail("Expected a real score but found: " + score);
+            }
+        }
+    }
+
+    private <T> String addValue(String propertyName, T value) {
+        String nodeKey = UUID.randomUUID().toString();
+        index.add(nodeKey, propertyName, value);
+        return nodeKey;
+    }
+
+    protected  <T> List<String> indexNodes(String propertyName, T...values) {
+        List<String> result = new ArrayList<>();
+        for (T value : values) {
+            result.add(addValue(propertyName, value));
+        }
+        return result;
+    }
+    
+    protected Constraint relike(Object value, String propertyName) {
+        PropertyValue propValue = new PropertyValue(SELECTOR, propertyName);
+        return new Relike(new Literal(value), propValue);
+    }
+    
+    protected Constraint and(Constraint left, Constraint right) {
+        return new And(left, right);
+    }  
+    
+    protected Constraint or(Constraint left, Constraint right) {
+        return new Or(left, right);
+    }  
+    
+    protected Constraint not(Constraint constraint) {
+        return new Not(constraint);
+    }
+    
+    protected Constraint set(String propertyName, Object...values) {
+        PropertyValue propValue = new PropertyValue(SELECTOR, propertyName);
+        Collection<StaticOperand> operands = new ArrayList<>(values.length);
+        for (Object value : values) {
+            operands.add(new Literal(value));                
+        }
+        return new SetCriteria(propValue, operands);
+    }
+    
+    protected Constraint between(String propertyName, Object lowerBound, boolean includeLowerBound, 
+                                 Object upperBound, boolean includeUpperBound) {
+        PropertyValue propValue = new PropertyValue(SELECTOR, propertyName);
+        return new Between(propValue, new Literal(lowerBound), new Literal(upperBound), includeLowerBound, includeUpperBound);
+    }
+    
+    protected Constraint fullTextSearch(String propertyName, String expression) {
+        return new FullTextSearch(SELECTOR, propertyName, expression);
+    }
+    
+    protected Comparison lowerCase( String propertyName, Operator operator, Object value ) {
+        PropertyValue propValue = new PropertyValue(SELECTOR, propertyName);
+        LowerCase lowerCase = new LowerCase(propValue);
+        return new Comparison(lowerCase, operator, new Literal(value));
+    } 
+    
+    protected Comparison upperCase( String propertyName, Operator operator, Object value ) {
+        PropertyValue propValue = new PropertyValue(SELECTOR, propertyName);
+        UpperCase upperCase = new UpperCase(propValue);
+        return new Comparison(upperCase, operator, new Literal(value));
+    }
+
+    protected Comparison propertyValue( String propertyName, Operator operator, Object value ) {
+        PropertyValue propValue = new PropertyValue(SELECTOR, propertyName);
+        return new Comparison(propValue, operator, new Literal(value));
+    }
+    
+    protected Comparison referenceValue( String propertyName, Operator operator, Object value, boolean includeWeak,
+                                         boolean includeSimple ) {
+        ReferenceValue referenceValue = new ReferenceValue(SELECTOR, propertyName, includeWeak, includeSimple);
+        return new Comparison(referenceValue, operator, new Literal(value));
+    }
+
+    protected Comparison length( String propertyName, Operator operator, Object value ) {
+        PropertyValue propValue = new PropertyValue(SELECTOR, propertyName);
+        Length length = new Length(propValue);
+        return new Comparison(length, operator, new Literal(value));
+    }
+    
+    protected PropertyExistence propertyExistence(String propertyName) {
+        return new PropertyExistence(SELECTOR, propertyName);
+    }
+
+    protected class BatchCollector implements ResultWriter {
+        private Map<String, Float> actualResults = new LinkedHashMap<>();
+
+        @Override
+        public void add( NodeKey nodeKey, float score ) {
+            actualResults.put(nodeKey.toString(), score);
+        }
+
+        @Override
+        public void add( Iterable<NodeKey> nodeKeys, float score ) {
+            for (NodeKey key : nodeKeys) {
+                actualResults.put(key.toString(), score);
+            }
+        }
+
+        @Override
+        public void add( Iterator<NodeKey> nodeKeys, float score ) {
+            while(nodeKeys.hasNext()) {
+                actualResults.put(nodeKeys.next().toString(), score);
+            }
+        }
+
+        protected Map<String, Float> actualResults() {
+            return actualResults;
+        }
+    }
+
+    protected class TestIndexConstraints implements org.modeshape.jcr.spi.index.IndexConstraints {
+
+        private final Constraint constraint;
+
+        private TestIndexConstraints( Constraint constraint ) {
+            this.constraint = constraint;
+        }
+
+        @Override
+        public boolean hasConstraints() {
+            return true;
+        }
+
+        @Override
+        public Collection<javax.jcr.query.qom.Constraint> getConstraints() {
+            return Collections.<javax.jcr.query.qom.Constraint>singleton(constraint);
+        }
+
+        @Override
+        public Collection<JoinCondition> getJoinConditions() {
+            return Collections.emptySet();
+        }
+
+        @Override
+        public Map<String, Object> getVariables() {
+            return Collections.emptyMap();
+        }
+
+        @Override
+        public ValueFactories getValueFactories() {
+            return context.getValueFactories();
+        }
+
+        @Override
+        public Map<String, Object> getParameters() {
+            return Collections.emptyMap();
+        }
+    }
+}

--- a/index-providers/modeshape-lucene-index-provider/src/test/java/org/modeshape/jcr/index/lucene/AbstractLuceneIndexSearchTest.java
+++ b/index-providers/modeshape-lucene-index-provider/src/test/java/org/modeshape/jcr/index/lucene/AbstractLuceneIndexSearchTest.java
@@ -118,7 +118,11 @@ public abstract class AbstractLuceneIndexSearchTest {
         }
     }
 
-    private <T> String addValue(String propertyName, T value) {
+    protected  <T> void addValues( String nodeKey, String propertyName, T... values ) {
+        index.add(nodeKey, propertyName, values);
+    }
+  
+    private <T> String insertValue( String propertyName, T value ) {
         String nodeKey = UUID.randomUUID().toString();
         index.add(nodeKey, propertyName, value);
         return nodeKey;
@@ -127,7 +131,7 @@ public abstract class AbstractLuceneIndexSearchTest {
     protected  <T> List<String> indexNodes(String propertyName, T...values) {
         List<String> result = new ArrayList<>();
         for (T value : values) {
-            result.add(addValue(propertyName, value));
+            result.add(insertValue(propertyName, value));
         }
         return result;
     }

--- a/index-providers/modeshape-lucene-index-provider/src/test/java/org/modeshape/jcr/index/lucene/LuceneIndexProviderI18nTest.java
+++ b/index-providers/modeshape-lucene-index-provider/src/test/java/org/modeshape/jcr/index/lucene/LuceneIndexProviderI18nTest.java
@@ -1,0 +1,30 @@
+/*
+ * ModeShape (http://www.modeshape.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.modeshape.jcr.index.lucene;
+
+import org.modeshape.common.AbstractI18nTest;
+
+/**
+ * Unit test for {@link LuceneIndexProviderI18n}
+ * 
+ * @author Horia Chiorean (hchiorea@redhat.com)
+ */
+public final class LuceneIndexProviderI18nTest extends AbstractI18nTest {
+    
+    public LuceneIndexProviderI18nTest() {
+        super(LuceneIndexProviderI18n.class);
+    }
+}

--- a/index-providers/modeshape-lucene-index-provider/src/test/java/org/modeshape/jcr/index/lucene/LuceneIndexProviderQueryTest.java
+++ b/index-providers/modeshape-lucene-index-provider/src/test/java/org/modeshape/jcr/index/lucene/LuceneIndexProviderQueryTest.java
@@ -1,0 +1,60 @@
+/*
+ * ModeShape (http://www.modeshape.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.modeshape.jcr.index.lucene;
+
+import javax.jcr.query.Query;
+import javax.jcr.query.QueryResult;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.modeshape.common.util.FileUtil;
+import org.modeshape.jcr.JcrQueryManagerTest;
+
+/**
+ * Extension of {@link JcrQueryManagerTest} which runs queries against Lucene indexes.
+ */
+public class LuceneIndexProviderQueryTest extends JcrQueryManagerTest {
+
+    @BeforeClass
+    public static void beforeAll() throws Exception {
+        // Clean up the indexes and storage ...
+        FileUtil.delete("target/LuceneIndexProviderQueryTest");
+
+        String configFileName = LuceneIndexProviderQueryTest.class.getSimpleName() + ".json";
+        JcrQueryManagerTest.beforeAll(configFileName);
+    }
+
+    @Override
+    @Test
+    public void shouldBeAbleToExecuteXPathQueryWithCompoundCriteria() throws Exception {
+        //overrides the default to add explicit property name in FTS @car:engine, otherwise the 'textFromCarMaker' index would be used
+        //and no results would be returned
+        String xpath = "/jcr:root/Cars//element(*,car:Car)[@car:year='2008' and jcr:contains(@car:engine, '\"liters V 12\"')]";
+        Query query = getSession().getWorkspace().getQueryManager().createQuery(xpath, Query.XPATH);
+        QueryResult result = query.execute();
+        String[] columnNames = {"jcr:primaryType", "jcr:mixinTypes", "jcr:path", "jcr:score", "jcr:created", "jcr:createdBy",
+                                "jcr:name", "mode:localName", "mode:depth", "mode:id", "car:mpgCity", "car:userRating", "car:mpgHighway",
+                                "car:engine", "car:model", "car:year", "car:maker", "car:lengthInInches", "car:valueRating", "car:wheelbaseInInches",
+                                "car:msrp", "car:alternateModels"};
+        validateQuery().rowCount(1).hasColumns(columnNames).validate(query, result);
+
+        // Query again with a different criteria that should return no nodes ...
+        xpath = "/jcr:root/Cars//element(*,car:Car)[@car:year='2007' and jcr:contains(@car:engine, '\"liter V 12\"')]";
+        query = getSession().getWorkspace().getQueryManager().createQuery(xpath, Query.XPATH);
+        result = query.execute();
+        validateQuery().rowCount(0).hasColumns(columnNames).validate(query, result);
+    }
+}

--- a/index-providers/modeshape-lucene-index-provider/src/test/java/org/modeshape/jcr/index/lucene/LuceneIndexProviderTest.java
+++ b/index-providers/modeshape-lucene-index-provider/src/test/java/org/modeshape/jcr/index/lucene/LuceneIndexProviderTest.java
@@ -1,0 +1,147 @@
+/*
+ * ModeShape (http://www.modeshape.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.modeshape.jcr.index.lucene;
+
+import java.io.InputStream;
+import java.util.HashMap;
+import java.util.Map;
+import javax.jcr.Node;
+import javax.jcr.PropertyType;
+import org.junit.Test;
+import org.modeshape.jcr.LocalIndexProviderTest;
+import org.modeshape.jcr.api.JcrTools;
+import org.modeshape.jcr.api.index.IndexDefinition;
+import org.modeshape.jcr.api.index.InvalidIndexDefinitionException;
+import org.modeshape.jcr.api.query.Query;
+
+/**
+ * Unit test for {@link LuceneIndexProvider}. Since this is a local provider in term of repository locality, we want to run
+ * at least the same tests as for {@link org.modeshape.jcr.index.local.LocalIndexProvider}
+ * 
+ * @author Horia Chiorean (hchiorea@redhat.com)
+ */
+public class LuceneIndexProviderTest extends LocalIndexProviderTest {
+
+    @Override
+    public void beforeEach() throws Exception {
+        super.beforeEach();
+        tools = new JcrTools();
+    }
+
+    @Override
+    protected InputStream repositoryConfiguration() {
+        return resource("config/repo-config-persistent-lucene-provider-no-indexes.json");
+    }
+
+    @Override
+    protected String providerName() {
+        return "lucene";
+    }
+    
+    @Test
+    public void shouldUseMultiColumnIndex() throws Exception {
+        registerNodeType("nt:testType");
+        Map<String, Integer> properties = new HashMap<>();
+        properties.put("stringProp", PropertyType.STRING);
+        properties.put("longProp", PropertyType.LONG);
+        properties.put("jcr:name", PropertyType.NAME);
+        registerValueIndex("multiColIndex", "nt:testType", null, "*", properties);
+        
+        Node root = session().getRootNode();
+        Node node1 = root.addNode("node1", "nt:testType");
+        node1.setProperty("stringProp", "string1");
+
+        Node node2 = root.addNode("node2", "nt:testType");
+        node2.setProperty("longProp", 1);
+        
+        Node node3 = root.addNode("node3", "nt:testType");
+        node3.setProperty("stringProp", "string3");
+        node3.setProperty("longProp", 2);
+        
+        session.save();
+
+        Query query = jcrSql2Query("SELECT * FROM [nt:testType] WHERE stringProp LIKE 'string%'");
+        validateQuery().rowCount(2L).hasNodesAtPaths("/node1", "/node3").useIndex("multiColIndex").validate(query, query.execute());
+        
+        query = jcrSql2Query("SELECT * FROM [nt:testType] WHERE longProp >= 1");
+        validateQuery().rowCount(2L).hasNodesAtPaths("/node2", "/node3").useIndex("multiColIndex").validate(query, query.execute());        
+
+        query = jcrSql2Query("SELECT * FROM [nt:testType] WHERE longProp > 1 AND stringProp LIKE 'string%' ");
+        validateQuery().rowCount(1L).hasNodesAtPaths("/node3").useIndex("multiColIndex").validate(query, query.execute());        
+
+        query = jcrSql2Query("SELECT * FROM [nt:testType] WHERE NAME() LIKE 'node%' ");
+        validateQuery().rowCount(3L).hasNodesAtPaths("/node1", "/node2", "/node3").useIndex("multiColIndex").validate(query, query.execute());        
+    }
+    
+    @Test(expected = InvalidIndexDefinitionException.class)
+    public void shouldNotAllowMultiColumnTextIndex() throws  Exception {
+        Map<String, Integer> properties = new HashMap<>();
+        properties.put("prop1", PropertyType.STRING);
+        properties.put("prop2", PropertyType.STRING);
+        registerIndex("multiColTextIndex", IndexDefinition.IndexKind.TEXT, providerName(), "nt:unstructured", null, "*", properties);
+    }
+    
+    @Test
+    public void shouldUseIndexForFTSOnStringProperty() throws Exception {
+        registerNodeType("nt:testType");
+        registerTextIndex("textIndex", "nt:testType", null, "*", "FTSProp", PropertyType.STRING);
+
+        Node root = session().getRootNode();
+        Node node1 = root.addNode("node", "nt:testType");
+        String propertyText = "the quick Brown fox jumps over to the dog in at the gate";
+        node1.setProperty("FTSProp", propertyText);
+        session.save();
+
+
+        Query query = jcrSql2Query("select [jcr:path] from [nt:testType] as n where contains([nt:testType].*,'" + propertyText + "')");
+        validateQuery().rowCount(1L).hasNodesAtPaths("/node").useIndex("textIndex").validate(query, query.execute());
+
+        jcrSql2Query("select [jcr:path] from [nt:testType] as n where contains(FTSProp,'" + propertyText + "')");
+        validateQuery().rowCount(1L).hasNodesAtPaths("/node").useIndex("textIndex").validate(query, query.execute());
+
+        jcrSql2Query("select [jcr:path] from [nt:testType] as n where contains(FTSProp,'" + propertyText.toUpperCase() + "')");
+        validateQuery().rowCount(1L).hasNodesAtPaths("/node").useIndex("textIndex").validate(query, query.execute());
+
+        jcrSql2Query("select [jcr:path] from [nt:testType] as n where contains(FTSProp,'the quick Dog')");
+        validateQuery().rowCount(1L).hasNodesAtPaths("/node").useIndex("textIndex").validate(query, query.execute());
+
+        jcrSql2Query("select [jcr:path] from [nt:testType] as n where contains(n.*,'the quick Dog')");
+        validateQuery().rowCount(1L).hasNodesAtPaths("/node").useIndex("textIndex").validate(query, query.execute());
+
+        jcrSql2Query("select [jcr:path] from [nt:testType] as n where contains(FTSProp,'the quick jumps over gate')");
+        validateQuery().rowCount(1L).hasNodesAtPaths("/node").useIndex("textIndex").validate(query, query.execute());
+
+        jcrSql2Query("select [jcr:path] from [nt:testType] as n where contains(n.*,'the quick jumps over gate')");
+        validateQuery().rowCount(1L).hasNodesAtPaths("/node").useIndex("textIndex").validate(query, query.execute());
+
+        jcrSql2Query("select [jcr:path] from [nt:testType] as n where contains(FTSProp,'the gate')");
+        validateQuery().rowCount(1L).hasNodesAtPaths("/node").useIndex("textIndex").validate(query, query.execute());
+
+        jcrSql2Query("select [jcr:path] from [nt:testType] as n where contains(n.*,'the gate')");
+        validateQuery().rowCount(1L).hasNodesAtPaths("/node").useIndex("textIndex").validate(query, query.execute());
+    }   
+    
+    @Test
+    public void shouldUseIndexForFTSOnBinaryProperty() throws Exception {
+        registerTextIndex("textIndex", "nt:resource", null, "*", "jcr:data", PropertyType.BINARY);
+
+        tools.uploadFile(session, "/node", resourceStream("text-file.txt"));
+        session.save();
+       
+        Query query = jcrSql2Query("select [jcr:path] from [nt:resource] as n where contains(n.*,'the quick jumps')");
+        validateQuery().rowCount(1L).hasNodesAtPaths("/node/jcr:content").useIndex("textIndex").validate(query, query.execute());
+    }
+}

--- a/index-providers/modeshape-lucene-index-provider/src/test/java/org/modeshape/jcr/index/lucene/LuceneRepositoryTest.java
+++ b/index-providers/modeshape-lucene-index-provider/src/test/java/org/modeshape/jcr/index/lucene/LuceneRepositoryTest.java
@@ -1,0 +1,184 @@
+/*
+ * ModeShape (http://www.modeshape.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.modeshape.jcr.index.lucene;
+
+import static org.modeshape.jcr.ValidateQuery.validateQuery;
+import javax.jcr.Node;
+import javax.jcr.Session;
+import javax.jcr.query.Query;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.modeshape.common.FixFor;
+import org.modeshape.common.util.FileUtil;
+import org.modeshape.jcr.ClusteringHelper;
+import org.modeshape.jcr.JcrRepository;
+import org.modeshape.jcr.TestingUtil;
+
+/**
+ * Unit tests for generic operations involving a repository which has a {@link LuceneIndexProvider} configured. Tests which are 
+ * not index/search specific should go here. All others should go in {@link LuceneIndexProviderTest}
+ * 
+ * @author Horia Chiorean (hchiorea@redhat.com)
+ */
+public class LuceneRepositoryTest {
+
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        ClusteringHelper.bindJGroupsToLocalAddress();
+    }
+
+    @AfterClass
+    public static void afterClass() throws Exception {
+        ClusteringHelper.removeJGroupsBindings();
+    }
+    
+    @Test
+    public void shouldAllowAdvancedLuceneConfiguration() throws Exception {
+        FileUtil.delete("target/persistent_repository");
+        
+        JcrRepository repository = TestingUtil.startRepositoryWithConfig(
+                "config/repo-config-persistent-lucene-provider-advanced-settings.json");
+        
+        //add a node in the default ws
+        Session defaultSession = repository.login();
+        Node node = defaultSession.getRootNode().addNode("node1");
+        node.addMixin("mix:title");
+        node.setProperty("jcr:title", "title1");
+        defaultSession.save();
+
+        //add a node in the other ws
+        Session otherSession = repository.login("other");
+        node = otherSession.getRootNode().addNode("node2");
+        node.addMixin("mix:title");
+        node.setProperty("jcr:title", "title2");
+        otherSession.save();
+
+        //test that each query is local to its own workspace....
+        Query query = defaultSession.getWorkspace().getQueryManager().createQuery(
+                "select node.[jcr:path] from [mix:title] as node where node.[jcr:title] LIKE 'title%'", Query.JCR_SQL2);
+        validateQuery().hasNodesAtPaths("/node1").useIndex("titleIndex").validate(query, query.execute());
+
+        query = otherSession.getWorkspace().getQueryManager().createQuery(
+                "select node.[jcr:path] from [mix:title] as node where node.[jcr:title] LIKE 'title%'", Query.JCR_SQL2);
+        validateQuery().hasNodesAtPaths("/node2").useIndex("titleIndex").validate(query, query.execute());
+    }
+
+    @Test
+    @FixFor( "MODE-1903" )
+    public void shouldReindexContentInClusterIncrementally() throws Exception {
+        FileUtil.delete("target/clustered");
+        
+        JcrRepository repository1 = null;
+        JcrRepository repository2 = null;
+        try {
+            // Start the first process completely ...
+            repository1 = TestingUtil.startRepositoryWithConfig("config/clustered-repo-with-incremental-indexes-config-1.json");
+            Thread.sleep(300);
+
+            // Start the second process completely ...
+            repository2 = TestingUtil.startRepositoryWithConfig("config/clustered-repo-with-incremental-indexes-config-2.json");
+            Thread.sleep(300);
+
+            // make 1 change which should be propagated in the cluster
+            Session session1 = repository1.login();
+            Node node = session1.getRootNode().addNode("repo1_node1");
+            node.addMixin("mix:title");
+            node.setProperty("jcr:title", "title1");
+            session1.save();
+            Thread.sleep(300);
+
+            TestingUtil.killRepository(repository2);
+
+            // add a new node in the first repo
+            node = session1.getRootNode().addNode("repo1_node2");
+            node.addMixin("mix:title");
+            node.setProperty("jcr:title", "title2");
+            session1.save();
+
+            // start the 2nd repo back up - at the end of this the journals should be up-to-date and ISPN should've done the state
+            // transfer
+            repository2 = TestingUtil.startRepositoryWithConfig("config/clustered-repo-with-incremental-indexes-config-2.json");
+            Thread.sleep(300);
+
+            // run a query to check that the index are not yet up-to-date
+            Session session2 = repository2.login();
+            org.modeshape.jcr.api.Workspace workspace2 = (org.modeshape.jcr.api.Workspace)session2.getWorkspace();
+
+            // run queries to check that reindexing has worked
+            Query query = workspace2.getQueryManager().createQuery(
+                    "select node.[jcr:path] from [mix:title] as node where node.[jcr:title] = 'title2'",
+                    Query.JCR_SQL2);
+            validateQuery().hasNodesAtPaths("/repo1_node2").useIndex("titleIndex").validate(query, query.execute());
+
+            // shut the first repo down    
+            TestingUtil.killRepository(repository1);
+
+            // add a new node in the second repo
+            node = session2.getRootNode().addNode("repo2_node1");
+            node.addMixin("mix:title");
+            node.setProperty("jcr:title", "title3");
+            session2.save();
+
+            // start the 1st repo back up - at the end of this the journals should be up-to-date and ISPN should've done the state
+            // transfer
+            repository1 = TestingUtil.startRepositoryWithConfig("config/clustered-repo-with-incremental-indexes-config-1.json");
+            Thread.sleep(300);
+
+            session1 = repository1.login();
+            query = session1.getWorkspace().getQueryManager().createQuery(
+                    "select node.[jcr:path] from [mix:title] as node where node.[jcr:title] = 'title3'",
+                    Query.JCR_SQL2);
+            validateQuery().hasNodesAtPaths("/repo2_node1").useIndex("titleIndex").validate(query, query.execute());
+
+            // shut the second repo down
+            TestingUtil.killRepository(repository2);
+
+            // remove a node from the first repo and change a value for the other node
+            session1.getNode("/repo1_node2").remove();
+            session1.getNode("/repo1_node1").setProperty("jcr:title", "title1_edited");
+            session1.save();
+
+            // bring the 2nd repo back up
+            // start the 2nd repo back up - at the end of this the journals should be up-to-date and ISPN should've done the state
+            // transfer
+            repository2 = TestingUtil.startRepositoryWithConfig("config/clustered-repo-with-incremental-indexes-config-2.json");
+            Thread.sleep(300);
+
+            // run a query to check that the indexes are synced
+            session2 = repository2.login();
+            workspace2 = (org.modeshape.jcr.api.Workspace)session2.getWorkspace();
+
+            query = workspace2.getQueryManager().createQuery(
+                    "select node.[jcr:path] from [mix:title] as node where node.[jcr:title] = 'title2'",
+                    Query.JCR_SQL2);
+            validateQuery().rowCount(0).useIndex("titleIndex").validate(query, query.execute());
+
+            query = workspace2.getQueryManager().createQuery(
+                    "select node.[jcr:path] from [mix:title] as node where node.[jcr:title] = 'title1'",
+                    Query.JCR_SQL2);
+            validateQuery().rowCount(0).useIndex("titleIndex").validate(query, query.execute());
+
+            query = workspace2.getQueryManager().createQuery(
+                    "select node.[jcr:path] from [mix:title] as node where node.[jcr:title] = 'title1_edited'",
+                    Query.JCR_SQL2);
+            validateQuery().hasNodesAtPaths("/repo1_node1").useIndex("titleIndex").validate(query, query.execute());
+
+        } finally {
+            TestingUtil.killRepositories(repository1, repository2);
+        }
+    }
+}

--- a/index-providers/modeshape-lucene-index-provider/src/test/java/org/modeshape/jcr/index/lucene/MultiColumnIndexPersistenceTest.java
+++ b/index-providers/modeshape-lucene-index-provider/src/test/java/org/modeshape/jcr/index/lucene/MultiColumnIndexPersistenceTest.java
@@ -1,0 +1,90 @@
+/*
+ * ModeShape (http://www.modeshape.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.modeshape.jcr.index.lucene;
+
+import static org.junit.Assert.assertEquals;
+import java.util.UUID;
+import org.junit.Test;
+import org.modeshape.jcr.value.PropertyType;
+
+/**
+ * Tests CRUD operations on the {@link MultiColumnIndex} index.
+ * 
+ * @author Horia Chiorean (hchiorea@redhat.com)
+ */
+public class MultiColumnIndexPersistenceTest extends SingleColumnIndexPersistenceTest {
+
+    @Override
+    protected LuceneIndex createIndex( String name ) {
+        return new MultiColumnIndex(name + "-multi-valued", config, PropertiesTestUtil.ALLOWED_PROPERTIES, context);
+    }
+
+    @Test
+    public void shouldUpdateMultipleValuesForSameNodeWithIndividualCommits() throws Exception {
+        String nodeKey = UUID.randomUUID().toString();
+        //call 'add' a number of times, committing each time
+        addMultiplePropertiesToSameNode(index, nodeKey, 2, PropertyType.LONG);
+        index.commit();
+        addMultiplePropertiesToSameNode(index, nodeKey, 1, PropertyType.DECIMAL);
+        index.commit();
+        addMultiplePropertiesToSameNode(index, nodeKey, 1, PropertyType.STRING);
+        index.commit();
+        addMultiplePropertiesToSameNode(index, nodeKey, 1, PropertyType.STRING);
+        index.commit();
+        addMultiplePropertiesToSameNode(index, nodeKey, 1, PropertyType.URI);
+        index.commit();
+        assertEquals(1, index.estimateTotalCount());
+    }
+
+    @Test
+    public void shouldUpdateMultipleValuesForSameNodeWithBatchCommit() throws Exception {
+        String nodeKey = UUID.randomUUID().toString();
+        //call 'add' without committing  
+        addMultiplePropertiesToSameNode(index, nodeKey, 2, PropertyType.LONG);
+        addMultiplePropertiesToSameNode(index, nodeKey, 1, PropertyType.DECIMAL);
+        addMultiplePropertiesToSameNode(index, nodeKey, 1, PropertyType.STRING);
+        addMultiplePropertiesToSameNode(index, nodeKey, 1, PropertyType.STRING);
+        addMultiplePropertiesToSameNode(index, nodeKey, 1, PropertyType.URI);
+
+        index.commit();
+        assertEquals(1, index.estimateTotalCount());
+    }
+    
+    @Test
+    @Override
+    public void shouldRemoveAllValues() throws Exception {
+        String nodeKey = UUID.randomUUID().toString();
+        addMultiplePropertiesToSameNode(index, nodeKey, 2, PropertyType.LONG);
+        addMultiplePropertiesToSameNode(index, nodeKey, 1, PropertyType.STRING);
+        index.commit();
+
+        index.remove(nodeKey);
+        index.commit();
+        assertEquals(0, index.estimateTotalCount());
+    }
+    
+    @Test
+    public void shouldRemoveSingleValue() throws Exception {
+        String nodeKey = UUID.randomUUID().toString();
+        addMultiplePropertiesToSameNode(index, nodeKey, 2, PropertyType.LONG);
+        String stringProperty = addMultiplePropertiesToSameNode(index, nodeKey, 1, PropertyType.STRING);
+        index.commit();
+        
+        index.remove(nodeKey, stringProperty);
+        index.commit();
+        assertEquals(1, index.estimateTotalCount());
+    }
+}

--- a/index-providers/modeshape-lucene-index-provider/src/test/java/org/modeshape/jcr/index/lucene/MultiColumnIndexPersistenceTest.java
+++ b/index-providers/modeshape-lucene-index-provider/src/test/java/org/modeshape/jcr/index/lucene/MultiColumnIndexPersistenceTest.java
@@ -29,7 +29,7 @@ public class MultiColumnIndexPersistenceTest extends SingleColumnIndexPersistenc
 
     @Override
     protected LuceneIndex createIndex( String name ) {
-        return new MultiColumnIndex(name + "-multi-valued", config, PropertiesTestUtil.ALLOWED_PROPERTIES, context);
+        return new MultiColumnIndex(name + "-multi-valued", "default", config, PropertiesTestUtil.ALLOWED_PROPERTIES, context);
     }
 
     @Test

--- a/index-providers/modeshape-lucene-index-provider/src/test/java/org/modeshape/jcr/index/lucene/MultiColumnIndexSearchTest.java
+++ b/index-providers/modeshape-lucene-index-provider/src/test/java/org/modeshape/jcr/index/lucene/MultiColumnIndexSearchTest.java
@@ -36,7 +36,7 @@ public class MultiColumnIndexSearchTest extends SingleColumnIndexSearchTest {
 
     @Override
     protected LuceneIndex createIndex( String name ) {
-        return new MultiColumnIndex(name + "-multi-valued", config, PropertiesTestUtil.ALLOWED_PROPERTIES, context);
+        return new MultiColumnIndex(name + "-multi-valued", "default", config, PropertiesTestUtil.ALLOWED_PROPERTIES, context);
     }
 
     @Override
@@ -48,13 +48,13 @@ public class MultiColumnIndexSearchTest extends SingleColumnIndexSearchTest {
         
         String weakRef1 = UUID.randomUUID().toString(); 
         String weakRef2 = UUID.randomUUID().toString();
-        addValue(nodesWithRefProp.get(0), WEAK_REF_PROP, weakRef1);
-        addValue(nodesWithRefProp.get(1), WEAK_REF_PROP, weakRef2);
+        addValues(nodesWithRefProp.get(0), WEAK_REF_PROP, weakRef1);
+        addValues(nodesWithRefProp.get(1), WEAK_REF_PROP, weakRef2);
 
         String simpleRef1 = UUID.randomUUID().toString(); 
         String simpleRef2 = UUID.randomUUID().toString();
-        addValue(nodesWithRefProp.get(0), SIMPLE_REF_PROP, simpleRef1);
-        addValue(nodesWithRefProp.get(1), SIMPLE_REF_PROP, simpleRef2);
+        addValues(nodesWithRefProp.get(0), SIMPLE_REF_PROP, simpleRef1);
+        addValues(nodesWithRefProp.get(1), SIMPLE_REF_PROP, simpleRef2);
         
         Constraint constraint = referenceValue(REF_PROP, EQUAL_TO, strongRef1, true, true);
         validateCardinality(constraint, 1);
@@ -80,7 +80,7 @@ public class MultiColumnIndexSearchTest extends SingleColumnIndexSearchTest {
     public void shouldSearchForPropertyExistence() throws Exception {
         List<String> nodes = indexNodes(LONG_PROP, 1l, 3l);
         String node1 = nodes.get(0);
-        addValue(node1, STRING_PROP, "a");
+        addValues(node1, STRING_PROP, "a");
        
         Constraint existsLongProp = propertyExistence(LONG_PROP);
         validateCardinality(existsLongProp, 2);
@@ -97,9 +97,5 @@ public class MultiColumnIndexSearchTest extends SingleColumnIndexSearchTest {
         validateCardinality(existsLongProp, 1);
         validateFilterResults(existsLongProp, 1, false, nodes.get(1));
     }
-
-    private <T> String addValue( String nodeKey , String propertyName, T value) {
-        index.add(nodeKey, propertyName, value);
-        return nodeKey;
-    }
+    
 }

--- a/index-providers/modeshape-lucene-index-provider/src/test/java/org/modeshape/jcr/index/lucene/MultiColumnIndexSearchTest.java
+++ b/index-providers/modeshape-lucene-index-provider/src/test/java/org/modeshape/jcr/index/lucene/MultiColumnIndexSearchTest.java
@@ -1,0 +1,105 @@
+/*
+ * ModeShape (http://www.modeshape.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.modeshape.jcr.index.lucene;
+
+import static org.modeshape.jcr.api.query.qom.Operator.EQUAL_TO;
+import static org.modeshape.jcr.index.lucene.PropertiesTestUtil.DATE_PROP;
+import static org.modeshape.jcr.index.lucene.PropertiesTestUtil.LONG_PROP;
+import static org.modeshape.jcr.index.lucene.PropertiesTestUtil.REF_PROP;
+import static org.modeshape.jcr.index.lucene.PropertiesTestUtil.SIMPLE_REF_PROP;
+import static org.modeshape.jcr.index.lucene.PropertiesTestUtil.STRING_PROP;
+import static org.modeshape.jcr.index.lucene.PropertiesTestUtil.WEAK_REF_PROP;
+import java.util.List;
+import java.util.UUID;
+import org.junit.Test;
+import org.modeshape.jcr.query.model.Constraint;
+
+/**
+ * Tests the search behavior of the {@link MultiColumnIndex}
+ * 
+ * @author Horia Chiorean (hchiorea@redhat.com)
+ */
+public class MultiColumnIndexSearchTest extends SingleColumnIndexSearchTest {
+
+    @Override
+    protected LuceneIndex createIndex( String name ) {
+        return new MultiColumnIndex(name + "-multi-valued", config, PropertiesTestUtil.ALLOWED_PROPERTIES, context);
+    }
+
+    @Override
+    @Test
+    public void shouldSearchForReferenceValueInComparisonConstraint() throws Exception {
+        String strongRef1 = UUID.randomUUID().toString();
+        String strongRef2 = UUID.randomUUID().toString();
+        List<String> nodesWithRefProp = indexNodes(REF_PROP, strongRef1, strongRef2);
+        
+        String weakRef1 = UUID.randomUUID().toString(); 
+        String weakRef2 = UUID.randomUUID().toString();
+        addValue(nodesWithRefProp.get(0), WEAK_REF_PROP, weakRef1);
+        addValue(nodesWithRefProp.get(1), WEAK_REF_PROP, weakRef2);
+
+        String simpleRef1 = UUID.randomUUID().toString(); 
+        String simpleRef2 = UUID.randomUUID().toString();
+        addValue(nodesWithRefProp.get(0), SIMPLE_REF_PROP, simpleRef1);
+        addValue(nodesWithRefProp.get(1), SIMPLE_REF_PROP, simpleRef2);
+        
+        Constraint constraint = referenceValue(REF_PROP, EQUAL_TO, strongRef1, true, true);
+        validateCardinality(constraint, 1);
+        validateFilterResults(constraint, 1, false, nodesWithRefProp.get(0));
+
+        constraint = referenceValue(null, EQUAL_TO, weakRef1, true, true);
+        validateCardinality(constraint, 1);
+        validateFilterResults(constraint, 1, false, nodesWithRefProp.get(0));
+
+        constraint = referenceValue(null, EQUAL_TO, weakRef1, false, true);
+        validateCardinality(constraint, 0);
+
+        constraint = referenceValue(null, EQUAL_TO, simpleRef2, true, true);
+        validateCardinality(constraint, 1);
+        validateFilterResults(constraint, 1, false, nodesWithRefProp.get(1));
+
+        constraint = referenceValue(null, EQUAL_TO, simpleRef2, false, false);
+        validateCardinality(constraint, 0);
+    }
+
+    @Override
+    @Test
+    public void shouldSearchForPropertyExistence() throws Exception {
+        List<String> nodes = indexNodes(LONG_PROP, 1l, 3l);
+        String node1 = nodes.get(0);
+        addValue(node1, STRING_PROP, "a");
+       
+        Constraint existsLongProp = propertyExistence(LONG_PROP);
+        validateCardinality(existsLongProp, 2);
+        validateFilterResults(existsLongProp, 2, false, nodes.toArray(new String[nodes.size()]));
+
+        Constraint existsStringProp = propertyExistence(STRING_PROP);
+        validateCardinality(existsStringProp, 1);
+        validateFilterResults(existsStringProp, 1, false, node1);
+
+        Constraint nonExistentProp = propertyExistence(DATE_PROP);
+        validateCardinality(nonExistentProp, 0);
+
+        index.remove(node1, LONG_PROP);
+        validateCardinality(existsLongProp, 1);
+        validateFilterResults(existsLongProp, 1, false, nodes.get(1));
+    }
+
+    private <T> String addValue( String nodeKey , String propertyName, T value) {
+        index.add(nodeKey, propertyName, value);
+        return nodeKey;
+    }
+}

--- a/index-providers/modeshape-lucene-index-provider/src/test/java/org/modeshape/jcr/index/lucene/PropertiesTestUtil.java
+++ b/index-providers/modeshape-lucene-index-provider/src/test/java/org/modeshape/jcr/index/lucene/PropertiesTestUtil.java
@@ -1,0 +1,61 @@
+/*
+ * ModeShape (http://www.modeshape.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.modeshape.jcr.index.lucene;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.modeshape.jcr.value.PropertyType;
+
+/**
+ * Utility for the various Lucene tests.
+ * 
+ * @author Horia Chiorean (hchiorea@redhat.com)
+ */
+public final class PropertiesTestUtil {
+ 
+    static final String BINARY_PROP = "prop:binary";
+    static final String BOOLEAN_PROP = "prop:boolean";
+    static final String DATE_PROP = "prop:date";
+    static final String DECIMAL_PROP = "prop:decimal";
+    static final String DOUBLE_PROP = "prop:double";
+    static final String LONG_PROP = "prop:long";
+    static final String REF_PROP = "prop:ref";
+    static final String WEAK_REF_PROP = "prop:weakref";
+    static final String STRING_PROP = "prop:string";
+    static final String SIMPLE_REF_PROP = "prop:simpleref";
+    static final String URI_PROP = "prop:uri";
+    static final String PATH_PROP = "prop:path";
+    static final String NAME_PROP = "prop:name";
+    
+    static final Map<String, PropertyType> ALLOWED_PROPERTIES = new HashMap<String, PropertyType>() {{
+        put(NAME_PROP, PropertyType.NAME);
+        put(PATH_PROP, PropertyType.PATH);
+        put(BINARY_PROP, PropertyType.BINARY);
+        put(BOOLEAN_PROP, PropertyType.BOOLEAN);
+        put(DATE_PROP, PropertyType.DATE);
+        put(DECIMAL_PROP, PropertyType.DECIMAL);
+        put(DOUBLE_PROP, PropertyType.DOUBLE);
+        put(LONG_PROP, PropertyType.LONG);
+        put(REF_PROP, PropertyType.REFERENCE);
+        put(WEAK_REF_PROP, PropertyType.WEAKREFERENCE);
+        put(STRING_PROP, PropertyType.STRING);
+        put(SIMPLE_REF_PROP, PropertyType.SIMPLEREFERENCE);
+        put(URI_PROP, PropertyType.URI);
+    }};
+
+    private PropertiesTestUtil() {
+    }
+}

--- a/index-providers/modeshape-lucene-index-provider/src/test/java/org/modeshape/jcr/index/lucene/SingleColumnIndexPersistenceTest.java
+++ b/index-providers/modeshape-lucene-index-provider/src/test/java/org/modeshape/jcr/index/lucene/SingleColumnIndexPersistenceTest.java
@@ -1,0 +1,290 @@
+/*
+ * ModeShape (http://www.modeshape.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.modeshape.jcr.index.lucene;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.modeshape.jcr.value.PropertyType;
+
+/**
+ * Tests CRUD operations on the {@link SingleColumnIndex} index.
+ * 
+ * @author Horia Chiorean (hchiorea@redhat.com)
+ */
+public class SingleColumnIndexPersistenceTest extends AbstractIndexPersistenceTest {
+
+    @Override
+    protected LuceneIndex createIndex( String name ) {
+        return new SingleColumnIndex(name + "-single-valued", config, PropertiesTestUtil.ALLOWED_PROPERTIES, context);
+    }
+
+    @Test
+    public void shouldClearAllData() throws Exception {
+        assertEquals(0, index.estimateTotalCount());
+        IndexedProperty property = newProperty(PropertyType.STRING);
+        index.add(UUID.randomUUID().toString(), property.getName(), property.getValue());
+        index.commit();
+        assertEquals(1, index.estimateTotalCount());
+        index.clearAllData();
+        assertEquals(0, index.estimateTotalCount());
+    }
+
+    @Test
+    public void shouldAddNodesWithSingleValues() throws Exception {
+        assertEquals(0, index.estimateTotalCount());
+        assertTrue(index.requiresReindexing());
+
+        List<PropertyType> types = new ArrayList<>(Arrays.asList(PropertyType.values()));
+        types.remove(PropertyType.OBJECT);
+        for (PropertyType type : types) {
+            String nodeKey = UUID.randomUUID().toString();
+            IndexedProperty property = newProperty(type);
+            index.add(nodeKey, property.getName(), property.getValue());
+        }
+        index.commit();
+        assertEquals(types.size(), index.estimateTotalCount());
+        assertFalse(index.requiresReindexing());
+    }
+
+    @Test
+    public void shouldAddNodesWithMultipleValues() throws Exception {
+        PropertyType[] types = new PropertyType[] {PropertyType.BOOLEAN, PropertyType.LONG, PropertyType.PATH};
+        addMultipleNodes(index, 3, types);
+        assertEquals(types.length, index.estimateTotalCount());
+    }
+
+    @Test
+    public void shouldUpdateValueForSameNodes() throws Exception {
+        String nodeKey1 = UUID.randomUUID().toString();
+        addMultiplePropertiesToSameNode(index, nodeKey1, 1, PropertyType.STRING);
+        addMultiplePropertiesToSameNode(index, nodeKey1, 1, PropertyType.STRING);
+        index.commit();
+
+        String nodeKey2 = UUID.randomUUID().toString();
+        addMultiplePropertiesToSameNode(index, nodeKey2, 1, PropertyType.STRING);
+        addMultiplePropertiesToSameNode(index, nodeKey2, 1, PropertyType.STRING);
+        index.commit();
+
+        assertEquals(2, index.estimateTotalCount());
+    }
+
+    @Test
+    public void shouldRemoveSingleValue() throws Exception {
+        String nodeKey = UUID.randomUUID().toString();
+        String propertyName = addMultiplePropertiesToSameNode(index, nodeKey, 1, PropertyType.STRING);
+        index.commit();
+
+        index.remove(nodeKey, propertyName);
+        index.commit();
+        assertEquals(0, index.estimateTotalCount());
+    }
+
+    @Test
+    public void shouldRemoveAllValues() throws Exception {
+        String nodeKey = UUID.randomUUID().toString();
+        addMultiplePropertiesToSameNode(index, nodeKey, 2, PropertyType.LONG);
+        index.commit();
+
+        index.remove(nodeKey);
+        index.commit();
+        assertEquals(0, index.estimateTotalCount());
+    }
+
+    @Test
+    public void shouldUpdateValuesBetweenRestarts() throws Exception {
+        String nodeKey = UUID.randomUUID().toString();
+        // a new node to the index
+        addMultiplePropertiesToSameNode(index, nodeKey, 2, PropertyType.LONG);
+        index.commit();
+
+        // restart the index without clearing the data
+        index.shutdown(false);
+        index = defaultIndex();
+
+        // and check that data is still there
+        assertFalse(index.requiresReindexing());
+        assertEquals(1, index.estimateTotalCount());
+        addMultiplePropertiesToSameNode(index, nodeKey, 1, PropertyType.STRING);
+        index.commit();
+        assertEquals(1, index.estimateTotalCount());
+
+        //add a new document
+        nodeKey = UUID.randomUUID().toString();
+        addMultiplePropertiesToSameNode(index, nodeKey, 2, PropertyType.DECIMAL);
+        index.commit();
+
+        // restart the index without clearing the data
+        index.shutdown(false);
+        index = defaultIndex();
+
+        // and check the second update
+        assertFalse(index.requiresReindexing());
+        assertEquals(2, index.estimateTotalCount());
+        // remove a node
+        index.remove(nodeKey);
+        index.commit();
+
+        // restart the index without clearing the data
+        index.shutdown(false);
+        index = defaultIndex();
+        // and check the removal
+        assertFalse(index.requiresReindexing());
+        assertEquals(1, index.estimateTotalCount());
+        addMultiplePropertiesToSameNode(index, nodeKey, 2, PropertyType.DECIMAL);
+        index.commit();
+        assertEquals(2, index.estimateTotalCount());
+    }
+
+    @Test
+    @Ignore("perf test")
+    public void singleIndexCrudPerformance() {
+        int nodeCount = 100000;
+        int valuesPerProperty = 2;
+        int batchSize = 1000;
+        runPerfTestForIndex(nodeCount, valuesPerProperty, batchSize, this.index);
+    }
+
+    @Test
+    @Ignore("perf test")
+    public void multiIndexCrudPerformance() throws Exception {
+        final int nodeCount = 100000;
+        final int valuesPerProperty = 1;
+        final int batchSize = 1000;
+        int indexesCount = 20;
+        ExecutorService executorService = Executors.newFixedThreadPool(indexesCount);
+        List<Future<?>> result = new ArrayList<>(indexesCount);
+        for (int i = 0; i < indexesCount; i++) {
+            LuceneIndex index = createIndex("index" + i);
+            IndexThread<Void> perfThread = new IndexThread<>(index, new IndexOperation<Void>() {
+                @Override
+                public Void execute( final LuceneIndex index ) throws Exception {
+                    runPerfTestForIndex(nodeCount, valuesPerProperty, batchSize, index);
+                    return null;
+                }
+            });
+            result.add(executorService.submit(perfThread));
+        }
+
+        try {
+            for (Future<?> future : result) {
+                try {
+                    future.get(3, TimeUnit.MINUTES);
+                } catch (TimeoutException e) {
+                    future.cancel(true);
+                }
+            }
+        } finally {
+            executorService.shutdownNow();
+        }
+    }
+
+    private void runPerfTestForIndex( int nodeCount, int valuesPerProperty, int batchSize, LuceneIndex index ) {
+        List<String> nodeKeys = new ArrayList<>();
+        long start = System.nanoTime();
+        // insert
+        for (int i = 0; i < nodeCount; i++) {
+            String nodeKey = UUID.randomUUID().toString();
+            nodeKeys.add(nodeKey);
+            addMultiplePropertiesToSameNode(index, nodeKey, valuesPerProperty, PropertyType.STRING);
+            if (i > 0 && i % batchSize == 0) {
+                index.commit();
+                System.out.println("Inserted " + i + " nodes");
+            }
+        }
+        index.commit();
+        assertEquals(nodeCount, index.estimateTotalCount());
+        long insertTime = TimeUnit.SECONDS.convert(System.nanoTime() - start, TimeUnit.NANOSECONDS);
+        System.out.println("(" + index.getName() + ") Total time to insert " + nodeCount + " nodes: " + (insertTime / 60d) + " minutes");
+
+
+        // update
+        start = System.nanoTime();
+        for (int i = 0; i < nodeCount; i++) {
+            String nodeKey = nodeKeys.get(i);
+            addMultiplePropertiesToSameNode(index, nodeKey, valuesPerProperty, PropertyType.STRING);
+            if (i > 0 && i % batchSize == 0) {
+                index.commit();
+                System.out.println("Updated "  + i + " nodes");
+            }
+        }
+        index.commit();
+        assertEquals(nodeCount, index.estimateTotalCount());
+        long updateTime = TimeUnit.SECONDS.convert(System.nanoTime() - start, TimeUnit.NANOSECONDS);
+        System.out.println("(" + index.getName() + ") Total time to update " + nodeCount + " nodes: " + (updateTime / 60d) + " minutes");
+
+        // delete
+        start = System.nanoTime();
+        for (int i = 0; i < nodeCount; i++) {
+            String nodeKey = nodeKeys.get(i);
+            index.remove(nodeKey);
+            if (i > 0 && i % batchSize == 0) {
+                index.commit();
+                System.out.println("Removed "  + i + " nodes");
+            }
+        }
+        index.commit();
+        assertEquals(0, index.estimateTotalCount());
+        long deleteTime = TimeUnit.SECONDS.convert(System.nanoTime() - start, TimeUnit.NANOSECONDS);
+        System.out.println("(" + index.getName() + ") Total time to delete " + nodeCount + " nodes: " + (deleteTime / 60d) + " minutes");
+    }
+
+    private void addMultipleNodes( LuceneIndex index, int propertiesCount, PropertyType[] types ) {
+        for (PropertyType type : types) {
+            String nodeKey = UUID.randomUUID().toString();
+            addMultiplePropertiesToSameNode(index, nodeKey, propertiesCount, type);
+        }
+        index.commit();
+    }
+
+    private static interface IndexOperation<T> {
+        T execute(final LuceneIndex index) throws Exception;
+    }
+
+    private static class IndexThread<T> implements Callable<T> {
+        private final LuceneIndex index;
+        private final IndexOperation<T> operation;
+
+        protected IndexThread( LuceneIndex index, IndexOperation<T> operation) {
+            this.index = index;
+            this.operation = operation;
+        }
+
+        @Override
+        public T call() throws Exception {
+            try {
+                return operation.execute(index);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                return null;
+            } finally {
+                index.shutdown(true);
+            }
+        }
+    }
+}

--- a/index-providers/modeshape-lucene-index-provider/src/test/java/org/modeshape/jcr/index/lucene/SingleColumnIndexSearchTest.java
+++ b/index-providers/modeshape-lucene-index-provider/src/test/java/org/modeshape/jcr/index/lucene/SingleColumnIndexSearchTest.java
@@ -1,0 +1,634 @@
+/*
+ * ModeShape (http://www.modeshape.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.modeshape.jcr.index.lucene;
+
+import static org.junit.Assert.fail;
+import static org.modeshape.jcr.api.query.qom.Operator.EQUAL_TO;
+import static org.modeshape.jcr.api.query.qom.Operator.GREATER_THAN;
+import static org.modeshape.jcr.api.query.qom.Operator.GREATER_THAN_OR_EQUAL_TO;
+import static org.modeshape.jcr.api.query.qom.Operator.LESS_THAN;
+import static org.modeshape.jcr.api.query.qom.Operator.LESS_THAN_OR_EQUAL_TO;
+import static org.modeshape.jcr.api.query.qom.Operator.LIKE;
+import static org.modeshape.jcr.api.query.qom.Operator.NOT_EQUAL_TO;
+import static org.modeshape.jcr.index.lucene.PropertiesTestUtil.BINARY_PROP;
+import static org.modeshape.jcr.index.lucene.PropertiesTestUtil.BOOLEAN_PROP;
+import static org.modeshape.jcr.index.lucene.PropertiesTestUtil.DATE_PROP;
+import static org.modeshape.jcr.index.lucene.PropertiesTestUtil.DECIMAL_PROP;
+import static org.modeshape.jcr.index.lucene.PropertiesTestUtil.DOUBLE_PROP;
+import static org.modeshape.jcr.index.lucene.PropertiesTestUtil.LONG_PROP;
+import static org.modeshape.jcr.index.lucene.PropertiesTestUtil.NAME_PROP;
+import static org.modeshape.jcr.index.lucene.PropertiesTestUtil.PATH_PROP;
+import static org.modeshape.jcr.index.lucene.PropertiesTestUtil.REF_PROP;
+import static org.modeshape.jcr.index.lucene.PropertiesTestUtil.STRING_PROP;
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.UUID;
+import org.junit.Test;
+import org.modeshape.jcr.api.value.DateTime;
+import org.modeshape.jcr.query.model.Constraint;
+import org.modeshape.jcr.value.BinaryValue;
+import org.modeshape.jcr.value.NameFactory;
+import org.modeshape.jcr.value.PathFactory;
+import org.modeshape.jcr.value.StringFactory;
+import org.modeshape.jcr.value.ValueFormatException;
+import org.modeshape.jcr.value.basic.JodaDateTime;
+
+/**
+ * Tests the search behavior of the {@link SingleColumnIndex}
+ *
+ * @author Horia Chiorean (hchiorea@redhat.com)
+ */
+public class SingleColumnIndexSearchTest extends AbstractLuceneIndexSearchTest {
+
+    @Override
+    protected LuceneIndex createIndex( String name ) {
+        return new MultiColumnIndex(name + "-multi-valued", config, PropertiesTestUtil.ALLOWED_PROPERTIES, context);
+    }
+    
+    @Test
+    public void shouldSearchForStringPropertyValueInComparisonConstraint() throws Exception {
+        List<String> nodeKeys = indexNodes(STRING_PROP, "s1", "s2", "s1");
+
+        // nodes where value = s1
+        Constraint constraint = propertyValue(STRING_PROP, EQUAL_TO, "s1");
+        validateCardinality(constraint, 2);
+        validateFilterResults(constraint, 2, false, nodeKeys.get(0), nodeKeys.get(2));
+
+        // nodes where value = s2
+        constraint = propertyValue(STRING_PROP, EQUAL_TO, "s2");
+        validateCardinality(constraint, 1);
+        validateFilterResults(constraint, 1, false, nodeKeys.get(1));
+
+        //nodes where value = s3
+        constraint = propertyValue(STRING_PROP, EQUAL_TO, "s3");
+        validateCardinality(constraint, 0);
+        validateFilterResults(constraint, 0, false);
+
+        // nodes where value > s1
+        constraint = propertyValue(STRING_PROP, GREATER_THAN, "s1");
+        validateCardinality(constraint, 1);
+        validateFilterResults(constraint, 1, false, nodeKeys.get(1));
+
+        // nodes where value >= s1
+        constraint = propertyValue(STRING_PROP, GREATER_THAN_OR_EQUAL_TO, "s1");
+        validateCardinality(constraint, 3);
+        validateFilterResults(constraint, 3, false, nodeKeys.toArray(new String[3]));
+
+        // nodes where value < s2
+        constraint = propertyValue(STRING_PROP, LESS_THAN, "s2");
+        validateCardinality(constraint, 2);
+        validateFilterResults(constraint, 2, false, nodeKeys.get(0), nodeKeys.get(2));
+
+        // nodes where value <= s2
+        constraint = propertyValue(STRING_PROP, LESS_THAN_OR_EQUAL_TO, "s2");
+        validateCardinality(constraint, 3);
+        validateFilterResults(constraint, 2, false, nodeKeys.toArray(new String[3]));
+
+        // nodes where values LIKE 's'
+        constraint = propertyValue(STRING_PROP, LIKE, "s%");
+        validateCardinality(constraint, 3);
+        validateFilterResults(constraint, 1, false, nodeKeys.toArray(new String[3]));
+
+        constraint = propertyValue(STRING_PROP, LIKE, "%s%");
+        validateCardinality(constraint, 3);
+        validateFilterResults(constraint, 1, false, nodeKeys.toArray(new String[3]));
+
+        // nodes where values != s11
+        constraint = propertyValue(STRING_PROP, NOT_EQUAL_TO, "s1");
+        validateCardinality(constraint, 1);
+        validateFilterResults(constraint, 1, false, nodeKeys.get(1));
+    }
+
+    @Test
+    public void shouldSearchForPathPropertyValueInComparisonConstraint() throws Exception {
+        PathFactory pathFactory = valueFactories.getPathFactory();
+        List<String> nodeKeys = indexNodes(PropertiesTestUtil.PATH_PROP, pathFactory.create("/a/b"), pathFactory.create("/a/d"),
+                                           pathFactory.create("/b"));
+
+        // nodes where value = /a/b
+        Constraint constraint = propertyValue(PropertiesTestUtil.PATH_PROP, EQUAL_TO, "/a/b");
+        validateCardinality(constraint, 1);
+        validateFilterResults(constraint, 1, false, nodeKeys.get(0));
+
+
+        //nodes where value = /c
+        constraint = propertyValue(PropertiesTestUtil.PATH_PROP, EQUAL_TO, "/c");
+        validateCardinality(constraint, 0);
+        validateFilterResults(constraint, 0, false);
+
+        // nodes where value > /a/a
+        constraint = propertyValue(PropertiesTestUtil.PATH_PROP, GREATER_THAN, "/a/a");
+        validateCardinality(constraint, 3);
+        validateFilterResults(constraint, 2, false, nodeKeys.toArray(new String[3]));
+
+        // nodes where value >= /a/b
+        constraint = propertyValue(PropertiesTestUtil.PATH_PROP, GREATER_THAN_OR_EQUAL_TO, "/a/b");
+        validateCardinality(constraint, 3);
+        validateFilterResults(constraint, 2, false, nodeKeys.toArray(new String[3]));
+
+        // nodes where value < /z
+        constraint = propertyValue(PropertiesTestUtil.PATH_PROP, LESS_THAN, "/z");
+        validateCardinality(constraint, 3);
+        validateFilterResults(constraint, 2, false, nodeKeys.toArray(new String[3]));
+
+        // nodes where value <= /b
+        constraint = propertyValue(PropertiesTestUtil.PATH_PROP, LESS_THAN_OR_EQUAL_TO, "/b");
+        validateCardinality(constraint, 3);
+        validateFilterResults(constraint, 2, false, nodeKeys.toArray(new String[3]));
+
+        // nodes where values LIKE '/a/%'
+        constraint = propertyValue(PropertiesTestUtil.PATH_PROP, LIKE, "/a/%");
+        validateCardinality(constraint, 2);
+        validateFilterResults(constraint, 1, false, nodeKeys.get(0), nodeKeys.get(1));
+
+        // nodes where values != '/a/b'
+        constraint = propertyValue(PropertiesTestUtil.PATH_PROP, NOT_EQUAL_TO, "/a/b");
+        validateCardinality(constraint, 2);
+        validateFilterResults(constraint, 2, false, nodeKeys.get(0), nodeKeys.get(1));
+    }
+
+    @Test
+    public void shouldSearchForNamePropertyValueInComparisonConstraint() throws Exception {
+        NameFactory nameFactory = valueFactories.getNameFactory();
+        List<String> nodeKeys = indexNodes(NAME_PROP,
+                                           nameFactory.create("jcr:name1"),
+                                           nameFactory.create("jcr:name2"),
+                                           nameFactory.create("mode:name1"));
+
+        // nodes where value = jcr:name1
+        Constraint constraint = propertyValue(NAME_PROP, EQUAL_TO, "jcr:name1");
+        validateCardinality(constraint, 1);
+        validateFilterResults(constraint, 1, false, nodeKeys.get(0));
+
+
+        //nodes where value = /jcr:name3
+        constraint = propertyValue(NAME_PROP, EQUAL_TO, "jcr:name3");
+        validateCardinality(constraint, 0);
+        validateFilterResults(constraint, 0, false);
+
+        // nodes where value > jcr:name
+        constraint = propertyValue(NAME_PROP, GREATER_THAN, "jcr:name");
+        validateCardinality(constraint, 3);
+        validateFilterResults(constraint, 2, false, nodeKeys.toArray(new String[3]));
+
+        // nodes where value >= jcr:name1
+        constraint = propertyValue(NAME_PROP, GREATER_THAN_OR_EQUAL_TO, "jcr:name1");
+        validateCardinality(constraint, 3);
+        validateFilterResults(constraint, 2, false, nodeKeys.toArray(new String[3]));
+
+        // nodes where value < "mode:name1"
+        constraint = propertyValue(NAME_PROP, LESS_THAN, "mode:name1");
+        validateCardinality(constraint, 1);
+        validateFilterResults(constraint, 2, false, nodeKeys.get(0));
+
+        // nodes where value <= mode:name1
+        constraint = propertyValue(NAME_PROP, LESS_THAN_OR_EQUAL_TO, "mode:name1");
+        validateCardinality(constraint, 2);
+        validateFilterResults(constraint, 2, false, nodeKeys.get(0), nodeKeys.get(2));
+
+        // nodes where values LIKE 'jcr:'
+        constraint = propertyValue(NAME_PROP, LIKE, "jcr:%");
+        validateCardinality(constraint, 2);
+        validateFilterResults(constraint, 1, false, nodeKeys.get(0), nodeKeys.get(1));
+
+        // nodes where values != 'mode:name1'
+        constraint = propertyValue(NAME_PROP, NOT_EQUAL_TO, "mode:name1");
+        validateCardinality(constraint, 2);
+        validateFilterResults(constraint, 2, false, nodeKeys.get(1), nodeKeys.get(2));
+    }
+
+    @Test
+    public void shouldSearchForDecimalPropertyValueInComparisonConstraint() throws Exception {
+        List<String> nodesWithDecimalProp = indexNodes(DECIMAL_PROP,
+                                                       BigDecimal.valueOf(1.1),
+                                                       BigDecimal.valueOf(1.3),
+                                                       BigDecimal.valueOf(1.5));
+
+        // = 
+        Constraint constraint = propertyValue(DECIMAL_PROP, EQUAL_TO, "1.1");
+        validateCardinality(constraint, 1);
+        validateFilterResults(constraint, 1, false, nodesWithDecimalProp.get(0));
+
+        // >
+        constraint = propertyValue(DECIMAL_PROP, GREATER_THAN, "1.1");
+        validateCardinality(constraint, 2);
+        validateFilterResults(constraint, 1, false, nodesWithDecimalProp.get(1), nodesWithDecimalProp.get(2));
+
+        // >=
+        constraint = propertyValue(DECIMAL_PROP, GREATER_THAN_OR_EQUAL_TO, "1.1");
+        validateCardinality(constraint, 3);
+        validateFilterResults(constraint, 2, false, nodesWithDecimalProp.toArray(new String[3]));
+
+        // <
+        constraint = propertyValue(DECIMAL_PROP, LESS_THAN, "1.3");
+        validateCardinality(constraint, 1);
+        validateFilterResults(constraint, 2, false, nodesWithDecimalProp.get(0));
+
+        // <=
+        constraint = propertyValue(DECIMAL_PROP, LESS_THAN_OR_EQUAL_TO, "1.3");
+        validateCardinality(constraint, 2);
+        validateFilterResults(constraint, 2, false, nodesWithDecimalProp.get(0), nodesWithDecimalProp.get(1));
+
+        // LIKE (should work because big decimals are stored as strings...)
+        constraint = propertyValue(DECIMAL_PROP, LIKE, "1%");
+        validateCardinality(constraint, 3);
+        validateFilterResults(constraint, 1, false, nodesWithDecimalProp.toArray(new String[3]));
+
+        // !=
+        constraint = propertyValue(DECIMAL_PROP, NOT_EQUAL_TO, "1.3");
+        validateCardinality(constraint, 2);
+        validateFilterResults(constraint, 2, false, nodesWithDecimalProp.get(0), nodesWithDecimalProp.get(2));
+    }
+
+    @Test
+    public void shouldSearchForLongPropertyValueInComparisonConstraint() throws Exception {
+        List<String> nodesWithLongProp = indexNodes(LONG_PROP, 101l, 103l, 105l);
+
+        // = 
+        Constraint constraint = propertyValue(LONG_PROP, EQUAL_TO, "103");
+        validateCardinality(constraint, 1);
+        validateFilterResults(constraint, 1, false, nodesWithLongProp.get(1));
+
+        // >
+        constraint = propertyValue(LONG_PROP, GREATER_THAN, "101");
+        validateCardinality(constraint, 2);
+        validateFilterResults(constraint, 1, false, nodesWithLongProp.get(1), nodesWithLongProp.get(2));
+
+        // >=
+        constraint = propertyValue(LONG_PROP, GREATER_THAN_OR_EQUAL_TO, "101");
+        validateCardinality(constraint, 3);
+        validateFilterResults(constraint, 2, false, nodesWithLongProp.toArray(new String[3]));
+
+        // <
+        constraint = propertyValue(LONG_PROP, LESS_THAN, "103");
+        validateCardinality(constraint, 1);
+        validateFilterResults(constraint, 2, false, nodesWithLongProp.get(0));
+
+        // <=
+        constraint = propertyValue(LONG_PROP, LESS_THAN_OR_EQUAL_TO, "103");
+        validateCardinality(constraint, 2);
+        validateFilterResults(constraint, 2, false, nodesWithLongProp.get(0), nodesWithLongProp.get(1));
+
+        // LIKE (compare as strings)
+        constraint = propertyValue(LONG_PROP, LIKE, "10%");
+        try {
+            validateCardinality(constraint, 3);
+            fail("Should not be able to use the LIKE operator on LONG values");
+        } catch (ValueFormatException e) {
+            //expected (can't search using LIKE)            
+        }
+
+        // !=
+        constraint = propertyValue(LONG_PROP, NOT_EQUAL_TO, "103");
+        validateCardinality(constraint, 2);
+        validateFilterResults(constraint, 2, false, nodesWithLongProp.get(0), nodesWithLongProp.get(2));
+    }
+
+    @Test
+    public void shouldSearchForDoublePropertyValueInComparisonConstraint() throws Exception {
+        List<String> nodesWithDoubleProp = indexNodes(DOUBLE_PROP, 10d, 13d, 15d);
+
+        // =
+        Constraint constraint = propertyValue(DOUBLE_PROP, EQUAL_TO, "15");
+        validateCardinality(constraint, 1);
+        validateFilterResults(constraint, 1, false, nodesWithDoubleProp.get(2));
+
+        // >
+        constraint = propertyValue(DOUBLE_PROP, GREATER_THAN, "10");
+        validateCardinality(constraint, 2);
+        validateFilterResults(constraint, 1, false, nodesWithDoubleProp.get(1), nodesWithDoubleProp.get(2));
+
+        // >=
+        constraint = propertyValue(DOUBLE_PROP, GREATER_THAN_OR_EQUAL_TO, "10");
+        validateCardinality(constraint, 3);
+        validateFilterResults(constraint, 2, false, nodesWithDoubleProp.toArray(new String[3]));
+
+        // <
+        constraint = propertyValue(DOUBLE_PROP, LESS_THAN, "13");
+        validateCardinality(constraint, 1);
+        validateFilterResults(constraint, 2, false, nodesWithDoubleProp.get(0));
+
+        // <=
+        constraint = propertyValue(DOUBLE_PROP, LESS_THAN_OR_EQUAL_TO, "13");
+        validateCardinality(constraint, 2);
+        validateFilterResults(constraint, 2, false, nodesWithDoubleProp.get(0), nodesWithDoubleProp.get(1));
+
+        // LIKE (compare as strings)
+        constraint = propertyValue(DOUBLE_PROP, LIKE, "10%");
+        try {
+            validateCardinality(constraint, 3);
+            fail("Should not be able to use the LIKE operator on DOUBLE values");
+        } catch (ValueFormatException e) {
+            //expected (can't search using LIKE)            
+        }
+
+        // !=
+        constraint = propertyValue(DOUBLE_PROP, NOT_EQUAL_TO, "13");
+        validateCardinality(constraint, 2);
+        validateFilterResults(constraint, 2, false, nodesWithDoubleProp.get(0), nodesWithDoubleProp.get(2));
+    }
+
+    @Test
+    public void shouldSearchForDatePropertyValueInComparisonConstraint() throws Exception {
+        List<String> nodesWithDateProp = indexNodes(DATE_PROP,
+                                                    new JodaDateTime("2015-10-13"),
+                                                    new JodaDateTime("2015-10-15"),
+                                                    new JodaDateTime("2015-10-17"));
+
+        // =
+        Constraint constraint = propertyValue(DATE_PROP, EQUAL_TO, "2015-10-17");
+        validateCardinality(constraint, 1);
+        validateFilterResults(constraint, 1, false, nodesWithDateProp.get(2));
+
+        // >
+        constraint = propertyValue(DATE_PROP, GREATER_THAN, "2015-10-13");
+        validateCardinality(constraint, 2);
+        validateFilterResults(constraint, 1, false, nodesWithDateProp.get(1), nodesWithDateProp.get(2));
+
+        // >=
+        constraint = propertyValue(DATE_PROP, GREATER_THAN_OR_EQUAL_TO, "2015-10-13");
+        validateCardinality(constraint, 3);
+        validateFilterResults(constraint, 2, false, nodesWithDateProp.toArray(new String[3]));
+
+        // <
+        constraint = propertyValue(DATE_PROP, LESS_THAN, "2015-10-15");
+        validateCardinality(constraint, 1);
+        validateFilterResults(constraint, 2, false, nodesWithDateProp.get(0));
+
+        // <=
+        constraint = propertyValue(DATE_PROP, LESS_THAN_OR_EQUAL_TO, "2015-10-15");
+        validateCardinality(constraint, 2);
+        validateFilterResults(constraint, 2, false, nodesWithDateProp.get(0), nodesWithDateProp.get(1));
+
+        // LIKE (compare as strings)
+        constraint = propertyValue(DATE_PROP, LIKE, "2015-10-15%");
+        try {
+            validateCardinality(constraint, 3);
+            fail("Should not be able to use the LIKE operator on DOUBLE values");
+        } catch (ValueFormatException e) {
+            //expected (can't search using LIKE)            
+        }
+
+        // !=
+        constraint = propertyValue(DATE_PROP, NOT_EQUAL_TO, "2015-10-15");
+        validateCardinality(constraint, 2);
+        validateFilterResults(constraint, 2, false, nodesWithDateProp.get(0), nodesWithDateProp.get(2));
+    }
+
+    @Test
+    public void shouldSearchForBooleanPropertyValueInComparisonConstraint() throws Exception {
+        List<String> nodesWithBooleanProp = indexNodes(BOOLEAN_PROP, false, true, false);
+
+        // =
+        Constraint constraint = propertyValue(BOOLEAN_PROP, EQUAL_TO, true);
+        validateCardinality(constraint, 1);
+        validateFilterResults(constraint, 1, false, nodesWithBooleanProp.get(1));
+
+        // >
+        constraint = propertyValue(BOOLEAN_PROP, GREATER_THAN, false);
+        validateCardinality(constraint, 1);
+        validateFilterResults(constraint, 1, false, nodesWithBooleanProp.get(1));
+
+        constraint = propertyValue(BOOLEAN_PROP, GREATER_THAN, true);
+        validateCardinality(constraint, 0);
+
+        // >=
+        constraint = propertyValue(BOOLEAN_PROP, GREATER_THAN_OR_EQUAL_TO, false);
+        validateCardinality(constraint, 3);
+        validateFilterResults(constraint, 2, false, nodesWithBooleanProp.toArray(new String[3]));
+
+        // <
+        constraint = propertyValue(BOOLEAN_PROP, LESS_THAN, true);
+        validateCardinality(constraint, 2);
+        validateFilterResults(constraint, 2, false, nodesWithBooleanProp.get(0), nodesWithBooleanProp.get(1));
+        constraint = propertyValue(BOOLEAN_PROP, LESS_THAN, false);
+        validateCardinality(constraint, 0);
+
+
+        // <=
+        constraint = propertyValue(BOOLEAN_PROP, LESS_THAN_OR_EQUAL_TO, true);
+        validateCardinality(constraint, 3);
+        validateFilterResults(constraint, 2, false, nodesWithBooleanProp.toArray(new String[3]));
+
+        // LIKE (compare as strings)
+        constraint = propertyValue(BOOLEAN_PROP, LIKE, "true%");
+        try {
+            validateCardinality(constraint, 3);
+            fail("Should not be able to use the LIKE operator on DOUBLE values");
+        } catch (LuceneIndexException e) {
+            //expected (can't search using LIKE)            
+        }
+
+        // !=
+        constraint = propertyValue(BOOLEAN_PROP, NOT_EQUAL_TO, true);
+        validateCardinality(constraint, 2);
+        validateFilterResults(constraint, 2, false, nodesWithBooleanProp.get(0), nodesWithBooleanProp.get(2));
+    }
+
+    @Test
+    public void shouldSearchForReferencePropertyValueInComparisonConstraint() throws Exception {
+        String ref1 = UUID.randomUUID().toString();
+        String ref2 = UUID.randomUUID().toString();
+        List<String> nodesWithRefProp = indexNodes(REF_PROP, ref1, ref2);
+
+        // =
+        Constraint constraint = propertyValue(REF_PROP, EQUAL_TO, ref1);
+        validateCardinality(constraint, 1);
+        validateFilterResults(constraint, 1, false, nodesWithRefProp.get(0));
+
+        // !=
+        constraint = propertyValue(REF_PROP, NOT_EQUAL_TO, ref1);
+        validateCardinality(constraint, 1);
+        validateFilterResults(constraint, 1, false, nodesWithRefProp.get(1));
+    }
+
+    @Test
+    public void shouldSearchForReferenceValueInComparisonConstraint() throws Exception {
+        String ref1 = UUID.randomUUID().toString();
+        String ref2 = UUID.randomUUID().toString();
+        List<String> nodesWithRefProp = indexNodes(REF_PROP, ref1, ref2);
+
+        Constraint constraint = referenceValue(REF_PROP, EQUAL_TO, ref1, true, true);
+        validateCardinality(constraint, 1);
+        validateFilterResults(constraint, 1, false, nodesWithRefProp.get(0));
+        constraint = referenceValue(null, EQUAL_TO, ref1, true, true);
+        validateCardinality(constraint, 1);
+        validateFilterResults(constraint, 1, false, nodesWithRefProp.get(0));
+    }
+
+    @Test
+    public void shouldSearchForLengthInComparisonConstraint() throws Exception {
+        String stringVal = "1234";
+        String stringNode = indexNodes(STRING_PROP, stringVal).get(0);
+
+        NameFactory nameFactory = valueFactories.getNameFactory();
+        StringFactory stringFactory = valueFactories.getStringFactory();
+        String nameVal = stringFactory.create(nameFactory.create("jcr:value"));
+        String nameNode = indexNodes(NAME_PROP, nameVal).get(0);
+
+        PathFactory pathFactory = valueFactories.getPathFactory();
+        String pathVal = stringFactory.create(pathFactory.create("/a/b"));
+        String pathNode = indexNodes(PATH_PROP, pathVal).get(0);
+
+        BigDecimal decimal = BigDecimal.valueOf(12.4);
+        String decimalStr = stringFactory.create(decimal);
+        String decimalNode = indexNodes(DECIMAL_PROP, decimal).get(0);
+
+        long longValue = 1234l;
+        String longStr = stringFactory.create(longValue);
+        String longNode = indexNodes(LONG_PROP, longValue).get(0);
+
+        double doubleValue = 12346.35d;
+        String doubleStr = stringFactory.create(doubleValue);
+        String doubleNode = indexNodes(DOUBLE_PROP, doubleValue).get(0);
+
+        DateTime dateValue = valueFactories.getDateFactory().create("2015-10-10");
+        String dateStr = stringFactory.create(dateValue);
+        String dateNode = indexNodes(DATE_PROP, dateValue).get(0);
+
+        String ref = UUID.randomUUID().toString();
+        String refNode = indexNodes(REF_PROP, ref).get(0);
+
+        boolean booleanValue = true;
+        String booleanStr= stringFactory.create(booleanValue);
+        String booleanNode = indexNodes(BOOLEAN_PROP, booleanValue).get(0);
+
+        BinaryValue binaryValue = valueFactories.getBinaryFactory().create("some_binary");
+        String binaryNode = indexNodes(BINARY_PROP, binaryValue).get(0);
+
+        assertLengthComparisonConstraint(STRING_PROP, stringNode, stringVal.length());
+        assertLengthComparisonConstraint(NAME_PROP, nameNode, nameVal.length());
+        assertLengthComparisonConstraint(PATH_PROP, pathNode, pathVal.length());
+        assertLengthComparisonConstraint(DECIMAL_PROP, decimalNode, decimalStr.length());
+        assertLengthComparisonConstraint(LONG_PROP, longNode, longStr.length());
+        assertLengthComparisonConstraint(DOUBLE_PROP, doubleNode, doubleStr.length());
+        assertLengthComparisonConstraint(DATE_PROP, dateNode, dateStr.length());
+        assertLengthComparisonConstraint(REF_PROP, refNode, ref.length());
+        assertLengthComparisonConstraint(BOOLEAN_PROP, booleanNode, booleanStr.length());
+        assertLengthComparisonConstraint(BINARY_PROP, binaryNode, (int)binaryValue.getSize());
+    }
+
+    @Test
+    public void shouldSearchForLowerAndUpperCasesInComparisonConstraint() throws Exception {
+        List<String> nodeKeys = indexNodes(STRING_PROP, "A", "b");
+
+        Constraint constraint = lowerCase(STRING_PROP, EQUAL_TO, "a");
+        validateCardinality(constraint, 1);
+        validateFilterResults(constraint, 1, false, nodeKeys.get(0));
+
+        constraint = lowerCase(STRING_PROP, EQUAL_TO, "b");
+        validateCardinality(constraint, 1);
+        validateFilterResults(constraint, 1, false, nodeKeys.get(1));
+
+        constraint = upperCase(STRING_PROP, EQUAL_TO, "B");
+        validateCardinality(constraint, 1);
+        validateFilterResults(constraint, 1, false, nodeKeys.get(1));
+
+        constraint = upperCase(STRING_PROP, EQUAL_TO, "A");
+        validateCardinality(constraint, 1);
+        validateFilterResults(constraint, 1, false, nodeKeys.get(0));
+    }
+
+    @Test
+    public void shouldSearchForAndConstraint() throws Exception {
+        List<String> nodeKeys = indexNodes(LONG_PROP, 1l, 3l, 5l);
+        // >1 && <5
+        Constraint constraint = and(propertyValue(LONG_PROP, GREATER_THAN, 1),
+                                    propertyValue(LONG_PROP, LESS_THAN, 5));
+        validateCardinality(constraint, 1);
+        validateFilterResults(constraint, 1, false, nodeKeys.get(1));
+    }
+
+    @Test
+    public void shouldSearchForOrConstraint() throws Exception {
+        List<String> nodeKeys = indexNodes(LONG_PROP, 1l, 3l, 5l);
+        //>1 || <5
+        Constraint constraint = or(propertyValue(LONG_PROP, GREATER_THAN, 1),
+                                   propertyValue(LONG_PROP, LESS_THAN, 5));
+        validateCardinality(constraint, 3);
+        validateFilterResults(constraint, 3, false, nodeKeys.toArray(new String[nodeKeys.size()]));
+    }
+
+    @Test
+    public void shouldSearchForNotConstraint() throws Exception {
+        List<String> nodeKeys = indexNodes(LONG_PROP, 1l, 3l, 5l);
+        // >1
+        Constraint constraint = not(propertyValue(LONG_PROP, GREATER_THAN, 1));
+        validateCardinality(constraint, 1);
+        validateFilterResults(constraint, 1, false, nodeKeys.get(0));
+    }
+
+    @Test
+    public void shouldSearchForSetConstraint() throws Exception {
+        List<String> nodeKeys = indexNodes(LONG_PROP, 1l, 3l, 5l);
+        // IN (1,2,3,4)
+        Constraint constraint = set(LONG_PROP, 1, 2, 3, 4);
+        validateCardinality(constraint, 2);
+        validateFilterResults(constraint, 2, false, nodeKeys.get(0), nodeKeys.get(1));
+    }
+
+    @Test
+    public void shouldSearchForPropertyExistence() throws Exception {
+        String longNode = indexNodes(LONG_PROP, 1l).get(0);
+        Constraint constraint = propertyExistence(LONG_PROP);
+        validateCardinality(constraint, 1);
+        validateFilterResults(constraint, 1, false, longNode);
+
+        String stringNode = indexNodes(STRING_PROP, "a").get(0);
+        constraint = propertyExistence(STRING_PROP);
+        validateCardinality(constraint, 1);
+        validateFilterResults(constraint, 1, false, stringNode);
+
+        constraint = propertyExistence(DATE_PROP);
+        validateCardinality(constraint, 0);
+    }
+
+    @Test
+    public void shouldSearchForBetweenConstraint() throws Exception {
+        List<String> nodeKeys = indexNodes(LONG_PROP, 1l, 3l);
+        // (0,2)
+        Constraint between = between(LONG_PROP, 0, false, 2, false);
+        validateCardinality(between, 1);
+        validateFilterResults(between, 1, false, nodeKeys.get(0));
+        // [1,2)
+        between = between(LONG_PROP, 1, true, 2, false);
+        validateCardinality(between, 1);
+        validateFilterResults(between, 1, false, nodeKeys.get(0));
+        // (1,2)
+        between = between(LONG_PROP, 1, false, 2, false);
+        validateCardinality(between, 0);
+        // (2,4)
+        between = between(LONG_PROP, 2, false, 4, false);
+        validateCardinality(between, 1);
+        validateFilterResults(between, 1, false, nodeKeys.get(1));
+        // (3,5)
+        between = between(LONG_PROP, 3, false, 5, false);
+        validateCardinality(between, 0);
+    }
+
+    @Test
+    public void shouldSearchForRelikeConstraint() throws Exception {
+        String node = indexNodes(STRING_PROP, "string%").get(0);
+        Constraint relike = relike("string-1", STRING_PROP);
+        validateCardinality(relike, 1);
+        validateFilterResults(relike, 1, false, node);
+    }
+    
+    @Test(expected = UnsupportedOperationException.class)
+    public void shouldSupportFTSConstraint() throws Exception {
+        validateCardinality(fullTextSearch(STRING_PROP, "some string"), 1);                        
+    }
+}

--- a/index-providers/modeshape-lucene-index-provider/src/test/java/org/modeshape/jcr/index/lucene/TextIndexPersistenceTest.java
+++ b/index-providers/modeshape-lucene-index-provider/src/test/java/org/modeshape/jcr/index/lucene/TextIndexPersistenceTest.java
@@ -1,0 +1,29 @@
+/*
+ * ModeShape (http://www.modeshape.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.modeshape.jcr.index.lucene;
+
+/**
+ * Tests CRUD operations on the {@link TextIndex} index.
+ *
+ * @author Horia Chiorean (hchiorea@redhat.com)
+ */
+public class TextIndexPersistenceTest extends SingleColumnIndexPersistenceTest {
+    
+    @Override
+    protected LuceneIndex createIndex( String name ) {
+        return new TextIndex(name + "-text", config, PropertiesTestUtil.ALLOWED_PROPERTIES, context);
+    }
+}

--- a/index-providers/modeshape-lucene-index-provider/src/test/java/org/modeshape/jcr/index/lucene/TextIndexPersistenceTest.java
+++ b/index-providers/modeshape-lucene-index-provider/src/test/java/org/modeshape/jcr/index/lucene/TextIndexPersistenceTest.java
@@ -24,6 +24,6 @@ public class TextIndexPersistenceTest extends SingleColumnIndexPersistenceTest {
     
     @Override
     protected LuceneIndex createIndex( String name ) {
-        return new TextIndex(name + "-text", config, PropertiesTestUtil.ALLOWED_PROPERTIES, context);
+        return new TextIndex(name + "-text", "default", config, PropertiesTestUtil.ALLOWED_PROPERTIES, context);
     }
 }

--- a/index-providers/modeshape-lucene-index-provider/src/test/java/org/modeshape/jcr/index/lucene/TextIndexSearchTest.java
+++ b/index-providers/modeshape-lucene-index-provider/src/test/java/org/modeshape/jcr/index/lucene/TextIndexSearchTest.java
@@ -1,0 +1,130 @@
+/*
+ * ModeShape (http://www.modeshape.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.modeshape.jcr.index.lucene;
+
+import static org.modeshape.jcr.index.lucene.PropertiesTestUtil.STRING_PROP;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.Test;
+import org.modeshape.jcr.query.model.Constraint;
+import org.modeshape.jcr.value.PropertyType;
+
+/**
+ * Tests the search behavior of the {@link TextIndex}
+ *
+ * @author Horia Chiorean (hchiorea@redhat.com)
+ */
+public class TextIndexSearchTest extends AbstractLuceneIndexSearchTest {
+    
+    private static final Map<String, PropertyType> ALLOWED_PROPERTIES = new HashMap<String, PropertyType>(){
+        {
+            put(STRING_PROP, PropertyType.STRING);
+        }
+    };    
+    
+    @Override
+    protected LuceneIndex createIndex( String name ) {
+        return new TextIndex(name + "-text", config, ALLOWED_PROPERTIES, context);
+    }
+
+    @Test
+    public void shouldSupportFTSWithSimpleExpressions() throws Exception {
+        List<String> nodeKeys = indexNodes(STRING_PROP, "the quick", "brown fox", "green fox");
+        
+        Constraint fts = fullTextSearch(STRING_PROP, "quick");
+        validateCardinality(fts, 1);
+        validateFilterResults(fts, 1, true, nodeKeys.get(0));
+
+        fts = fullTextSearch(STRING_PROP, "fox");
+        validateCardinality(fts, 2);
+        validateFilterResults(fts, 1, true, nodeKeys.get(1), nodeKeys.get(2));
+
+        // any except
+        fts = fullTextSearch(STRING_PROP, "-fox");
+        validateCardinality(fts, 1);
+        validateFilterResults(fts, 1, true, nodeKeys.get(0));
+
+        fts = fullTextSearch(STRING_PROP, "fo*");
+        validateCardinality(fts, 2);
+        // we can't really expect a real score here because it's searching via regex 
+        validateFilterResults(fts, 1, false, nodeKeys.get(1), nodeKeys.get(2));
+    }
+
+    @Test
+    public void shouldSupportFTSWithSimpleExpressionsAndNoPropertyName() throws Exception {
+        List<String> nodeKeys = indexNodes(STRING_PROP, "the quick", "brown fox", "green fox");
+
+        Constraint fts = fullTextSearch(null, "quick");
+        validateCardinality(fts, 1);
+        validateFilterResults(fts, 1, true, nodeKeys.get(0));
+    }
+    
+    @Test
+    public void shouldSupportFTSWithConjunctions() throws Exception {
+        List<String> nodeKeys = indexNodes(STRING_PROP, "the quick brown fox", "jumps over");
+        
+        Constraint fts = fullTextSearch(STRING_PROP, "quick brown");
+        validateCardinality(fts, 1);
+        validateFilterResults(fts, 1, true, nodeKeys.get(0));
+
+        fts = fullTextSearch(STRING_PROP, "jumps o*");
+        validateCardinality(fts, 1);
+        validateFilterResults(fts, 1, false, nodeKeys.get(1));
+
+        fts = fullTextSearch(STRING_PROP, "-jumps brown");
+        validateCardinality(fts, 1);
+        validateFilterResults(fts, 1, true, nodeKeys.get(0));
+
+        fts = fullTextSearch(STRING_PROP, "-jumps -brown");
+        validateCardinality(fts, 0);
+    } 
+    
+    @Test
+    public void shouldSupportFTSWithDisjunctions() throws Exception {
+        List<String> nodeKeys = indexNodes(STRING_PROP, "the quick brown fox", "jumps over");
+        
+        Constraint fts = fullTextSearch(STRING_PROP, "quick OR over");
+        validateCardinality(fts, 2);
+        validateFilterResults(fts, 1, true, nodeKeys.toArray(new String[nodeKeys.size()]));
+
+        fts = fullTextSearch(STRING_PROP, "jumps OR o*");
+        validateCardinality(fts, 1);
+        validateFilterResults(fts, 1, false, nodeKeys.get(1));
+
+        fts = fullTextSearch(STRING_PROP, "-jumps OR brown");
+        validateCardinality(fts, 1);
+        validateFilterResults(fts, 1, true, nodeKeys.get(0));
+
+        fts = fullTextSearch(STRING_PROP, "-jumps OR -brown");
+        validateCardinality(fts, 2);
+        validateFilterResults(fts, 2, true, nodeKeys.toArray(new String[nodeKeys.size()]));
+    }
+
+    @Test
+    public void shouldSupportFTSWithDisjunctionsAndConjunctions() throws Exception {
+        List<String> nodeKeys = indexNodes(STRING_PROP, "the quick brown fox", "jumps over");
+
+        // MUST NOT 'over' AND MUST 'jumps'....
+        Constraint fts = fullTextSearch(STRING_PROP, "-quick OR -over jumps");
+        validateCardinality(fts, 0);
+
+        // (SHOULD 'quick') OR (MUST NOT 'fox' AND MUST 'jumps')  
+        fts = fullTextSearch(STRING_PROP, "quick OR -fox jumps");
+        validateCardinality(fts, 2);
+        validateFilterResults(fts, 1, true, nodeKeys.toArray(new String[nodeKeys.size()]));
+    }
+}

--- a/index-providers/modeshape-lucene-index-provider/src/test/java/org/modeshape/jcr/index/lucene/TextIndexSearchTest.java
+++ b/index-providers/modeshape-lucene-index-provider/src/test/java/org/modeshape/jcr/index/lucene/TextIndexSearchTest.java
@@ -38,7 +38,7 @@ public class TextIndexSearchTest extends AbstractLuceneIndexSearchTest {
     
     @Override
     protected LuceneIndex createIndex( String name ) {
-        return new TextIndex(name + "-text", config, ALLOWED_PROPERTIES, context);
+        return new TextIndex(name + "-text", "default", config, ALLOWED_PROPERTIES, context);
     }
 
     @Test

--- a/index-providers/modeshape-lucene-index-provider/src/test/resources/config/LuceneIndexProviderQueryTest.json
+++ b/index-providers/modeshape-lucene-index-provider/src/test/resources/config/LuceneIndexProviderQueryTest.json
@@ -1,10 +1,10 @@
 {
     "name" : "Test Repository",
     "indexProviders" : {
-        "local" : {
-            "classname" : "org.modeshape.jcr.index.local.LocalIndexProvider",
-            "directory" : "target/LocalIndexProviderQueryTest"
-        },
+        "lucene" : {
+            "classname" : "lucene",
+            "directory" : "target/LuceneIndexProviderQueryTest"
+        }
     },
     "node-types" : [
         "cnd/cars.cnd"
@@ -12,40 +12,52 @@
     "indexes" : {
         "carsByYear" : {
             "kind" : "value",
-            "provider" : "local",
+            "provider" : "lucene",
             "nodeType" : "car:Car",
             "columns" : "car:year(LONG)",
             "description" : "Index for 'car:year' property, which is defined in CND as a string, but all values must be longs"
         },
         "carsByMSRP" : {
             "kind" : "value",
-            "provider" : "local",
+            "provider" : "lucene",
             "nodeType" : "car:Car",
             "columns" : "car:msrp(STRING)"
         },
         "nodesByName" : {
             "kind" : "value",
-            "provider" : "local",
+            "provider" : "lucene",
             "nodeType" : "nt:base",
             "columns" : "jcr:name(NAME)"
         },
         "nodesByLocalName" : {
             "kind" : "value",
-            "provider" : "local",
+            "provider" : "lucene",
             "nodeType" : "nt:base",
             "columns" : "mode:localName(STRING)"
         },
         "nodesByDepth" : {
             "kind" : "value",
-            "provider" : "local",
+            "provider" : "lucene",
             "nodeType" : "nt:base",
             "columns" : "mode:depth(LONG)"
         },
         "nodesByPath" : {
             "kind" : "value",
-            "provider" : "local",
+            "provider" : "lucene",
             "nodeType" : "nt:base",
             "columns" : "jcr:path(PATH)"
+        },
+        "textFromCarMaker" : {
+            "kind" : "text",
+            "provider" : "lucene",
+            "nodeType" : "car:Car",
+            "columns" : "car:maker(STRING)"
+        },
+        "textFromMixTitle" : {
+            "kind" : "text",
+            "provider" : "lucene",
+            "nodeType" : "mix:title",
+            "columns" : "FTSProp(STRING)"
         }
     },
     "reindexing" : {

--- a/index-providers/modeshape-lucene-index-provider/src/test/resources/config/clustered-repo-with-incremental-indexes-config-1.json
+++ b/index-providers/modeshape-lucene-index-provider/src/test/resources/config/clustered-repo-with-incremental-indexes-config-1.json
@@ -1,0 +1,33 @@
+{
+    "name" : "Clustered Repository with Incremental Indexes 1",
+    "workspaces" : {
+        "predefined" : ["otherWorkspace"],
+        "default" : "default",
+        "allowCreation" : true
+    },
+    "storage" : {
+        "cacheName" : "persistentRepository",
+        "cacheConfiguration" : "config/infinispan-clustered-persistent-1.xml" //this is picked up from the modeshape-jcr-tests.jar artifact....
+    },
+    "journaling" : {
+        "location" : "target/clustered/journal1"
+    },
+    "indexProviders" : {
+        "lucene" : {
+            "classname" : "lucene",
+            "directory" : "target/clustered/repo1_indexes"
+        }
+    },
+    "indexes" : {
+        "titleIndex" : {
+            "kind" : "value",
+            "provider" : "lucene",
+            "nodeType" : "mix:title",
+            "columns" : "jcr:title(STRING)"
+        }
+    },
+    "reindexing" : {
+        "async" : false,
+        "mode" : "incremental"
+    }
+}

--- a/index-providers/modeshape-lucene-index-provider/src/test/resources/config/clustered-repo-with-incremental-indexes-config-2.json
+++ b/index-providers/modeshape-lucene-index-provider/src/test/resources/config/clustered-repo-with-incremental-indexes-config-2.json
@@ -1,0 +1,33 @@
+{
+    "name" : "Clustered Repository with Incremental Indexes 2",
+    "workspaces" : {
+        "predefined" : ["otherWorkspace"],
+        "default" : "default",
+        "allowCreation" : true
+    },
+    "storage" : {
+        "cacheName" : "persistentRepository",
+        "cacheConfiguration" : "config/infinispan-clustered-persistent-2.xml" //this is picked up from the modeshape-jcr-tests.jar artifact....
+    },
+    "journaling" : {
+        "location" : "target/clustered/journal2"
+    },
+    "indexProviders" : {
+        "lucene" : {
+            "classname" : "lucene",
+            "directory" : "target/clustered/repo2_indexes"
+        }
+    },
+    "indexes" : {
+        "titleIndex" : {
+            "kind" : "value",
+            "provider" : "lucene",
+            "nodeType" : "mix:title",
+            "columns" : "jcr:title(STRING)"
+        }
+    },
+    "reindexing" : {
+        "async" : false,
+        "mode" : "incremental"
+    }
+}

--- a/index-providers/modeshape-lucene-index-provider/src/test/resources/config/repo-config-persistent-lucene-provider-advanced-settings.json
+++ b/index-providers/modeshape-lucene-index-provider/src/test/resources/config/repo-config-persistent-lucene-provider-advanced-settings.json
@@ -1,0 +1,31 @@
+{
+    "name": "Persistent repo no indexes",
+    "storage": {
+        "cacheName": "persistentRepository"
+    },
+    "workspaces": {
+        "default": "default",
+        "predefined" : ["other"],
+        "allowCreation": true
+    },
+    "indexProviders" : {
+        "lucene" : {
+            "classname" : "lucene",
+            "lockFactoryClass" : "org.apache.lucene.store.NoLockFactory",
+            "directoryClass" : "org.apache.lucene.store.RAMDirectory",
+            "analyzerClass" : "org.apache.lucene.analysis.ro.RomanianAnalyzer",
+            "codec" : "Lucene53"
+        }
+    },
+    "indexes" : {
+        "titleIndex" : {
+            "kind" : "value",
+            "provider" : "lucene",
+            "nodeType" : "mix:title",
+            "columns" : "jcr:title(STRING)"
+        }
+    },
+    "reindexing" : {
+        "async" : false //make sure this is sync to avoid waiting in tests after registering indexes
+    }
+}

--- a/index-providers/modeshape-lucene-index-provider/src/test/resources/config/repo-config-persistent-lucene-provider-no-indexes.json
+++ b/index-providers/modeshape-lucene-index-provider/src/test/resources/config/repo-config-persistent-lucene-provider-no-indexes.json
@@ -2,7 +2,7 @@
     "name": "Persistent repo no indexes",
     "storage": {
         "cacheName": "persistentRepository",
-        "cacheConfiguration": "config/infinispan-persistent.xml",
+        "cacheConfiguration": "config/infinispan-persistent.xml", //this is picked up from the modeshape-jcr-tests.jar artifact....
         "binaryStorage": {
             "type": "file",
             "directory": "target/persistent_repository/binaries",
@@ -14,17 +14,25 @@
         "allowCreation": true
     },
     "indexProviders" : {
-        "local" : {
-            "classname" : "org.modeshape.jcr.index.local.LocalIndexProvider",
-            "directory" : "target/persistent_repository/indexes/local"
+        "lucene" : {
+            "classname" : "lucene",
+            "directory" : "target/persistent_repository/indexes/lucene_primary"
         },
         "secondary" : {
-            "classname" : "org.modeshape.jcr.index.local.LocalIndexProvider",
-            "path" : "indexes/secondary",
+            "classname" : "lucene",
+            "path" : "indexes/lucene_secondary",
             "relative-to" : "target/persistent_repository"
-        },
+        }
     },
     "reindexing" : {
         "async" : false //make sure this is sync to avoid waiting in tests after registering indexes
+    }, 
+    "textExtraction": {
+        "extractors": {
+            "tikaExtractor": {
+                "name": "Tika content-based extractor",
+                "classname": "tika"
+            }
+        }
     }
 }

--- a/index-providers/modeshape-lucene-index-provider/src/test/resources/text-file.txt
+++ b/index-providers/modeshape-lucene-index-provider/src/test/resources/text-file.txt
@@ -1,0 +1,1 @@
+The Quick Red Fox Jumps Over the Lazy Brown Dog

--- a/index-providers/pom.xml
+++ b/index-providers/pom.xml
@@ -38,7 +38,9 @@
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>
-
+        <!--
+            Allows not only test classes, but also test resources (e.g. ISPN configuration files) to be reused.
+        -->
         <dependency>
             <groupId>org.modeshape</groupId>
             <artifactId>modeshape-jcr</artifactId>

--- a/index-providers/pom.xml
+++ b/index-providers/pom.xml
@@ -1,0 +1,107 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.modeshape</groupId>
+        <artifactId>modeshape-parent</artifactId>
+        <version>4.5-SNAPSHOT</version>
+        <relativePath>../modeshape-parent/pom.xml</relativePath>
+    </parent>
+    <!-- The groupId and version values are inherited from parent -->
+    <artifactId>modeshape-index-providers</artifactId>
+    <packaging>pom</packaging>
+    <name>ModeShape Index Providers</name>
+    <description>ModeShape built-in index providers</description>
+    <url>http://www.modeshape.org</url>
+    <dependencies>
+        <!-- Common (annotations & text parsers) -->
+        <dependency>
+            <groupId>org.modeshape</groupId>
+            <artifactId>modeshape-common</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.modeshape</groupId>
+            <artifactId>modeshape-jcr-api</artifactId>
+        </dependency>  
+		
+		<dependency>
+            <groupId>org.modeshape</groupId>
+            <artifactId>modeshape-jcr</artifactId>
+        </dependency>
+
+        <!-- Testing -->
+        <dependency>
+            <groupId>org.modeshape</groupId>
+            <artifactId>modeshape-common</artifactId>
+            <version>${project.version}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.modeshape</groupId>
+            <artifactId>modeshape-jcr</artifactId>
+            <version>${project.version}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.modeshape</groupId>
+            <artifactId>modeshape-schematic</artifactId>
+            <version>${project.version}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-all</artifactId>
+        </dependency>
+
+        <!-- Logging-->
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-log4j12</artifactId>
+        </dependency>
+        <dependency>
+           <groupId>log4j</groupId>
+           <artifactId>log4j</artifactId>
+        </dependency>
+    </dependencies>
+
+    <modules>
+        <module>modeshape-lucene-index-provider</module>      
+    </modules>
+
+    <profiles>
+        <profile>
+            <id>assembly</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-assembly-plugin</artifactId>
+                        <configuration>
+                            <descriptorRefs>
+                                <descriptorRef>module-with-dependencies</descriptorRef>
+                            </descriptorRefs>
+                            <attach>false</attach>
+                            <finalName>${binary.dist.name}</finalName>
+                            <appendAssemblyId>false</appendAssemblyId>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+</project>

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrRepository.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrRepository.java
@@ -1204,8 +1204,13 @@ public class JcrRepository implements org.modeshape.jcr.api.Repository {
                 this.indexingExecutor = this.context.getThreadPool("modeshape-reindexing");
                 this.queryParsers = new QueryParsers(new JcrSql2QueryParser(), new XPathQueryParser(),
                                                      new FullTextSearchParser(), new JcrSqlQueryParser(), new JcrQomQueryParser());
-                this.repositoryQueryManager = new RepositoryQueryManager(this, indexingExecutor, config);
-                this.changeBus.register(this.repositoryQueryManager);
+                RepositoryConfiguration.Reindexing reindexingCfg = config.getReindexing();
+                this.repositoryQueryManager = new RepositoryQueryManager(this, indexingExecutor, config, reindexingCfg);
+                if (reindexingCfg.isAsync()) {
+                    this.changeBus.register(this.repositoryQueryManager);
+                } else {
+                    this.changeBus.registerInThread(this.repositoryQueryManager);    
+                }
 
                 // Check that we have parsers for all the required languages ...
                 assert this.queryParsers.getParserFor(Query.XPATH) != null;

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/RepositoryConfiguration.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/RepositoryConfiguration.java
@@ -660,7 +660,7 @@ public class RepositoryConfiguration {
         String localIndexProvider = LocalIndexProvider.class.getName();
         aliases = new HashMap<String, String>();
         aliases.put("local", localIndexProvider);
-        // aliases.put("files", localIndexProvider);
+        aliases.put("lucene", "org.modeshape.jcr.index.lucene.LuceneIndexProvider");
 
         INDEX_PROVIDER_ALIASES = Collections.unmodifiableMap(aliases);
 

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/RepositoryIndexManager.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/RepositoryIndexManager.java
@@ -492,7 +492,7 @@ class RepositoryIndexManager implements IndexManager, NodeTypes.Listener {
             }
             IndexProvider provider = providers.get(providerName);
             if (provider == null) {
-                problems.addError(JcrI18n.indexProviderDoesNotExist, defn, repository.name());
+                problems.addError(JcrI18n.indexProviderDoesNotExist, defn.getName(), repository.name());
             } else {
                 // Perform some default validations that should be applied to all providers... 
                 provider.validateDefaultColumnTypes(context, defn, problems);

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/query/engine/ScanningQueryEngine.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/query/engine/ScanningQueryEngine.java
@@ -1164,6 +1164,7 @@ public class ScanningQueryEngine implements org.modeshape.jcr.query.QueryEngine 
                 return NodeSequence.NO_PASS_ROW_FILTER;
             }
             final NodeKey parentKey = parent.getKey();
+            final boolean isParentRoot = parentPath.isRoot();
             final String selectorName = childConstraint.getSelectorName();
             final int index = columns.getSelectorIndex(selectorName);
             return new RowFilter() {
@@ -1171,6 +1172,7 @@ public class ScanningQueryEngine implements org.modeshape.jcr.query.QueryEngine 
                 public boolean isCurrentRowValid( Batch batch ) {
                     CachedNode node = batch.getNode(index);
                     if (node == null) return false;
+                    if (isParentRoot) return true;
                     if (parentKey.equals(node.getParentKey(cache))) return true;
                     // Don't have to check the additional parents since we only find shared nodes in the original location ...
                     return false;

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/spi/index/provider/IndexChangeAdapter.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/spi/index/provider/IndexChangeAdapter.java
@@ -35,12 +35,12 @@ public abstract class IndexChangeAdapter extends ChangeSetAdapter {
 
     protected final String workspaceName;
     protected final ProvidedIndex<?> index;
-    protected final Logger logger; 
+    protected final Logger logger;
 
     protected IndexChangeAdapter( ExecutionContext context,
-                               String workspaceName,
-                               NodeTypePredicate predicate, 
-                               ProvidedIndex<?> index ) {
+                                  String workspaceName,
+                                  NodeTypePredicate predicate,
+                                  ProvidedIndex<?> index ) {
         super(context, predicate);
         assert index != null;
         this.index = index;

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/spi/index/provider/IndexUsage.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/spi/index/provider/IndexUsage.java
@@ -155,6 +155,9 @@ public class IndexUsage {
         if (constraint instanceof PropertyExistence) {
             return indexAppliesTo((PropertyExistence)constraint);
         }
+        if (constraint instanceof FullTextSearch) {
+            return applies((FullTextSearch)constraint);
+        }
         return false;
     }
 
@@ -242,9 +245,6 @@ public class IndexUsage {
         if (operand instanceof ReferenceValue) {
             return applies((ReferenceValue)operand);
         }
-        if (operand instanceof FullTextSearch) {
-            return applies((FullTextSearch)operand);
-        }
         return false;
     }
 
@@ -318,8 +318,18 @@ public class IndexUsage {
         return false;
     }
 
-    protected boolean applies( FullTextSearch operand ) {
-        return defn.getKind() == IndexDefinition.IndexKind.TEXT;
+    protected boolean applies( FullTextSearch constraint ) {
+        if (defn.getKind() != IndexDefinition.IndexKind.TEXT) {
+            return false;
+        }
+        if (!matchesSelectorName(constraint.getSelectorName())) {
+            return false;
+        }
+        String propertyName = constraint.getPropertyName();
+        if (propertyName != null && !defn.appliesToProperty(propertyName)) {
+            return false;
+        }
+        return true;
     }
 
     protected final boolean matchesSelectorName( String selectorName ) {

--- a/modeshape-jcr/src/test/java/org/modeshape/jcr/JcrQueryManagerTest.java
+++ b/modeshape-jcr/src/test/java/org/modeshape/jcr/JcrQueryManagerTest.java
@@ -3149,30 +3149,31 @@ public class JcrQueryManagerTest extends MultiUseAbstractTest {
     public void shouldBeAbleToExecuteFullTextSearchQueriesOnPropertiesWhichIncludeStopWords() throws Exception {
         String propertyText = "the quick Brown fox jumps over to the dog in at the gate";
         Node ftsNode = session.getRootNode().addNode("FTSNode").setProperty("FTSProp", propertyText).getParent();
+        ftsNode.addMixin("mix:title");
         try {
             session.save();
 
-            executeQueryWithSingleResult("select [jcr:path] from [nt:unstructured] as n where contains([nt:unstructured].*,'"
+            executeQueryWithSingleResult("select [jcr:path] from [mix:title] as n where contains([mix:title].*,'"
                                          + propertyText + "')");
 
-            executeQueryWithSingleResult("select [jcr:path] from [nt:unstructured] as n where contains(FTSProp,'" + propertyText
+            executeQueryWithSingleResult("select [jcr:path] from [mix:title] as n where contains(FTSProp,'" + propertyText
                                          + "')");
-            executeQueryWithSingleResult("select [jcr:path] from [nt:unstructured] as n where contains(n.*,'" + propertyText
+            executeQueryWithSingleResult("select [jcr:path] from [mix:title] as n where contains(n.*,'" + propertyText
                                          + "')");
 
-            executeQueryWithSingleResult("select [jcr:path] from [nt:unstructured] as n where contains(FTSProp,'"
+            executeQueryWithSingleResult("select [jcr:path] from [mix:title] as n where contains(FTSProp,'"
                                          + propertyText.toUpperCase() + "')");
-            executeQueryWithSingleResult("select [jcr:path] from [nt:unstructured] as n where contains(n.*,'"
+            executeQueryWithSingleResult("select [jcr:path] from [mix:title] as n where contains(n.*,'"
                                          + propertyText.toUpperCase() + "')");
 
-            executeQueryWithSingleResult("select [jcr:path] from [nt:unstructured] as n where contains(FTSProp,'the quick Dog')");
-            executeQueryWithSingleResult("select [jcr:path] from [nt:unstructured] as n where contains(n.*,'the quick Dog')");
+            executeQueryWithSingleResult("select [jcr:path] from [mix:title] as n where contains(FTSProp,'the quick Dog')");
+            executeQueryWithSingleResult("select [jcr:path] from [mix:title] as n where contains(n.*,'the quick Dog')");
 
-            executeQueryWithSingleResult("select [jcr:path] from [nt:unstructured] as n where contains(FTSProp,'the quick jumps over gate')");
-            executeQueryWithSingleResult("select [jcr:path] from [nt:unstructured] as n where contains(n.*,'the quick jumps over gate')");
+            executeQueryWithSingleResult("select [jcr:path] from [mix:title] as n where contains(FTSProp,'the quick jumps over gate')");
+            executeQueryWithSingleResult("select [jcr:path] from [mix:title] as n where contains(n.*,'the quick jumps over gate')");
 
-            executeQueryWithSingleResult("select [jcr:path] from [nt:unstructured] as n where contains(FTSProp,'the gate')");
-            executeQueryWithSingleResult("select [jcr:path] from [nt:unstructured] as n where contains(n.*,'the gate')");
+            executeQueryWithSingleResult("select [jcr:path] from [mix:title] as n where contains(FTSProp,'the gate')");
+            executeQueryWithSingleResult("select [jcr:path] from [mix:title] as n where contains(n.*,'the gate')");
         } finally {
             // Try to remove the node (which messes up the expected results from subsequent tests) ...
             ftsNode.remove();
@@ -3185,28 +3186,29 @@ public class JcrQueryManagerTest extends MultiUseAbstractTest {
     public void shouldBeAbleToExecuteFullTextSearchQueriesOnPropertiesWhichIncludeUmlauts() throws Exception {
         String propertyText = "Änderung: der schnelle braune Fuchs springt über den Hund";
         Node ftsNode = session.getRootNode().addNode("FTSNode").setProperty("FTSProp", propertyText).getParent();
+        ftsNode.addMixin("mix:title");
         try {
             session.save();
 
-            executeQueryWithSingleResult("select [jcr:path] from [nt:unstructured] as n where contains([nt:unstructured].*,'"
+            executeQueryWithSingleResult("select [jcr:path] from [mix:title] as n where contains([mix:title].*,'"
                                          + propertyText + "')");
 
-            executeQueryWithSingleResult("select [jcr:path] from [nt:unstructured] as n where contains(FTSProp,'" + propertyText
+            executeQueryWithSingleResult("select [jcr:path] from [mix:title] as n where contains(FTSProp,'" + propertyText
                                          + "')");
-            executeQueryWithSingleResult("select [jcr:path] from [nt:unstructured] as n where contains(n.*,'" + propertyText
+            executeQueryWithSingleResult("select [jcr:path] from [mix:title] as n where contains(n.*,'" + propertyText
                                          + "')");
 
-            executeQueryWithSingleResult("select [jcr:path] from [nt:unstructured] as n where contains(FTSProp,'"
+            executeQueryWithSingleResult("select [jcr:path] from [mix:title] as n where contains(FTSProp,'"
                                          + propertyText.toUpperCase() + "')");
-            executeQueryWithSingleResult("select [jcr:path] from [nt:unstructured] as n where contains(n.*,'"
+            executeQueryWithSingleResult("select [jcr:path] from [mix:title] as n where contains(n.*,'"
                                          + propertyText.toUpperCase() + "')");
 
-            executeQueryWithSingleResult("select [jcr:path] from [nt:unstructured] as n where contains(FTSProp,'Änderung')");
-            executeQueryWithSingleResult("select [jcr:path] from [nt:unstructured] as n where contains(FTSProp,'änderung')");
-            executeQueryWithSingleResult("select [jcr:path] from [nt:unstructured] as n where contains(FTSProp,'ÄNDERUNG')");
-            executeQueryWithSingleResult("select [jcr:path] from [nt:unstructured] as n where contains(FTSProp,'über den Hund')");
-            executeQueryWithSingleResult("select [jcr:path] from [nt:unstructured] as n where contains(FTSProp,'Über den Hund')");
-            executeQueryWithSingleResult("select [jcr:path] from [nt:unstructured] as n where contains(FTSProp,'ÜbEr dEn Hund')");
+            executeQueryWithSingleResult("select [jcr:path] from [mix:title] as n where contains(FTSProp,'Änderung')");
+            executeQueryWithSingleResult("select [jcr:path] from [mix:title] as n where contains(FTSProp,'änderung')");
+            executeQueryWithSingleResult("select [jcr:path] from [mix:title] as n where contains(FTSProp,'ÄNDERUNG')");
+            executeQueryWithSingleResult("select [jcr:path] from [mix:title] as n where contains(FTSProp,'über den Hund')");
+            executeQueryWithSingleResult("select [jcr:path] from [mix:title] as n where contains(FTSProp,'Über den Hund')");
+            executeQueryWithSingleResult("select [jcr:path] from [mix:title] as n where contains(FTSProp,'ÜbEr dEn Hund')");
         } finally {
             // Try to remove the node (which messes up the expected results from subsequent tests) ...
             ftsNode.remove();
@@ -3371,7 +3373,7 @@ public class JcrQueryManagerTest extends MultiUseAbstractTest {
 
             // save and slip a bit to have difference in time of node creation.
             session.save();
-            Thread.sleep(1000);
+            Thread.sleep(100);
 
             // add node f2 with child jcr:content
             Node f2 = src.addNode("f2", "nt:file");

--- a/modeshape-jcr/src/test/java/org/modeshape/jcr/LocalIndexProviderAsynchronousTest.java
+++ b/modeshape-jcr/src/test/java/org/modeshape/jcr/LocalIndexProviderAsynchronousTest.java
@@ -37,7 +37,7 @@ public class LocalIndexProviderAsynchronousTest extends AbstractIndexProviderTes
     
     @Override
     protected String providerName() {
-        return LOCAL_PROVIDER_NAME;
+        return "local";
     }
 
     // ---------------------------------------------------------------

--- a/modeshape-jcr/src/test/java/org/modeshape/jcr/LocalIndexProviderQueryTest.java
+++ b/modeshape-jcr/src/test/java/org/modeshape/jcr/LocalIndexProviderQueryTest.java
@@ -29,13 +29,7 @@ public class LocalIndexProviderQueryTest extends JcrQueryManagerTest {
         FileUtil.delete("target/LocalIndexProviderQueryTest");
 
         String configFileName = LocalIndexProviderQueryTest.class.getSimpleName() + ".json";
-        LocalIndexProviderQueryTest.beforeAll(configFileName);
-    }
-
-    protected static void beforeAll( String configFileName ) throws Exception {
         JcrQueryManagerTest.beforeAll(configFileName);
-        //add a bit of delay after calling the previous method since that inserts all the nodes and index processing is async
-        Thread.sleep(200);
     }
 
     @Test
@@ -44,7 +38,5 @@ public class LocalIndexProviderQueryTest extends JcrQueryManagerTest {
         session().save();
         added.remove();
         session().save();
-        Thread.sleep(200L);
     }
-
 }

--- a/modeshape-parent/pom.xml
+++ b/modeshape-parent/pom.xml
@@ -1601,7 +1601,7 @@
                 <scope>runtime</scope>
             </dependency>
 
-            <!-- Index Providers -->
+            <!-- Lucene Index Provider -->
             <dependency>
                 <groupId>org.apache.lucene</groupId>
                 <artifactId>lucene-core</artifactId>
@@ -1617,7 +1617,6 @@
                 <artifactId>lucene-queryparser</artifactId>
                 <version>${version.org.apache.lucene}</version>
             </dependency> 
-            
           
             <!--
                Web Modules dependencies

--- a/modeshape-parent/pom.xml
+++ b/modeshape-parent/pom.xml
@@ -301,6 +301,7 @@
         <eclipse.emf.ecorexmi.version>2.4.1</eclipse.emf.ecorexmi.version>
         <tika.version>1.8</tika.version>
         <image.metadata.extractor>2.6.2</image.metadata.extractor>
+        <version.org.apache.lucene>5.3.1</version.org.apache.lucene>
 
         <!-- Apache chemistry version -->
         <chemistry.version>0.11.0</chemistry.version>
@@ -1599,6 +1600,25 @@
                 <version>${sun.xml.bind.jaxbimpl.version}</version>
                 <scope>runtime</scope>
             </dependency>
+
+            <!-- Index Providers -->
+            <dependency>
+                <groupId>org.apache.lucene</groupId>
+                <artifactId>lucene-core</artifactId>
+                <version>${version.org.apache.lucene}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.lucene</groupId>
+                <artifactId>lucene-analyzers-common</artifactId>
+                <version>${version.org.apache.lucene}</version>
+            </dependency> 
+            <dependency>
+                <groupId>org.apache.lucene</groupId>
+                <artifactId>lucene-queryparser</artifactId>
+                <version>${version.org.apache.lucene}</version>
+            </dependency> 
+            
+          
             <!--
                Web Modules dependencies
             -->

--- a/pom.xml
+++ b/pom.xml
@@ -28,9 +28,9 @@
         <module>modeshape-schematic</module>
         <module>modeshape-jcr</module>
         <module>modeshape-unit-test</module>
-        <module>index-providers</module>
         <module>sequencers</module>
         <module>extractors</module>
+        <module>index-providers</module>
 
         <!--Connectors-->
         <module>connectors</module>

--- a/pom.xml
+++ b/pom.xml
@@ -28,6 +28,7 @@
         <module>modeshape-schematic</module>
         <module>modeshape-jcr</module>
         <module>modeshape-unit-test</module>
+        <module>index-providers</module>
         <module>sequencers</module>
         <module>extractors</module>
 


### PR DESCRIPTION
This uses the latest version of Lucene `5.3.1`. It supports both a simple (default) configuration:
```javascript
"indexProviders" : {
        "lucene" : {
            "classname" : "lucene",
            "directory" : "target/LuceneIndexProviderQueryTest"
        }
    }
```
and a more advanced one:
```javascript
"indexProviders" : {
        "lucene" : {
            "classname" : "lucene",
            "lockFactoryClass" : "org.apache.lucene.store.NoLockFactory",
            "directoryClass" : "org.apache.lucene.store.RAMDirectory",
            "analyzerClass" : "org.apache.lucene.analysis.ro.RomanianAnalyzer",
            "codec" : "Lucene53"
        }
    }
```
It supports all 4 index types, including text indexes which will only be used for FTS queries. Text indexes will not be selected *for anything else*. `LIKE` is supported by the default `value` indexes. If a FTS query doesn't contain a property name (uses `*`), __all FTS indexes which match the selector/node types__ will apply/be asked to contribute to node filtering.

It supports both single and multi-column indexes, with the caveat that multi-column indexes __will perform worse__ than single column. This is something which __will be documented__ and has to do with the fact that Lucene *does not support document merging (updating)*. This means that any changes to a multi-column index require an additional lookup to check if a document already exists and if so, creating the new "merged" document and then issuing an `update` to Lucene which will remove the old document and add the new one.

_This PR does not include AS support for the new index provider, which will be added via another PR_