### PR TITLE
MODE-2555 Adds the support of expressions to the <node-types/> WF configuration element

### DIFF
--- a/deploy/jbossas/modeshape-jbossas-subsystem/src/main/java/org/modeshape/jboss/subsystem/Attribute.java
+++ b/deploy/jbossas/modeshape-jbossas-subsystem/src/main/java/org/modeshape/jboss/subsystem/Attribute.java
@@ -35,6 +35,7 @@ public enum Attribute {
     CONFIG_RELATIVE_TO("config-relative-to"),
     CACHE_NAME("cache-name"),
     CLASSNAME("classname"),
+    REPOSITORY_MODULE_DEPENDENCIES("depends-on"),
     DATA_CACHE_NAME("data-cache-name"),
     DATA_SOURCE_JNDI_NAME("data-source-jndi-name"),
     DEFAULT_WORKSPACE("default-workspace"),

--- a/deploy/jbossas/modeshape-jbossas-subsystem/src/main/java/org/modeshape/jboss/subsystem/ModeShapeSubsystemXMLReader_2_1.java
+++ b/deploy/jbossas/modeshape-jbossas-subsystem/src/main/java/org/modeshape/jboss/subsystem/ModeShapeSubsystemXMLReader_2_1.java
@@ -194,6 +194,9 @@ public class ModeShapeSubsystemXMLReader_2_1 implements XMLStreamConstants, XMLE
                     case EVENT_BUS_SIZE: 
                         ModelAttributes.EVENT_BUS_SIZE.parseAndSetParameter(attrValue, repository, reader);
                         break;
+                    case REPOSITORY_MODULE_DEPENDENCIES:
+                        ModelAttributes.REPOSITORY_MODULE_DEPENDENCIES.parseAndSetParameter(attrValue, repository, reader);
+                        break;
                     default:
                         throw ParseUtils.unexpectedAttribute(reader, i);
                 }

--- a/deploy/jbossas/modeshape-jbossas-subsystem/src/main/java/org/modeshape/jboss/subsystem/ModeShapeSubsystemXMLWriter.java
+++ b/deploy/jbossas/modeshape-jbossas-subsystem/src/main/java/org/modeshape/jboss/subsystem/ModeShapeSubsystemXMLWriter.java
@@ -94,6 +94,7 @@ public class ModeShapeSubsystemXMLWriter implements XMLStreamConstants, XMLEleme
         ModelAttributes.DOCUMENT_OPTIMIZATION_CHILD_COUNT_TARGET.marshallAsAttribute(repository, false, writer);
         ModelAttributes.DOCUMENT_OPTIMIZATION_CHILD_COUNT_TOLERANCE.marshallAsAttribute(repository, false, writer);
         ModelAttributes.EVENT_BUS_SIZE.marshallAsAttribute(repository, false, writer);
+        ModelAttributes.REPOSITORY_MODULE_DEPENDENCIES.marshallAsAttribute(repository, false, writer);
 
         // Nested elements ...
         writeNodeTypes(writer, repository);

--- a/deploy/jbossas/modeshape-jbossas-subsystem/src/main/java/org/modeshape/jboss/subsystem/ModelAttributes.java
+++ b/deploy/jbossas/modeshape-jbossas-subsystem/src/main/java/org/modeshape/jboss/subsystem/ModelAttributes.java
@@ -45,8 +45,8 @@ public class ModelAttributes {
                                                                                          ModeShapeRoles.READWRITE);
     private static final ParameterValidator WORKSPACE_NAME_VALIDATOR = new ModelTypeValidator(ModelType.STRING, false, false,
                                                                                               true);
