### PR TITLE
MODE-2567 - Added a test and a fix to ensure that the Lucene index provider escapes Ampersands

### DIFF
--- a/index-providers/modeshape-lucene-index-provider/src/main/java/org/modeshape/jcr/index/lucene/query/CompareStringQuery.java
+++ b/index-providers/modeshape-lucene-index-provider/src/main/java/org/modeshape/jcr/index/lucene/query/CompareStringQuery.java
@@ -285,9 +285,9 @@ public class CompareStringQuery extends CompareQuery<String> {
         // Replace all '\x' with 'x' ...
         String result = likeExpression.replaceAll("\\\\(.)", "$1");
         // Escape characters used as metacharacters in regular expressions, including
-        // '[', '^', '\', '$', '.', '|', '+', '(', and ')'
+        // '[', '^', '\', '$', '.', '|', '+', '&', '(', and ')'
         // But leave '?' and '*'
-        result = result.replaceAll("([$.|+()\\[\\\\^\\\\\\\\])", "\\\\$1");
+        result = result.replaceAll("([$.|+()&\\[\\\\^\\\\\\\\])", "\\\\$1");
         // Replace '%'->'[.]*' and '_'->'[.]
         // (order of these calls is important!)
         result = result.replace("*", ".*").replace("?", ".");

--- a/index-providers/modeshape-lucene-index-provider/src/test/java/org/modeshape/jcr/index/lucene/SingleColumnIndexSearchTest.java
+++ b/index-providers/modeshape-lucene-index-provider/src/test/java/org/modeshape/jcr/index/lucene/SingleColumnIndexSearchTest.java
@@ -699,4 +699,29 @@ public class SingleColumnIndexSearchTest extends AbstractLuceneIndexSearchTest {
         long searchTime = TimeUnit.MILLISECONDS.convert(duration, TimeUnit.NANOSECONDS);
         System.out.println(Thread.currentThread().getName() + ": (" + index.getName() + ") Total time to search " + nodeKeys.size() + " nodes: " + searchTime/1000d + " seconds");
     }
+
+    @Test
+    public void shouldSearchForLikeConstraintContainingSpaceAmpersand() throws Exception {
+        List<String> nodeKeys = indexNodes(STRING_PROP, "Law & Order - S01E01");
+
+        // & works if there is not leading space
+        Constraint constraint = propertyValue(STRING_PROP, LIKE, "%&%");
+        validateCardinality(constraint, 1);
+        validateFilterResults(constraint, 1, false, nodeKeys.get(0));
+
+        // works if there is just a space
+        constraint = propertyValue(STRING_PROP, LIKE, "% %");
+        validateCardinality(constraint, 1);
+        validateFilterResults(constraint, 1, false, nodeKeys.get(0));
+
+        // & fails if there is a leading space
+        constraint = propertyValue(STRING_PROP, LIKE, "% &%");
+        validateCardinality(constraint, 1);
+        validateFilterResults(constraint, 1, false, nodeKeys.get(0));
+
+        // & fails if there is a trailing space
+        constraint = propertyValue(STRING_PROP, LIKE, "%& %");
+        validateCardinality(constraint, 1);
+        validateFilterResults(constraint, 1, false, nodeKeys.get(0));
+    }
 }

--- a/index-providers/modeshape-lucene-index-provider/src/test/java/org/modeshape/jcr/index/lucene/SingleColumnIndexSearchTest.java
+++ b/index-providers/modeshape-lucene-index-provider/src/test/java/org/modeshape/jcr/index/lucene/SingleColumnIndexSearchTest.java
@@ -704,23 +704,23 @@ public class SingleColumnIndexSearchTest extends AbstractLuceneIndexSearchTest {
     public void shouldSearchForLikeConstraintContainingSpaceAmpersand() throws Exception {
         List<String> nodeKeys = indexNodes(STRING_PROP, "Law & Order - S01E01");
 
-        // & works if there is not leading space
+        // no leading or trailing space
         Constraint constraint = propertyValue(STRING_PROP, LIKE, "%&%");
         validateCardinality(constraint, 1);
         validateFilterResults(constraint, 1, false, nodeKeys.get(0));
 
-        // works if there is just a space
-        constraint = propertyValue(STRING_PROP, LIKE, "% %");
-        validateCardinality(constraint, 1);
-        validateFilterResults(constraint, 1, false, nodeKeys.get(0));
-
-        // & fails if there is a leading space
+        // leading space
         constraint = propertyValue(STRING_PROP, LIKE, "% &%");
         validateCardinality(constraint, 1);
         validateFilterResults(constraint, 1, false, nodeKeys.get(0));
 
-        // & fails if there is a trailing space
+        // trailing space
         constraint = propertyValue(STRING_PROP, LIKE, "%& %");
+        validateCardinality(constraint, 1);
+        validateFilterResults(constraint, 1, false, nodeKeys.get(0));
+
+        // part of a larger search string
+        constraint = propertyValue(STRING_PROP, LIKE, "%Law & Order%");
         validateCardinality(constraint, 1);
         validateFilterResults(constraint, 1, false, nodeKeys.get(0));
     }


### PR DESCRIPTION
Lucene Index Provider does not correctly handle Like constraints containing an Ampersand with a leading or trailing space