### PR TITLE
MODE-2536, MODE-2537 Ads the ability for ModeShape to integrate with JTA and fixes some thread pool issues

### DIFF
--- a/boms/modeshape-bom-embedded/pom.xml
+++ b/boms/modeshape-bom-embedded/pom.xml
@@ -50,6 +50,7 @@
 
     <properties>
         <version.javax.jcr>2.0</version.javax.jcr>
+        <version.org.jboss.spec.javax.transaction.jboss-transaction-api_1.1_spec>1.0.1.Final</version.org.jboss.spec.javax.transaction.jboss-transaction-api_1.1_spec>
         <version.org.infinispan>7.2.4.Final</version.org.infinispan>
         <version.org.jgroups>3.6.2.Final</version.org.jgroups>
         <version.com.mchange.c3p0>0.9.5</version.com.mchange.c3p0>  <!-- same as the one used by Infinispan's JDBC cache store -->
@@ -313,6 +314,15 @@
                 <version>${version.javax.jcr}</version>
             </dependency>
 
+            <!--
+                Transactions
+            -->
+            <dependency>
+                <groupId>org.jboss.spec.javax.transaction</groupId>
+                <artifactId>jboss-transaction-api_1.1_spec</artifactId>
+                <version>${version.org.jboss.spec.javax.transaction.jboss-transaction-api_1.1_spec}</version>
+            </dependency>
+            
             <!--
                   Infinispan
               -->

--- a/modeshape-common/src/main/java/org/modeshape/common/util/Reflection.java
+++ b/modeshape-common/src/main/java/org/modeshape/common/util/Reflection.java
@@ -257,7 +257,14 @@ public class Reflection {
         }
     }
 