-    private static final ParameterValidator NODE_TYPE_VALIDATOR = new ModelTypeValidator(ModelType.STRING, false, false, true);
-    private static final ParameterValidator INITIAL_CONTENT_VALIDATOR = new ModelTypeValidator(ModelType.PROPERTY, false, false,
+    private static final ParameterValidator NODE_TYPE_VALIDATOR = new ModelTypeValidator(ModelType.STRING, false, true, true);
+    private static final ParameterValidator INITIAL_CONTENT_VALIDATOR = new ModelTypeValidator(ModelType.PROPERTY, false, true,
                                                                                                true);
     private static final ParameterValidator DEFAULT_INITIAL_CONTENT_VALIDATOR = new ModelTypeValidator(ModelType.STRING, true,
                                                                                                        false, true);
@@ -193,6 +193,14 @@ public class ModelAttributes {
                                                                                                                             true)
                                                                                                                     .setFlags(
                                                                                                                             AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
+                                                                                                                    .build();
+    
+    public static final SimpleAttributeDefinition REPOSITORY_MODULE_DEPENDENCIES = new MappedAttributeDefinitionBuilder(ModelKeys.REPOSITORY_MODULE_DEPENDENCIES,
+                                                                                                                        ModelType.STRING).setXmlName(Attribute.REPOSITORY_MODULE_DEPENDENCIES.getLocalName())
+                                                                                                                    .setAllowExpression(false)
+                                                                                                                    .setAllowNull(
+                                                                                                                            true)
+                                                                                                                    .setFlags(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
                                                                                                                     .build();
 
     public static final SimpleAttributeDefinition DATA_CACHE_NAME = new MappedAttributeDefinitionBuilder(
@@ -653,7 +661,7 @@ public class ModelAttributes {
 
     public static final SimpleAttributeDefinition DEFAULT_INITIAL_CONTENT = new MappedAttributeDefinitionBuilder(
                                                                                                                  ModelKeys.DEFAULT_INITIAL_CONTENT,
-                                                                                                                 ModelType.STRING).setAllowExpression(false)
+                                                                                                                 ModelType.STRING).setAllowExpression(true)
                                                                                                                                   .setAllowNull(true)
                                                                                                                                   .setValidator(DEFAULT_INITIAL_CONTENT_VALIDATOR)
                                                                                                                                   .setFlags(AttributeAccess.Flag.RESTART_NONE)
@@ -890,15 +898,17 @@ public class ModelAttributes {
 
     public static final AttributeDefinition[] WEBAPP_ATTRIBUTES = {EXPLODED};
 
-    public static final AttributeDefinition[] REPOSITORY_ATTRIBUTES = {CACHE_NAME, CACHE_CONFIG, CONFIG_RELATIVE_TO, JNDI_NAME, ENABLE_MONITORING,
-        SECURITY_DOMAIN, ANONYMOUS_ROLES, ANONYMOUS_USERNAME, USE_ANONYMOUS_IF_AUTH_FAILED, NODE_TYPES, DEFAULT_WORKSPACE,
-        PREDEFINED_WORKSPACE_NAMES, ALLOW_WORKSPACE_CREATION, WORKSPACES_CACHE_CONTAINER, DEFAULT_INITIAL_CONTENT,
-        WORKSPACES_INITIAL_CONTENT, GARBAGE_COLLECTION_THREAD_POOL,
-        GARBAGE_COLLECTION_INITIAL_TIME, GARBAGE_COLLECTION_INTERVAL, DOCUMENT_OPTIMIZATION_THREAD_POOL,
-        DOCUMENT_OPTIMIZATION_INITIAL_TIME, DOCUMENT_OPTIMIZATION_INTERVAL, DOCUMENT_OPTIMIZATION_CHILD_COUNT_TARGET,
-        DOCUMENT_OPTIMIZATION_CHILD_COUNT_TOLERANCE, JOURNAL_PATH, JOURNAL_RELATIVE_TO, MAX_DAYS_TO_KEEP_RECORDS,
-        JOURNAL_GC_INITIAL_TIME, JOURNAL_GC_THREAD_POOL, ASYNC_WRITES, JOURNALING, SEQUENCER_THREAD_POOL_NAME, SEQUENCER_MAX_POOL_SIZE, 
-        TEXT_EXTRACTOR_THREAD_POOL_NAME, TEXT_EXTRACTOR_MAX_POOL_SIZE, EVENT_BUS_SIZE, REINDEXING_ASYNC, REINDEXING_MODE};
+    public static final AttributeDefinition[] REPOSITORY_ATTRIBUTES = { CACHE_NAME, CACHE_CONFIG, CONFIG_RELATIVE_TO, JNDI_NAME,
+              ENABLE_MONITORING, REPOSITORY_MODULE_DEPENDENCIES,
+              SECURITY_DOMAIN, ANONYMOUS_ROLES, ANONYMOUS_USERNAME, USE_ANONYMOUS_IF_AUTH_FAILED, NODE_TYPES, DEFAULT_WORKSPACE,
+              PREDEFINED_WORKSPACE_NAMES, ALLOW_WORKSPACE_CREATION, WORKSPACES_CACHE_CONTAINER, DEFAULT_INITIAL_CONTENT,
+              WORKSPACES_INITIAL_CONTENT, GARBAGE_COLLECTION_THREAD_POOL,
+              GARBAGE_COLLECTION_INITIAL_TIME, GARBAGE_COLLECTION_INTERVAL, DOCUMENT_OPTIMIZATION_THREAD_POOL,
+              DOCUMENT_OPTIMIZATION_INITIAL_TIME, DOCUMENT_OPTIMIZATION_INTERVAL, DOCUMENT_OPTIMIZATION_CHILD_COUNT_TARGET,
+              DOCUMENT_OPTIMIZATION_CHILD_COUNT_TOLERANCE, JOURNAL_PATH, JOURNAL_RELATIVE_TO, MAX_DAYS_TO_KEEP_RECORDS,
+              JOURNAL_GC_INITIAL_TIME, JOURNAL_GC_THREAD_POOL, ASYNC_WRITES, JOURNALING, JOURNAL_ENABLED, SEQUENCER_THREAD_POOL_NAME,
+              SEQUENCER_MAX_POOL_SIZE, TEXT_EXTRACTOR_THREAD_POOL_NAME, TEXT_EXTRACTOR_MAX_POOL_SIZE, EVENT_BUS_SIZE, REINDEXING_ASYNC,
+              REINDEXING_MODE };
 
     public static final AttributeDefinition[] TRANSIENT_BINARY_STORAGE_ATTRIBUTES = {MINIMUM_BINARY_SIZE, MINIMUM_STRING_SIZE, 
                                                                                      MIME_TYPE_DETECTION}; 

--- a/deploy/jbossas/modeshape-jbossas-subsystem/src/main/java/org/modeshape/jboss/subsystem/ModelKeys.java
+++ b/deploy/jbossas/modeshape-jbossas-subsystem/src/main/java/org/modeshape/jboss/subsystem/ModelKeys.java
@@ -37,6 +37,7 @@ public class ModelKeys {
     static final String CONFIG_RELATIVE_TO = "config-relative-to";
     static final String CACHE_NAME = "cache-name";
     static final String CLASSNAME = "classname";
+    static final String REPOSITORY_MODULE_DEPENDENCIES = "depends-on";
     static final String DATA_CACHE_NAME = "data-cache-name";
     static final String DATA_SOURCE_JNDI_NAME = "data-source-jndi-name";
     static final String DEFAULT_WORKSPACE = "default-workspace";

--- a/deploy/jbossas/modeshape-jbossas-subsystem/src/main/resources/org/modeshape/jboss/subsystem/LocalDescriptions.properties
+++ b/deploy/jbossas/modeshape-jbossas-subsystem/src/main/resources/org/modeshape/jboss/subsystem/LocalDescriptions.properties
@@ -59,6 +59,7 @@ modeshape.repository.document-optimization-interval = The number of hours betwee
 modeshape.repository.document-optimization-child-count-target = The maximum number of children that are ideally stored in each document/page
 modeshape.repository.document-optimization-child-count-tolerance = The range that the actual number of children in a document/page can vary above the target before the documents are split, or below the target before documents are merged
 modeshape.repository.event-bus-size= The number of slots in the event bus
+modeshape.repository.depends-on= The comma separated list of modules name to be added to the repository classpath when resolving configuration files
 modeshape.repository.security-domain = The name of the security domain used for JAAS authentication and authorization of repository users
 modeshape.repository.anonymous-roles= The roles given to all anonymous users for accessing and changing repository content
 modeshape.repository.anonymous-roles.anonymous-role = The roles given to all anonymous users for accessing and changing repository content

--- a/deploy/jbossas/modeshape-jbossas-subsystem/src/main/resources/schema/modeshape_2_1.xsd
+++ b/deploy/jbossas/modeshape-jbossas-subsystem/src/main/resources/schema/modeshape_2_1.xsd
@@ -328,6 +328,15 @@
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>
+        <xs:attribute name="depends-on" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    A comma-separated list of module names on which the repository depends. These modules, if present in the
+                    configuration,will be added to the classpath whenever the repository attempts to resolve external files like
+                    node type definitions or initial content files
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
     </xs:complexType>
 
     <xs:complexType name="workspaces">

--- a/deploy/jbossas/modeshape-jbossas-subsystem/src/test/java/org/modeshape/jboss/subsystem/ModeShapeConfigurationTest.java
+++ b/deploy/jbossas/modeshape-jbossas-subsystem/src/test/java/org/modeshape/jboss/subsystem/ModeShapeConfigurationTest.java
@@ -175,6 +175,11 @@ public class ModeShapeConfigurationTest extends AbstractSubsystemBaseTest {
     @Test
     public void testOutputPersistenceOfConfigurationWithReindexing() throws Exception {
         parse(readResource("modeshape-reindexing.xml"));
+    }  
+    
+    @Test
+    public void testOutputPersistenceOfConfigurationWithCustomDependencies() throws Exception {
+        parse(readResource("modeshape-repository-dependencies-config.xml"));
     }
 
     @Test

--- a/deploy/jbossas/modeshape-jbossas-subsystem/src/test/resources/org/modeshape/jboss/subsystem/modeshape-initial-content-config.xml
+++ b/deploy/jbossas/modeshape-jbossas-subsystem/src/test/resources/org/modeshape/jboss/subsystem/modeshape-initial-content-config.xml
@@ -1,13 +1,6 @@
 <subsystem xmlns="urn:jboss:domain:modeshape:2.1">
   <repository name="sample"
-              cache-name="sample" 
-              cache-config="modeshape.xml"
-              jndi-name="jcr/local/sample"
-              enable-monitoring="true"
-              security-domain="modeshape-security"
-              anonymous-roles="readonly readwrite admin connect" 
-              anonymous-username="&lt;anonymous&gt;" 
-              use-anonymous-upon-failed-authentication="false">
+              cache-name="sample">
     <workspaces default-workspace="default" allow-workspace-creation="true">
       <workspace name="predefinedWorkspace1">
           <initial-content>file1</initial-content>
@@ -15,7 +8,7 @@
       <workspace name="predefinedWorkspace2">
           <initial-content>file2</initial-content>
       </workspace>
-      <initial-content>default_file</initial-content>
+      <initial-content>${jboss.server.config.dir}/default_file</initial-content>
     </workspaces>
   </repository>
 </subsystem>

--- a/deploy/jbossas/modeshape-jbossas-subsystem/src/test/resources/org/modeshape/jboss/subsystem/modeshape-node-types-config.xml
+++ b/deploy/jbossas/modeshape-jbossas-subsystem/src/test/resources/org/modeshape/jboss/subsystem/modeshape-node-types-config.xml
@@ -1,21 +1,9 @@
 <subsystem xmlns="urn:jboss:domain:modeshape:2.1">
   <repository name="sample"
-              cache-name="sample" 
-              cache-config="modeshape.xml"
-              jndi-name="jcr/local/sample"
-              enable-monitoring="true"
-              security-domain="modeshape-security"
-              anonymous-roles="readonly readwrite admin connect" 
-              anonymous-username="&lt;anonymous&gt;" 
-              use-anonymous-upon-failed-authentication="false">
-      <workspaces default-workspace="default" allow-workspace-creation="true">
-          <workspace name="predefinedWorkspace1" />
-          <workspace name="predefinedWorkspace2" />
-          <workspace name="predefinedWorkspace3" />
-      </workspaces>
+              cache-name="sample">
       <node-types>
           <node-type>file1.cnd</node-type>
-          <node-type>file2.cnd</node-type>
+          <node-type>${jboss.server.config.dir}/file2.cnd</node-type>
       </node-types>
   </repository>
 </subsystem>

--- a/deploy/jbossas/modeshape-jbossas-subsystem/src/test/resources/org/modeshape/jboss/subsystem/modeshape-repository-dependencies-config.xml
+++ b/deploy/jbossas/modeshape-jbossas-subsystem/src/test/resources/org/modeshape/jboss/subsystem/modeshape-repository-dependencies-config.xml
@@ -1,0 +1,21 @@
+<!--
+  ~ ModeShape (http://www.modeshape.org)
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~       http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<subsystem xmlns="urn:jboss:domain:modeshape:2.1">
+  <repository name="sample" depends-on="deployment.webapp.war, org.module"/>
+</subsystem>
+
+
+                            

--- a/integration/modeshape-jbossas-integration-tests/src/main/resources/kit/jboss-wf9/standalone/configuration/standalone-modeshape.xml
+++ b/integration/modeshape-jbossas-integration-tests/src/main/resources/kit/jboss-wf9/standalone/configuration/standalone-modeshape.xml
@@ -531,10 +531,20 @@
                                    username="arquillian"/>
                 </authenticators>
             </repository>
-
             <repository name="reindexingRepository" anonymous-roles="admin" cache-config="modeshape/infinispan-test-caches.xml" cache-name="sample">
                 <reindexing mode="incremental" async="false"/>
                 <journaling max-days-to-keep-records="15" async-writes="false"/>
+            </repository>    
+            <repository name="externalDependenciesRepository" anonymous-roles="admin" cache-config="modeshape/infinispan-test-caches.xml" 
+                        cache-name="sample" depends-on="deployment.external-dependencies.war">
+                <workspaces default-workspace="default" allow-workspace-creation="false">
+                    <workspace name="default">
+                        <initial-content>config/initial-content-cars.xml</initial-content>
+                    </workspace>
+                </workspaces>
+                <node-types>
+                    <node-type>config/cars.cnd</node-type>
+                </node-types>
             </repository>
 
             <!--These should be deployed after the repositories, because they use servlet context listeners to load all repositories-->

--- a/integration/modeshape-jbossas-integration-tests/src/test/java/org/modeshape/test/integration/ExternalDependenciesIntegrationTest.java
+++ b/integration/modeshape-jbossas-integration-tests/src/test/java/org/modeshape/test/integration/ExternalDependenciesIntegrationTest.java
@@ -1,0 +1,70 @@
+/*
+ * ModeShape (http://www.modeshape.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.modeshape.test.integration;
+
+import static org.junit.Assert.assertNotNull;
+import java.io.File;
+import javax.annotation.Resource;
+import javax.jcr.Node;
+import javax.jcr.Session;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.modeshape.jcr.JcrRepository;
+
+/**
+ * Arquillian test for the integration between a repository and external modules, more specifically webapps deployed
+ * in the server
+ * 
+ * @author Horia Chiorean (hchiorea@redhat.com)
+ */
+@RunWith( Arquillian.class )
+public class ExternalDependenciesIntegrationTest {
+
+    @Resource( mappedName = "java:/jcr/externalDependenciesRepository" )
+    private JcrRepository repository;
+
+    @Deployment
+    public static WebArchive createDeployment() {
+        WebArchive archive = ShrinkWrap.create(WebArchive.class, "external-dependencies.war");
+        // Add our custom Manifest, which has the additional Dependencies entry ...
+        archive.setManifest(new File("src/main/webapp/META-INF/MANIFEST.MF"));
+        archive.addAsResource(new File("src/test/resources/config"), "config");
+        return archive;
+    }
+
+    @Before
+    public void before() {
+        assertNotNull("repository not found", repository);
+    }
+
+    @Test
+    public void repositoryShouldResolveFilesFromExternalDependency() throws Exception {
+        Session session = repository.login();
+        try {
+            // validate initial content and custom node types
+            Node cars = session.getNode("/cars");
+            cars.addNode("car", "car:Car");
+            session.save();
+        } finally {
+            session.logout();
+        }
+    }
+}

--- a/integration/modeshape-jbossas-integration-tests/src/test/resources/config/cars.cnd
+++ b/integration/modeshape-jbossas-integration-tests/src/test/resources/config/cars.cnd
@@ -1,0 +1,41 @@
+/*
+ * ModeShape (http://www.modeshape.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+ 
+//------------------------------------------------------------------------------
+// N A M E S P A C E S
+//------------------------------------------------------------------------------
+<jcr='http://www.jcp.org/jcr/1.0'>
+<nt='http://www.jcp.org/jcr/nt/1.0'>
+<mix='http://www.jcp.org/jcr/mix/1.0'>
+<car='http://www.modeshape.org/examples/cars/1.0'>
+
+//------------------------------------------------------------------------------
+// N O D E T Y P E S
+//------------------------------------------------------------------------------
+
+[car:Car] > nt:unstructured
+  - car:maker (string)
+  - car:model (string)
+  - car:year (string) < '(19|20)\d{2}'                     // any 4 digit number starting with '19' or '20'
+  - car:msrp (string) < '[$]\d{1,3}[,]?\d{3}([.]\d{2})?'   // of the form "$X,XXX.ZZ", "$XX,XXX.ZZ" or "$XXX,XXX.ZZ" 
+                                                           // where '.ZZ' is optional
+  - car:userRating (long) < '[1,5]'                        // any value from 1 to 5 (inclusive)
+  - car:valueRating (long) < '[1,5]'                       // any value from 1 to 5 (inclusive)
+  - car:mpgCity (long) < '(0,]'                            // any value greater than 0
+  - car:mpgHighway (long) < '(0,]'                         // any value greater than 0
+  - car:lengthInInches (double) < '(0,]'                   // any value greater than 0
+  - car:wheelbaseInInches (double) < '(0,]'                // any value greater than 0
+  - car:engine (string)

--- a/integration/modeshape-jbossas-integration-tests/src/test/resources/config/initial-content-cars.xml
+++ b/integration/modeshape-jbossas-integration-tests/src/test/resources/config/initial-content-cars.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ ModeShape (http://www.modeshape.org)
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~       http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<jcr:root xmlns:jcr="http://www.jcp.org/jcr/1.0">
+    <cars jcr:mixinTypes="mix:created, mix:lastModified"/>
+</jcr:root>


### PR DESCRIPTION
This also introduces a more generic ability for a repository configured in WF to use the CL of another external (dependant) module when resolving configuration elements such as initial content files and node type files. 
For example, configuring a repository as:
```xml
<repository name="externalDependenciesRepository" depends-on="deployment.external-dependencies.war"/>
```
means that the repository will be able to locate & load node-types and initial content files located in the `external-dependencies.war` webapp