### PR TITLE
MODE-2499: Executing queries from ModeShape Explorer doesn't validate dialects

### DIFF
--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/query/xpath/XPathParser.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/query/xpath/XPathParser.java
@@ -84,7 +84,18 @@ public class XPathParser {
     public Component parseXPath( String xpath ) {
         Tokenizer tokenizer = new XPathTokenizer(false); // skip comments
         TokenStream tokens = new TokenStream(xpath, tokenizer, true).start(); // case sensitive!!
-        return parseXPath(tokens);
+        //do parsing
+        Component component = parseXPath(tokens);
+        
+        //no more tokens should remain, other wise this is not valid statement
+        if (tokens.hasNext()) {
+            throw new ParsingException(tokens.nextPosition(), 
+                    "Unexpected token: " + tokens.consume() + 
+                    " at line " + tokens.nextPosition().getLine() +
+                    ", column " + tokens.nextPosition().getColumn());
+        }
+        
+        return component;
     }
 
     protected Component parseXPath( TokenStream tokens ) {

--- a/modeshape-jcr/src/test/java/org/modeshape/jcr/JcrQueryManagerTest.java
+++ b/modeshape-jcr/src/test/java/org/modeshape/jcr/JcrQueryManagerTest.java
@@ -703,6 +703,17 @@ public class JcrQueryManagerTest extends MultiUseAbstractTest {
         validateQuery().rowCount(4).validate(query, query.execute());
     }
 
+    @FixFor("MODE-2499")
+    @Test
+    public void shouldThrowExceptionWhenXPathSyntaxNotValid() throws RepositoryException {
+        String sql = "select node.[jcr:name] from [nt:unstructured] as node";
+        try {
+            Query query = session.getWorkspace().getQueryManager().createQuery(sql, Query.XPATH);
+            fail("Should throw InvalidQueryException");
+        } catch (InvalidQueryException e) {
+        }
+    }
+    
     @FixFor("MODE-2490")
     @Test
     public void shouldOrderByTwoColumnsEvenIfNullable() throws RepositoryException {


### PR DESCRIPTION
This PR adds one more syntax checking rule for  the `XPathParser`: 
- after parsing no more tokens should remain. 

Without this check the beginning of some JCR-SQL2 statements (or even random text) will be interpreted as xpath query while remainder will be ignored. 

Web-Explorer correctly shows exception when it is fired by MS.