-    private static Field findFieldRecursively(Class<?> c, String fieldName) {
+    /**
+     * Searches for a given field recursively under a particular class 
+     * 
+     * @param c a {@link Class} instance, never null
+     * @param fieldName the name of the field, never null
+     * @return a {@link Field} instance if the field is located anywhere in the hierarchy or {@code null} if no such field exists
+     */
+    public static Field findFieldRecursively(Class<?> c, String fieldName) {
         Field f = null;
         try {
             f = c.getDeclaredField(fieldName);

--- a/modeshape-jcr-api/pom.xml
+++ b/modeshape-jcr-api/pom.xml
@@ -29,6 +29,14 @@
             <groupId>javax.jcr</groupId>
             <artifactId>jcr</artifactId>
         </dependency>
+        
+        <!--
+            Transactions API
+        -->
+        <dependency>
+            <groupId>org.jboss.spec.javax.transaction</groupId>
+            <artifactId>jboss-transaction-api_1.1_spec</artifactId>
+        </dependency>
 
         <!--
         These following are defined as 'provided' in the parent POM, since ModeShape

--- a/modeshape-jcr-api/src/main/java/org/modeshape/jcr/api/txn/TransactionManagerLookup.java
+++ b/modeshape-jcr-api/src/main/java/org/modeshape/jcr/api/txn/TransactionManagerLookup.java
@@ -1,0 +1,49 @@
+/*
+ * ModeShape (http://www.modeshape.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.modeshape.jcr.api.txn;
+
+import javax.transaction.TransactionManager;
+
+/**
+ * Factory interface which is used by ModeShape to obtain a reference to an existing transaction manager. Since ModeShape cannot
+ * be used without transactions, the runtime environment must have a {@link javax.transaction.TransactionManager} instance which
+ * is returned by an implementation of this class and which ModeShape can access. 
+ * <p>
+ * ModeShape provides an out-of-the-box implementation which integrates with most containers and JTA providers and which also
+ * falls back to a default, in-memory implementation. It may happen that this is not enough though, in which case clients should
+ * provide their own {@link TransactionManagerLookup} implementation and configure it in the repository:
+ * <pre>
+ *   {
+        "storage" : {
+            "transactionManagerLookup" : "org.modeshape.custom.CustomTransactionManagerLookup"
+         }
+ *   } 
+ * </pre>
+ * </p>
+ * 
+ * @author Horia Chiorean (hchiorea@redhat.com)
+ * @since 5.0
+ */
+public interface TransactionManagerLookup {
+  
+    /**
+     * Searches for a transaction manager instance. 
+     * 
+     * @return a {@link TransactionManager} instance; never {@code null}
+     * @throws Exception if no transaction manager is available or any other unexpected error occurs
+     */
+    TransactionManager getTransactionManager() throws Exception;
+}

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/Environment.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/Environment.java
@@ -43,7 +43,7 @@ public interface Environment {
      * needs.
      * 
      * @param fallbackLoader the classloader that should be used is the fallback class loader
-     * @param classpathEntries the logical classpath entries
+     * @param classpathEntries the logical classpath entries; may be null
      * @return the classloader
      */
     ClassLoader getClassLoader( ClassLoader fallbackLoader,

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrI18n.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrI18n.java
@@ -25,6 +25,9 @@ import org.modeshape.common.i18n.I18n;
 public final class JcrI18n {
 
     public static I18n initializing;
+    
+    public static I18n warnNoTxManagerFound;
+    public static I18n unableToInitializeTxManagerLookup;
 
     public static I18n engineStarting;
     public static I18n engineStarted;

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/RepositoryConfiguration.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/RepositoryConfiguration.java
@@ -53,7 +53,6 @@ import org.infinispan.schematic.document.EditableDocument;
 import org.infinispan.schematic.document.Editor;
 import org.infinispan.schematic.document.Json;
 import org.infinispan.schematic.document.ParsingException;
-import org.infinispan.transaction.lookup.GenericTransactionManagerLookup;
 import org.modeshape.common.annotation.Immutable;
 import org.modeshape.common.collection.Problems;
 import org.modeshape.common.collection.SimpleProblems;
@@ -69,6 +68,7 @@ import org.modeshape.connector.filesystem.FileSystemConnector;
 import org.modeshape.jcr.api.index.IndexColumnDefinition;
 import org.modeshape.jcr.api.index.IndexDefinition;
 import org.modeshape.jcr.api.index.IndexDefinition.IndexKind;
+import org.modeshape.jcr.api.txn.TransactionManagerLookup;
 import org.modeshape.jcr.index.local.LocalIndexProvider;
 import org.modeshape.jcr.mimetype.ContentDetector;
 import org.modeshape.jcr.mimetype.MimeTypeDetector;
@@ -220,15 +220,6 @@ public class RepositoryConfiguration {
         public static final String JNDI_NAME = "jndiName";
 
         /**
-         * The specification of whether the repository should expect and detect whether JCR clients modify the content within
-         * transactions. The default value of 'auto' will automatically detect the use of both user- and container-managed
-         * transactions and also works when the JCR client does not use transactions; this will work in most situations. The value
-         * of 'none' specifies that the repository should not attempt to detect existing transactions; this setting is an
-         * optimization that should be used *only* if JCR clients will never use transactions to change the repository content.
-         */
-        public static final String TRANSACTION_MODE = "transactionMode";
-
-        /**
          * The name for the field whose value is a document containing the monitoring information.
          */
         public static final String MONITORING = "monitoring";   
@@ -263,15 +254,9 @@ public class RepositoryConfiguration {
         public static final String CACHE_CONFIGURATION = "cacheConfiguration";
 
         /**
-         * The name for the field containing the name of the Infinispan transaction manager lookup class. This is only used if no
-         * {@link #CACHE_CONFIGURATION cacheConfiguration} value is specified and ModeShape needs to instantiate the Infinispan
-         * {@link CacheContainer}. By default, the {@link GenericTransactionManagerLookup} class is used.
-         *
-         * @deprecated The transaction manager lookup class should be specified in the Infinispan cache configuration (or in a
-         *             custom Environment subclass for default caches)
+         * The name of the field which contains the fully qualified name of the transaction manager lookup class to be used.
          */
-        @Deprecated
-        public static final String CACHE_TRANSACTION_MANAGER_LOOKUP = "transactionManagerLookup";
+        public static final String TRANSACTION_MANAGER_LOOKUP = "transactionManagerLookup";
 
         /**
          * The size threshold that dictates whether binary values should be stored in the binary store. Binary values smaller than
@@ -500,9 +485,9 @@ public class RepositoryConfiguration {
         public static final String DEFAULT = "default";
 
         /**
-         * The default value of the {@link FieldName#TRANSACTION_MODE} field is '{@value} '.
+         * The default value of the {@link FieldName#TRANSACTION_MANAGER_LOOKUP} field is '{@value} '.
          */
-        public static final TransactionMode TRANSACTION_MODE = TransactionMode.AUTO;
+        public static final String TRANSACTION_MANAGER_LOOKUP = "org.modeshape.jcr.txn.DefaultTransactionManagerLookup";
 
         /**
          * The default value of the {@link FieldName#EVENT_BUS_SIZE} field is '{@value}'
@@ -574,7 +559,7 @@ public class RepositoryConfiguration {
         public static final String MIMETYPE_DETECTION_CONTENT = "content";
     }
 
-    protected static final Set<List<String>> DEPRECATED_FIELDS;
+    protected static final Set<List<String>> DEPRECATED_FIELDS = Collections.emptySet();
 
     /**
      * The set of field names that should be skipped when {@link Component#createInstance(ClassLoader) instantiating a component}.
@@ -700,11 +685,6 @@ public class RepositoryConfiguration {
         } catch (IOException e) {
             LOGGER.error(e, JcrI18n.unableToLoadRepositoryConfigurationSchema, JSON_SCHEMA_RESOURCE_PATH);
         }
-
-        Set<List<String>> deprecatedFieldNames = new HashSet<List<String>>();
-        deprecatedFieldNames.add(Collections.unmodifiableList(Arrays.asList(new String[] {FieldName.STORAGE,
-            FieldName.CACHE_TRANSACTION_MANAGER_LOOKUP})));
-        DEPRECATED_FIELDS = Collections.unmodifiableSet(deprecatedFieldNames);
     }
 
     /**
@@ -907,6 +887,24 @@ public class RepositoryConfiguration {
             return storage.getString(FieldName.CACHE_CONFIGURATION);
         }
         return null;
+    }
+    
+    public TransactionManagerLookup getTransactionManagerLookup() {
+        Document storage = doc.getDocument(FieldName.STORAGE);
+        String className = Default.TRANSACTION_MANAGER_LOOKUP;
+        String classPath = null;
+        if (storage != null) {
+            Document txManagerLookupDoc = storage.getDocument(FieldName.TRANSACTION_MANAGER_LOOKUP);
+            if (txManagerLookupDoc != null) {
+                className = txManagerLookupDoc.getString(FieldName.NAME, Default.TRANSACTION_MANAGER_LOOKUP);
+                classPath = txManagerLookupDoc.getString(FieldName.CLASSLOADER);
+            }
+        }
+        try {
+            return new Component(className, classPath).createInstance(getClass().getClassLoader());
+        } catch (Exception e) {
+            throw new RuntimeException(JcrI18n.unableToInitializeTxManagerLookup.text(className), e);
+        }
     }
     
     public int getWorkspaceCacheSize() {
@@ -1235,13 +1233,13 @@ public class RepositoryConfiguration {
                 }
                 try {
                     // locate the field instance on which the value will be set
-                    java.lang.reflect.Field instanceField = findField(instance.getClass(), fieldName);
+                    java.lang.reflect.Field instanceField = Reflection.findFieldRecursively(instance.getClass(), fieldName);
                     if (instanceField == null) {
                         LOGGER.warn(JcrI18n.missingFieldOnInstance, fieldName, classname);
                         continue;
                     }
 
-                    Object convertedFieldValue = convertValueToType(instanceField.getType(), fieldValue);
+                    Object convertedFieldValue = DocumentReflection.convertValueToType(instanceField.getType(), fieldValue);
 
                     // if the value is a document, means there is a nested bean
                     if (convertedFieldValue instanceof Document) {
@@ -1258,141 +1256,6 @@ public class RepositoryConfiguration {
                 }
             }
         }
-
-        /**
-         * Attempts "its best" to convert a generic Object value (coming from a Document) to a value which can be set on the field
-         * of a component. Note: thanks to type erasure, generics are not supported.
-         *
-         * @param expectedType the {@link Class} of the field on which the value should be set
-         * @param value a generic value coming from a document. Can be a simple value, another {@link Document} or {@link Array}
-         * @return the converted value, which should be compatible with the expected type.
-         * @throws Exception if anything will fail during the conversion process
-         */
-        private Object convertValueToType( Class<?> expectedType,
-                                           Object value ) throws Exception {
-            // lists are converted to ArrayList
-            if (List.class.isAssignableFrom(expectedType)) {
-                return valueToCollection(value, new ArrayList<Object>());
-            }
-            // sets are converted to HashSet
-            if (Set.class.isAssignableFrom(expectedType)) {
-                return valueToCollection(value, new HashSet<Object>());
-            }
-            // arrays are converted as-is
-            if (expectedType.isArray()) {
-                return valueToArray(expectedType.getComponentType(), value);
-            }
-
-            // maps are converted to hashmap
-            if (Map.class.isAssignableFrom(expectedType)) {
-                // only string keys are supported atm
-                return ((Document)value).toMap();
-            }
-
-            // Strings can be parsed into numbers ...
-            if (value instanceof String) {
-                String strValue = (String)value;
-                // Try the smallest ranges first ...
-                if (Short.TYPE.isAssignableFrom(expectedType) || Short.class.isAssignableFrom(expectedType)) {
-                    try {
-                        return Short.parseShort(strValue);
-                    } catch (NumberFormatException e) {
-                        // ignore and continue ...
-                    }
-                }
-                if (Integer.TYPE.isAssignableFrom(expectedType) || Integer.class.isAssignableFrom(expectedType)) {
-                    try {
-                        return Integer.parseInt(strValue);
-                    } catch (NumberFormatException e) {
-                        // ignore and continue ...
-                    }
-                }
-                if (Long.TYPE.isAssignableFrom(expectedType) || Long.class.isAssignableFrom(expectedType)) {
-                    try {
-                        return Long.parseLong(strValue);
-                    } catch (NumberFormatException e) {
-                        // ignore and continue ...
-                    }
-                }
-                if (Boolean.TYPE.isAssignableFrom(expectedType) || Boolean.class.isAssignableFrom(expectedType)) {
-                    try {
-                        return Boolean.parseBoolean(strValue);
-                    } catch (NumberFormatException e) {
-                        // ignore and continue ...
-                    }
-                }
-                if (Float.TYPE.isAssignableFrom(expectedType) || Float.class.isAssignableFrom(expectedType)) {
-                    try {
-                        return Float.parseFloat(strValue);
-                    } catch (NumberFormatException e) {
-                        // ignore and continue ...
-                    }
-                }
-                if (Double.TYPE.isAssignableFrom(expectedType) || Double.class.isAssignableFrom(expectedType)) {
-                    try {
-                        return Double.parseDouble(strValue);
-                    } catch (NumberFormatException e) {
-                        // ignore and continue ...
-                    }
-                }
-            }
-
-            // return value as it is
-            return value;
-        }
-
-        private Object valueToArray( Class<?> arrayComponentType,
-                                     Object value ) throws Exception {
-            if (value instanceof Array) {
-                Array valueArray = (Array)value;
-                int arraySize = valueArray.size();
-                Object newArray = java.lang.reflect.Array.newInstance(arrayComponentType, arraySize);
-                for (int i = 0; i < ((Array)value).size(); i++) {
-                    Object element = valueArray.get(i);
-                    element = convertValueToType(arrayComponentType, element);
-                    java.lang.reflect.Array.set(newArray, i, element);
-                }
-                return newArray;
-            } else if (value instanceof String) {
-                // Parse the string into a comma-separated set of values (this works if it's just a single value) ...
-                String strValue = (String)value;
-                if (strValue.length() > 0) {
-                    String[] stringValues = strValue.split(",");
-                    Object newArray = java.lang.reflect.Array.newInstance(arrayComponentType, stringValues.length);
-                    for (int i = 0; i < stringValues.length; i++) {
-                        Object element = convertValueToType(arrayComponentType, stringValues[i]);
-                        java.lang.reflect.Array.set(newArray, i, element);
-                    }
-                    return newArray;
-                }
-            }
-
-            // Otherwise, just initialize it to an empty array ...
-            return java.lang.reflect.Array.newInstance(arrayComponentType, 0);
-        }
-
-        private Collection<?> valueToCollection( Object value,
-                                                 Collection<Object> collection ) throws Exception {
-            if (value instanceof Array) {
-                collection.addAll((List<?>)value);
-            } else {
-                collection.add(value);
-            }
-            return collection;
-        }
-
-        public java.lang.reflect.Field findField( Class<?> typeClass,
-                                                  String fieldName ) {
-            java.lang.reflect.Field field = null;
-            if (typeClass != null) {
-                try {
-                    field = typeClass.getDeclaredField(fieldName);
-                } catch (NoSuchFieldException e) {
-                    field = findField(typeClass.getSuperclass(), fieldName);
-                }
-            }
-            return field;
-        }
     }
 
     public boolean isCreatingWorkspacesAllowed() {
@@ -1403,11 +1266,6 @@ public class RepositoryConfiguration {
         return Default.ALLOW_CREATION;
     }
 
-    public TransactionMode getTransactionMode() {
-        String mode = doc.getString(FieldName.TRANSACTION_MODE);
-        return mode != null ? TransactionMode.valueOf(mode.trim().toUpperCase()) : Default.TRANSACTION_MODE;
-    }
-    
     public int getEventBusSize() {
         return doc.getInteger(FieldName.EVENT_BUS_SIZE, Default.EVENT_BUS_SIZE);
     }
@@ -2682,6 +2540,14 @@ public class RepositoryConfiguration {
         private final String classname;
         private final String classpath;
         private final Document document;
+        
+        protected Component(String classname) {
+            this(null, classname, null, EMPTY);
+        }
+        
+        protected Component(String classname, String classpath) {
+            this(null, classname, classpath, EMPTY);
+        } 
 
         protected Component( String name,
                              String classname,
@@ -2822,13 +2688,13 @@ public class RepositoryConfiguration {
                 }
                 try {
                     // locate the field instance on which the value will be set
-                    java.lang.reflect.Field instanceField = findField(instance.getClass(), fieldName);
+                    java.lang.reflect.Field instanceField = Reflection.findFieldRecursively(instance.getClass(), fieldName);
                     if (instanceField == null) {
                         LOGGER.warn(JcrI18n.missingFieldOnInstance, fieldName, getClassname());
                         continue;
                     }
 
-                    Object convertedFieldValue = convertValueToType(instanceField.getType(), fieldValue);
+                    Object convertedFieldValue = DocumentReflection.convertValueToType(instanceField.getType(), fieldValue);
 
                     // if the value is a document, means there is a nested bean
                     if (convertedFieldValue instanceof Document) {
@@ -2845,6 +2711,11 @@ public class RepositoryConfiguration {
                 }
             }
         }
+    }
+    
+    private static final class DocumentReflection {
+        private DocumentReflection() {
+        }
 
         /**
          * Attempts "its best" to convert a generic Object value (coming from a Document) to a value which can be set on the field
@@ -2855,8 +2726,8 @@ public class RepositoryConfiguration {
          * @return the converted value, which should be compatible with the expected type.
          * @throws Exception if anything will fail during the conversion process
          */
-        private Object convertValueToType( Class<?> expectedType,
-                                           Object value ) throws Exception {
+        private static Object convertValueToType(Class<?> expectedType,
+                                                 Object value) throws Exception {
             // lists are converted to ArrayList
             if (List.class.isAssignableFrom(expectedType)) {
                 return valueToCollection(value, new ArrayList<Object>());
@@ -2928,8 +2799,8 @@ public class RepositoryConfiguration {
             return value;
         }
 
-        private Object valueToArray( Class<?> arrayComponentType,
-                                     Object value ) throws Exception {
+        private static Object valueToArray(Class<?> arrayComponentType,
+                                           Object value) throws Exception {
             if (value instanceof Array) {
                 Array valueArray = (Array)value;
                 int arraySize = valueArray.size();
@@ -2958,8 +2829,8 @@ public class RepositoryConfiguration {
             return java.lang.reflect.Array.newInstance(arrayComponentType, 0);
         }
 
-        private Collection<?> valueToCollection( Object value,
-                                                 Collection<Object> collection ) throws Exception {
+        private static Collection<?> valueToCollection(Object value,
+                                                       Collection<Object> collection) throws Exception {
             if (value instanceof Array) {
                 collection.addAll((List<?>)value);
             } else {
@@ -2967,19 +2838,5 @@ public class RepositoryConfiguration {
             }
             return collection;
         }
-
-        private java.lang.reflect.Field findField( Class<?> typeClass,
-                                                   String fieldName ) {
-            java.lang.reflect.Field field = null;
-            if (typeClass != null) {
-                try {
-                    field = typeClass.getDeclaredField(fieldName);
-                } catch (NoSuchFieldException e) {
-                    field = findField(typeClass.getSuperclass(), fieldName);
-                }
-            }
-            return field;
-        }
     }
-
 }

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/RepositoryConfiguration.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/RepositoryConfiguration.java
@@ -76,6 +76,7 @@ import org.modeshape.jcr.mimetype.NameOnlyDetector;
 import org.modeshape.jcr.mimetype.NullMimeTypeDetector;
 import org.modeshape.jcr.security.AnonymousProvider;
 import org.modeshape.jcr.security.JaasProvider;
+import org.modeshape.jcr.txn.DefaultTransactionManagerLookup;
 import org.modeshape.jcr.value.PropertyType;
 import org.modeshape.jcr.value.binary.AbstractBinaryStore;
 import org.modeshape.jcr.value.binary.BinaryStore;
@@ -487,7 +488,7 @@ public class RepositoryConfiguration {
         /**
          * The default value of the {@link FieldName#TRANSACTION_MANAGER_LOOKUP} field is '{@value} '.
          */
-        public static final String TRANSACTION_MANAGER_LOOKUP = "org.modeshape.jcr.txn.DefaultTransactionManagerLookup";
+        public static final String TRANSACTION_MANAGER_LOOKUP = DefaultTransactionManagerLookup.class.getName();
 
         /**
          * The default value of the {@link FieldName#EVENT_BUS_SIZE} field is '{@value}'

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/txn/DefaultTransactionManagerLookup.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/txn/DefaultTransactionManagerLookup.java
@@ -1,0 +1,147 @@
+/*
+ * ModeShape (http://www.modeshape.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.modeshape.jcr.txn;
+
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.stream.Stream;
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
+import javax.transaction.TransactionManager;
+import org.modeshape.common.logging.Logger;
+import org.modeshape.common.util.Reflection;
+import org.modeshape.jcr.JcrI18n;
+import org.modeshape.jcr.api.txn.TransactionManagerLookup;
+
+/**
+ * ModeShape's default implementation of a {@link TransactionManagerLookup}. This is used by default when no other explicit
+ * lookup instance is present and looks for a transaction manager in the following order:
+ * <pre>
+ *     <ol>
+ *         <li>JNDI: it searches JNDI for a number of known bindings of transaction managers, specific most JEE containers</li>
+ *         <li>Standalone JBoss JTA: it searches for a local JBoss JTA instance</li>
+ *         <li>Atomikos JTA: it searches for a local Atomikos instance</li>
+ *     </ol>
+ * </pre>
+ * 
+ * If none of the above steps are able to locate a transaction manager, ModeShape will fall back to a {@link LocalTransactionManager}
+ * instance.
+ * 
+ * @author Horia Chiorean (hchiorea@redhat.com)
+ * @since 5.0
+ */
+public class DefaultTransactionManagerLookup implements TransactionManagerLookup {
+
+    /**
+     * A list of known JNDI binding for different transaction manager implementations
+     * 
+     * see https://java.net/jira/browse/JAVAEE_SPEC-8
+     */
+    private static final List<String> JNDI_BINDINGS = Arrays.asList("java:jboss/TransactionManager",
+                                                                    "java:comp/TransactionManager",
+                                                                    "java:comp/UserTransaction",
+                                                                    "java:/TransactionManager",
+                                                                    "java:appserver/TransactionManager",
+                                                                    "java:pm/TransactionManager",
+                                                                    "javax.transaction.TransactionManager",
+                                                                    "osgi:service/javax.transaction.TransactionManager");
+
+    private static final Logger LOGGER = Logger.getLogger(DefaultTransactionManagerLookup.class); 
+    
+    @Override
+    public TransactionManager getTransactionManager() throws Exception {
+        Supplier<Optional<TransactionManager>> jndi = this::lookInJNDI;
+        Supplier<Optional<TransactionManager>> jbossJTA = this::lookForStandaloneJBossJTA;
+        Supplier<Optional<TransactionManager>> atomikosJTA = this::lookForAtomikosJTA;
+        Optional<TransactionManager> result = Stream.of(jndi, jbossJTA, atomikosJTA)
+                                                    .map(Supplier::get)
+                                                    .filter(Optional::isPresent)
+                                                    .map(Optional::get)
+                                                    .peek((transactionManager)->LOGGER.debug("Found tx manager '{0}'", 
+                                                                                             transactionManager.getClass().getName()))
+                                                    .findFirst();
+        return result.orElseGet(() -> {
+            LOGGER.warn(JcrI18n.warnNoTxManagerFound);
+            return new LocalTransactionManager();
+        });
+    }
+    
+    private Optional<TransactionManager> lookForAtomikosJTA() {
+        LOGGER.debug("Looking for Atomikos JTA...");
+        try {
+            Class<?> clazz = getClass().getClassLoader().loadClass("com.atomikos.icatch.jta.UserTransactionManager");
+            Object result = clazz.newInstance();
+            return result instanceof TransactionManager ? Optional.of((TransactionManager) result) : Optional.empty();
+        } catch (ClassNotFoundException e) {
+            return Optional.empty();
+        } catch (Exception e) {
+            LOGGER.debug(e, "Error while trying to instantiate an Atomikos JTA instance...");
+            return Optional.empty();
+        } 
+    }
+    
+    private Optional<TransactionManager> lookForStandaloneJBossJTA() {
+        LOGGER.debug("Looking for JBoss Standalone JTA...");
+        try {
+            Class<?> clazz = getClass().getClassLoader().loadClass("com.arjuna.ats.jta.TransactionManager");
+            Method method = Reflection.findMethod(clazz, "transactionManager");
+            Object result = Reflection.invokeAccessibly(null, method, null);
+            return result instanceof TransactionManager ? Optional.of((TransactionManager) result) : Optional.empty();
+        } catch (ClassNotFoundException e) {
+            return Optional.empty();
+        } catch (Exception e) {
+            LOGGER.debug(e, "Error while trying to instantiate a standalone JBoss JTA instance...");
+            return Optional.empty();            
+        }
+    }
+
+    private Optional<TransactionManager> lookInJNDI() {
+        Function<String, TransactionManager> jndiSupplier = jndiName -> {
+            InitialContext context = null;
+            try {
+                context = new InitialContext();
+            } catch (NamingException e) {
+                LOGGER.debug(e, "Cannot create initial JNDI context");
+                return null;
+            }
+
+            try {
+                LOGGER.debug("Looking up transaction manager at: '{0}'", jndiName);
+                Object obj = context.lookup(jndiName);
+                if (obj instanceof TransactionManager) {
+                    return (TransactionManager)obj;
+                }
+                LOGGER.debug("Transaction manager not found at: '{0}'", jndiName);
+                return null;
+            } catch (NamingException e) {
+                LOGGER.debug(e, "Failed to lookup '{0}' in JNDI", jndiName);
+                return null;
+            } finally {
+                try {
+                    context.close();
+                } catch (NamingException e) {
+                    LOGGER.debug(e, "Cannot close JNDI context");
+                }
+            }
+        };
+
+        return JNDI_BINDINGS.stream().map(jndiSupplier).filter((manager) -> manager != null).findFirst();
+    }
+}

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/txn/LocalTransaction.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/txn/LocalTransaction.java
@@ -1,0 +1,147 @@
+/*
+ * ModeShape (http://www.modeshape.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.modeshape.jcr.txn;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
+import javax.transaction.HeuristicMixedException;
+import javax.transaction.HeuristicRollbackException;
+import javax.transaction.RollbackException;
+import javax.transaction.Status;
+import javax.transaction.Synchronization;
+import javax.transaction.SystemException;
+import javax.transaction.Transaction;
+import javax.transaction.xa.XAResource;
+import org.modeshape.common.annotation.Immutable;
+import org.modeshape.common.annotation.ThreadSafe;
+
+/**
+ * Transaction type returned by {@link LocalTransactionManager}
+ * 
+ * @author Horia Chiorean (hchiorea@redhat.com)
+ * @since 5.0
+ */         
+@Immutable
+@ThreadSafe
+public class LocalTransaction implements Transaction {
+    private final List<Synchronization> synchronizations = new ArrayList<>();
+    private final AtomicInteger status;
+    private final String id;
+    
+    protected LocalTransaction() {
+        this.status = new AtomicInteger(Status.STATUS_ACTIVE);
+        this.id = UUID.randomUUID().toString();
+    }
+
+    @Override
+    public void commit() throws RollbackException, HeuristicMixedException, HeuristicRollbackException, SecurityException, SystemException {
+        try {
+            validateThreadOwnership();
+            if (markedForRollback()) {
+                rollback();
+                throw new RollbackException("Transaction was marked for rollback");
+            }
+            if (!isActive()) {
+               throw new SystemException("Illegal transaction status:" + status); 
+            }
+            synchronizations.stream().forEach(Synchronization::beforeCompletion);
+            status.compareAndSet(Status.STATUS_ACTIVE, Status.STATUS_COMMITTED);
+            synchronizations.stream().forEach((sync)->sync.afterCompletion(status.get()));
+        } finally {
+            LocalTransactionManager.clear();
+        }
+    }
+
+    private void validateThreadOwnership() {
+        LocalTransaction txForThread =
+                LocalTransactionManager.hasActiveTransaction() ? LocalTransactionManager.transactionForThread()
+                                                               : null;
+        if (!this.equals(txForThread)) {
+            throw new IllegalStateException("Current thread does not own the transaction");
+        }
+    }
+
+    private boolean markedForRollback() {
+        return status.get() == Status.STATUS_MARKED_ROLLBACK;
+    }
+
+    private boolean isActive() {
+        return status.get() == Status.STATUS_ACTIVE;
+    }
+
+    @Override
+    public void rollback() throws IllegalStateException, SystemException {
+        try {
+            validateThreadOwnership();
+            if (!isActive() && !markedForRollback()) {
+                throw new SystemException("Illegal transaction status:" + status);
+            }
+            synchronizations.stream().forEach(Synchronization::beforeCompletion);
+            status.set(Status.STATUS_ROLLEDBACK);
+            synchronizations.stream().forEach((sync)->sync.afterCompletion(status.get()));
+        } finally {
+            LocalTransactionManager.clear();
+        }
+    }
+
+    @Override
+    public void setRollbackOnly() throws IllegalStateException, SystemException {
+        if (!isActive()) {
+            throw new IllegalStateException("Current status is invalid" + status.get()); 
+        }
+        this.status.compareAndSet(Status.STATUS_ACTIVE, Status.STATUS_MARKED_ROLLBACK);
+    }
+
+    @Override
+    public int getStatus() throws SystemException {
+        return status.get();
+    }
+
+    @Override
+    public boolean enlistResource(XAResource xaRes) throws RollbackException, IllegalStateException, SystemException {
+        throw new UnsupportedOperationException("Local transactions do not support XA resources...");
+    }
+
+    @Override
+    public boolean delistResource(XAResource xaRes, int flag) throws IllegalStateException, SystemException {
+        throw new UnsupportedOperationException("Local transactions do not support XA resources...");
+    }
+
+    @Override
+    public void registerSynchronization(Synchronization sync) throws RollbackException, IllegalStateException, SystemException {
+        synchronizations.add(sync);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        LocalTransaction that = (LocalTransaction) o;
+        return Objects.equals(id, that.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
+    }
+}

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/txn/LocalTransactionManager.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/txn/LocalTransactionManager.java
@@ -1,0 +1,120 @@
+/*
+ * ModeShape (http://www.modeshape.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.modeshape.jcr.txn;
+
+import java.util.Optional;
+import javax.transaction.HeuristicMixedException;
+import javax.transaction.HeuristicRollbackException;
+import javax.transaction.InvalidTransactionException;
+import javax.transaction.NotSupportedException;
+import javax.transaction.RollbackException;
+import javax.transaction.Status;
+import javax.transaction.SystemException;
+import javax.transaction.Transaction;
+import javax.transaction.TransactionManager;
+import org.infinispan.schematic.document.ThreadSafe;
+import org.modeshape.common.annotation.Immutable;
+
+/**
+ * A simple, in-memory local transaction manager implementation which is used as fallback by ModeShape when no other "real" transaction
+ * manager can be located and which supports only local transactions. 
+ * <p>
+ * Transactions managed by this manager DO NOT support {@link javax.transaction.xa.XAResource xa resources} and therefore 
+ * global transactions.
+ * </p>
+ *
+ * @author Horia Chiorean (hchiorea@redhat.com)
+ * @since 5.0
+ */
+@ThreadSafe
+@Immutable
+public class LocalTransactionManager implements TransactionManager {
+    private static final ThreadLocal<Optional<LocalTransaction>> ACTIVE_TRANSACTION = ThreadLocal.withInitial(Optional::empty);
+    
+    @Override
+    public void begin() throws NotSupportedException, SystemException {
+        if (hasActiveTransaction()) {
+            throw new NotSupportedException("Nested transactions are not supported");
+        }
+        ACTIVE_TRANSACTION.set(Optional.of(new LocalTransaction()));
+    }
+
+    protected static boolean hasActiveTransaction() {
+        return ACTIVE_TRANSACTION.get().isPresent();
+    }
+    
+    protected static void clear() {
+        ACTIVE_TRANSACTION.set(Optional.empty());
+    }
+
+    @Override
+    public void commit() throws RollbackException, HeuristicMixedException, HeuristicRollbackException, SecurityException, IllegalStateException, SystemException {
+        transactionForThread().commit();
+    }
+
+    protected static LocalTransaction transactionForThread() {
+        return ACTIVE_TRANSACTION.get().orElseThrow(
+                () -> new IllegalStateException("Current thread does not have a transaction"));
+    }
+
+    @Override
+    public void rollback() throws IllegalStateException, SecurityException, SystemException {
+        transactionForThread().rollback();
+    }
+
+    @Override
+    public void setRollbackOnly() throws IllegalStateException, SystemException {
+        transactionForThread().setRollbackOnly();
+    }
+
+    @Override
+    public int getStatus() throws SystemException {
+        Optional<LocalTransaction> localTransaction = ACTIVE_TRANSACTION.get();
+        return localTransaction.isPresent() ? localTransaction.get().getStatus() : Status.STATUS_NO_TRANSACTION;  
+    }
+
+    @Override
+    public Transaction getTransaction() throws SystemException {
+        return ACTIVE_TRANSACTION.get().orElse(null);
+    }
+
+    @Override
+    public void setTransactionTimeout(int seconds) throws SystemException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Transaction suspend() throws SystemException {
+        Optional<LocalTransaction> localTransaction = ACTIVE_TRANSACTION.get();
+        if (localTransaction.isPresent()) {
+            LocalTransaction tx = localTransaction.get();
+            clear();
+            return tx;
+        } 
+        return null;
+    }
+
+    @Override
+    public void resume(Transaction tobj) throws InvalidTransactionException, IllegalStateException, SystemException {
+        if (ACTIVE_TRANSACTION.get().isPresent()) {
+            throw new IllegalStateException("Current thread has a tx associated");
+        }
+        if (!(tobj instanceof LocalTransaction)) {
+            throw new InvalidTransactionException(tobj +  " is not a valid local transaction");
+        }
+        ACTIVE_TRANSACTION.set(Optional.of((LocalTransaction) tobj));
+    }
+}

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/txn/NoClientTransactions.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/txn/NoClientTransactions.java
@@ -32,7 +32,7 @@ public final class NoClientTransactions extends Transactions {
      * nested simple transactions, so we need effective make sure that only 1 instance of an active transaction can exist at any
      * given time. We cannot use multiple instance because completion functions are instance-dependent
      */
-    private static final ThreadLocal<NestableThreadLocalTransaction> ACTIVE_TRANSACTION = new ThreadLocal<NestableThreadLocalTransaction>();
+    private static final ThreadLocal<NestableThreadLocalTransaction> ACTIVE_TRANSACTION = new ThreadLocal<>();
 
     /**
      * Creates a new instance passing in the given monitor factory and transaction manager

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/txn/SynchronizedTransactions.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/txn/SynchronizedTransactions.java
@@ -40,7 +40,7 @@ import org.modeshape.jcr.cache.document.WorkspaceCache;
  */
 public final class SynchronizedTransactions extends Transactions {
 
-    private static final ThreadLocal<NestableThreadLocalTransaction> LOCAL_TRANSACTION = new ThreadLocal<NestableThreadLocalTransaction>();
+    private static final ThreadLocal<NestableThreadLocalTransaction> LOCAL_TRANSACTION = new ThreadLocal<>();
 
     @SuppressWarnings( "rawtypes")
     private final Cache localCache;

--- a/modeshape-jcr/src/main/resources/org/modeshape/jcr/JcrI18n.properties
+++ b/modeshape-jcr/src/main/resources/org/modeshape/jcr/JcrI18n.properties
@@ -16,6 +16,8 @@
 
 initializing = {0} version {1}
 
+warnNoTxManagerFound = No javax.transaction.TransactionManager was found; falling back to LocalTransactionManager. Enable DEBUG logging for more information.
+unableToInitializeTxManagerLookup = Unable to create TransactionManagerLookup instance '{0}'. Please check your configuration.
 engineStarting = ModeShape engine starting...
 engineStarted = ModeShape engine started in {0} ms
 couldNotStartEngine = Could not start the ModeShape engine

--- a/modeshape-jcr/src/main/resources/org/modeshape/jcr/repository-config-schema.json
+++ b/modeshape-jcr/src/main/resources/org/modeshape/jcr/repository-config-schema.json
@@ -18,11 +18,6 @@
             "type" : "string",
             "description" : "The name in JNDI where this repository is to be registered. If not specified, the location is assumed to be 'java:jcr/local/<name>', where '<name>' is the repository name. Setting this field to an empty string signals that the repository should not be registered in JNDI."
         },
-        "transactionMode" : {
-            "type" : "string",
-            "description" : "Whether the repository should expect and detect whether JCR clients modify the content within transactions. The default value of 'auto' will automatically detect the use of both user- and container-managed transactions and also works when the JCR client does not use transactions; this will work in most situations. The value of 'none' specifies that the repository should not attempt to detect existing transactions; this setting is an optimization that should be used *only* if JCR clients will never use transactions to change the repository content.",
-            "enum" : [ "auto", "none" ]
-        },
         "eventBusSize" : {
             "type" : "number",
             "description" : "The maximum number of events that can co-exit in the event bus, before blocking and waiting for the slowest consumer(s) to finish and free up subsequent slots. Should be a power of 2, or the system will auto-adjust to the closest power of 2",
@@ -85,9 +80,21 @@
                     "description" : "The name of the Infinispan configuration file for creating a new cache manager. If a file could not be found (on the thread context classloader, on the application's classpath, or on the system classpath), then the name is assumed to reference an existing Infinispan CacheContainer instance via a valid JNDI name or as the name of a service as defined by the local environment. If no such container is found, then a default Infinispan configuration (a basic, local mode, non-clustered cache) will be used."
                 },
                 "transactionManagerLookup" : {
-                    "type" : "string",
-                    "default" : "org.infinispan.transaction.lookup.GenericTransactionManagerLookup",
-                    "description" : "DEPRECATED: This is no longer used. The transaction manager lookup class should be specified in the Infinispan cache configuration (or in a custom Environment subclass for default caches)."
+                    "type" : "object",
+                    "default" : "default",
+                    "description" : "The configuration of the transaction manager lookup instance",
+                    "additionalProperties" : false,
+                    "properties" : {
+                        "name" : {
+                            "type" : "string",
+                            "default" : "org.modeshape.jcr.txn.DefaultTransactionManagerLookup",
+                            "description" : "The fully qualified name of the TransactionManagerLookup instance which ModeShape should use to detect an active transaction manager"
+                        },
+                        "classloader" : {
+                            "type" : "string",
+                            "description" : "The optional paths that should be used to load the transaction manager lookup class."
+                        }
+                    }
                 },
                 "documentOptimization" : {
                     "type" : "object",

--- a/modeshape-jcr/src/test/java/org/modeshape/jcr/JcrObservationManagerTest.java
+++ b/modeshape-jcr/src/test/java/org/modeshape/jcr/JcrObservationManagerTest.java
@@ -110,7 +110,7 @@ public final class JcrObservationManagerTest extends SingleUseAbstractTest {
     @Before
     public void beforeEach() throws Exception {
         super.beforeEach();
-        FileUtil.delete("target/journal");
+        FileUtil.delete("target/obs_journal");
         startRepositoryWithConfiguration(resourceStream("config/repo-config-observation.json"));
         session = login(WORKSPACE);
 

--- a/modeshape-jcr/src/test/java/org/modeshape/jcr/JcrRepositoryStartupTest.java
+++ b/modeshape-jcr/src/test/java/org/modeshape/jcr/JcrRepositoryStartupTest.java
@@ -27,8 +27,7 @@ import java.io.IOException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.Callable;
-import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import javax.jcr.NoSuchWorkspaceException;
@@ -82,59 +81,43 @@ public class JcrRepositoryStartupTest extends MultiPassAbstractTest {
 
         String repositoryConfigFile = "config/repo-config-persistent-cache.json";
 
-        startRunStop(new RepositoryOperation() {
-            @Override
-            public Void call() throws Exception {
-                Session session = repository.login();
-                session.getRootNode().addNode("testNode");
-                session.save();
+        startRunStop(repository -> {
+            Session session = repository.login();
+            session.getRootNode().addNode("testNode");
+            session.save();
 
-                // create 2 new workspaces
-                session.getWorkspace().createWorkspace("ws1");
-                session.getWorkspace().createWorkspace("ws2");
-                session.logout();
-
-                return null;
-            }
+            // create 2 new workspaces
+            session.getWorkspace().createWorkspace("ws1");
+            session.getWorkspace().createWorkspace("ws2");
+            session.logout();
         }, repositoryConfigFile);
 
-        startRunStop(new RepositoryOperation() {
-            @Override
-            public Void call() throws Exception {
+        startRunStop(repository -> {
+            Session session = repository.login();
+            assertNotNull(session.getNode("/testNode"));
+            session.logout();
 
-                Session session = repository.login();
-                assertNotNull(session.getNode("/testNode"));
-                session.logout();
+            // check the workspaces were persisted
+            Session newWsSession = repository.login("ws1");
+            newWsSession.getRootNode().addNode("newWsTestNode");
+            newWsSession.save();
+            newWsSession.logout();
 
-                // check the workspaces were persisted
-                Session newWsSession = repository.login("ws1");
-                newWsSession.getRootNode().addNode("newWsTestNode");
-                newWsSession.save();
-                newWsSession.logout();
-
-                Session newWs1Session = repository.login("ws2");
-                newWs1Session.getWorkspace().deleteWorkspace("ws2");
-                newWs1Session.logout();
-
-                return null;
-            }
+            Session newWs1Session = repository.login("ws2");
+            newWs1Session.getWorkspace().deleteWorkspace("ws2");
+            newWs1Session.logout();
         }, repositoryConfigFile);
 
-        startRunStop(new RepositoryOperation() {
-            @Override
-            public Void call() throws Exception {
-                Session newWsSession = repository.login("ws1");
-                assertNotNull(newWsSession.getNode("/newWsTestNode"));
-                newWsSession.logout();
-
-                // check a workspace was deleted
-                try {
-                    repository.login("ws2");
-                    fail("Workspace was not deleted from the repository");
-                } catch (NoSuchWorkspaceException e) {
-                    // expected
-                }
-                return null;
+        startRunStop(repository -> {
+            Session newWsSession = repository.login("ws1");
+            assertNotNull(newWsSession.getNode("/newWsTestNode"));
+            newWsSession.logout();
+            // check a workspace was deleted
+            try {
+                repository.login("ws2");
+                fail("Workspace was not deleted from the repository");
+            } catch (NoSuchWorkspaceException e) {
+                // expected
             }
         }, repositoryConfigFile);
     }
@@ -145,35 +128,27 @@ public class JcrRepositoryStartupTest extends MultiPassAbstractTest {
         FileUtil.delete("target/persistent_repository_initial_content");
 
         String repositoryConfigFile = "config/repo-config-persistent-cache-initial-content.json";
-        startRunStop(new RepositoryOperation() {
-            @Override
-            public Void call() throws Exception {
-                JcrSession ws1Session = repository.login("ws1");
-                // check the initial import
-                AbstractJcrNode node = ws1Session.getNode("/cars");
-                assertNotNull(node);
-                // remove the node initially imported and add a new one
-                node.remove();
-                ws1Session.getRootNode().addNode("testNode");
+        startRunStop(repository -> {
+            Session ws1Session = repository.login("ws1");
+            // check the initial import
+            Node node = ws1Session.getNode("/cars");
+            assertNotNull(node);
+            // remove the node initially imported and add a new one
+            node.remove();
+            ws1Session.getRootNode().addNode("testNode");
 
-                ws1Session.save();
-                return null;
-            }
+            ws1Session.save();
         }, repositoryConfigFile);
 
-        startRunStop(new RepositoryOperation() {
-            @Override
-            public Void call() throws Exception {
-                JcrSession ws1Session = repository.login("ws1");
-                try {
-                    ws1Session.getNode("/cars");
-                    fail("The initial content should be be re-imported if a workspace is not empty");
-                } catch (PathNotFoundException e) {
-                    // expected
-                }
-                ws1Session.getNode("/testNode");
-                return null;
+        startRunStop(repository -> {
+            Session ws1Session = repository.login("ws1");
+            try {
+                ws1Session.getNode("/cars");
+                fail("The initial content should be be re-imported if a workspace is not empty");
+            } catch (PathNotFoundException e) {
+                // expected
             }
+            ws1Session.getNode("/testNode");
         }, repositoryConfigFile);
     }
 
@@ -189,41 +164,32 @@ public class JcrRepositoryStartupTest extends MultiPassAbstractTest {
         FileUtil.delete("target/federation_persistent_repository");
 
         String repositoryConfigFile = "config/repo-config-mock-federation-persistent.json";
-        startRunStop(new RepositoryOperation() {
-            @Override
-            public Void call() throws Exception {
-                Session session = repository.login();
-                Node testRoot = session.getRootNode().addNode("testRoot");
-                session.save();
+        startRunStop(repository -> {
+            Session session = repository.login();
+            Node testRoot = session.getRootNode().addNode("testRoot");
+            session.save();
 
-                FederationManager federationManager = ((Workspace)session.getWorkspace()).getFederationManager();
+            FederationManager federationManager = ((Workspace)session.getWorkspace()).getFederationManager();
 
-                federationManager.createProjection("/testRoot", "mock-source", MockConnector.DOC1_LOCATION, "federated1");
-                federationManager.createProjection("/testRoot", "mock-source", MockConnector.DOC2_LOCATION, null);
-                Node doc1Federated = session.getNode("/testRoot/federated1");
-                assertNotNull(doc1Federated);
-                assertEquals(testRoot.getIdentifier(), doc1Federated.getParent().getIdentifier());
-
-                return null;
-            }
+            federationManager.createProjection("/testRoot", "mock-source", MockConnector.DOC1_LOCATION, "federated1");
+            federationManager.createProjection("/testRoot", "mock-source", MockConnector.DOC2_LOCATION, null);
+            Node doc1Federated = session.getNode("/testRoot/federated1");
+            assertNotNull(doc1Federated);
+            assertEquals(testRoot.getIdentifier(), doc1Federated.getParent().getIdentifier());
         }, repositoryConfigFile);
 
-        startRunStop(new RepositoryOperation() {
-            @Override
-            public Void call() throws Exception {
-                Session session = repository.login();
-                Node testRoot = session.getNode("/testRoot");
-                assertNotNull(testRoot);
+        startRunStop(repository -> {
+            Session session = repository.login();
+            Node testRoot = session.getNode("/testRoot");
+            assertNotNull(testRoot);
 
-                Node doc1Federated = session.getNode("/testRoot/federated1");
-                assertNotNull(doc1Federated);
-                assertEquals(testRoot.getIdentifier(), doc1Federated.getParent().getIdentifier());
+            Node doc1Federated = session.getNode("/testRoot/federated1");
+            assertNotNull(doc1Federated);
+            assertEquals(testRoot.getIdentifier(), doc1Federated.getParent().getIdentifier());
 
-                Node doc2Federated = session.getNode("/testRoot" + MockConnector.DOC2_LOCATION);
-                assertNotNull(doc2Federated);
-                assertEquals(testRoot.getIdentifier(), doc2Federated.getParent().getIdentifier());
-                return null;
-            }
+            Node doc2Federated = session.getNode("/testRoot" + MockConnector.DOC2_LOCATION);
+            assertNotNull(doc2Federated);
+            assertEquals(testRoot.getIdentifier(), doc2Federated.getParent().getIdentifier());
         }, repositoryConfigFile);
     }
 
@@ -232,13 +198,9 @@ public class JcrRepositoryStartupTest extends MultiPassAbstractTest {
         FileUtil.delete("target/federation_persistent_repository");
 
         String repositoryConfigFile = "config/repo-config-federation-persistent-projections.json";
-        RepositoryOperation checkPreconfiguredProjection = new RepositoryOperation() {
-            @Override
-            public Void call() throws Exception {
-                Session session = repository.login();
-                assertNotNull(session.getNode("/preconfiguredProjection"));
-                return null;
-            }
+        RepositoryOperation checkPreconfiguredProjection = repository -> {
+            Session session = repository.login();
+            assertNotNull(session.getNode("/preconfiguredProjection"));
         };
         startRunStop(checkPreconfiguredProjection, repositoryConfigFile);
         startRunStop(checkPreconfiguredProjection, repositoryConfigFile);
@@ -249,38 +211,30 @@ public class JcrRepositoryStartupTest extends MultiPassAbstractTest {
         FileUtil.delete("target/federation_persistent_repository");
 
         String repositoryConfigFile = "config/repo-config-mock-federation-persistent.json";
-        startRunStop(new RepositoryOperation() {
-            @Override
-            public Void call() throws Exception {
-                Session session = repository.login();
-                session.getRootNode().addNode("testRoot");
-                session.save();
+        startRunStop(repository -> {
+            Session session = repository.login();
+            session.getRootNode().addNode("testRoot");
+            session.save();
 
-                FederationManager federationManager = ((Workspace)session.getWorkspace()).getFederationManager();
-                federationManager.createProjection("/testRoot", "mock-source", MockConnector.DOC1_LOCATION, "federated1");
-                federationManager.createProjection("/testRoot", "mock-source", MockConnector.DOC2_LOCATION, "federated2");
-                Node projection = session.getNode("/testRoot/federated1");
-                assertNotNull(projection);
+            FederationManager federationManager = ((Workspace)session.getWorkspace()).getFederationManager();
+            federationManager.createProjection("/testRoot", "mock-source", MockConnector.DOC1_LOCATION, "federated1");
+            federationManager.createProjection("/testRoot", "mock-source", MockConnector.DOC2_LOCATION, "federated2");
+            Node projection = session.getNode("/testRoot/federated1");
+            assertNotNull(projection);
 
-                projection.remove();
-                session.save();
-                return null;
-            }
+            projection.remove();
+            session.save();
         }, repositoryConfigFile);
 
-        startRunStop(new RepositoryOperation() {
-            @Override
-            public Void call() throws Exception {
-                Session session = repository.login();
-                // check the 2nd projection
-                assertNotNull(session.getNode("/testRoot/federated2"));
-                try {
-                    session.getNode("/testRoot/federated1");
-                    fail("Projection has not been cleaned up");
-                } catch (PathNotFoundException e) {
-                    // expected
-                }
-                return null;
+        startRunStop(repository -> {
+            Session session = repository.login();
+            // check the 2nd projection
+            assertNotNull(session.getNode("/testRoot/federated2"));
+            try {
+                session.getNode("/testRoot/federated1");
+                fail("Projection has not been cleaned up");
+            } catch (PathNotFoundException e) {
+                // expected
             }
         }, repositoryConfigFile);
     }
@@ -290,75 +244,48 @@ public class JcrRepositoryStartupTest extends MultiPassAbstractTest {
     public void shouldNotRemainInInconsistentStateIfErrorsOccurOnStartup() throws Exception {
         FileUtil.delete("target/persistent_repository_initial_content");
         // try and start with a config that will produce an exception
-        String repositoryConfigFile = "config/invalid-repo-config-persistent-initial-content.json";
         try {
-            startRunStop(new RepositoryOperation() {
-                @Override
-                public Void call() throws Exception {
-                    return null;
-                }
-            }, repositoryConfigFile);
+            startRunStop(repository -> {}, "config/invalid-repo-config-persistent-initial-content.json");
             fail("Expected a repository exception");
-        } catch (RepositoryException e) {
-            // expected
+        } catch (RuntimeException e) {
+            if (!(e.getCause() instanceof RepositoryException)) {
+                throw e;
+            }
         }
 
-        final CountDownLatch restartLatch = new CountDownLatch(1);
-        Callable<Void> restartRunnable = new Callable<Void>() {
-            @Override
-            public Void call() throws Exception {
-                startRunStop(new RepositoryOperation() {
-                    @Override
-                    public Void call() throws Exception {
-                        restartLatch.countDown();
-                        return null;
-                    }
-                }, "config/repo-config-persistent-cache-initial-content.json");
-                return null;
-            }
-        };
-        Executors.newSingleThreadExecutor().submit(restartRunnable);
-        // wait the repo to restart or fail
-        assertTrue("Repository did not restart in the expected amount of time", restartLatch.await(1, TimeUnit.MINUTES));
+        ExecutorService executorService = Executors.newSingleThreadExecutor();
+        try {
+            executorService.submit(()-> startRunStop(repository -> {}, "config/repo-config-persistent-cache-initial-content.json"))
+                            .get(10, TimeUnit.SECONDS);
+            // wait the repo to restart or fail
+        } catch (java.util.concurrent.TimeoutException e) {
+            fail("Repository did not restart in the expected amount of time");
+        }
+        finally {
+            executorService.shutdownNow();
+        }
     }
 
     @Test
     @FixFor( "MODE-2031" )
     public void shouldRestartWithModifiedCNDFile() throws Exception {
         FileUtil.delete("target/persistent_repository/");
-        startRunStop(new RepositoryOperation() {
-            @Override
-            public Void call() throws Exception {
-                JcrSession session = repository.login();
-                Node content = session.getRootNode().addNode("content", "jj:content");
-                content.setProperty("_name", "name");
-                content.setProperty("_type", "type");
-                session.save();
-                return null;
-            }
+        startRunStop(repository -> {
+            Session session = repository.login();
+            Node content = session.getRootNode().addNode("content", "jj:content");
+            content.setProperty("_name", "name");
+            content.setProperty("_type", "type");
+            session.save();
         }, "config/repo-config-jj-initial.json");
 
-        startRunStop(new RepositoryOperation() {
-            @Override
-            public Void call() throws Exception {
-                JcrSession session = repository.login();
-                Node content = session.getNode("/content");
-                assertEquals("name", content.getProperty("_name").getString());
-                assertEquals("type", content.getProperty("_type").getString());
-                return null;
-            }
-        }, "config/repo-config-jj-modified.json");
-
-        startRunStop(new RepositoryOperation() {
-            @Override
-            public Void call() throws Exception {
-                JcrSession session = repository.login();
-                Node content = session.getNode("/content");
-                assertEquals("name", content.getProperty("_name").getString());
-                assertEquals("type", content.getProperty("_type").getString());
-                return null;
-            }
-        }, "config/repo-config-jj-modified.json");
+        RepositoryOperation operation = (repository) -> {
+            Session session = repository.login();
+            Node content = session.getNode("/content");
+            assertEquals("name", content.getProperty("_name").getString());
+            assertEquals("type", content.getProperty("_type").getString());
+        };
+        startRunStop(operation, "config/repo-config-jj-modified.json");
+        startRunStop(operation, "config/repo-config-jj-modified.json");
     }
 
     @Test
@@ -366,54 +293,44 @@ public class JcrRepositoryStartupTest extends MultiPassAbstractTest {
     public void shouldRun3_6_0UpgradeFunction() throws Exception {
         FileUtil.delete("target/persistent_repository/");
         // first run is empty, so no upgrades will be performed
-        startRunStop(new RepositoryOperation() {
-            @SuppressWarnings( "deprecation" )
-            @Override
-            public Void call() throws Exception {
-                // modify the repository-info document to force an upgrade on the next restart
-                changeLastUpgradeId(repository, Upgrades.ModeShape_3_6_0.INSTANCE.getId() - 1);
+        startRunStop(repository ->  {
+            // modify the repository-info document to force an upgrade on the next restart
+            changeLastUpgradeId(repository, Upgrades.ModeShape_3_6_0.INSTANCE.getId() - 1);
 
-                // create a non-session lock on a node
-                JcrSession session = repository.login();
-                PropertyFactory propertyFactory = session.context().getPropertyFactory();
-                AbstractJcrNode node = session.getRootNode().addNode("/test");
-                node.addMixin("mix:lockable");
-                session.save();
-                session.lockManager().lock(node, true, false, Long.MAX_VALUE, null);
+            // create a non-session lock on a node
+            JcrSession session = repository.login();
+            PropertyFactory propertyFactory = session.context().getPropertyFactory();
+            AbstractJcrNode node = session.getRootNode().addNode("/test");
+            node.addMixin("mix:lockable");
+            session.save();
+            session.lockManager().lock(node, true, false, Long.MAX_VALUE, null);
 
-                // manipulate that lock using the system cache to simulate corrupt data
-                SessionCache systemSession = repository.createSystemSession(repository.runningState().context(), false);
-                SystemContent systemContent = new SystemContent(systemSession);
-                ChildReferences childReferences = systemContent.locksNode().getChildReferences(systemSession);
-                assertFalse("No locks found", childReferences.isEmpty());
-                for (ChildReference childReference : childReferences) {
-                    MutableCachedNode lock = systemSession.mutable(childReference.getKey());
-                    lock.setProperty(systemSession, propertyFactory.create(ModeShapeLexicon.IS_DEEP, true));
-                    lock.setProperty(systemSession, propertyFactory.create(ModeShapeLexicon.LOCKED_KEY, node.key().toString()));
-                    lock.setProperty(systemSession, propertyFactory.create(ModeShapeLexicon.SESSION_SCOPE, false));
-                }
-                systemSession.save();
-                return null;
+            // manipulate that lock using the system cache to simulate corrupt data
+            SessionCache systemSession = repository.createSystemSession(repository.runningState().context(), false);
+            SystemContent systemContent = new SystemContent(systemSession);
+            ChildReferences childReferences = systemContent.locksNode().getChildReferences(systemSession);
+            assertFalse("No locks found", childReferences.isEmpty());
+            for (ChildReference childReference : childReferences) {
+                MutableCachedNode lock = systemSession.mutable(childReference.getKey());
+                lock.setProperty(systemSession, propertyFactory.create(ModeShapeLexicon.IS_DEEP, true));
+                lock.setProperty(systemSession, propertyFactory.create(ModeShapeLexicon.LOCKED_KEY, node.key().toString()));
+                lock.setProperty(systemSession, propertyFactory.create(ModeShapeLexicon.SESSION_SCOPE, false));
             }
+            systemSession.save();
         }, "config/repo-config-persistent-no-indexes.json");
 
         // second run should run the upgrade
-        startRunStop(new RepositoryOperation() {
-            @SuppressWarnings( "deprecation" )
-            @Override
-            public Void call() throws Exception {
-                // manipulate that lock using the system cache to simulate corrupt data
-                SessionCache systemSession = repository.createSystemSession(repository.runningState().context(), true);
-                SystemContent systemContent = new SystemContent(systemSession);
-                ChildReferences childReferences = systemContent.locksNode().getChildReferences(systemSession);
-                assertFalse("No locks found", childReferences.isEmpty());
-                for (ChildReference childReference : childReferences) {
-                    CachedNode lock = systemSession.getNode(childReference.getKey());
-                    assertNull("Property not removed", lock.getProperty(ModeShapeLexicon.IS_DEEP, systemSession));
-                    assertNull("Property not removed", lock.getProperty(ModeShapeLexicon.LOCKED_KEY, systemSession));
-                    assertNull("Property not removed", lock.getProperty(ModeShapeLexicon.SESSION_SCOPE, systemSession));
-                }
-                return null;
+        startRunStop(repository -> {
+            // manipulate that lock using the system cache to simulate corrupt data
+            SessionCache systemSession = repository.createSystemSession(repository.runningState().context(), true);
+            SystemContent systemContent = new SystemContent(systemSession);
+            ChildReferences childReferences = systemContent.locksNode().getChildReferences(systemSession);
+            assertFalse("No locks found", childReferences.isEmpty());
+            for (ChildReference childReference : childReferences) {
+                CachedNode lock = systemSession.getNode(childReference.getKey());
+                assertNull("Property not removed", lock.getProperty(ModeShapeLexicon.IS_DEEP, systemSession));
+                assertNull("Property not removed", lock.getProperty(ModeShapeLexicon.LOCKED_KEY, systemSession));
+                assertNull("Property not removed", lock.getProperty(ModeShapeLexicon.SESSION_SCOPE, systemSession));
             }
         }, "config/repo-config-persistent-no-indexes.json");
     }
@@ -421,49 +338,26 @@ public class JcrRepositoryStartupTest extends MultiPassAbstractTest {
     @Test
     @FixFor( "MODE-2049" )
     public void shouldStartAndStopRepositoryWithoutMonitoringConfigured() throws Exception {
-        startRunStop(new RepositoryOperation() {
-            @Override
-            public Void call() throws Exception {
-                repository.login().logout();
-                return null;
-            }
-        }, "config/repo-config-inmemory-local-environment-no-monitoring.json");
+        startRunStop(repository -> repository.login().logout(), "config/repo-config-inmemory-local-environment-no-monitoring.json");
     }
 
     @Test
     @FixFor( "MODE-1683" )
     public void shouldAppendJournalEntriesBetweenRestarts() throws Exception {
         FileUtil.delete("target/journal/");
-        final List<Integer> recordsOnStartup = new ArrayList<Integer>(2);
-        startRunStop(new RepositoryOperation() {
-            @Override
-            public Void call() throws Exception {
-                Session session = repository.login();
-                session.getRootNode().addNode("node1");
-                session.save();
-                session.logout();
-                Thread.sleep(100);
-                int records = repository.runningState().journal().allRecords(false).size();
-                assertTrue(records > 0);
-                recordsOnStartup.add(records);
-                return null;
-            }
-        }, "config/repo-config-journaling.json");
-
-        startRunStop(new RepositoryOperation() {
-            @Override
-            public Void call() throws Exception {
-                Session session = repository.login();
-                session.getRootNode().addNode("node1");
-                session.save();
-                session.logout();
-                Thread.sleep(100);
-                int records = repository.runningState().journal().allRecords(false).size();
-                assertTrue(records > 0);
-                recordsOnStartup.add(records);
-                return null;
-            }
-        }, "config/repo-config-journaling.json");
+        final List<Integer> recordsOnStartup = new ArrayList<>(2);
+        RepositoryOperation operation = repository -> {
+            Session session = repository.login();
+            session.getRootNode().addNode("node1");
+            session.save();
+            session.logout();
+            Thread.sleep(100);
+            int records = repository.runningState().journal().allRecords(false).size();
+            assertTrue(records > 0);
+            recordsOnStartup.add(records);
+        };
+        startRunStop(operation, "config/repo-config-journaling.json");
+        startRunStop(operation, "config/repo-config-journaling.json");
 
         int countFirstTime = recordsOnStartup.get(0);
         int countSecondTime = recordsOnStartup.get(1);
@@ -476,18 +370,14 @@ public class JcrRepositoryStartupTest extends MultiPassAbstractTest {
         FileUtil.delete("target/persistent_repository/");
         URL configUrl = getClass().getClassLoader().getResource("config/repo-config-persistent-predefined-ws.json");
         RepositoryConfiguration config = RepositoryConfiguration.read(configUrl);
-        startRunStop(new RepositoryOperation() {
-            @Override
-            public Void call() throws Exception {
-                JcrSession session = repository.login("default");
-                session.logout();
-                session = repository.login("ws1");
-                session.getWorkspace().createWorkspace("ws2");
-                session.logout();
-                session = repository.login("ws2");
-                session.logout();
-                return null;
-            }
+        startRunStop(repository -> {
+            JcrSession session = repository.login("default");
+            session.logout();
+            session = repository.login("ws1");
+            session.getWorkspace().createWorkspace("ws2");
+            session.logout();
+            session = repository.login("ws2");
+            session.logout();
         }, config);
 
         final Editor editor = config.edit();
@@ -496,65 +386,45 @@ public class JcrRepositoryStartupTest extends MultiPassAbstractTest {
         predefinedWs.add("ws3");
         predefinedWs.add("ws4");
 
-        startRunStop(new RepositoryOperation() {
-            @Override
-            public Void call() throws Exception {
-                repository.apply(editor.getChanges());
-
-                JcrSession session = repository.login("default");
-                session.logout();
-                session = repository.login("ws1");
-                session.logout();
-                session = repository.login("ws2");
-                session.logout();
-                session = repository.login("ws3");
-                session.logout();
-                session = repository.login("ws4");
-                session.logout();
-                return null;
-            }
+        startRunStop(repository -> {
+            repository.apply(editor.getChanges());
+            JcrSession session = repository.login("default");
+            session.logout();
+            session = repository.login("ws1");
+            session.logout();
+            session = repository.login("ws2");
+            session.logout();
+            session = repository.login("ws3");
+            session.logout();
+            session = repository.login("ws4");
+            session.logout();
         }, config);
     }
 
     @Test
     @FixFor( "MODE-2100" )
-    public void shouldAddPredefinedWorkspacesOnRestartViaConfigChange() throws Exception {
+    public void shouldAddPredefinedWorkspacesOnRestartViaConfigChange() throws Exception{
         FileUtil.delete("target/persistent_repository/");
-        startRunStop(new RepositoryOperation() {
-            @Override
-            public Void call() throws Exception {
-                JcrSession session = repository.login("ws1");
-                session.getWorkspace().createWorkspace("ws3");
-                session.logout();
-                session = repository.login("ws3");
-                session.logout();
-                return null;
-            }
+        startRunStop(repository -> {
+            JcrSession session = repository.login("ws1");
+            session.getWorkspace().createWorkspace("ws3");
+            session.logout();
+            session = repository.login("ws3");
+            session.logout();
         }, "config/repo-config-persistent-predefined-ws.json");
 
-        startRunStop(new RepositoryOperation() {
-            @Override
-            public Void call() throws Exception {
-                JcrSession session = repository.login("default");
-                session.logout();
-                session = repository.login("ws1");
-                session.logout();
-                session = repository.login("ws2");
-                session.logout();
-                session = repository.login("ws3");
-                session.logout();
-                return null;
-            }
+        startRunStop(repository -> {
+            JcrSession session = repository.login("default");
+            session.logout();
+            session = repository.login("ws1");
+            session.logout();
+            session = repository.login("ws2");
+            session.logout();
+            session = repository.login("ws3");
+            session.logout();
         }, "config/repo-config-persistent-predefined-ws-update.json");
 
-        startRunStop(new RepositoryOperation() {
-            @Override
-            public Void call() throws Exception {
-                JcrSession session = repository.login("ws2");
-                session.logout();
-                return null;
-            }
-        }, "config/repo-config-persistent-predefined-ws.json");
+        startRunStop(repository -> repository.login("ws2").logout(), "config/repo-config-persistent-predefined-ws.json");
     }
 
     @Test
@@ -568,41 +438,32 @@ public class JcrRepositoryStartupTest extends MultiPassAbstractTest {
         final String uri = "http://www.admb.be/modeshape/admb/1.0";
         final String nodeTypeName = prefix + ":test";
 
-        startRunStop(new RepositoryOperation() {
-            @Override
-            public Void call() throws Exception {
-                Session session = repository.login();
+        startRunStop(repository -> {
+            Session session = repository.login();
 
-                NodeTypeManager nodeTypeManager = session.getWorkspace().getNodeTypeManager();
+            NodeTypeManager nodeTypeManager = session.getWorkspace().getNodeTypeManager();
 
-                // First create a namespace for the nodeType which is going to be added
-                session.getWorkspace().getNamespaceRegistry().registerNamespace(prefix, uri);
+            // First create a namespace for the nodeType which is going to be added
+            session.getWorkspace().getNamespaceRegistry().registerNamespace(prefix, uri);
 
-                // Start creating a nodeTypeTemplate, keep it basic.
-                NodeTypeTemplate nodeTypeTemplate = nodeTypeManager.createNodeTypeTemplate();
-                nodeTypeTemplate.setName(nodeTypeName);
-                nodeTypeManager.registerNodeType(nodeTypeTemplate, false);
+            // Start creating a nodeTypeTemplate, keep it basic.
+            NodeTypeTemplate nodeTypeTemplate = nodeTypeManager.createNodeTypeTemplate();
+            nodeTypeTemplate.setName(nodeTypeName);
+            nodeTypeManager.registerNodeType(nodeTypeTemplate, false);
 
-                session.getRootNode().addNode("testNode", nodeTypeName);
-                session.save();
+            session.getRootNode().addNode("testNode", nodeTypeName);
+            session.save();
 
-                Node node = session.getNode("/testNode");
-                assertEquals(nodeTypeName, node.getPrimaryNodeType().getName());
-                session.setNamespacePrefix("newPrefix", uri);
-                assertEquals("newPrefix:test", node.getPrimaryNodeType().getName());
-
-                return null;
-            }
+            Node node = session.getNode("/testNode");
+            assertEquals(nodeTypeName, node.getPrimaryNodeType().getName());
+            session.setNamespacePrefix("newPrefix", uri);
+            assertEquals("newPrefix:test", node.getPrimaryNodeType().getName());
         }, repositoryConfigFile);
 
-        startRunStop(new RepositoryOperation() {
-            @Override
-            public Void call() throws Exception {
-                Session session = repository.login();
-                Node node = session.getNode("/testNode");
-                assertEquals(nodeTypeName, node.getPrimaryNodeType().getName());
-                return null;
-            }
+        startRunStop(repository -> {
+            Session session = repository.login();
+            Node node = session.getNode("/testNode");
+            assertEquals(nodeTypeName, node.getPrimaryNodeType().getName());
         }, repositoryConfigFile);
     }
 
@@ -613,55 +474,46 @@ public class JcrRepositoryStartupTest extends MultiPassAbstractTest {
 
         String repositoryConfigFile = "config/repo-config-persistent-cache.json";
 
-        startRunStop(new RepositoryOperation() {
-            @Override
-            public Void call() throws Exception {
-                Session session = repository.login();
-                Node testNode = session.getRootNode().addNode("testNode");
-                testNode.addNode("node1");
-                testNode.addNode("node2");
-                session.save();
+        startRunStop(repository -> {
+            Session session = repository.login();
+            Node testNode = session.getRootNode().addNode("testNode");
+            testNode.addNode("node1");
+            testNode.addNode("node2");
+            session.save();
 
-                AccessControlManager acm = session.getAccessControlManager();
+            AccessControlManager acm = session.getAccessControlManager();
 
-                AccessControlList aclNode1 = getACL(acm, "/testNode/node1");
-                aclNode1.addAccessControlEntry(SimplePrincipal.newInstance("anonymous"),
-                                               new Privilege[] {acm.privilegeFromName(Privilege.JCR_ALL)});
-                acm.setPolicy("/testNode/node1", aclNode1);
+            AccessControlList aclNode1 = getACL(acm, "/testNode/node1");
+            aclNode1.addAccessControlEntry(SimplePrincipal.newInstance("anonymous"),
+                                           new Privilege[] {acm.privilegeFromName(Privilege.JCR_ALL)});
+            acm.setPolicy("/testNode/node1", aclNode1);
 
-                AccessControlList aclNode2 = getACL(acm, "/testNode/node2");
-                aclNode2.addAccessControlEntry(SimplePrincipal.newInstance("anonymous"),
-                                               new Privilege[] {acm.privilegeFromName(Privilege.JCR_ALL)});
-                acm.setPolicy("/testNode/node2", aclNode2);
+            AccessControlList aclNode2 = getACL(acm, "/testNode/node2");
+            aclNode2.addAccessControlEntry(SimplePrincipal.newInstance("anonymous"),
+                                           new Privilege[] {acm.privilegeFromName(Privilege.JCR_ALL)});
+            acm.setPolicy("/testNode/node2", aclNode2);
 
-                // access control should not be enabled yet because we haven't saved the session
-                assertFalse(repository.runningState().repositoryCache().isAccessControlEnabled());
+            // access control should not be enabled yet because we haven't saved the session
+            assertFalse(repository.runningState().repositoryCache().isAccessControlEnabled());
 
-                session.save();
-                assertTrue(repository.runningState().repositoryCache().isAccessControlEnabled());
-
-                return null;
-            }
+            session.save();
+            assertTrue(repository.runningState().repositoryCache().isAccessControlEnabled());
         }, repositoryConfigFile);
 
-        startRunStop(new RepositoryOperation() {
-            @Override
-            public Void call() throws Exception {
-                assertTrue(repository.runningState().repositoryCache().isAccessControlEnabled());
+        startRunStop(repository -> {
+            assertTrue(repository.runningState().repositoryCache().isAccessControlEnabled());
 
-                Session session = repository.login();
-                AccessControlManager acm = session.getAccessControlManager();
-                // TODO author=Horia Chiorean date=25-Mar-14 description=Why null here !?!
-                acm.removePolicy("/testNode/node1", null);
-                acm.removePolicy("/testNode/node2", null);
-                session.save();
+            Session session = repository.login();
+            AccessControlManager acm = session.getAccessControlManager();
+            // TODO author=Horia Chiorean date=25-Mar-14 description=Why null here !?!
+            acm.removePolicy("/testNode/node1", null);
+            acm.removePolicy("/testNode/node2", null);
+            session.save();
 
-                assertFalse(repository.runningState().repositoryCache().isAccessControlEnabled());
+            assertFalse(repository.runningState().repositoryCache().isAccessControlEnabled());
 
-                session.getNode("/testNode").remove();
-                session.save();
-                return null;
-            }
+            session.getNode("/testNode").remove();
+            session.save();
         }, repositoryConfigFile);
     }
 
@@ -671,78 +523,65 @@ public class JcrRepositoryStartupTest extends MultiPassAbstractTest {
         FileUtil.delete("target/persistent_repository/");
         String config = "config/repo-config-persistent-no-indexes.json";
         // first run is empty, so no upgrades will be performed
-        startRunStop(new RepositoryOperation() {
-            @Override
-            public Void call() throws Exception {
-                changeLastUpgradeId(repository, Upgrades.ModeShape_4_0_0_Alpha1.INSTANCE.getId() - 1);
+        startRunStop(repository -> {
+            changeLastUpgradeId(repository, Upgrades.ModeShape_4_0_0_Alpha1.INSTANCE.getId() - 1);
 
-                // modify some ACLs
-                JcrSession session = repository.login();
-                session.getRootNode().addNode("testNode");
-                session.save();
+            // modify some ACLs
+            JcrSession session = repository.login();
+            session.getRootNode().addNode("testNode");
+            session.save();
 
-                AccessControlManager acm = session.getAccessControlManager();
+            AccessControlManager acm = session.getAccessControlManager();
 
-                AccessControlList acl = getACL(acm, "/testNode");
-                acl.addAccessControlEntry(SimplePrincipal.newInstance("anonymous"),
-                                          new Privilege[] {acm.privilegeFromName(Privilege.JCR_ALL)});
-                acm.setPolicy("/testNode", acl);
-                session.save();
+            AccessControlList acl = getACL(acm, "/testNode");
+            acl.addAccessControlEntry(SimplePrincipal.newInstance("anonymous"),
+                                      new Privilege[] {acm.privilegeFromName(Privilege.JCR_ALL)});
+            acm.setPolicy("/testNode", acl);
+            session.save();
 
-                // remove the new property from 4.0 which actually stores the ACL count to simulate a pre 4.0 repository
-                SessionCache systemSession = repository.createSystemSession(repository.runningState().context(), false);
-                SystemContent systemContent = new SystemContent(systemSession);
-                MutableCachedNode systemNode = systemContent.mutableSystemNode();
-                systemNode.removeProperty(systemSession, ModeShapeLexicon.ACL_COUNT);
-                systemSession.save();
-                return null;
-            }
+            // remove the new property from 4.0 which actually stores the ACL count to simulate a pre 4.0 repository
+            SessionCache systemSession = repository.createSystemSession(repository.runningState().context(), false);
+            SystemContent systemContent = new SystemContent(systemSession);
+            MutableCachedNode systemNode = systemContent.mutableSystemNode();
+            systemNode.removeProperty(systemSession, ModeShapeLexicon.ACL_COUNT);
+            systemSession.save();
         }, config);
 
         // second run should run the upgrade
-        startRunStop(new RepositoryOperation() {
-            @Override
-            public Void call() throws Exception {
-                // check that the upgrade function correctly added the new property
-                SessionCache systemSession = repository.createSystemSession(repository.runningState().context(), false);
-                SystemContent systemContent = new SystemContent(systemSession);
-                MutableCachedNode systemNode = systemContent.mutableSystemNode();
-                Property aclCountProp = systemNode.getProperty(ModeShapeLexicon.ACL_COUNT, systemSession);
-                assertNotNull("ACL count property not found after upgrade", aclCountProp);
-                assertEquals(1, Long.valueOf(aclCountProp.getFirstValue().toString()).longValue());
+        startRunStop(repository -> {
+            // check that the upgrade function correctly added the new property
+            SessionCache systemSession = repository.createSystemSession(repository.runningState().context(), false);
+            SystemContent systemContent = new SystemContent(systemSession);
+            MutableCachedNode systemNode = systemContent.mutableSystemNode();
+            Property aclCountProp = systemNode.getProperty(ModeShapeLexicon.ACL_COUNT, systemSession);
+            assertNotNull("ACL count property not found after upgrade", aclCountProp);
+            assertEquals(1, Long.valueOf(aclCountProp.getFirstValue().toString()).longValue());
 
-                // force a 2nd upgrade
-                changeLastUpgradeId(repository, Upgrades.ModeShape_4_0_0_Alpha1.INSTANCE.getId() - 1);
+            // force a 2nd upgrade
+            changeLastUpgradeId(repository, Upgrades.ModeShape_4_0_0_Alpha1.INSTANCE.getId() - 1);
 
-                // remove all ACLs
-                JcrSession session = repository.login();
-                AccessControlManager acm = session.getAccessControlManager();
-                // TODO author=Horia Chiorean date=25-Mar-14 description=Why null ?!
-                acm.removePolicy("/testNode", null);
-                session.save();
+            // remove all ACLs
+            JcrSession session = repository.login();
+            AccessControlManager acm = session.getAccessControlManager();
+            // TODO author=Horia Chiorean date=25-Mar-14 description=Why null ?!
+            acm.removePolicy("/testNode", null);
+            session.save();
 
-                // remove the new property from 4.0 which actually stores the ACL count to simulate a pre 4.0 repository
-                systemNode.removeProperty(systemSession, ModeShapeLexicon.ACL_COUNT);
-                systemSession.save();
-                return null;
-            }
+            // remove the new property from 4.0 which actually stores the ACL count to simulate a pre 4.0 repository
+            systemNode.removeProperty(systemSession, ModeShapeLexicon.ACL_COUNT);
+            systemSession.save();
         }, config);
 
         // check that the upgrade disabled ACLs
-        startRunStop(new RepositoryOperation() {
-            @Override
-            public Void call() throws Exception {
+        startRunStop(repository -> {
+            SessionCache systemSession = repository.createSystemSession(repository.runningState().context(), true);
+            SystemContent systemContent = new SystemContent(systemSession);
+            CachedNode systemNode = systemContent.systemNode();
+            Property aclCountProp = systemNode.getProperty(ModeShapeLexicon.ACL_COUNT, systemSession);
+            assertNotNull("ACL count property not found after upgrade", aclCountProp);
+            assertEquals(0, Long.valueOf(aclCountProp.getFirstValue().toString()).longValue());
 
-                SessionCache systemSession = repository.createSystemSession(repository.runningState().context(), true);
-                SystemContent systemContent = new SystemContent(systemSession);
-                CachedNode systemNode = systemContent.systemNode();
-                Property aclCountProp = systemNode.getProperty(ModeShapeLexicon.ACL_COUNT, systemSession);
-                assertNotNull("ACL count property not found after upgrade", aclCountProp);
-                assertEquals(0, Long.valueOf(aclCountProp.getFirstValue().toString()).longValue());
-
-                assertFalse(repository.runningState().repositoryCache().isAccessControlEnabled());
-                return null;
-            }
+            assertFalse(repository.runningState().repositoryCache().isAccessControlEnabled());
         }, config);
     }
 
@@ -752,36 +591,28 @@ public class JcrRepositoryStartupTest extends MultiPassAbstractTest {
         FileUtil.delete("target/persistent_repository/");
 
         prepareExternalDirectory("target/federation_persistent_1");
-        startRunStop(new RepositoryOperation() {
-            @Override
-            public Void call() throws Exception {
-                JcrSession session = repository.login();
-                assertNotNull(session.getNode("/fs1"));
-                assertNotNull(session.getNode("/fs1/file.txt"));
-                assertNotNull(session.getNode("/fs2"));
-                assertNotNull(session.getNode("/fs2/file.txt"));
-                return null;
-            }
+        startRunStop(repository-> {
+            JcrSession session = repository.login();
+            assertNotNull(session.getNode("/fs1"));
+            assertNotNull(session.getNode("/fs1/file.txt"));
+            assertNotNull(session.getNode("/fs2"));
+            assertNotNull(session.getNode("/fs2/file.txt"));
         }, "config/repo-config-persistent-cache-fs-connector1.json");
 
         FileUtil.delete("target/federation_persistent_1");
         prepareExternalDirectory("target/federation_persistent_2");
         // restart with a configuration file which a) has a new external source, b) has changed the directory path of "fs2" and
         // c) has removed the fs1 projection
-        startRunStop(new RepositoryOperation() {
-            @Override
-            public Void call() throws Exception {
-                JcrSession session = repository.login();
-                try {
-                    session.getNode("/fs1");
-                    fail("The projection should not have been found");
-                } catch (PathNotFoundException e) {
-                    // expected
-                }
-                assertNotNull(session.getNode("/fs2"));
-                assertNotNull(session.getNode("/fs2/file.txt"));
-                return null;
+        startRunStop(repository -> {
+            JcrSession session = repository.login();
+            try {
+                session.getNode("/fs1");
+                fail("The projection should not have been found");
+            } catch (PathNotFoundException e) {
+                // expected
             }
+            assertNotNull(session.getNode("/fs2"));
+            assertNotNull(session.getNode("/fs2/file.txt"));
         }, "config/repo-config-persistent-cache-fs-connector2.json");
     }
 
@@ -797,31 +628,23 @@ public class JcrRepositoryStartupTest extends MultiPassAbstractTest {
         final BinaryKey binaryKey = new BinaryKey("ef2138973a86a8929eebe7bf52419b7cde73ba0a");
         // first run is empty, so no upgrades will be performed but we'll decrement the last upgrade ID to force an upgrade next
         // restart
-        startRunStop(new RepositoryOperation() {
-            @Override
-            public Void call() throws Exception {
-                changeLastUpgradeId(repository, Upgrades.ModeShape_4_0_0_Beta3.INSTANCE.getId() - 1);
-                FileSystemBinaryStore binaryStore = (FileSystemBinaryStore)repository.runningState().binaryStore();
-                assertFalse("No used binaries expected", binaryStore.getAllBinaryKeys().iterator().hasNext());
-                assertFalse("The binary should not be found", binaryStore.hasBinary(binaryKey));
-                File mainStorageDirectory = binaryStore.getDirectory();
-                File[] files = mainStorageDirectory.listFiles();
-                assertEquals("Just the trash directory was expected", 1, files.length);
-                File trash = files[0];
-                assertTrue(trash.isDirectory());
-                return null;
-            }
+        startRunStop(repository -> {
+            changeLastUpgradeId(repository, Upgrades.ModeShape_4_0_0_Beta3.INSTANCE.getId() - 1);
+            FileSystemBinaryStore binaryStore = (FileSystemBinaryStore)repository.runningState().binaryStore();
+            assertFalse("No used binaries expected", binaryStore.getAllBinaryKeys().iterator().hasNext());
+            assertFalse("The binary should not be found", binaryStore.hasBinary(binaryKey));
+            File mainStorageDirectory = binaryStore.getDirectory();
+            File[] files = mainStorageDirectory.listFiles();
+            assertEquals("Just the trash directory was expected", 1, files.length);
+            File trash = files[0];
+            assertTrue(trash.isDirectory());
         }, config);
 
         // run the repo a second time, which should run the upgrade
-        startRunStop(new RepositoryOperation() {
-            @Override
-            public Void call() throws Exception {
-                FileSystemBinaryStore binaryStore = (FileSystemBinaryStore)repository.runningState().binaryStore();
-                assertFalse("No used binaries expected", binaryStore.getAllBinaryKeys().iterator().hasNext());
-                assertTrue("The binary should be found", binaryStore.hasBinary(binaryKey));
-                return null;
-            }
+        startRunStop(repository -> {
+            FileSystemBinaryStore binaryStore = (FileSystemBinaryStore)repository.runningState().binaryStore();
+            assertFalse("No used binaries expected", binaryStore.getAllBinaryKeys().iterator().hasNext());
+            assertTrue("The binary should be found", binaryStore.hasBinary(binaryKey));
         }, config);
     }
 
@@ -855,34 +678,30 @@ public class JcrRepositoryStartupTest extends MultiPassAbstractTest {
     }
 
     private RepositoryOperation reindexingExternalContentOperation() {
-        return new RepositoryOperation() {
-            @Override
-            public Void call() throws Exception {
-                JcrSession session = repository.login();
-                // sleep a bit to make sure reindexing completes
-                Thread.sleep(100);
-                try {
-                    AbstractJcrNode node = session.getNode("/fs2/file.txt");
-                    String createdBy = node.getProperty("jcr:createdBy").getString();
-                    assertNotNull(createdBy);
-                    JcrQueryManager jcrQueryManager = session.getWorkspace().getQueryManager();
-                    Query query = jcrQueryManager.createQuery("select file.[jcr:path] from [nt:file] as file where file.[jcr:createdBy]='" +
-                                                              createdBy + "'",
-                                                              JcrQuery.JCR_SQL2);
-                    ValidateQuery.validateQuery()
-                                 .useIndex("nodesByAuthor")
-                                 .hasNodesAtPaths("/fs2/file.txt")
-                                 .validate(query, query.execute());
+        return repository -> {
+            JcrSession session = repository.login();
+            // sleep a bit to make sure reindexing completes
+            Thread.sleep(100);
+            try {
+                AbstractJcrNode node = session.getNode("/fs2/file.txt");
+                String createdBy = node.getProperty("jcr:createdBy").getString();
+                assertNotNull(createdBy);
+                JcrQueryManager jcrQueryManager = session.getWorkspace().getQueryManager();
+                Query query = jcrQueryManager.createQuery("select file.[jcr:path] from [nt:file] as file where file.[jcr:createdBy]='" +
+                                                          createdBy + "'",
+                                                          JcrQuery.JCR_SQL2);
+                ValidateQuery.validateQuery()
+                             .useIndex("nodesByAuthor")
+                             .hasNodesAtPaths("/fs2/file.txt")
+                             .validate(query, query.execute());
 
-                    session.getWorkspace().reindex();
-                    ValidateQuery.validateQuery()
-                                 .useIndex("nodesByAuthor")
-                                 .hasNodesAtPaths("/fs2/file.txt")
-                                 .validate(query, query.execute());
-                } finally {
-                    session.logout();
-                }
-                return null;
+                session.getWorkspace().reindex();
+                ValidateQuery.validateQuery()
+                             .useIndex("nodesByAuthor")
+                             .hasNodesAtPaths("/fs2/file.txt")
+                             .validate(query, query.execute());
+            } finally {
+                session.logout();
             }
         };
     }
@@ -894,33 +713,25 @@ public class JcrRepositoryStartupTest extends MultiPassAbstractTest {
         FileUtil.delete("target/persistent_repository");
         // clean the indexes
         FileUtil.delete("target/startup_test_indexes");
-        startRunStop(new RepositoryOperation() {
-            @Override
-            public Void call() throws Exception {
-                long initialSize = FileUtil.size("target/startup_test_indexes");
-                JcrSession session = repository.login();
-                int nodeCount = 100;
-                for (int i = 0; i < nodeCount; i++) {
-                    session.getRootNode().addNode("node_" + i);
-                }
-                session.save();  
-                session.logout();
-                // the indexes are sync, so the FS size should've increased because of the new nodes
-                assertTrue(initialSize < FileUtil.size("target/startup_test_indexes"));
-                return null;  
+        startRunStop(repository -> {
+            long initialSize = FileUtil.size("target/startup_test_indexes");
+            JcrSession session = repository.login();
+            int nodeCount = 100;
+            for (int i = 0; i < nodeCount; i++) {
+                session.getRootNode().addNode("node_" + i);
             }
+            session.save();  
+            session.logout();
+            // the indexes are sync, so the FS size should've increased because of the new nodes
+            assertTrue(initialSize < FileUtil.size("target/startup_test_indexes"));
         }, "config/repo-config-persistent-local-indexes.json");
        
         long indexFolderSize = FileUtil.size("target/startup_test_indexes"); 
         assertTrue(indexFolderSize > 0);
-        startRunStop(new RepositoryOperation() {
-            @Override
-            public Void call() throws Exception {
-                // wait a bit so that if reindexing was happening it would be finished before shutting down
-                Thread.sleep(200);
-                repository.login().logout();
-                return null;
-            }
+        startRunStop(repository -> {
+            // wait a bit so that if reindexing was happening it would be finished before shutting down
+            Thread.sleep(200);
+            repository.login().logout();
         }, "config/repo-config-persistent-local-indexes.json");
         // if reindexing was happening, it would be async so the next assert would normally fail
         assertEquals("Re-indexing should not be happening", indexFolderSize, FileUtil.size("target/startup_test_indexes"));
@@ -933,33 +744,25 @@ public class JcrRepositoryStartupTest extends MultiPassAbstractTest {
         FileUtil.delete("target/persistent_repository");
         // clean the indexes
         FileUtil.delete("target/startup_test_indexes");
-        startRunStop(new RepositoryOperation() {
-            @Override
-            public Void call() throws Exception {
-                JcrSession session = repository.login();
-                session.getRootNode().addNode("testRoot");
-                session.save();
-                String sql = "select [jcr:path] from [nt:unstructured] where [jcr:name] = 'testRoot'";
-                Query query = session.getWorkspace().getQueryManager().createQuery(sql, Query.JCR_SQL2);
-                ValidateQuery.validateQuery().rowCount(1).useIndex("nodesByName").validate(query, query.execute());
-                session.logout();
-                return null;
-            }
+        startRunStop(repository -> {
+            JcrSession session = repository.login();
+            session.getRootNode().addNode("testRoot");
+            session.save();
+            String sql = "select [jcr:path] from [nt:unstructured] where [jcr:name] = 'testRoot'";
+            Query query = session.getWorkspace().getQueryManager().createQuery(sql, Query.JCR_SQL2);
+            ValidateQuery.validateQuery().rowCount(1).useIndex("nodesByName").validate(query, query.execute());
+            session.logout();
         }, "config/repo-config-persistent-local-indexes.json");
-        startRunStop(new RepositoryOperation() {
-            @Override
-            public Void call() throws Exception {
-                JcrSession session = repository.login();
-                // force a re-index of the entire workspace - this should clear the existing indexes first
-                session.getWorkspace().reindex();
-                // then force a reindex of a certain path 
-                session.getWorkspace().reindex("/testRoot");
-                //then check that still only 1 node is returned
-                String sql = "select [jcr:path] from [nt:unstructured] where [jcr:name] = 'testRoot'";
-                Query query = session.getWorkspace().getQueryManager().createQuery(sql, Query.JCR_SQL2);
-                ValidateQuery.validateQuery().rowCount(1).useIndex("nodesByName").validate(query, query.execute());
-                return null;
-            }
+        startRunStop(repository -> {
+            JcrSession session = repository.login();
+            // force a re-index of the entire workspace - this should clear the existing indexes first
+            session.getWorkspace().reindex();
+            // then force a reindex of a certain path 
+            session.getWorkspace().reindex("/testRoot");
+            //then check that still only 1 node is returned
+            String sql = "select [jcr:path] from [nt:unstructured] where [jcr:name] = 'testRoot'";
+            Query query = session.getWorkspace().getQueryManager().createQuery(sql, Query.JCR_SQL2);
+            ValidateQuery.validateQuery().rowCount(1).useIndex("nodesByName").validate(query, query.execute());
         }, "config/repo-config-persistent-local-indexes.json");
     }
 

--- a/modeshape-jcr/src/test/java/org/modeshape/jcr/JcrRepositoryTest.java
+++ b/modeshape-jcr/src/test/java/org/modeshape/jcr/JcrRepositoryTest.java
@@ -1374,7 +1374,6 @@ public class JcrRepositoryTest {
                                                                       "Deprecated config");
         repository = new JcrRepository(config);
         Problems problems = repository.getStartupProblems();
-        assertEquals("Expected 2 startup warnings:" + problems.toString(), 1, problems.warningCount());
         assertEquals("Expected 2 startup errors: " + problems.toString(), 2, problems.errorCount());
     }
 
@@ -1387,10 +1386,10 @@ public class JcrRepositoryTest {
                                                                       "Deprecated config");
         repository = new JcrRepository(config);
         Problems problems = repository.getStartupProblems();
-        assertEquals("Invalid startup problems:" + problems.toString(), 3, problems.size());
+        assertEquals("Invalid startup problems:" + problems.toString(), 2, problems.size());
         repository.shutdown().get();
         problems = repository.getStartupProblems();
-        assertEquals("Invalid startup problems:" + problems.toString(), 3, problems.size());
+        assertEquals("Invalid startup problems:" + problems.toString(), 2, problems.size());
     }
 
     @FixFor( "MODE-2033" )
@@ -1404,7 +1403,6 @@ public class JcrRepositoryTest {
         repository = new JcrRepository(config);
         repository.start();
         Problems problems = repository.getStartupProblems();
-        assertEquals("Expected 2 startup warnings:" + problems.toString(), 1, problems.warningCount());
         assertEquals("Expected 2 startup errors: " + problems.toString(), 2, problems.errorCount());
     }
 

--- a/modeshape-jcr/src/test/java/org/modeshape/jcr/JcrTckTest.java
+++ b/modeshape-jcr/src/test/java/org/modeshape/jcr/JcrTckTest.java
@@ -32,7 +32,7 @@ public class JcrTckTest {
      * @return a new instance of {@link TestSuite} which contains the exact same tests as {@link org.apache.jackrabbit.test.JCRTestSuite}.
      */
     public static Test suite() {
-        FileUtil.delete("target/journal");
+        FileUtil.delete("target/tck_journal");
         return JcrTckSuites.defaultSuiteInline();
     }
 }

--- a/modeshape-jcr/src/test/java/org/modeshape/jcr/RepositoryBackupAndRestoreTest.java
+++ b/modeshape-jcr/src/test/java/org/modeshape/jcr/RepositoryBackupAndRestoreTest.java
@@ -107,7 +107,7 @@ public class RepositoryBackupAndRestoreTest extends SingleUseAbstractTest {
         assertNoProblems(problems);
 
         // shutdown the repo and remove all repo data (stored on disk)
-        repository().doShutdown();
+        repository().doShutdown(false);
         assertTrue(FileUtil.delete("target/backupArea/backRepo/binaries"));
         assertTrue(FileUtil.delete("target/backupArea/backRepo/store"));
 
@@ -160,7 +160,7 @@ public class RepositoryBackupAndRestoreTest extends SingleUseAbstractTest {
         assertNoProblems(problems);
 
         // shutdown the repo and remove just the repo main store (not the binary store)
-        repository().doShutdown();
+        repository().doShutdown(false);
         assertTrue(FileUtil.delete("target/backupArea/backRepo/store"));
 
         // start a fresh empty repo and then restore just the data without binaries

--- a/modeshape-jcr/src/test/java/org/modeshape/jcr/RepositoryConfigurationTest.java
+++ b/modeshape-jcr/src/test/java/org/modeshape/jcr/RepositoryConfigurationTest.java
@@ -34,7 +34,6 @@ import org.modeshape.jcr.RepositoryConfiguration.FieldName;
 import org.modeshape.jcr.RepositoryConfiguration.Indexes;
 import org.modeshape.jcr.RepositoryConfiguration.JaasSecurity;
 import org.modeshape.jcr.RepositoryConfiguration.Security;
-import org.modeshape.jcr.RepositoryConfiguration.TransactionMode;
 import org.modeshape.jcr.api.index.IndexDefinition;
 import org.modeshape.jcr.api.index.IndexDefinition.IndexKind;
 
@@ -107,14 +106,12 @@ public class RepositoryConfigurationTest {
 
     @Test
     public void shouldSuccessfullyValidateSampleRepositoryConfiguration() {
-        RepositoryConfiguration config = assertHasWarnings(0, "sample-repo-config.json");
-        assertThat(config.getTransactionMode(), is(TransactionMode.AUTO));
+        assertHasWarnings(0, "sample-repo-config.json");
     }
 
     @Test
     public void shouldSuccessfullyValidateSampleRepositoryConfiguration2() {
-        RepositoryConfiguration config = assertValid("config/sample-repo-config.json");
-        assertThat(config.getTransactionMode(), is(TransactionMode.NONE));
+        assertValid("config/sample-repo-config.json");
     }
 
     @Test

--- a/modeshape-jcr/src/test/java/org/modeshape/jcr/TransactionsTest.java
+++ b/modeshape-jcr/src/test/java/org/modeshape/jcr/TransactionsTest.java
@@ -353,11 +353,14 @@ public class TransactionsTest extends SingleUseAbstractTest {
             results.add(result);
         }
 
-        for (Future<Void> result : results) {
-            result.get(10, TimeUnit.SECONDS);
-            result.cancel(true);
+        try {
+            for (Future<Void> result : results) {
+                result.get(10, TimeUnit.SECONDS);
+                result.cancel(true);
+            }
+        } finally {
+            executorService.shutdownNow();
         }
-        executorService.shutdown();
     }
 
     @Test
@@ -387,14 +390,17 @@ public class TransactionsTest extends SingleUseAbstractTest {
             results.add(result);
         }
 
-        for (Future<Void> result : results) {
-            result.get(10, TimeUnit.SECONDS);
+        try {
+            for (Future<Void> result : results) {
+                result.get(10, TimeUnit.SECONDS);
+            }
+            Session session = repository.login();
+            // don't count jcr:system
+            assertEquals(threadsCount, session.getNode("/").getNodes().getSize() - 1);
+            session.logout();
+        } finally {
+            executorService.shutdownNow();
         }
-        executorService.shutdown();
-        Session session = repository.login();
-        // don't count jcr:system
-        assertEquals(threadsCount, session.getNode("/").getNodes().getSize() - 1);
-        session.logout();
     }
 
     @FixFor( "MODE-2371" )
@@ -449,23 +455,24 @@ public class TransactionsTest extends SingleUseAbstractTest {
         node2 = mainSession.getNode("/node2");
         
         ExecutorService executorService = Executors.newFixedThreadPool(1);
-        Future<Void> updaterResult = executorService.submit(new Callable<Void>() {
-            @Override
-            public Void call() throws Exception {
+        try {
+            Future<Void> updaterResult = executorService.submit((Callable<Void>) () -> {
                 JcrSession updater = repository.login();
                 startTransaction();
-                AbstractJcrNode node2 = updater.getNode("/node2");
-                node2.setProperty("prop", "bar");
+                AbstractJcrNode node21 = updater.getNode("/node2");
+                node21.setProperty("prop", "bar");
                 updater.save();
                 commitTransaction();
                 updater.logout();
                 return null;
-            }
-        });
-        updaterResult.get();
-        node2 = mainSession.getNode("/node2");
-        assertEquals("bar", node2.getProperty("prop").getString());
-        mainSession.logout();
+            });
+            updaterResult.get();
+            node2 = mainSession.getNode("/node2");
+            assertEquals("bar", node2.getProperty("prop").getString());
+            mainSession.logout();
+        } finally {
+            executorService.shutdownNow();
+        }
     }
 
     @Test

--- a/modeshape-jcr/src/test/java/org/modeshape/jcr/bus/ClusteredChangeBusTest.java
+++ b/modeshape-jcr/src/test/java/org/modeshape/jcr/bus/ClusteredChangeBusTest.java
@@ -20,6 +20,7 @@ import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -35,6 +36,7 @@ import org.modeshape.jcr.clustering.ClusteringService;
  */
 public class ClusteredChangeBusTest extends AbstractChangeBusTest {
 
+    private ExecutorService executorService = Executors.newCachedThreadPool();
     private List<ChangeBus> buses = new ArrayList<>();
     private List<ClusteringService> clusteringServices = new ArrayList<>();
 
@@ -61,6 +63,7 @@ public class ClusteredChangeBusTest extends AbstractChangeBusTest {
         for (ClusteringService clusteringService : clusteringServices) {
             clusteringService.shutdown();
         }
+        executorService.shutdownNow();
     }
 
     @Test
@@ -295,7 +298,7 @@ public class ClusteredChangeBusTest extends AbstractChangeBusTest {
         ClusteringService clusteringService = ClusteringService.startStandalone("test-bus-process",
                                                                                 "config/cluster/jgroups-test-config.xml");
         clusteringServices.add(clusteringService);
-        ChangeBus internalBus = new RepositoryChangeBus("repo", Executors.newCachedThreadPool());
+        ChangeBus internalBus = new RepositoryChangeBus("repo", executorService);
         ClusteredChangeBus bus = new ClusteredChangeBus(internalBus, clusteringService);
         bus.start();
         buses.add(bus);

--- a/modeshape-jcr/src/test/java/org/modeshape/jcr/journal/LocalJournalTest.java
+++ b/modeshape-jcr/src/test/java/org/modeshape/jcr/journal/LocalJournalTest.java
@@ -53,8 +53,8 @@ public class LocalJournalTest {
 
     @Before
     public void before() throws Exception {
-        FileUtil.delete("target/journal");
-        this.journal = new LocalJournal("target/journal");
+        FileUtil.delete("target/local_journal");
+        this.journal = new LocalJournal("target/local_journal");
         journal.start();
         insertTestRecords();
     }

--- a/modeshape-jcr/src/test/java/org/modeshape/jcr/txn/DefaultTransactionManagerLookupTest.java
+++ b/modeshape-jcr/src/test/java/org/modeshape/jcr/txn/DefaultTransactionManagerLookupTest.java
@@ -1,0 +1,51 @@
+/*
+ * ModeShape (http://www.modeshape.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.modeshape.jcr.txn;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import javax.transaction.Transaction;
+import javax.transaction.TransactionManager;
+import org.junit.Before;
+import org.junit.Test;
+import org.modeshape.jcr.api.txn.TransactionManagerLookup;
+
+/**
+ * Unit test for {@link DefaultTransactionManagerLookup}
+ * 
+ * @author Horia Chiorean (hchiorea@redhat.com)
+ */
+public class DefaultTransactionManagerLookupTest {
+    
+    private TransactionManagerLookup txLookup;
+
+    @Before
+    public void setup() {
+        txLookup = new DefaultTransactionManagerLookup();    
+    }
+    
+    @Test
+    public void shouldDetectJBossJTAStandaloneJTAManager() throws Exception {
+        //JBoss JTA (Narayana) is used by default with the 'test' scope, so just test that the lookup picks this up by default
+        TransactionManager transactionManager = txLookup.getTransactionManager();
+        assertNotNull(transactionManager);
+        assertTrue(transactionManager.getClass().getName().contains("arjuna"));
+        transactionManager.begin();
+        Transaction tx = transactionManager.getTransaction();
+        assertNotNull(tx);
+        tx.commit();
+    }
+}

--- a/modeshape-jcr/src/test/java/org/modeshape/jcr/txn/LocalTransactionManagerTest.java
+++ b/modeshape-jcr/src/test/java/org/modeshape/jcr/txn/LocalTransactionManagerTest.java
@@ -1,0 +1,197 @@
+/*
+ * ModeShape (http://www.modeshape.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.modeshape.jcr.txn;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicBoolean;
+import javax.transaction.NotSupportedException;
+import javax.transaction.RollbackException;
+import javax.transaction.Status;
+import javax.transaction.Synchronization;
+import javax.transaction.Transaction;
+import org.junit.Test;
+
+/**
+ * Unit test for {@link LocalTransactionManagerTest}
+ * 
+ * @author Horia Chiorean (hchiorea@redhat.com)
+ */
+public class LocalTransactionManagerTest {
+    
+    private final LocalTransactionManager txManager = new LocalTransactionManager();
+    private final TestSynchronization sync = new TestSynchronization();
+    
+    @Test
+    public void shouldCreateNewTransactions() throws Exception {
+        assertEquals(Status.STATUS_NO_TRANSACTION, txManager.getStatus());
+        txManager.begin();
+        Transaction tx = txManager.getTransaction();
+        assertNotNull(tx);
+        assertEquals(Status.STATUS_ACTIVE, tx.getStatus());
+        tx.commit();
+    }
+    
+    @Test(expected = NotSupportedException.class)
+    public void shouldNotSupportNestedTransactions() throws Exception {
+        try {
+            txManager.begin();
+            txManager.begin();
+        } finally {
+            LocalTransactionManager.clear();
+        }
+    }
+    
+    @Test
+    public void shouldCommitTransaction() throws Exception {
+        txManager.begin();
+        Transaction tx = txManager.getTransaction();
+        assertEquals(Status.STATUS_ACTIVE, tx.getStatus());
+        assertEquals(Status.STATUS_ACTIVE, txManager.getStatus());
+        tx.registerSynchronization(sync);
+        txManager.commit();
+        sync.assertBeforeCompletion(true);
+        sync.assertAfterCompletion(true);
+        sync.assertAfterCompletionStatus(Status.STATUS_COMMITTED);
+        assertNull(txManager.getTransaction());
+    }
+    
+    @Test
+    public void shouldRollbackTransaction() throws Exception {
+        txManager.begin();
+        Transaction tx = txManager.getTransaction();
+        tx.registerSynchronization(sync);
+        txManager.rollback();
+        sync.assertBeforeCompletion(true);
+        sync.assertAfterCompletion(true);
+        sync.assertAfterCompletionStatus(Status.STATUS_ROLLEDBACK);
+        assertNull(txManager.getTransaction());
+    }
+    
+    @Test
+    public void shouldSupportRollbackOnlyTransactionsWithCommit() throws Exception {
+        txManager.begin();
+        Transaction tx = txManager.getTransaction();
+        tx.registerSynchronization(sync);
+        txManager.setRollbackOnly();
+        try {
+            tx.commit();
+            fail("Expected Rollback Exception");
+        } catch (RollbackException e) {
+            //expected
+        }
+        sync.assertBeforeCompletion(true);
+        sync.assertAfterCompletion(true);
+        sync.assertAfterCompletionStatus(Status.STATUS_ROLLEDBACK);
+        assertNull(txManager.getTransaction());
+    }
+
+    @Test
+    public void shouldSupportRollbackOnlyTransactionsWithRollback() throws Exception {
+        txManager.begin();
+        Transaction tx = txManager.getTransaction();
+        tx.registerSynchronization(sync);
+        txManager.setRollbackOnly();
+        tx.rollback();
+        sync.assertBeforeCompletion(true);
+        sync.assertAfterCompletion(true);
+        sync.assertAfterCompletionStatus(Status.STATUS_ROLLEDBACK);
+        assertNull(txManager.getTransaction());
+    }
+    
+    @Test
+    public void shouldSuspendAndResumeTransaction() throws Exception {
+        txManager.begin();
+        Transaction tx = txManager.suspend();
+        assertNotNull(tx);
+        assertEquals(Status.STATUS_NO_TRANSACTION, txManager.getStatus());
+        assertNull(txManager.getTransaction());
+        txManager.resume(tx);
+        assertEquals(Status.STATUS_ACTIVE, txManager.getStatus());
+        tx.commit();
+        assertNull(txManager.getTransaction());
+    }
+    
+    @Test
+    public void shouldConfineTransactionToThread() throws Exception {
+        txManager.begin();
+        Transaction tx = txManager.getTransaction();
+        tx.registerSynchronization(sync);
+        ExecutorService executorService = Executors.newSingleThreadExecutor();
+        try {
+            Callable<Void> task =  () -> {
+                try {
+                    tx.commit();
+                    fail("Should not allow committing off another thread");
+                } catch (IllegalStateException e) {
+                    //expected
+                }
+                txManager.begin();
+                TestSynchronization sync = new TestSynchronization();
+                txManager.getTransaction().registerSynchronization(sync);
+                txManager.commit();
+                sync.assertBeforeCompletion(true);
+                sync.assertAfterCompletion(true);
+                sync.assertAfterCompletionStatus(Status.STATUS_COMMITTED);
+                return null;
+            };
+            executorService.submit(task).get();
+            txManager.commit();
+            sync.assertBeforeCompletion(true);
+            sync.assertAfterCompletion(true);
+            sync.assertAfterCompletionStatus(Status.STATUS_COMMITTED);
+            assertNull(txManager.getTransaction());
+        } finally {
+            executorService.shutdown();
+        }
+    }
+
+    protected static class TestSynchronization implements Synchronization  {
+        private AtomicBoolean beforeCompletion = new AtomicBoolean();
+        private AtomicBoolean afterCompletion = new AtomicBoolean();
+        private int afterCompletionStatus = -1;
+        
+        @Override
+        public void beforeCompletion() {
+            beforeCompletion.compareAndSet(false, true);            
+        }
+
+        @Override
+        public void afterCompletion(int status) {
+            afterCompletion.compareAndSet(false, true);
+            afterCompletionStatus = status;
+        }
+        
+        protected void assertBeforeCompletion(boolean called) {   
+            assertThat("beforeCompletion invocation failed", called, is(beforeCompletion.get()));
+        }
+
+        protected void assertAfterCompletion(boolean called) {
+            assertThat("afterCompletion invocation failed", called, is(afterCompletion.get()));
+        }
+        
+        protected void assertAfterCompletionStatus(int status) {
+            assertThat("afterCompletion status is invalid", status, is(this.afterCompletionStatus));    
+        }
+    }
+}

--- a/modeshape-jcr/src/test/java/org/modeshape/jcr/value/binary/infinispan/InfinispanDistBinaryStoreTest.java
+++ b/modeshape-jcr/src/test/java/org/modeshape/jcr/value/binary/infinispan/InfinispanDistBinaryStoreTest.java
@@ -22,7 +22,9 @@ import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.transaction.LockingMode;
 import org.infinispan.transaction.TransactionMode;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 
+@Ignore("remove in 5")
 public class InfinispanDistBinaryStoreTest extends AbstractInfinispanStoreTest {
 
     @BeforeClass

--- a/modeshape-jcr/src/test/java/org/modeshape/jcr/value/binary/infinispan/InfinispanReplBinaryStoreTest.java
+++ b/modeshape-jcr/src/test/java/org/modeshape/jcr/value/binary/infinispan/InfinispanReplBinaryStoreTest.java
@@ -22,7 +22,9 @@ import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.transaction.LockingMode;
 import org.infinispan.transaction.TransactionMode;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 
+@Ignore("remove in 5")
 public class InfinispanReplBinaryStoreTest extends AbstractInfinispanStoreTest {
 
     @BeforeClass

--- a/modeshape-jcr/src/test/resources/config/invalid-old-style-sequencers-config.json
+++ b/modeshape-jcr/src/test/resources/config/invalid-old-style-sequencers-config.json
@@ -1,6 +1,5 @@
 {
     "name" : "Thorough",
-    "transactionMode" : "auto",
     "monitoring" : {
         "enabled" : true,
     },

--- a/modeshape-jcr/src/test/resources/config/repo-config-initial-content-children-order.json
+++ b/modeshape-jcr/src/test/resources/config/repo-config-initial-content-children-order.json
@@ -1,6 +1,5 @@
 {
     "name" : "Repository with initial content",
-    "transactionMode" : "none",
     "workspaces" : {
         "default" : "default",
         "allowCreation" : true,

--- a/modeshape-jcr/src/test/resources/config/repo-config-initial-content-transaction-mode-none.json
+++ b/modeshape-jcr/src/test/resources/config/repo-config-initial-content-transaction-mode-none.json
@@ -1,6 +1,5 @@
 {
     "name" : "Repository with initial content",
-    "transactionMode" : "none",
     "workspaces" : {
         "default" : "default",
         "allowCreation" : true,

--- a/modeshape-jcr/src/test/resources/config/repo-config-inmemory-local-environment-no-client-tx.json
+++ b/modeshape-jcr/src/test/resources/config/repo-config-inmemory-local-environment-no-client-tx.json
@@ -1,6 +1,5 @@
 {
     "name" : "No Client Tx Repository",
-    "transactionMode" : "none",
     "storage" : {
         "cacheName" : "inmemoryRepository"
     },

--- a/modeshape-jcr/src/test/resources/config/repo-config-inmemory-local-environment-no-monitoring.json
+++ b/modeshape-jcr/src/test/resources/config/repo-config-inmemory-local-environment-no-monitoring.json
@@ -1,6 +1,5 @@
 {
     "name" : "No Monitoring Repository",
-    "transactionMode" : "none",
     "monitoring" : {
         "enabled" : false
     },

--- a/modeshape-jcr/src/test/resources/config/repo-config-observation.json
+++ b/modeshape-jcr/src/test/resources/config/repo-config-observation.json
@@ -18,7 +18,7 @@
         ]
     },
     "journaling": {
-        "location": "target/journal",
+        "location": "target/obs_journal",
         "asyncWritesEnabled": false
     }
 }

--- a/modeshape-jcr/src/test/resources/config/repo-config-with-startup-problems.json
+++ b/modeshape-jcr/src/test/resources/config/repo-config-with-startup-problems.json
@@ -1,7 +1,6 @@
 {
     "name" : "Test Repository",
     "jndiName" : "",
-    "transactionMode" : "none",
     "monitoring" : {
         "enabled" : true
     },
@@ -9,9 +8,6 @@
         "predefined" : ["otherWorkspace"],
         "default" : "default",
         "allowCreation" : true
-    },
-    "storage" : {
-        "transactionManagerLookup" : "org.infinispan.transaction.lookup.DummyTransactionManagerLookup"
     },
     "security" : {
         "anonymous" : {

--- a/modeshape-jcr/src/test/resources/config/sample-repo-config.json
+++ b/modeshape-jcr/src/test/resources/config/sample-repo-config.json
@@ -1,6 +1,5 @@
 {
     "name" : "Test Repository",
-    "transactionMode" : "none",
     "workspaces" : {
         "predefined" : ["otherWorkspace"],
         "default" : "default",

--- a/modeshape-jcr/src/test/resources/config/thorough-repo-config.json
+++ b/modeshape-jcr/src/test/resources/config/thorough-repo-config.json
@@ -1,6 +1,5 @@
 {
     "name" : "Thorough",
-    "transactionMode" : "auto",
     "monitoring" : {
         "enabled" : true,
     },
@@ -19,6 +18,10 @@
     "storage" : {
         "cacheName" : "Thorough",
         "cacheConfiguration" : "infinispan_configuration.xml",
+        "transactionManagerLookup" : {
+            "name" : "org.modeshape.jcr.txn.DefaultTransactionManagerLookup",
+            "classloader" : "some_path"
+        },
         "binaryStorage" : {
             "type" : "file",
             "directory" : "Thorough/binaries",    

--- a/modeshape-jcr/src/test/resources/config/thorough-with-desc-repo-config.json
+++ b/modeshape-jcr/src/test/resources/config/thorough-with-desc-repo-config.json
@@ -1,6 +1,5 @@
 {
     "name" : "Thorough",
-    "transactionMode" : "auto",
     "description" : "This is a sample configuration that defines options with their defaults.",
     "monitoring" : {
         "enabled" : true,

--- a/modeshape-jcr/src/test/resources/load/concurrent-load-repo-config.json
+++ b/modeshape-jcr/src/test/resources/load/concurrent-load-repo-config.json
@@ -1,7 +1,6 @@
 {
     "name" : "config",
     "jndiName" : "",
-    "transactionMode" : "none",
     "workspaces" : {
         "default" : "load",
         "predefined" : ["load"],

--- a/modeshape-jcr/src/test/resources/tck/default/repo-config.json
+++ b/modeshape-jcr/src/test/resources/tck/default/repo-config.json
@@ -6,7 +6,7 @@
         "allowCreation" : true
     },
     "journaling": {
-        "location": "target/journal",
+        "location": "target/tck_journal",
         "asyncWritesEnabled": false
     },
     "security" : {

--- a/modeshape-parent/pom.xml
+++ b/modeshape-parent/pom.xml
@@ -157,7 +157,8 @@
         <version.org.jboss.jbossts.jta>5.1.0.Final</version.org.jboss.jbossts.jta>
         <version.com.atomikos>3.8.0</version.com.atomikos>
         <version.org.picketbox>4.0.21.Final</version.org.picketbox>
-        
+
+        <version.org.jboss.spec.javax.transaction.jboss-transaction-api_1.1_spec>1.0.1.Final</version.org.jboss.spec.javax.transaction.jboss-transaction-api_1.1_spec>
         <version.com.googlecode.concurrentlinkedhashmap>1.4.2</version.com.googlecode.concurrentlinkedhashmap>
         <version.org.infinispan>7.2.4.Final</version.org.infinispan>
         <infinispan.module.slot>ispn-7.2</infinispan.module.slot>
@@ -247,7 +248,6 @@
         <!-- Make sure the version of the bundle plugin is at least this, otherwise it will fork like crazy...-->
         <version.bundle.plugin>3.0.0</version.bundle.plugin>
         <version.gwt.maven.plugin>2.5.1</version.gwt.maven.plugin>
-
         <!--The name of the modeshape-client artifact used by tools-->
         <client.artifactId>modeshape-client</client.artifactId>
 
@@ -792,6 +792,7 @@
             </plugin>
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
+                <version>${version.surefire.plugin}</version>
                 <!-- Manually specify the JUnit provider; see MODE-1140 -->
                 <dependencies>
                     <dependency>
@@ -824,6 +825,7 @@
                     <argLine>-Xmx1524M ${debug.argline} -Xss1024k -Djava.awt.headless=true</argLine>
                     <runOrder>alphabetical</runOrder>
                     <useFile>false</useFile>
+                    <trimStackTrace>false</trimStackTrace>
                 </configuration>
             </plugin>
 
@@ -1200,6 +1202,12 @@
                 <groupId>com.googlecode.concurrentlinkedhashmap</groupId>
                 <artifactId>concurrentlinkedhashmap-lru</artifactId>
                 <version>${version.com.googlecode.concurrentlinkedhashmap}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.jboss.spec.javax.transaction</groupId>
+                <artifactId>jboss-transaction-api_1.1_spec</artifactId>
+                <version>${version.org.jboss.spec.javax.transaction.jboss-transaction-api_1.1_spec}</version>
             </dependency>
             <!--
                 Infinispan

--- a/modeshape-schematic/src/test/resources/json/sample-repo-config.json
+++ b/modeshape-schematic/src/test/resources/json/sample-repo-config.json
@@ -1,6 +1,5 @@
 {
     "name" : "Thorough",
-    "transactionMode" : "auto",
     "monitoring" : {
         "enabled" : true,
     },

--- a/modeshape-schematic/src/test/resources/json/schema/repository-config-schema.json
+++ b/modeshape-schematic/src/test/resources/json/schema/repository-config-schema.json
@@ -18,11 +18,6 @@
             "type" : "string",
             "description" : "The name in JNDI where this repository is to be registered. If not specified, the location is assumed to be 'java:jcr/local/<name>', where '<name>' is the repository name. Setting this field to an empty string signals that the repository should not be registered in JNDI."
         },
-        "transactionMode" : {
-            "type" : "string",
-            "description" : "Whether the repository should expect and detect whether JCR clients modify the content within transactions. The default value of 'auto' will automatically detect the use of both user- and container-managed transactions and also works when the JCR client does not use transactions; this will work in most situations. The value of 'none' specifies that the repository should not attempt to detect existing transactions; this setting is an optimization that should be used *only* if JCR clients will never use transactions to change the repository content.",
-            "enum" : [ "auto", "none" ]
-        },
         "monitoring" : {
             "type" : "object",
             "description" : "The specification for the monitoring system for the repositories.",


### PR DESCRIPTION
- `MODE-2536` is required because in the absence of ISPN, ModeShape will have to be able to support both local and user transactions, regardless of the environment it's being run in. This commit also removes the `transactionMode` configuration option, as ModeShape should be able to auto-detect if it's being run or not in the context of a user transaction.
- `MODE-2537` fixes the improper shutdown of certain thread pools in the case of a repository crash