### PR TITLE
MODE-2518: Attach binary content jcr:content

### DIFF
--- a/web/modeshape-web-explorer/src/main/java/org/modeshape/web/server/JcrServiceImpl.java
+++ b/web/modeshape-web-explorer/src/main/java/org/modeshape/web/server/JcrServiceImpl.java
@@ -352,15 +352,16 @@ public class JcrServiceImpl extends RemoteServiceServlet implements JcrService {
             String name = def.getName();
             String type = PropertyType.nameFromValue(def.getRequiredType());
             
-            Property p;
+            Property p = null;
             try {
                 p = node.getProperty(def.getName());
-                String display = values(def, p);
-                String value = p.isMultiple() ? multiValue(p)
-                        : singleValue(p, def, repository, workspace, path);
-                list.add(new JcrProperty(name, type, value, display));
             } catch (PathNotFoundException e) {
             }
+
+            String display = values(def, p);
+            String value = def.isMultiple() ? multiValue(p)
+                    : singleValue(p, def, repository, workspace, path);
+            list.add(new JcrProperty(name, type, value, display));
             
         }
         return list;
@@ -380,6 +381,10 @@ public class JcrServiceImpl extends RemoteServiceServlet implements JcrService {
     }
     
     private String multiValue(Property p) throws RepositoryException {
+        if (p == null) {
+            return "";
+        }
+        
         Value[] values = p.getValues();
 
         if (values == null || values.length == 0) {

--- a/web/modeshape-web-explorer/src/main/java/org/modeshape/web/server/impl/ConnectorImpl.java
+++ b/web/modeshape-web-explorer/src/main/java/org/modeshape/web/server/impl/ConnectorImpl.java
@@ -52,7 +52,7 @@ public class ConnectorImpl implements Connector {
     private transient String userName;
     
     private transient ModeShapeEngine engine;
-    private RepositoryList repoList;
+    private transient RepositoryList repoList;
     
     //reference to the server's env
     private transient ServletContext context;


### PR DESCRIPTION
This PR fixes bug when property with null value (ie just created node) is not displayed by property editor.