### PR TITLE
MODE-2554 Add Geometry Type to Teiid DDL dialect

### DIFF
--- a/sequencers/modeshape-sequencer-ddl/src/main/java/org/modeshape/sequencer/ddl/dialect/teiid/TeiidDdlConstants.java
+++ b/sequencers/modeshape-sequencer-ddl/src/main/java/org/modeshape/sequencer/ddl/dialect/teiid/TeiidDdlConstants.java
@@ -172,6 +172,7 @@ public interface TeiidDdlConstants extends DdlConstants {
         DECIMAL,
         DOUBLE,
         FLOAT,
+        GEOMETRY,
         INTEGER,
         LONG,
         OBJECT,

--- a/sequencers/modeshape-sequencer-ddl/src/test/java/org/modeshape/sequencer/ddl/dialect/teiid/TeiidDataTypeParserTest.java
+++ b/sequencers/modeshape-sequencer-ddl/src/test/java/org/modeshape/sequencer/ddl/dialect/teiid/TeiidDataTypeParserTest.java
@@ -137,6 +137,11 @@ public class TeiidDataTypeParserTest {
     }
 
     @Test
+    public void shouldParseGeometry() {
+        assertNameAndDefaults(TeiidDataType.GEOMETRY);
+    }
+
+    @Test
     public void shouldParseInteger() {
         assertNameAndDefaults(TeiidDataType.INTEGER);
     }


### PR DESCRIPTION
Just needed to add the new GEOMETRY data type to the data type enum. No additional code needed. Wrote test to make sure the parser recognized the new data type.