### PR TITLE
MODE-2565 Fixes the behavior of the Lucene index provider to avoid reindexing at startup if data exists

### DIFF
--- a/index-providers/modeshape-elasticsearch-index-provider/src/test/java/org/modeshape/jcr/index/elasticsearch/EsIndexProviderTest.java
+++ b/index-providers/modeshape-elasticsearch-index-provider/src/test/java/org/modeshape/jcr/index/elasticsearch/EsIndexProviderTest.java
@@ -53,11 +53,11 @@ public class EsIndexProviderTest extends LocalIndexProviderTest {
         esNode =  NodeBuilder.nodeBuilder().settings(localSettings).local(false).build().start();
 
     }
-    
+
     @AfterClass
     public static void tearDownClass() {
-            esNode.close();
-            FileUtil.delete("target/data");
+        esNode.close();
+        FileUtil.delete("target/data");
     }
     
     @Override
@@ -127,5 +127,9 @@ public class EsIndexProviderTest extends LocalIndexProviderTest {
         //This test case is excluded due to local ES node failre after
         //client disconnection
     }
-    
+
+    @Override
+    protected void assertStorageLocationUnchangedAfterRestart() throws Exception {
+        //nothing to assert, ES does not store indexes locally....
+    }
 }

--- a/index-providers/modeshape-lucene-index-provider/src/main/java/org/modeshape/jcr/index/lucene/LuceneConfig.java
+++ b/index-providers/modeshape-lucene-index-provider/src/main/java/org/modeshape/jcr/index/lucene/LuceneConfig.java
@@ -87,11 +87,9 @@ public final class LuceneConfig {
         try {
             Directory directory = directory(directoryClass, workspaceName, indexName);
             IndexWriter indexWriter = new IndexWriter(directory, newIndexWriterConfig());
-            if (!DirectoryReader.indexExists(directory)) {
-                indexWriter.commit();
-            } else {
+            if (DirectoryReader.indexExists(directory)) {
                 readLatestCommitTime(indexWriter);
-            }
+            } 
             return indexWriter;
         } catch (IOException e) {
             throw new LuceneIndexException("Cannot create index writer", e);

--- a/index-providers/modeshape-lucene-index-provider/src/main/java/org/modeshape/jcr/index/lucene/LuceneIndex.java
+++ b/index-providers/modeshape-lucene-index-provider/src/main/java/org/modeshape/jcr/index/lucene/LuceneIndex.java
@@ -30,6 +30,7 @@ import org.apache.lucene.document.Field;
 import org.apache.lucene.document.IntField;
 import org.apache.lucene.document.LongField;
 import org.apache.lucene.document.StringField;
+import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.IndexWriter;
 import org.modeshape.common.annotation.Immutable;
 import org.modeshape.common.annotation.ThreadSafe;
@@ -131,7 +132,12 @@ public abstract class LuceneIndex implements ProvidedIndex<Object> {
 
     @Override
     public boolean requiresReindexing() {
-        return writer.numDocs() <= 0;
+        try {
+            return !DirectoryReader.indexExists(writer.getDirectory());
+        } catch (IOException e) {
+            logger.debug(e, "cannot determine if lucene index exists...");
+            return false;
+        }
     }
 
     public void commit() {

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/RepositoryIndexManager.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/RepositoryIndexManager.java
@@ -909,8 +909,7 @@ class RepositoryIndexManager implements IndexManager, NodeTypes.Listener {
     }
 
     static interface ScanOperation {
-        public void scan( String workspace,
-                          Path path );
+        public void scan(String workspace, Path path, IndexWriter writer );
     }
 
     /**
@@ -957,27 +956,15 @@ class RepositoryIndexManager implements IndexManager, NodeTypes.Listener {
             for (Map.Entry<String, PathToScan> entry : pathsToScanByWorkspace.entries()) {
                 String workspaceName = entry.getKey();
                 PathToScan pathToScan = entry.getValue();
-                try {
-                    for (IndexingCallback callback : pathToScan) {
-                        try {
-                            callback.beforeIndexing();
-                        } catch (RuntimeException e) {
-                            Logger.getLogger(getClass()).error(e, JcrI18n.errorIndexing, pathToScan.path(), workspaceName,
-                                                               e.getMessage());
-                        }
-                    }
-                    operation.scan(workspaceName, pathToScan.path());
-                } catch (RuntimeException e) {
-                    Logger.getLogger(getClass())
-                          .error(e, JcrI18n.errorIndexing, pathToScan.path(), workspaceName, e.getMessage());
-                } finally {
-                    for (IndexingCallback callback : pathToScan) {
-                        try {
-                            callback.afterIndexing();
-                        } catch (RuntimeException e) {
-                            Logger.getLogger(getClass()).error(e, JcrI18n.errorIndexing, pathToScan.path(), workspaceName,
-                                                               e.getMessage());
-                        }
+                for (IndexingCallback callback : pathToScan) {
+                    callback.beforeIndexing();
+                    try {
+                        operation.scan(workspaceName, pathToScan.path(), callback.writer());
+                    } catch (Exception e) {
+                        Logger.getLogger(getClass()).error(e, JcrI18n.errorIndexing, pathToScan.path(), workspaceName,
+                                                           e.getMessage());
+                    } finally {
+                        callback.afterIndexing();
                     }
                 }
             }

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/RepositoryQueryManager.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/RepositoryQueryManager.java
@@ -346,16 +346,16 @@ class RepositoryQueryManager implements ChangeSetListener {
     protected void reindexIfNeeded( boolean async, final boolean includeSystemContent ) {
         final ScanningRequest request = toBeScanned.drain();
         if (!request.isEmpty()) {
-            final IndexWriter writer = indexManager.getIndexWriterForProviders(request.providerNames());
             final RepositoryCache repoCache = runningState.repositoryCache();
-            scan(async, writer, new Callable<Void>() {
+            scan(async, new Callable<Void>() {
                 @Override
                 public Void call() throws Exception {
                     // Scan each of the workspace-path pairs ...
                     ScanOperation op = new ScanOperation() {
                         @Override
                         public void scan( String workspaceName,
-                                          Path path ) {
+                                          Path path,
+                                          IndexWriter writer) {
                             NodeCache workspaceCache = repoCache.getWorkspaceCache(workspaceName);
                             if (workspaceCache != null) {
                                 // The workspace is still valid ...
@@ -430,6 +430,21 @@ class RepositoryQueryManager implements ChangeSetListener {
                 } catch (Exception e) {
                     throw new RuntimeException();
                 }
+            }
+        }
+    } 
+    
+    private void scan( boolean async,
+                       Callable<Void> callable ) {
+        if (async) {
+            asyncReindexingResult = indexingExecutorService.submit(callable);
+        } else {
+            try {
+                callable.call();
+            } catch (RuntimeException e) {
+                throw e;
+            } catch (Exception e) {
+                throw new RuntimeException();
             }
         }
     }

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/spi/index/IndexFeedback.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/spi/index/IndexFeedback.java
@@ -32,6 +32,8 @@ public interface IndexFeedback {
         void beforeIndexing();
 
         void afterIndexing();
+        
+        IndexWriter writer();
     }
 
     /**

--- a/modeshape-jcr/src/test/java/org/modeshape/jcr/cache/document/AbstractSessionCacheTest.java
+++ b/modeshape-jcr/src/test/java/org/modeshape/jcr/cache/document/AbstractSessionCacheTest.java
@@ -66,7 +66,11 @@ public abstract class AbstractSessionCacheTest extends AbstractNodeCacheTest {
     @Override
     protected void shutdownCache( NodeCache cache ) {
         super.shutdownCache(cache);
-        executor.shutdown();
+        try {
+            changeBus.shutdown();
+        } finally {
+            executor.shutdownNow();    
+        }
     }
 
     protected abstract SessionCache createSessionCache( ExecutionContext context,

--- a/modeshape-jcr/src/test/java/org/modeshape/jcr/cache/document/WorkspaceCacheTest.java
+++ b/modeshape-jcr/src/test/java/org/modeshape/jcr/cache/document/WorkspaceCacheTest.java
@@ -45,6 +45,10 @@ public class WorkspaceCacheTest extends AbstractNodeCacheTest {
     @Override
     protected void shutdownCache( NodeCache cache ) {
         super.shutdownCache(cache);
-        executor.shutdown();
+        try {
+            changeBus.shutdown();
+        } finally {
+            executor.shutdownNow();    
+        }
     }
 }


### PR DESCRIPTION
Also, it updates the general IF_MISSING reindexing logic, so that only the indexes which actually do require reindexing are reindexed, as opposed to the all the indexes of a particular provider.