### PR TITLE
MODE-1660: Initial implementation for command line shell

### DIFF
--- a/modeshape-parent/pom.xml
+++ b/modeshape-parent/pom.xml
@@ -209,6 +209,8 @@
         <version.org.wildfly.plugings.wildfly-maven-plugin>1.0.2.Final</version.org.wildfly.plugings.wildfly-maven-plugin>
         <version.elasticsearch>2.1.0</version.elasticsearch>
         <version.jna>4.1.0</version.jna>
+        <version.jboss.aesh>0.66.4</version.jboss.aesh>
+        <version.sshd-core>0.9.0</version.sshd-core>
         <!--The name of the modeshape-client artifact used by tools-->
         <client.artifactId>modeshape-client</client.artifactId>
 
@@ -1048,6 +1050,11 @@
            <dependency>
                 <groupId>org.modeshape</groupId>
                 <artifactId>modeshape-jbossas-subsystem</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.modeshape</groupId>
+                <artifactId>modeshape-shell</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
@@ -2009,6 +2016,19 @@
                 <version>${version.commons-naming}</version>
                 <scope>test</scope>
             </dependency>
+            
+            <!-- Shell console dependecy-->
+            <dependency>
+                <groupId>org.jboss.aesh</groupId>
+                <artifactId>aesh</artifactId>
+                <version>${version.jboss.aesh}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.sshd</groupId>
+                <artifactId>sshd-core</artifactId>
+                <version>${version.sshd-core}</version>
+            </dependency>
+            
         </dependencies>
     </dependencyManagement>
 

--- a/modeshape-shell/pom.xml
+++ b/modeshape-shell/pom.xml
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.modeshape</groupId>
+        <artifactId>modeshape-parent</artifactId>
+        <version>5.1-SNAPSHOT</version>
+        <relativePath>../modeshape-parent/pom.xml</relativePath>
+    </parent>
+
+    <!-- The groupId and version values are inherited from parent -->
+    <artifactId>modeshape-shell</artifactId>
+    <packaging>jar</packaging>
+    <name>ModeShape Shell</name>
+    <description>ModeShape command line shell unit</description>
+    <url>http://www.modeshape.org</url>
+
+    <!--
+      Define the dependencies. Note that all version and scopes default to those defined in the dependencyManagement section of the
+      parent pom.
+    -->
+    <dependencies>
+        <dependency>
+            <groupId>org.jboss.aesh</groupId>
+            <artifactId>aesh</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>javax.jcr</groupId>
+            <artifactId>jcr</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.modeshape</groupId>
+            <artifactId>modeshape-jcr-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.modeshape</groupId>
+            <artifactId>modeshape-jcr</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.modeshape</groupId>
+            <artifactId>modeshape-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.modeshape</groupId>
+            <artifactId>modeshape-schematic</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.sshd</groupId>
+            <artifactId>sshd-core</artifactId>
+        </dependency>
+    </dependencies>
+    <profiles>
+        <profile>
+            <id>assembly</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-assembly-plugin</artifactId>
+                        <configuration>
+                            <descriptorRefs>
+                                <descriptorRef>module-with-dependencies</descriptorRef>
+                            </descriptorRefs>
+                            <attach>false</attach>
+                            <finalName>${binary.dist.name}</finalName>
+                            <appendAssemblyId>false</appendAssemblyId>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>single</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+</project>

--- a/modeshape-shell/src/main/java/org/modeshape/shell/Interpreter.java
+++ b/modeshape-shell/src/main/java/org/modeshape/shell/Interpreter.java
@@ -1,0 +1,132 @@
+/*
+ * ModeShape (http://www.modeshape.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.modeshape.shell;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import org.modeshape.shell.cmd.ShellCommand;
+
+/**
+ * Interpreter of the shell commands.
+ * 
+ * Interpreter provides basic implementation of the process of command 
+ * execution, prompt displayed in console and calculates command completions.
+ * 
+ * 
+ * @author kulikov
+ */
+public class Interpreter {
+    //prompt 
+    private final String prompt;
+    //map between command name and command instance.
+    private final HashMap<String, ShellCommand> commandsMap = new HashMap<>();
+
+    /**
+     * Creates new instance of the interpreter.
+     * 
+     * @param prompt console prompt
+     * @param commands list of commands this interpreter will execute.
+     */
+    public Interpreter(String prompt, ArrayList<ShellCommand> commands) {
+        this.prompt = prompt;
+        for (ShellCommand c : commands) {
+            commandsMap.putAll(c.buildCommands());
+        }
+    }
+
+    /**
+     * Creates new instance of the interpreter.
+     * 
+     * @param prompt console prompt
+     * @param commands list of commands this interpreter will execute.
+     */
+    public Interpreter(String prompt, ShellCommand[] commands) {
+        this.prompt = prompt;
+        for (ShellCommand c : commands) {
+            commandsMap.putAll(c.buildCommands());
+        }
+    }
+    
+    /**
+     * Prompt related to this interpreter.
+     * 
+     * @return 
+     */
+    public String prompt() {
+        return prompt;
+    }
+    
+    /**
+     * Computes possible commands started from the given text.
+     * 
+     * @param prefix text given from user input 
+     * @return possible commands.
+     */
+    public List<String> completions(String prefix) {
+        ArrayList<String> list = new ArrayList<>();
+        for (String s : commandsMap.keySet()) {
+            if (s.startsWith(prefix)) list.add(s);
+        }
+        return list;
+    }
+    
+    /**
+     * Executes given command line.
+     * 
+     * @param session the current shell session.
+     * @param cmd command line
+     * @return execution response
+     * @throws Exception if exception happend during command execution or parsing.
+     */
+    public String execute(ShellSession session, String cmd) throws Exception {
+        //find command and parse arguments
+        ShellCommand command = lookup(cmd);
+        command.prepare(cmd);
+
+        //delegate execution to command instance
+        return command.perform(session);
+    }
+
+    
+    /**
+     * Searches command instance related to the given user input.
+     * 
+     * @param cmdLine user's input
+     * @return  command instance or null if not found.
+     */
+    public ShellCommand lookup(String cmdLine) {
+        String[] tokens = cmdLine.split(" ");
+        
+        int i = 0;
+        ShellCommand command = null;
+        while (i < tokens.length && commandsMap.containsKey(key(tokens, i))) {
+            command = commandsMap.get(key(tokens, i));
+            i++;
+        }
+        
+        return command;
+    }
+    
+    private String key(String[] tokens, int len) {
+        String k = "";
+        for (int i = 0; i < len + 1; i++) {
+            k += " " + tokens[i];
+        }
+        return k.trim();
+    }
+    
+}

--- a/modeshape-shell/src/main/java/org/modeshape/shell/ShellAuthenticator.java
+++ b/modeshape-shell/src/main/java/org/modeshape/shell/ShellAuthenticator.java
@@ -1,0 +1,46 @@
+/*
+ * ModeShape (http://www.modeshape.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.modeshape.shell;
+
+import org.apache.sshd.server.PasswordAuthenticator;
+import org.apache.sshd.server.session.ServerSession;
+
+/**
+ * Authenticator that uses user name and password for the authentication.
+ * 
+ * @author kulikov
+ */
+public class ShellAuthenticator implements PasswordAuthenticator {
+    private final String user;
+    private final String password;
+   
+    /**
+     * Creates new authenticator for the given user.
+     * 
+     * @param user user's name
+     * @param password user's password.
+     */
+    public ShellAuthenticator(String user, String password) {
+        this.user = user;
+        this.password = password;
+    }
+    
+    @Override
+    public boolean authenticate(String user, String password, ServerSession session) {
+        return this.user.equals(user) && this.password.equals(password);
+    }
+    
+}

--- a/modeshape-shell/src/main/java/org/modeshape/shell/ShellCommandProcessor.java
+++ b/modeshape-shell/src/main/java/org/modeshape/shell/ShellCommandProcessor.java
@@ -1,0 +1,184 @@
+/*
+ * ModeShape (http://www.modeshape.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.modeshape.shell;
+
+import java.io.BufferedInputStream;
+import java.io.FilterOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.PrintStream;
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.sshd.server.Command;
+import org.apache.sshd.server.Environment;
+import org.apache.sshd.server.ExitCallback;
+import org.jboss.aesh.complete.CompleteOperation;
+import org.jboss.aesh.complete.Completion;
+import org.jboss.aesh.console.AeshConsoleCallback;
+import org.jboss.aesh.console.Console;
+import org.jboss.aesh.console.ConsoleOperation;
+import org.jboss.aesh.console.Prompt;
+import org.jboss.aesh.console.settings.SettingsBuilder;
+import org.jboss.aesh.terminal.Color;
+import org.jboss.aesh.terminal.TerminalCharacter;
+import org.jboss.aesh.terminal.TerminalColor;
+
+/**
+ * Command processor wraps shell console.
+ * 
+ * @author kulikov
+ */
+public class ShellCommandProcessor implements Command {
+    
+    //ssh session
+    private final ShellSession session;
+    
+    //ssh server std streams
+    private InputStream in;
+    private OutputStream out;
+    private OutputStream err;
+    
+    private ExitCallback callback;
+    private Environment environment;
+    
+    //shell  console
+    private Console console;
+    
+    public ShellCommandProcessor(ShellSession session) {
+        this.session = session;
+    }
+    
+    @Override
+    public void setInputStream(InputStream in) {  
+        this.in = new BufferedInputStream(in) {
+            @Override
+            public int read(byte[] buff, int offset, int len) throws IOException {
+                int res = super.read(buff, offset, len);
+                for (int i = 0; i < res; i++) {
+                    if (buff[i] == '\r') {
+                        buff[i] = '\n'; 
+                    }
+                }
+                return res;
+            }
+        };
+    }
+
+    @Override
+    public void setOutputStream(OutputStream out) {
+        this.out = new FilterOutputStream(out){
+            @Override
+            public void write(int b) throws IOException {
+                if (b == '\n') {
+                    super.write('\r');
+                }
+                super.write(b);
+            }
+        };
+    }
+
+    @Override
+    public void setErrorStream(OutputStream out) {
+        this.err = new FilterOutputStream(out){
+            @Override
+            public void write(int b) throws IOException {
+                if (b == '\n') {
+                    super.write('\r');
+                }
+                super.write(b);
+            }
+        };
+    }
+
+    @Override
+    public void setExitCallback(ExitCallback ec) {
+        this.callback = ec;
+        session.setExitCallback(callback);
+    }
+
+    @Override
+    public void start(Environment e) throws IOException {
+        this.environment = e;
+        //create shell console and assign std streams
+        console = new Console(new SettingsBuilder()
+                .readInputrc(false)
+                .logging(false)
+                .ansi(true)               
+                .inputStream(in)
+                .outputStream(new PrintStream(out))
+                .outputStreamError(new PrintStream(err))
+                .create());
+        
+        console.setPrompt(prompt("[modeshape]$ "));
+        console.setCompletionEnabled(true);
+        
+        console.setConsoleCallback(new AeshConsoleCallback() {
+            @Override
+            public int execute(ConsoleOperation co) throws InterruptedException {
+                String cmd = co.getBuffer();
+                try {
+                    //execute command using active interpreter
+                    String res = session.getInterpreter().execute(session, cmd);
+                    
+                    //update prompt 
+                    console.setPrompt(prompt(session.getInterpreter().prompt()));
+                    
+                    //print response and flush output
+                    console.getShell().out().println(res);
+                    console.getShell().out().flush();
+                } catch (Exception e) {
+                    //print error message and flush stream
+                    console.getShell().err().println(e.getMessage());
+                    console.getShell().err().flush();
+                }
+                
+                return 1;
+            }
+             
+        });
+        
+        console.addCompletion(new Completion() {
+            @Override
+            public void complete(CompleteOperation co) {
+                co.addCompletionCandidates(session.getInterpreter().completions(co.getBuffer()));
+            }
+        });
+        
+        console.start();
+    }
+
+    @Override
+    public void destroy() {
+    }
+
+    public void setPrompt(String prompt) {
+        console.setPrompt(prompt(prompt));
+    }
+    
+    private Prompt prompt(String prompt) {
+        List<TerminalCharacter> chars = new ArrayList<>();
+        for (int i = 0; i < prompt.length(); i++) {
+            chars.add(new TerminalCharacter(prompt.charAt(i), new TerminalColor(Color.DEFAULT, Color.DEFAULT)));
+        }
+        return new Prompt(chars);
+    }
+    
+    protected void exit() {
+        this.callback.onExit(0);
+    }
+    
+}

--- a/modeshape-shell/src/main/java/org/modeshape/shell/ShellI18n.java
+++ b/modeshape-shell/src/main/java/org/modeshape/shell/ShellI18n.java
@@ -1,0 +1,106 @@
+/*
+ * ModeShape (http://www.modeshape.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.modeshape.shell;
+
+import org.modeshape.common.i18n.I18n;
+
+/**
+ *
+ * @author kulikov
+ */
+public class ShellI18n {
+    public static I18n sshUserNotSpecified;
+    public static I18n sshCouldNotStartServer;
+    public static I18n unknownCommand;
+    public static I18n connectHelp;
+    public static I18n changeNodeHelp;
+    public static I18n pwdHelp;
+    public static I18n queryHelp;
+    public static I18n nodeAddMixinHelp;
+    public static I18n nodeAddNodeHelp;
+    public static I18n nodeShowIndexHelp;
+    public static I18n nodeShowIdentifierHelp;
+    public static I18n nodeShowPrimaryTypeHelp;
+    public static I18n nodeShowMixinsHelp;
+    public static I18n nodeShowNodesHelp;
+    public static I18n nodeShowPropertiesHelp;
+    public static I18n nodeShowPropertyHelp;
+    public static I18n nodeShowReferencesHelp;
+    public static I18n nodeSetPrimaryTypeHelp;
+    public static I18n nodeSetPropertyValueHelp;
+    public static I18n nodeUploadHelp;
+    public static I18n nodeDownloadHelp;
+    public static I18n repositoryBackupHelp;
+    public static I18n repositoryRestoreHelp;
+    public static I18n scriptHelp;
+    public static I18n sessionRefreshHelp;
+    public static I18n sessionExitHelp;
+    public static I18n sessionSaveHelp;
+    public static I18n sessionStatusHelp;
+    public static I18n sessionImpersonateHelp;
+    public static I18n sessionMoveHelp;
+    public static I18n sessionRemoveHelp;
+    public static I18n sessionImportHelp;
+    public static I18n sessionExportHelp;
+    public static I18n sessionShowAttributesHelp;
+    public static I18n sessionShowAttributeHelp;
+    public static I18n sessionShowPrefixesHelp;
+    public static I18n sessionShowPrefixHelp;
+    public static I18n sessionShowUriHelp;
+    public static I18n versionCheckinHelp;
+    public static I18n versionCheckoutHelp;
+    public static I18n versionMergeHelp;
+    public static I18n versionRestoreHelp;
+    public static I18n versionShowBaseVersion;
+    public static I18n versionShowHistoryHelp;
+    public static I18n versionShowStatusHelp;
+    public static I18n workspaceCloneHelp;
+    public static I18n workspaceCopyHelp;
+    public static I18n workspaceCreateHelp;
+    public static I18n workspaceDeleteHelp;
+    public static I18n workspaceImport;
+    public static I18n workspaceShowName;
+    public static I18n workspaceShowNames;
+    public static I18n typeRegisterHelp;
+    public static I18n typeUnregisterHelp;
+    public static I18n typeShowTypesHelp;
+    public static I18n typeShowPropertyDefsHelp;
+    public static I18n typeShowNodeDefsHelp;
+    public static I18n aclShowHelp;
+    public static I18n aclSetHelp;
+    public static I18n aclRemoveHelp;
+    public static I18n engineExitHelp;
+    public static I18n engineShowRepositoriesHelp;
+    public static I18n engineShowRepositoryStateHelp;
+    public static I18n engineStartRepositoryHelp;
+    public static I18n engineStopRepositoryHelp;
+    public static I18n engineDeployRepositoryHelp;
+    public static I18n engineUndeployRepositoryHelp;
+    public static I18n engineConfigureRepositoryHelp;
+    public static I18n configureSaveHelp;
+    
+    private ShellI18n() {
+    }
+
+    static {
+        try {
+            I18n.initialize(ShellI18n.class);
+        } catch (final Exception err) {
+            // CHECKSTYLE IGNORE check FOR NEXT 1 LINES
+            System.err.println(err);
+        }
+    }    
+}

--- a/modeshape-shell/src/main/java/org/modeshape/shell/ShellServer.java
+++ b/modeshape-shell/src/main/java/org/modeshape/shell/ShellServer.java
@@ -1,0 +1,100 @@
+/*
+ * ModeShape (http://www.modeshape.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.modeshape.shell;
+
+import java.io.IOException;
+import java.util.Properties;
+import org.apache.sshd.SshServer;
+import org.apache.sshd.common.Factory;
+import org.apache.sshd.server.Command;
+import org.apache.sshd.server.keyprovider.SimpleGeneratorHostKeyProvider;
+import org.modeshape.common.logging.Logger;
+import org.modeshape.jcr.ModeShapeEngine;
+
+/**
+ * Wraps shell console with secure shell server.
+ *
+ * @author kulikov
+ */
+public class ShellServer {
+
+    private final SshServer sshd = SshServer.setUpDefaultServer();
+    private final ModeShapeEngine engine;
+    private final Properties config;
+    private static final Logger LOGGER = Logger.getLogger(ShellServer.class);
+
+    /**
+     * Creates instance of the server.
+     *
+     * @param engine engine instance running this server.
+     * @param config bootstrap parameters.
+     */
+    public ShellServer(ModeShapeEngine engine, Properties config) {
+        this.engine = engine;
+        this.config = config;
+    }
+
+    /**
+     * Starts this server.
+     *
+     */
+    public void start() {
+        if (config == null) {
+            LOGGER.warn(ShellI18n.sshUserNotSpecified);
+            return;
+        }
+        int port = 2222;
+        if (config.containsKey("ssh.port")) {
+            port = Integer.parseInt(config.getProperty("ssh.port"));
+        }
+        sshd.setPort(port);
+
+        String user = config.getProperty("ssh.user");
+        String password = config.getProperty("ssh.password");
+
+        sshd.setPasswordAuthenticator(new ShellAuthenticator(user, password));
+        sshd.setShellFactory(new FactoryImpl());
+
+        sshd.setKeyPairProvider(new SimpleGeneratorHostKeyProvider());
+        if (user == null || password == null) {
+            LOGGER.warn(ShellI18n.sshUserNotSpecified);
+            return;
+        }
+
+        try {
+            sshd.start();
+        } catch (IOException e) {
+            LOGGER.warn(ShellI18n.sshCouldNotStartServer, e.getMessage());
+        }
+    }
+
+    private class FactoryImpl implements Factory<Command> {
+        @Override
+        public Command create() {
+            return new ShellCommandProcessor(new ShellSession(engine));
+        }
+    }
+
+    /**
+     * Stops this server immediately.
+     */
+    public void stop() {
+        try {
+            sshd.stop(true);
+        } catch (InterruptedException e) {
+        }
+    }
+}

--- a/modeshape-shell/src/main/java/org/modeshape/shell/ShellSession.java
+++ b/modeshape-shell/src/main/java/org/modeshape/shell/ShellSession.java
@@ -1,0 +1,117 @@
+/*
+ * ModeShape (http://www.modeshape.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.modeshape.shell;
+
+import javax.jcr.Session;
+import org.apache.sshd.server.ExitCallback;
+import org.modeshape.jcr.JcrRepository;
+import org.modeshape.jcr.ModeShapeEngine;
+import org.modeshape.jcr.RepositoryConfiguration;
+import org.modeshape.shell.cmd.jcrsession.JcrSessionInterpreter;
+import org.modeshape.shell.cmd.config.ConfigurationInterpreter;
+import org.modeshape.shell.cmd.engine.EngineCommandInterpreter;
+
+/**
+ *
+ * @author kulikov
+ */
+public class ShellSession {
+    
+    public final static Interpreter ENGINE_COMMAND_INTERPRETER = new EngineCommandInterpreter();
+    public final static Interpreter CONFIGURATION_INTERPRETER = new ConfigurationInterpreter();
+    public final static Interpreter JCR_SESSION_INTERPRETER = new JcrSessionInterpreter();
+    
+    private final ModeShapeEngine engine;
+    private ExitCallback exitCallback;
+    private Session session;
+    private String path;
+    private Interpreter interpreter = ENGINE_COMMAND_INTERPRETER;
+    private JcrRepository repository;
+    private RepositoryConfiguration configuration;
+    
+    public ShellSession(ModeShapeEngine engine) {
+        this.engine = engine;
+    }
+
+    public boolean isAlive() {
+        return session != null && session.isLive();
+    }
+    
+    public String getId() {
+        if (session == null) {
+            return null;
+        }
+        
+        String[] tokens = session.toString().split(" ");        
+        return tokens[1];
+    }
+    
+    public Session jcrSession() {
+        return session;
+    }
+    
+    public void setJcrSession(Session session) {
+        this.session = session;
+    }
+    
+    public void setPath(String path) {
+        this.path = path;
+    }
+    
+    public String getPath() {
+        return path;
+    }
+    
+    public ModeShapeEngine engine() {
+        return engine;
+    }
+    
+    public Interpreter getInterpreter() {
+        return interpreter;
+    }
+    
+    public void setInterpreter(Interpreter interpreter) {
+        this.interpreter = interpreter;
+/*        if (factory != null) {
+            factory.setPrompt(interpreter.prompt());
+        }
+        */ 
+    }
+ 
+    public JcrRepository getRepository() {
+        return repository;
+    }
+    
+    public void setRepository(JcrRepository repository) {
+        this.repository = repository;
+    }
+    
+    public void setRepositoryConfiguration(RepositoryConfiguration configuration) {
+        this.configuration = configuration;
+    }
+    
+    public RepositoryConfiguration getRepositoryConfiguration() {
+        return configuration;
+    }
+    
+    public void setExitCallback(ExitCallback exitCallback) {
+        this.exitCallback = exitCallback;
+    }
+    
+    public void exit() {
+        exitCallback.onExit(0);
+    }
+}

--- a/modeshape-shell/src/main/java/org/modeshape/shell/cmd/CommandParser.java
+++ b/modeshape-shell/src/main/java/org/modeshape/shell/cmd/CommandParser.java
@@ -1,0 +1,72 @@
+/*
+ * ModeShape (http://www.modeshape.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.modeshape.shell.cmd;
+
+/**
+ * Utility class from command line parsing.
+ * 
+ * @author kulikov
+ */
+public class CommandParser {
+    public static String commandName(String cmd) {
+        int len = cmd.indexOf(' ');
+        return len > 0 ? cmd.substring(0, cmd.indexOf(' ')) : cmd;
+    }
+    
+    public static String getOptionValue(String option, String cmd) {
+        int pos = cmd.indexOf(option);
+        
+        //no such key at all
+        if (pos < 0) {
+            return null;
+        }
+        
+        //shift to the end of key position
+        pos += option.length();
+        
+        //ignore leadeing whitespaces
+        while (pos < cmd.length()) {
+            if (cmd.charAt(pos) == ' ') {
+                pos++;
+            } else {
+                break;
+            }
+        }
+        
+        
+        int eos = pos + 1;
+        
+        //end of line
+        if (eos >= cmd.length()) {
+            return "";
+        }
+        
+        //quoted text?
+        if (cmd.charAt(pos) == '\'') {
+            eos = cmd.indexOf('\'', eos);
+            pos++;
+        } else if (cmd.charAt(pos) == '"') {
+            eos = cmd.indexOf('"', eos);
+            pos++;
+        } else {
+            eos = cmd.indexOf(' ', eos);
+        }
+        
+        eos = eos < 0 ? cmd.length() : eos;        
+        return cmd.substring(pos, eos).trim();
+    }
+    
+}

--- a/modeshape-shell/src/main/java/org/modeshape/shell/cmd/ShellCommand.java
+++ b/modeshape-shell/src/main/java/org/modeshape/shell/cmd/ShellCommand.java
@@ -1,0 +1,311 @@
+/*
+ * ModeShape (http://www.modeshape.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.modeshape.shell.cmd;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.modeshape.common.i18n.I18n;
+import org.modeshape.shell.ShellSession;
+import org.modeshape.shell.ShellI18n;
+
+/**
+ * Basic class for shell command.
+ * 
+ * @author kulikov
+ */
+public abstract class ShellCommand {
+    public final static String SILENCE = "";
+    public final static String EOL = System.getProperty("line.separator");
+    public final static String TAB3 = "\t\t\t";
+    
+    //name of the command
+    private final String name;
+    private String fqn;
+    
+    //set of child commands; 
+    //child command starts with name of this command
+    private final HashMap<String, ShellCommand> childCommands = new HashMap<>();
+    
+    //options and arguments of this command
+    //arguments are separated by whitespace and options are highlighed by -key
+    private final HashMap<String, String> options = new HashMap<>();    
+    private final ArrayList<String> arguments = new ArrayList<>();
+
+    //message displayed on help request
+    private final I18n helpMessage;
+    
+    /**
+     * Creates new instance of this command.
+     * 
+     * @param name 
+     */
+    public ShellCommand( String name ) {
+        this.name = this.convertCamelCase(name);
+        this.fqn = this.convertCamelCase(name);
+        this.helpMessage = ShellI18n.unknownCommand;
+    }
+
+    /**
+     * Creates new command instance.
+     * 
+     * @param name the name of the command
+     * @param helpMessage help message.
+     */
+    public ShellCommand( String name, I18n helpMessage ) {
+        this.name = this.convertCamelCase(name);
+        this.fqn = this.convertCamelCase(name);
+        this.helpMessage = helpMessage;
+    }
+    
+    /**
+     * Gets the name of this command.
+     * 
+     * @return command name irrespective of parent
+     */
+    public String name() {
+        return name;
+    }
+   
+    /**
+     * The whole command name including name of parent commands.
+     * 
+     * @return 
+     */
+    protected String fqn() {
+        return fqn;
+    }
+    
+    /**
+     * List of arguments detected by the command.
+     * 
+     * @return 
+     */
+    protected List<String> arguments() {
+        return this.arguments;
+    }
+    
+    /**
+     * List of options detected by the command.
+     * 
+     * @return 
+     */
+    protected Map<String, String> options() {
+        return this.options;
+    }
+    
+    /**
+     * Adds given command to the list of child commands.
+     * 
+     * @param command 
+     */
+    protected void addChild(ShellCommand command) {
+        childCommands.put(command.name, command);
+    }
+    
+    /**
+     * Builds subcommands.
+     * 
+     * @return map between command name command instance.
+     */
+    public Map<String, ShellCommand> buildCommands() {
+        final HashMap<String, ShellCommand> map = new HashMap<>();
+        map.put(this.name, this);
+        for (ShellCommand c : childCommands.values()) {
+            Map<String, ShellCommand> children = c.buildCommands();
+            for (String cname : children.keySet()) {
+                ShellCommand cmd = children.get(cname);
+                cmd.fqn = this.name + " " + cname;
+                map.put(cmd.fqn, cmd);
+            }
+        }        
+        return Collections.unmodifiableMap(map);
+    }
+    
+    /**
+     * Parse command line.
+     * 
+     * @param cmd 
+     */
+    public void prepare(String cmd) {
+        parseOptions(cmd);
+        parseArgs(cmd);
+    }
+    
+    public void prepare(List<String> args, Map<String, String> options) {
+        this.arguments.clear();
+        this.options.clear();
+        
+        this.arguments.addAll(args);
+        this.options.putAll(options);
+    }
+
+    private void parseOptions(String cmd) {
+        options.clear();
+        
+        //determine all option entries
+        String[] tokens = cmd.trim().split(" ");
+        for (String token : tokens) {
+            //is this an option key
+            if (token.startsWith("-")) {
+                options.put(token, CommandParser.getOptionValue(token, cmd));
+            }
+        }
+    }
+    
+    private void parseArgs(String cmd) {
+        int i = cmd.indexOf(fqn) + fqn.length() + 1;
+        String args = i < cmd.length() ? cmd.substring(i) : "";
+        for (String key : options.keySet()) {
+            args = args.replace(key, "");
+            args = args.replace(options.get(key), "");
+        }
+        
+        args = args.trim();
+        
+        int pos = 0;
+        arguments.clear();
+        
+        while (pos < args.length()) {
+            int pos1 = pos + 1;
+            
+            if (args.charAt(pos) == '\'') {
+                pos1 = args.indexOf('\'', pos1);
+                pos++;
+            } else if (args.charAt(pos) == '"') {
+                pos++;
+                pos1 = args.indexOf('"', pos1);
+            } else {
+                pos1 = args.indexOf(' ', pos1);
+            }
+            
+            if (pos1 == -1) pos1 = args.length();
+            arguments.add(args.substring(pos, pos1).trim());
+            pos = pos1;
+        }
+    }
+    
+    /**
+     * Gets value of the given option.
+     * 
+     * @param option option's key
+     * @return option's value as text.
+     */
+    public String optionValue(String option) {
+        return options.get(option);
+    }
+    
+    /**
+     * Gets argument with given index.
+     * 
+     * @param i index value
+     * @return argument value as text or null if index out of range.
+     */
+    public String args(int i) {
+        return i < arguments.size() ? arguments.get(i) : null;
+    }
+    
+    /**
+     * Executes command.
+     * 
+     * @param session
+     * @return
+     * @throws Exception 
+     */
+    public String perform(ShellSession session) throws Exception {
+        if (options.containsKey("-help") || options.containsKey("--help")) {
+            return help();
+        }
+        
+        //execute action if this command has no childs
+        if (childCommands.isEmpty()) {
+            return exec(session);
+        }
+        
+        //otherwise return list of child commands
+        //as completion of this command
+        return complete();
+    }
+    
+    
+    private String complete() {
+        StringBuilder builder = new StringBuilder();
+        
+        ArrayList<String> cnames = new ArrayList<>();
+        cnames.addAll(childCommands.keySet());
+        Collections.sort(cnames);
+        
+        for (String cname : cnames) {
+            builder.append(this.name).append(" ").append(cname).append(" ");
+        }
+        
+        return builder.toString();
+    }
+    
+    /**
+     * This command action implementation.
+     * 
+     * @param shell
+     * @return
+     * @throws Exception 
+     */
+    public String exec(ShellSession session) throws Exception {
+        return SILENCE;
+    }
+    
+    /**
+     * Help message.
+     * 
+     * @return 
+     */
+    public String help() {
+        if (!this.childCommands.isEmpty()) {
+            String opts = "";
+            for (ShellCommand cmd : childCommands.values()) {
+                opts = opts.length() > 0 ? opts + "|" + cmd.name : opts + cmd.name;
+            }
+            return "Usage: " + this.fqn + " " + opts;
+        }
+        return helpMessage.text();
+    }
+
+    public String help(Object... args) {
+        return helpMessage.text(args);
+    }
+    
+    protected boolean allArgsSpecified(Object... args) {
+        for (int i = 0; i < args.length; i++) {
+            if (args[i] == null) return false;
+        }
+        return true;
+    }
+    
+    private String convertCamelCase(String name) {
+        String s = name.toLowerCase();
+        StringBuilder builder = new StringBuilder();
+        for (int i = 0; i < name.length(); i++) {
+            if (name.charAt(i) == s.charAt(i)) {
+                builder.append(name.charAt(i));
+            } else {
+                builder.append('-');
+                builder.append(s.charAt(i));
+            }
+        }
+        return builder.toString();
+    }
+}

--- a/modeshape-shell/src/main/java/org/modeshape/shell/cmd/config/ConfigurationInterpreter.java
+++ b/modeshape-shell/src/main/java/org/modeshape/shell/cmd/config/ConfigurationInterpreter.java
@@ -1,0 +1,37 @@
+/*
+ * ModeShape (http://www.modeshape.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.modeshape.shell.cmd.config;
+
+import org.modeshape.shell.Interpreter;
+import org.modeshape.shell.cmd.ShellCommand;
+
+/**
+ *
+ * @author kulikov
+ */
+public class ConfigurationInterpreter extends Interpreter {
+    private final static String PROMPT = "[configure]$ ";
+    private final static ShellCommand[] COMMANDS = new ShellCommand[] {
+        new ShowCommand(),
+        new SetCommand(),
+        new ExitCommand(),
+        new SaveCommand()
+    };
+    
+    public ConfigurationInterpreter() {
+        super(PROMPT, COMMANDS);
+    }
+}

--- a/modeshape-shell/src/main/java/org/modeshape/shell/cmd/config/ExitCommand.java
+++ b/modeshape-shell/src/main/java/org/modeshape/shell/cmd/config/ExitCommand.java
@@ -1,0 +1,36 @@
+/*
+ * ModeShape (http://www.modeshape.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.modeshape.shell.cmd.config;
+
+import org.modeshape.shell.ShellSession;
+import org.modeshape.shell.cmd.ShellCommand;
+
+/**
+ *
+ * @author kulikov
+ */
+public class ExitCommand extends ShellCommand {
+
+    public ExitCommand() {
+        super("exit");
+    }
+
+    @Override
+    public String exec(ShellSession session) throws Exception {
+        session.setInterpreter(ShellSession.ENGINE_COMMAND_INTERPRETER);
+        return "";
+    }
+}

--- a/modeshape-shell/src/main/java/org/modeshape/shell/cmd/config/SaveCommand.java
+++ b/modeshape-shell/src/main/java/org/modeshape/shell/cmd/config/SaveCommand.java
@@ -1,0 +1,44 @@
+/*
+ * ModeShape (http://www.modeshape.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.modeshape.shell.cmd.config;
+
+import java.io.FileOutputStream;
+import org.modeshape.shell.ShellI18n;
+import org.modeshape.shell.ShellSession;
+import org.modeshape.shell.cmd.ShellCommand;
+
+/**
+ *
+ * @author kulikov
+ */
+public class SaveCommand extends ShellCommand {
+    public SaveCommand() {
+        super("save", ShellI18n.configureSaveHelp);
+    }
+    
+    @Override
+    public String exec(ShellSession session) throws Exception {
+        String fileName = this.optionValue("--destination");
+        if (fileName == null) {
+            throw new IllegalArgumentException(help());
+        }
+        try (FileOutputStream fout = new FileOutputStream(fileName)) {
+            fout.write(session.getRepositoryConfiguration().getDocument().toString().getBytes());
+            fout.flush();
+        }
+        return "";
+    }
+}

--- a/modeshape-shell/src/main/java/org/modeshape/shell/cmd/config/SetCommand.java
+++ b/modeshape-shell/src/main/java/org/modeshape/shell/cmd/config/SetCommand.java
@@ -1,0 +1,34 @@
+/*
+ * ModeShape (http://www.modeshape.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.modeshape.shell.cmd.config;
+
+/**
+ *
+ * @author kulikov
+ */
+public class SetCommand extends SubCommand {
+
+    public SetCommand() {
+        super(null, "set", "", "", "");
+        this.loadSubcommands(this, schema());
+    }
+    
+    @Override
+    protected SubCommand create(SubCommand parent, String name, String type, String defaultValue, String help) {
+        return new SetSubCommand(parent, name, type, defaultValue, help);
+    }
+    
+}

--- a/modeshape-shell/src/main/java/org/modeshape/shell/cmd/config/SetSubCommand.java
+++ b/modeshape-shell/src/main/java/org/modeshape/shell/cmd/config/SetSubCommand.java
@@ -1,0 +1,78 @@
+/*
+ * ModeShape (http://www.modeshape.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.modeshape.shell.cmd.config;
+
+import java.util.List;
+import org.modeshape.jcr.RepositoryConfiguration;
+import org.modeshape.schematic.DocumentFactory;
+import org.modeshape.schematic.document.Document;
+import org.modeshape.schematic.document.EditableDocument;
+import org.modeshape.shell.ShellSession;
+
+/**
+ *
+ * @author kulikov
+ */
+public class SetSubCommand extends SubCommand {
+
+    public SetSubCommand(SubCommand parent, String name, String type, String defaultValue, String help) {
+        super(parent, name, type, defaultValue, help);
+    }
+
+    @Override
+    public String exec(ShellSession session) throws Exception {
+        String value = args(0);
+        if (value == null) {
+            return help();
+        }
+        
+        RepositoryConfiguration cfg = session.getRepositoryConfiguration();
+        
+        List<String> segments = path();
+        EditableDocument newDoc = cfg.edit();
+        EditableDocument doc = findOrCreateEnclosingDocument(newDoc, segments);
+        
+        if (type.equals("array")) {
+            String[] tokens = value.split(",");
+            doc.setArray(segments.get(segments.size() - 1), (Object[]) tokens);
+        } else {        
+            doc.set(segments.get(segments.size() - 1), value);
+        }
+        
+        RepositoryConfiguration cfg1 = new RepositoryConfiguration(newDoc, cfg.getName());
+        
+        session.setRepositoryConfiguration(cfg1);
+        return "";
+    }
+
+    private EditableDocument findOrCreateEnclosingDocument(EditableDocument config, List<String> path) {
+        EditableDocument doc = config;
+        for (int i = 0; i < path.size() - 1; i++) {
+            Object obj = doc.getDocument(path.get(i));
+            if (obj == null) {
+                obj = DocumentFactory.newDocument();
+                doc.set(path.get(i), obj);
+            }
+            doc = ((Document) obj).editable();
+        }
+        return doc;
+    }
+    
+    @Override
+    protected SubCommand create(SubCommand parent, String name, String type, String defaultValue, String help) {
+        return new SetSubCommand(parent, name, type, defaultValue, help);
+    }
+}

--- a/modeshape-shell/src/main/java/org/modeshape/shell/cmd/config/ShowCommand.java
+++ b/modeshape-shell/src/main/java/org/modeshape/shell/cmd/config/ShowCommand.java
@@ -1,0 +1,33 @@
+/*
+ * ModeShape (http://www.modeshape.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.modeshape.shell.cmd.config;
+
+/**
+ *
+ * @author kulikov
+ */
+public class ShowCommand extends SubCommand {
+
+    public ShowCommand() {
+        super(null, "show", "", "", "");
+        this.loadSubcommands(this, schema());
+    }
+
+    @Override
+    protected SubCommand create(SubCommand parent, String name, String type, String defaultValue, String help) {
+        return new ShowSubCommand(parent, name, type, defaultValue, help);
+    }
+}

--- a/modeshape-shell/src/main/java/org/modeshape/shell/cmd/config/ShowSubCommand.java
+++ b/modeshape-shell/src/main/java/org/modeshape/shell/cmd/config/ShowSubCommand.java
@@ -1,0 +1,57 @@
+/*
+ * ModeShape (http://www.modeshape.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.modeshape.shell.cmd.config;
+
+import java.util.List;
+import org.modeshape.jcr.RepositoryConfiguration;
+import org.modeshape.schematic.document.Document;
+import org.modeshape.shell.ShellSession;
+
+/**
+ *
+ * @author kulikov
+ */
+public class ShowSubCommand extends SubCommand {
+
+    public ShowSubCommand(SubCommand parent, String name, String type, String defaultValue, String help) {
+        super(parent, name, type, defaultValue, help);
+    }
+
+    @Override
+    public String exec(ShellSession session) throws Exception {
+        RepositoryConfiguration cfg = session.getRepositoryConfiguration();
+        List<String> segments = path();
+        Document doc = findEnclosingDocument(cfg.edit(), segments);
+                
+        return doc == null ? defaultValue
+                : doc.get(segments.get(segments.size() - 1)).toString();
+    }
+    
+    private Document findEnclosingDocument(Document config, List<String> path) {
+        Document doc = config;
+        int i = 0;
+        while ((i < path.size() - 1) && ((doc = doc.getDocument(path.get(i))) != null)) {
+            i++;
+        }
+        return doc;
+    }
+
+    @Override
+    protected SubCommand create(SubCommand parent, String name, String type, String defaultValue, String help) {
+        return new ShowSubCommand(parent, name, type, defaultValue, help);
+    }
+    
+}

--- a/modeshape-shell/src/main/java/org/modeshape/shell/cmd/config/SubCommand.java
+++ b/modeshape-shell/src/main/java/org/modeshape/shell/cmd/config/SubCommand.java
@@ -1,0 +1,112 @@
+/*
+ * ModeShape (http://www.modeshape.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.modeshape.shell.cmd.config;
+
+import java.io.InputStream;
+import java.util.ArrayList;
+import org.modeshape.schematic.document.Document;
+import org.modeshape.schematic.document.Json;
+import org.modeshape.schematic.document.ParsingException;
+import org.modeshape.shell.cmd.ShellCommand;
+
+/**
+ * This class is used for dynamic building configuration commands using schema.
+ *
+ * @author kulikov
+ */
+public abstract class SubCommand extends ShellCommand {
+
+    private final static String SCHEMA_PATH = "org/modeshape/jcr/repository-config-schema.json";
+    private final SubCommand parent;
+    private final String help;
+    private final String paramName;
+    protected final String type;
+    protected final String defaultValue;
+    
+    public SubCommand(SubCommand parent, String name, String type, String defaultValue, String help) {
+        super(name);
+        this.paramName = name;
+        this.parent = parent;
+        this.type = type;
+        this.help = help;
+        this.defaultValue = defaultValue;
+    }
+
+    protected Document schema() {
+        Document doc = null;
+        try {
+            InputStream schemaFileStream = getClass().getClassLoader().getResourceAsStream(SCHEMA_PATH);
+            doc = Json.read(schemaFileStream);
+            doc = doc.getDocument("properties");
+            return doc;
+        } catch (ParsingException e) {
+        }        
+        return doc;
+    }
+    
+    @Override
+    public String help() {
+        return help != null && help.length() > 0 ? help : super.help();
+    }
+
+    protected abstract SubCommand create(SubCommand parent, String name, 
+            String type, String defaultValue, String help);
+    
+    protected void loadSubcommands(SubCommand parent, Document doc) {
+        for (Document.Field f : doc.fields()) {
+            Document schema = f.getValueAsDocument();
+
+            String t = schema.getString("type");
+            String description = schema.getString("description");
+            String defValue = defaultValue(schema);
+
+            SubCommand ccmd = create(parent, f.getName(), type, 
+                    defValue, description);
+
+            if (t != null && t.equals("object")) {
+                Document d = schema.getDocument("properties");
+                if (d != null) {
+                    loadSubcommands(ccmd, d);
+                }
+            }
+            
+            parent.addChild(ccmd);
+        }
+    }
+    
+    /**
+     * Determines default value of the parameter described by the given schema.
+     * 
+     * @param schema
+     * @return 
+     */
+    private String defaultValue(Document schema) {
+        Object obj = schema.get("default");
+        return obj != null ? obj.toString() : "not specified";
+    }
+    
+    protected ArrayList<String> path() {
+        ArrayList<String> list = new ArrayList<>();
+        list.add(this.paramName);
+        SubCommand p = parent;
+        while (p != null && p.parent != null) {
+            list.add(0, p.paramName);
+            p = p.parent;
+        }
+        return list;
+    }
+    
+}

--- a/modeshape-shell/src/main/java/org/modeshape/shell/cmd/engine/ConfigureCommand.java
+++ b/modeshape-shell/src/main/java/org/modeshape/shell/cmd/engine/ConfigureCommand.java
@@ -1,0 +1,45 @@
+/*
+ * ModeShape (http://www.modeshape.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.modeshape.shell.cmd.engine;
+
+import org.modeshape.jcr.JcrRepository;
+import org.modeshape.shell.ShellI18n;
+import org.modeshape.shell.ShellSession;
+import org.modeshape.shell.cmd.ShellCommand;
+
+/**
+ *
+ * @author kulikov
+ */
+public class ConfigureCommand extends ShellCommand {
+
+    public ConfigureCommand() {
+        super("configure", ShellI18n.engineConfigureRepositoryHelp);
+    }
+
+    @Override
+    public String exec(ShellSession session) throws Exception {
+        String repoName = this.args(0);
+        if (repoName == null) throw new IllegalArgumentException(help());
+        
+        JcrRepository repository = session.engine().getRepository(repoName);
+        session.setRepository(repository);
+        session.setRepositoryConfiguration(repository.getConfiguration());
+        session.setInterpreter(ShellSession.CONFIGURATION_INTERPRETER);
+        
+        return "";
+    }
+}

--- a/modeshape-shell/src/main/java/org/modeshape/shell/cmd/engine/ConnectCommand.java
+++ b/modeshape-shell/src/main/java/org/modeshape/shell/cmd/engine/ConnectCommand.java
@@ -1,0 +1,77 @@
+/*
+ * ModeShape (http://www.modeshape.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.modeshape.shell.cmd.engine;
+
+import javax.jcr.Credentials;
+import javax.jcr.SimpleCredentials;
+import org.modeshape.shell.ShellSession;
+import org.modeshape.shell.ShellI18n;
+import org.modeshape.shell.cmd.ShellCommand;
+
+/**
+ *
+ * @author kulikov
+ */
+public class ConnectCommand extends ShellCommand {
+
+    private final static String RESPONSE  = "Connected to workspace '%s' as user '%s'";
+
+    public ConnectCommand() {
+        super("connect", ShellI18n.connectHelp);
+    }
+
+    @Override
+    public String exec(ShellSession session) throws Exception {
+        String repoName = args(0);
+        if (repoName == null) {
+            throw new IllegalArgumentException(help());
+        }
+        if (session.isAlive()) {
+            return "Session already exists";
+        }
+        
+        String userName = optionValue("--user");
+        String password = optionValue("--password");
+        String workspace = optionValue("--workspace");
+
+        session.setPath("/");
+        session.setRepository(session.engine().getRepository(repoName));
+        if (userName == null && password == null && workspace == null) {
+            session.setJcrSession(session.getRepository().login());
+            session.setInterpreter(ShellSession.JCR_SESSION_INTERPRETER);
+            return String.format(RESPONSE, "default", "anonymous");
+        }
+
+        if (userName == null && password == null && workspace != null) {
+            session.setJcrSession(session.getRepository().login(workspace));
+            session.setInterpreter(ShellSession.JCR_SESSION_INTERPRETER);
+            return String.format(RESPONSE, workspace, "anonymous");
+        }
+
+        char[] paswd = password != null ? password.toCharArray() : new char[]{};
+        Credentials creds = new SimpleCredentials(userName, paswd);
+        if (workspace != null) {
+            session.setJcrSession(session.getRepository().login(creds, workspace));
+            session.setInterpreter(ShellSession.JCR_SESSION_INTERPRETER);
+            return String.format(RESPONSE, workspace, userName);
+        }
+        
+        session.setJcrSession(session.getRepository().login(creds));
+        session.setInterpreter(ShellSession.JCR_SESSION_INTERPRETER);
+        return String.format(RESPONSE, "default", userName);
+    }
+
+}

--- a/modeshape-shell/src/main/java/org/modeshape/shell/cmd/engine/DeployCommand.java
+++ b/modeshape-shell/src/main/java/org/modeshape/shell/cmd/engine/DeployCommand.java
@@ -1,0 +1,46 @@
+/*
+ * ModeShape (http://www.modeshape.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.modeshape.shell.cmd.engine;
+
+import org.modeshape.jcr.RepositoryConfiguration;
+import org.modeshape.shell.ShellI18n;
+import org.modeshape.shell.ShellSession;
+import org.modeshape.shell.cmd.ShellCommand;
+
+/**
+ *
+ * @author kulikov
+ */
+public class DeployCommand extends ShellCommand {
+
+    public DeployCommand() {
+        super("deploy", ShellI18n.engineDeployRepositoryHelp);
+    }
+    
+    @Override
+    public String exec(ShellSession session) throws Exception {
+        String file = this.optionValue("--configuration-file");
+        if (file == null) {
+            throw new IllegalArgumentException(help());
+        }
+        
+        RepositoryConfiguration cfg = new RepositoryConfiguration(file);
+        session.engine().deploy(cfg);
+        
+        return "Deployed " + cfg.getName();
+    }
+
+}

--- a/modeshape-shell/src/main/java/org/modeshape/shell/cmd/engine/EngineCommandInterpreter.java
+++ b/modeshape-shell/src/main/java/org/modeshape/shell/cmd/engine/EngineCommandInterpreter.java
@@ -1,0 +1,40 @@
+/*
+ * ModeShape (http://www.modeshape.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.modeshape.shell.cmd.engine;
+
+import org.modeshape.shell.Interpreter;
+import org.modeshape.shell.cmd.ShellCommand;
+
+/**
+ *
+ * @author kulikov
+ */
+public class EngineCommandInterpreter extends Interpreter {
+    private final static String PROMPT = "[modeshape]$";
+    private final static ShellCommand[] COMMANDS = new ShellCommand[] {
+        new ConfigureCommand(),
+        new DeployCommand(),
+        new ShowCommand(),
+        new StartCommand(),
+        new StopCommand(),
+        new ExitCommand(),
+        new ConnectCommand()        
+    };
+    
+    public EngineCommandInterpreter() {
+        super(PROMPT, COMMANDS);
+    }
+}

--- a/modeshape-shell/src/main/java/org/modeshape/shell/cmd/engine/ExitCommand.java
+++ b/modeshape-shell/src/main/java/org/modeshape/shell/cmd/engine/ExitCommand.java
@@ -1,0 +1,37 @@
+/*
+ * ModeShape (http://www.modeshape.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.modeshape.shell.cmd.engine;
+
+import org.modeshape.shell.ShellI18n;
+import org.modeshape.shell.ShellSession;
+import org.modeshape.shell.cmd.ShellCommand;
+
+/**
+ *
+ * @author kulikov
+ */
+public class ExitCommand extends ShellCommand {
+
+    public ExitCommand() {
+        super("exit", ShellI18n.engineExitHelp);
+    }
+
+    @Override
+    public String exec(ShellSession session) throws Exception {
+        session.exit();
+        return "";        
+    }
+}

--- a/modeshape-shell/src/main/java/org/modeshape/shell/cmd/engine/ShowCommand.java
+++ b/modeshape-shell/src/main/java/org/modeshape/shell/cmd/engine/ShowCommand.java
@@ -1,0 +1,83 @@
+/*
+ * ModeShape (http://www.modeshape.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.modeshape.shell.cmd.engine;
+
+import java.util.Set;
+import org.modeshape.jcr.ModeShapeEngine.State;
+import org.modeshape.shell.ShellI18n;
+import org.modeshape.shell.ShellSession;
+import org.modeshape.shell.cmd.ShellCommand;
+
+/**
+ *
+ * @author kulikov
+ */
+public class ShowCommand extends ShellCommand {
+
+    public ShowCommand() {
+        super("show");
+        addChild(new ShowRepositories());
+        addChild(new ShowState());
+    }
+
+    private class ShowRepositories extends ShellCommand {
+
+        public ShowRepositories() {
+            super("repositories", ShellI18n.engineShowRepositoriesHelp);
+        }
+
+        @Override
+        public String exec(ShellSession session) throws Exception {
+            Set<String> names = session.engine().getRepositoryNames();
+            if (names.isEmpty()) {
+                return "<empty-set>";
+            }
+            
+            StringBuilder builder = new StringBuilder();
+            for (String s : names) {
+                builder.append(s);
+                builder.append("\n");
+            }
+            return builder.toString();
+        }
+
+    }
+    
+    private class ShowState extends ShellCommand {
+
+        public ShowState() {
+            super("state", ShellI18n.engineShowRepositoryStateHelp);
+        }
+
+        @Override
+        public String exec(ShellSession session) throws Exception {
+            String name = this.optionValue("--repository-name");
+            
+            if (name == null) {
+                throw new IllegalArgumentException();
+            }
+            
+            State state = session.engine().getRepositoryState(name);
+            if (state == null) {
+                throw new IllegalStateException("Unknown repository name " + name);
+            }
+            
+            return state.toString();
+        }
+
+    }
+    
+}

--- a/modeshape-shell/src/main/java/org/modeshape/shell/cmd/engine/StartCommand.java
+++ b/modeshape-shell/src/main/java/org/modeshape/shell/cmd/engine/StartCommand.java
@@ -1,0 +1,41 @@
+/*
+ * ModeShape (http://www.modeshape.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.modeshape.shell.cmd.engine;
+
+import org.modeshape.shell.ShellI18n;
+import org.modeshape.shell.ShellSession;
+import org.modeshape.shell.cmd.ShellCommand;
+
+/**
+ *
+ * @author kulikov
+ */
+public class StartCommand extends ShellCommand {
+
+    public StartCommand() {
+        super("start", ShellI18n.engineStartRepositoryHelp);
+    }
+
+    @Override
+    public String exec(ShellSession session) throws Exception {
+        String name = this.optionValue("--repository-name");
+        if (name == null) {
+            throw new IllegalArgumentException();
+        }
+        session.engine().startRepository(name);
+        return "starting '" + name + "' ...";
+    }
+}

--- a/modeshape-shell/src/main/java/org/modeshape/shell/cmd/engine/StopCommand.java
+++ b/modeshape-shell/src/main/java/org/modeshape/shell/cmd/engine/StopCommand.java
@@ -1,0 +1,41 @@
+/*
+ * ModeShape (http://www.modeshape.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.modeshape.shell.cmd.engine;
+
+import org.modeshape.shell.ShellI18n;
+import org.modeshape.shell.ShellSession;
+import org.modeshape.shell.cmd.ShellCommand;
+
+/**
+ *
+ * @author kulikov
+ */
+public class StopCommand extends ShellCommand {
+
+    public StopCommand() {
+        super("stop", ShellI18n.engineStopRepositoryHelp);
+    }
+
+    @Override
+    public String exec(ShellSession session) throws Exception {
+        String name = this.optionValue("--repository-name");
+        if (name == null) {
+            throw new IllegalArgumentException();
+        }
+        session.engine().shutdownRepository(name);
+        return "stoping '" + name + "' ...";
+    }
+}

--- a/modeshape-shell/src/main/java/org/modeshape/shell/cmd/engine/UndeployCommand.java
+++ b/modeshape-shell/src/main/java/org/modeshape/shell/cmd/engine/UndeployCommand.java
@@ -1,0 +1,42 @@
+/*
+ * ModeShape (http://www.modeshape.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.modeshape.shell.cmd.engine;
+
+import org.modeshape.shell.ShellI18n;
+import org.modeshape.shell.ShellSession;
+import org.modeshape.shell.cmd.ShellCommand;
+
+/**
+ *
+ * @author kulikov
+ */
+public class UndeployCommand extends ShellCommand {
+
+    public UndeployCommand() {
+        super("deploy", ShellI18n.engineUndeployRepositoryHelp);
+    }
+    
+    @Override
+    public String exec(ShellSession session) throws Exception {
+        String name = this.optionValue("--repository-name");
+        if (name == null) {
+            throw new IllegalArgumentException(help());
+        }
+        session.engine().undeploy(name);
+        return "Undeployed " + name;
+    }
+
+}

--- a/modeshape-shell/src/main/java/org/modeshape/shell/cmd/jcrsession/AclCommand.java
+++ b/modeshape-shell/src/main/java/org/modeshape/shell/cmd/jcrsession/AclCommand.java
@@ -1,0 +1,170 @@
+/*
+ * ModeShape (http://www.modeshape.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.modeshape.shell.cmd.jcrsession;
+
+import org.modeshape.shell.cmd.ShellCommand;
+import java.security.Principal;
+import javax.jcr.RepositoryException;
+import javax.jcr.security.AccessControlEntry;
+import javax.jcr.security.AccessControlException;
+import javax.jcr.security.AccessControlList;
+import javax.jcr.security.AccessControlManager;
+import javax.jcr.security.AccessControlPolicy;
+import javax.jcr.security.AccessControlPolicyIterator;
+import javax.jcr.security.Privilege;
+import org.modeshape.jcr.security.SimplePrincipal;
+import org.modeshape.shell.ShellSession;
+import org.modeshape.shell.ShellI18n;
+
+/**
+ *
+ * @author kulikov
+ */
+public class AclCommand extends ShellCommand {
+
+    public AclCommand() {
+        super("acl");
+        addChild(new ShowCommand());
+        addChild(new SetCommand());
+        addChild(new RemoveCommand());
+    }
+    
+    private class ShowCommand extends ShellCommand {
+
+        public ShowCommand() {
+            super("show", ShellI18n.aclShowHelp);
+        }
+        
+        @Override
+        public String exec(ShellSession session) throws Exception {
+            String path = session.getPath();
+            AccessControlManager acm = session.jcrSession().getAccessControlManager();
+            AccessControlPolicy[] policies = acm.getPolicies(path);
+            if (policies == null || policies.length == 0) {
+                return "<Empty set>";
+            }
+            
+            StringBuilder builder = new StringBuilder();
+            for (AccessControlPolicy p : policies) {
+                AccessControlList acl = (AccessControlList)p;
+                AccessControlEntry[] entries = acl.getAccessControlEntries();
+                for (AccessControlEntry en : entries) {
+                    builder.append(en.getPrincipal());
+                    builder.append("\t{");
+                    
+                    Privilege[] perms = en.getPrivileges();
+                    for (int i = 0; i < perms.length; i++) {
+                        if (i > 0) builder.append(", ");
+                        builder.append(perms[i]);
+                    }
+                }           
+            }
+            return builder.toString();
+        }
+
+    }
+    
+    private class SetCommand extends ShellCommand {
+        public SetCommand() {
+            super("set", ShellI18n.aclSetHelp);
+        }
+        
+        @Override
+        public String exec(ShellSession session) throws Exception {
+            String principal = optionValue("--principal");
+            String perms = optionValue("--permissions");
+            
+            if (principal == null || perms == null) {
+                return help();
+            }
+            
+            String path = session.getPath();
+            
+            
+            AccessControlManager acm = session.jcrSession().getAccessControlManager();
+            AccessControlPolicy[] policies = acm.getPolicies(path);
+            
+            AccessControlList acl;
+            if (policies != null && policies.length > 0) {
+                acl = (AccessControlList) policies[0];
+            } else {
+                AccessControlPolicyIterator it = acm.getApplicablePolicies(path);
+                acl = (AccessControlList) it.nextAccessControlPolicy();
+            }
+            
+            acl.addAccessControlEntry(principal(principal), privileges(acm, perms));
+            acm.setPolicy(path, acl);
+            
+            return SILENCE;
+        }
+
+    }
+
+    private class RemoveCommand extends ShellCommand {
+
+        public RemoveCommand() {
+            super("remove", ShellI18n.aclRemoveHelp);
+        }
+        
+        @Override
+        public String exec(ShellSession session) throws Exception {
+            String path = session.getPath();
+            AccessControlManager acm = session.jcrSession().getAccessControlManager();
+            AccessControlPolicy[] policies = acm.getPolicies(path);
+
+            
+            if (policies == null || policies.length == 0) {
+                return SILENCE;
+            }
+            
+            String principal = this.optionValue("--principal");
+            if (principal == null) {
+                acm.removePolicy(path, policies[0]);
+                return SILENCE;
+            }
+            
+            AccessControlList acl = (AccessControlList) policies[0];
+            AccessControlEntry entry = null;
+            
+            for (AccessControlEntry en : acl.getAccessControlEntries()) {
+                if (en.getPrincipal().getName().equals(principal)) {
+                    entry = en;
+                    break;
+                }
+            }
+            
+            if (entry != null) {
+                acl.removeAccessControlEntry(entry);
+            }
+
+            acm.setPolicy(path, acl);
+            return SILENCE;
+        }
+    }
+    
+    private Principal principal(String name) {
+        return SimplePrincipal.newInstance(name);
+    }
+    
+    private Privilege[] privileges(AccessControlManager acm, String list) throws AccessControlException, RepositoryException {
+        String tokens[] = list.split(",");
+        Privilege privileges[] = new Privilege[tokens.length];
+        for (int i = 0; i < tokens.length; i++) {
+            privileges[i] = acm.privilegeFromName(tokens[i]);
+        }
+        return privileges;
+    }
+}

--- a/modeshape-shell/src/main/java/org/modeshape/shell/cmd/jcrsession/ChangeNodeCommand.java
+++ b/modeshape-shell/src/main/java/org/modeshape/shell/cmd/jcrsession/ChangeNodeCommand.java
@@ -1,0 +1,86 @@
+/*
+ * ModeShape (http://www.modeshape.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.modeshape.shell.cmd.jcrsession;
+
+import org.modeshape.shell.cmd.ShellCommand;
+import javax.jcr.Node;
+import javax.jcr.PathNotFoundException;
+import javax.jcr.RepositoryException;
+import javax.jcr.Session;
+import org.modeshape.shell.ShellSession;
+import org.modeshape.shell.ShellI18n;
+
+/**
+ *
+ * @author kulikov
+ */
+public class ChangeNodeCommand extends ShellCommand {
+
+    public ChangeNodeCommand() {
+        super("cd", ShellI18n.changeNodeHelp);
+    }
+
+    @Override
+    public String exec(ShellSession session) throws Exception {
+        //required argument
+        String dest = args(0);
+
+        //validate arguments
+        if (!allArgsSpecified(dest)) {
+            return help();
+        }
+
+        //if path is absolute start from root node otherwise from current position
+        String startPoint = isAbsolute(dest) ? "/" : session.getPath();
+        String[] segments = dest.split("/");
+
+        try {
+            String path = changePathStepByStep(session, startPoint, segments);
+            session.setPath(path);
+            return SILENCE;
+        } catch (PathNotFoundException e) {
+            return "Unknown node in the path: " + e.getMessage();
+        }
+    }
+
+    private String changePathStepByStep(ShellSession session, String from, String[] segments) throws PathNotFoundException, RepositoryException {
+        String path = from;
+        for (String name : segments) {
+            path = changePathOnOneStep(session, path, name);
+        }
+        return path;
+    }
+
+    private String changePathOnOneStep(ShellSession s, String from, String step)
+            throws PathNotFoundException, RepositoryException {
+        Session session = s.jcrSession();
+        boolean stepUp = step.equals("..");
+
+        String path = from;
+        Node node = session.getNode(path);
+        if (stepUp) {
+            path = node.getParent().getPath();
+        } else {
+            path = node.getNode(step).getPath();
+        }
+
+        return path;
+    }
+
+    private boolean isAbsolute(String path) {
+        return path.startsWith("/");
+    }
+}

--- a/modeshape-shell/src/main/java/org/modeshape/shell/cmd/jcrsession/ExitCommand.java
+++ b/modeshape-shell/src/main/java/org/modeshape/shell/cmd/jcrsession/ExitCommand.java
@@ -1,0 +1,36 @@
+/*
+ * ModeShape (http://www.modeshape.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.modeshape.shell.cmd.jcrsession;
+
+import org.modeshape.shell.cmd.ShellCommand;
+import org.modeshape.shell.ShellSession;
+
+/**
+ *
+ * @author kulikov
+ */
+public class ExitCommand extends ShellCommand {
+
+    public ExitCommand() {
+        super("exit");
+    }
+
+    @Override
+    public String exec(ShellSession session) throws Exception {
+        session.setInterpreter(ShellSession.ENGINE_COMMAND_INTERPRETER);
+        return "";
+    }
+}

--- a/modeshape-shell/src/main/java/org/modeshape/shell/cmd/jcrsession/JcrSessionInterpreter.java
+++ b/modeshape-shell/src/main/java/org/modeshape/shell/cmd/jcrsession/JcrSessionInterpreter.java
@@ -1,0 +1,46 @@
+/*
+ * ModeShape (http://www.modeshape.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.modeshape.shell.cmd.jcrsession;
+
+import org.modeshape.shell.cmd.ShellCommand;
+import org.modeshape.shell.Interpreter;
+
+/**
+ *
+ * @author kulikov
+ */
+public class JcrSessionInterpreter extends Interpreter {
+    private final static String PROMPT = "[session]$ ";
+    private final static ShellCommand[] COMMANDS = new ShellCommand[] {
+        new SessionCommand(),
+        new WorkspaceCommand(),
+        new NodeCommand(),
+        new VersionCommand(),
+        new TypeCommand(),
+        new ExitCommand(),
+        new ScriptCommand(),
+        new ShowCommand(),
+        new QueryCommand(),
+        new ChangeNodeCommand(),
+        new PwdCommand(),
+        new AclCommand(),
+        new RepositoryCommand()
+    };
+    
+    public JcrSessionInterpreter() {
+        super(PROMPT, COMMANDS);
+    }
+}

--- a/modeshape-shell/src/main/java/org/modeshape/shell/cmd/jcrsession/NodeCommand.java
+++ b/modeshape-shell/src/main/java/org/modeshape/shell/cmd/jcrsession/NodeCommand.java
@@ -1,0 +1,416 @@
+/*
+ * ModeShape (http://www.modeshape.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.modeshape.shell.cmd.jcrsession;
+
+import org.modeshape.shell.cmd.ShellCommand;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import javax.jcr.Binary;
+import javax.jcr.Node;
+import javax.jcr.NodeIterator;
+import javax.jcr.Property;
+import javax.jcr.PropertyIterator;
+import javax.jcr.Value;
+import javax.jcr.ValueFactory;
+import javax.jcr.nodetype.NodeType;
+import org.h2.util.IOUtils;
+import org.modeshape.shell.ShellSession;
+import org.modeshape.shell.ShellI18n;
+
+/**
+ *
+ * @author kulikov
+ */
+public class NodeCommand extends ShellCommand {
+
+    public NodeCommand() {
+        super("node");
+        addChild(new AddCommand());
+        addChild(new ShowCommand());
+        addChild(new SetCommand());
+        addChild(new UploadCommand());
+        addChild(new DownloadCommand());
+    }
+
+    private class AddCommand extends ShellCommand {
+
+        public AddCommand() {
+            super("add");
+            addChild(new AddMixinTypeCommand());
+            addChild(new AddNodeCommand());
+        }
+    }
+
+    private class AddMixinTypeCommand extends ShellCommand {
+
+        public AddMixinTypeCommand() {
+            super("mixin", ShellI18n.nodeAddMixinHelp);
+        }
+
+        @Override
+        public String exec(ShellSession shell) throws Exception {
+            String value = this.args(0);
+            
+            if (value == null) {
+                return help();
+            }
+            
+            String path = shell.getPath();
+            Node node = shell.jcrSession().getNode(path);
+            node.addMixin(value);
+            
+            return SILENCE;
+        }
+
+    }
+
+    private class AddNodeCommand extends ShellCommand {
+
+        public AddNodeCommand() {
+            super("node", ShellI18n.nodeAddNodeHelp);
+        }
+
+        @Override
+        public String exec(ShellSession shell) throws Exception {
+            String relPath = this.args(0);
+            String primaryType = this.optionValue("--primary-type");
+
+            //relative path is mandatory
+            if (relPath == null) {
+                return help();
+            }
+
+            if (relPath.startsWith("/")) {
+                throw new IllegalArgumentException("path must be relative");
+            }
+            
+            String path = shell.getPath();
+            Node node = shell.jcrSession().getNode(path);
+
+            if (primaryType != null) {
+                node.addNode(relPath, primaryType);
+            } else {
+                node.addNode(relPath);
+            }
+            
+            return SILENCE;
+        }
+
+    }
+
+    private class ShowCommand extends ShellCommand {
+
+        public ShowCommand() {
+            super("show");
+            addChild(new ShowIndexCommand());
+            addChild(new ShowIdentifierCommand());
+            addChild(new ShowMixinTypesCommand());
+            addChild(new ShowNodesCommand());
+            addChild(new ShowPropertiesCommand());
+            addChild(new ShowPrimaryTypeCommand());
+            addChild(new ShowPropertyCommand());
+            addChild(new ShowReferencesCommand());
+        }
+    }
+
+    private class ShowIndexCommand extends ShellCommand {
+
+        public ShowIndexCommand() {
+            super("index", ShellI18n.nodeShowIndexHelp);
+        }
+
+        @Override
+        public String exec(ShellSession shell) throws Exception {
+            String path = shell.getPath();
+            Node node = shell.jcrSession().getNode(path);
+            return Integer.toString(node.getIndex());
+        }
+
+    }
+
+    private class ShowIdentifierCommand extends ShellCommand {
+
+        public ShowIdentifierCommand() {
+            super("identifier", ShellI18n.nodeShowIdentifierHelp);
+        }
+
+        @Override
+        public String exec(ShellSession shell) throws Exception {
+            String path = shell.getPath();
+            Node node = shell.jcrSession().getNode(path);
+            return Integer.toString(node.getIndex());
+        }
+
+    }
+
+    private class ShowPrimaryTypeCommand extends ShellCommand {
+
+        public ShowPrimaryTypeCommand() {
+            super("primary-type", ShellI18n.nodeShowPrimaryTypeHelp);
+        }
+
+        @Override
+        public String exec(ShellSession shell) throws Exception {
+            String path = shell.getPath();
+            Node node = shell.jcrSession().getNode(path);
+            return node.getPrimaryNodeType().getName();
+        }
+
+    }
+
+    private class ShowMixinTypesCommand extends ShellCommand {
+
+        public ShowMixinTypesCommand() {
+            super("mixins", ShellI18n.nodeShowMixinsHelp);
+        }
+
+        @Override
+        public String exec(ShellSession shell) throws Exception {
+            String path = shell.getPath();
+            Node node = shell.jcrSession().getNode(path);
+
+            NodeType[] list = node.getMixinNodeTypes();
+            if (list.length == 0) {
+                return "<empty set>";
+            }
+            
+            StringBuilder builder = new StringBuilder();
+            for (NodeType t : list) {
+                builder.append(t.getName()).append(EOL);
+            }
+            return builder.toString();
+        }
+
+    }
+
+    private class ShowNodesCommand extends ShellCommand {
+
+        public ShowNodesCommand() {
+            super("nodes", ShellI18n.nodeShowNodesHelp);
+        }
+
+        @Override
+        public String exec(ShellSession shell) throws Exception {
+            String path = shell.getPath();
+            Node node = shell.jcrSession().getNode(path);
+
+            NodeIterator list = node.getNodes();
+            if (!list.hasNext()) {
+                return "<empty set>";
+            }
+            
+            StringBuilder builder = new StringBuilder();
+            while (list.hasNext()) {
+                builder.append(list.nextNode().getName()).append(EOL);
+            }
+            return builder.toString();
+        }
+
+    }
+
+    private class ShowPropertiesCommand extends ShellCommand {
+
+        public ShowPropertiesCommand() {
+            super("properties", ShellI18n.nodeShowPropertiesHelp);
+        }
+
+        @Override
+        public String exec(ShellSession shell) throws Exception {
+            String path = shell.getPath();
+            Node node = shell.jcrSession().getNode(path);
+
+            PropertyIterator list = node.getProperties();
+            StringBuilder builder = new StringBuilder();
+            while (list.hasNext()) {
+                builder.append(list.nextProperty().getName()).append(EOL);
+            }
+            return builder.toString();
+        }
+    }
+
+    private class ShowPropertyCommand extends ShellCommand {
+
+        public ShowPropertyCommand() {
+            super("property", ShellI18n.nodeShowPropertyHelp);
+        }
+
+        @Override
+        public String exec(ShellSession shell) throws Exception {
+            String pname = args(0);
+            
+            if (pname == null) {
+                return help();
+            }
+            
+            String path = shell.getPath();
+            Node node = shell.jcrSession().getNode(path);
+
+            Property p = node.getProperty(pname);
+            return p != null ? p.getString() : "not assigned";
+        }
+
+    }
+
+    private class ShowReferencesCommand extends ShellCommand {
+
+        public ShowReferencesCommand() {
+            super("references", ShellI18n.nodeShowReferencesHelp);
+        }
+
+        @Override
+        public String exec(ShellSession shell) throws Exception {
+            String path = shell.getPath();
+            Node node = shell.jcrSession().getNode(path);
+
+            StringBuilder builder = new StringBuilder();
+            PropertyIterator list = node.getReferences();
+            while (list.hasNext()) {
+                builder.append(list.nextProperty().getName()).append(EOL);
+            }
+            return builder.toString();
+        }
+
+    }
+
+    private class SetCommand extends ShellCommand {
+        public SetCommand() {
+            super("set");
+            addChild(new SetPrimaryTypeCommand());
+            addChild(new SetPropertyCommand());
+        }
+    }
+
+    private class SetPrimaryTypeCommand extends ShellCommand {
+
+        public SetPrimaryTypeCommand() {
+            super("primary-type", ShellI18n.nodeSetPrimaryTypeHelp);
+        }
+        
+        @Override
+        public String exec(ShellSession shell) throws Exception {
+            String typeName = args(0);
+            
+            if (typeName == null) {
+                return help();
+            }
+            
+            String path = shell.getPath();
+            Node node = shell.jcrSession().getNode(path);
+            node.setPrimaryType(typeName);
+            
+            return "";
+        }
+    }
+    
+    private class SetPropertyCommand extends ShellCommand {
+
+        public SetPropertyCommand() {
+            super("property-value", ShellI18n.nodeSetPropertyValueHelp);
+        }
+
+        @Override
+        public String exec(ShellSession shell) throws Exception {
+            String pname = optionValue("--name");
+            String pvalue = optionValue("--value");
+            String pvalues = optionValue("--values");
+
+            if (pname == null) {
+                return help();
+            }
+            
+            if (pvalues == null && pvalue == null) {
+                return help();
+            }
+            
+            String path = shell.getPath();
+            Node node = shell.jcrSession().getNode(path);
+            
+            ValueFactory factory = shell.jcrSession().getValueFactory();
+            
+            if (pvalue != null) {
+                node.setProperty(pname, factory.createValue(pvalue));
+            } else {
+                String[] tokens = pvalues.split(",");
+                Value[] values = new Value[tokens.length];
+                for (int i = 0; i < values.length; i++) {
+                    values[i] = factory.createValue(tokens[i]);
+                }
+                node.setProperty(path, values);
+            }
+
+            return SILENCE;
+        }
+
+    }
+
+    private class UploadCommand extends ShellCommand {
+
+        public UploadCommand() {
+            super("upload", ShellI18n.nodeUploadHelp);
+        }
+
+        @Override
+        public String exec(ShellSession shell) throws Exception {
+            String path = shell.getPath();
+
+            String pname = optionValue("--property-name");
+            String fname = optionValue("--file");
+
+            if (fname == null || pname == null) {
+                return help();
+            }
+            
+            try (FileInputStream fin = new FileInputStream(fname)) {
+                ValueFactory valueFactory = shell.jcrSession().getValueFactory();
+
+                Binary binaryValue = valueFactory.createBinary(fin);
+                shell.jcrSession().getNode(path).setProperty(pname, binaryValue);
+            }
+            return SILENCE;
+        }
+
+    }
+
+    private class DownloadCommand extends ShellCommand {
+
+        public DownloadCommand() {
+            super("download", ShellI18n.nodeDownloadHelp);
+        }
+
+        @Override
+        public String exec(ShellSession shell) throws Exception {
+            String path = shell.getPath();
+
+            String pname = optionValue("--name");
+            String fname = optionValue("--file");
+
+            if (fname == null || pname == null) {
+                return help();
+            }
+
+            FileOutputStream fout = new FileOutputStream(fname);
+            try {
+                Binary binaryValue = shell.jcrSession().getNode(path).getProperty(pname).getBinary();
+                IOUtils.copy(binaryValue.getStream(), fout);
+            } finally {
+                fout.flush();
+                fout.close();
+            }
+            return SILENCE;
+        }
+
+    }
+}

--- a/modeshape-shell/src/main/java/org/modeshape/shell/cmd/jcrsession/PwdCommand.java
+++ b/modeshape-shell/src/main/java/org/modeshape/shell/cmd/jcrsession/PwdCommand.java
@@ -1,0 +1,38 @@
+/*
+ * ModeShape (http://www.modeshape.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.modeshape.shell.cmd.jcrsession;
+
+import org.modeshape.shell.cmd.ShellCommand;
+import org.modeshape.shell.ShellSession;
+import org.modeshape.shell.ShellI18n;
+
+/**
+ * Print current node path command.
+ * 
+ * @author kulikov
+ */
+public class PwdCommand extends ShellCommand {
+
+    public PwdCommand() {
+        super("pwd", ShellI18n.pwdHelp);
+    }
+    
+    @Override
+    public String exec(ShellSession session) throws Exception {
+        return session.getPath();
+    }
+    
+}

--- a/modeshape-shell/src/main/java/org/modeshape/shell/cmd/jcrsession/QueryCommand.java
+++ b/modeshape-shell/src/main/java/org/modeshape/shell/cmd/jcrsession/QueryCommand.java
@@ -1,0 +1,80 @@
+/*
+ * ModeShape (http://www.modeshape.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.modeshape.shell.cmd.jcrsession;
+
+import org.modeshape.shell.cmd.ShellCommand;
+import javax.jcr.RepositoryException;
+import javax.jcr.Value;
+import javax.jcr.query.Query;
+import javax.jcr.query.QueryResult;
+import javax.jcr.query.Row;
+import javax.jcr.query.RowIterator;
+import org.modeshape.shell.ShellSession;
+import org.modeshape.shell.ShellI18n;
+
+/**
+ *
+ * @author kulikov
+ */
+public class QueryCommand extends ShellCommand {
+
+    public QueryCommand() {
+        super("query", ShellI18n.queryHelp);
+    }
+    
+    @Override
+    public String exec(ShellSession session) throws Exception {
+        String lang = optionValue("--lang");
+        String queryString = args(0);
+        
+        if (!this.allArgsSpecified(lang, queryString)) {
+            return help();
+        }
+        
+        //execute query
+        Query query = session.jcrSession().getWorkspace().getQueryManager().createQuery(queryString, lang);
+        QueryResult res = query.execute();
+
+        StringBuilder builder = new StringBuilder();
+
+        printColumns(res.getColumnNames(), builder);
+        printRows(res.getRows(), builder);
+        
+        return builder.toString();
+    }
+
+    private void printColumns(String[] columns, StringBuilder builder) {
+        for (int i = 0; i < columns.length; i++) {
+            if (i > 0) {
+                builder.append(TAB3);
+            }
+            builder.append(columns[i]);
+        }
+        builder.append(EOL);
+    }
+    
+    private void printRows(RowIterator it, StringBuilder builder) throws RepositoryException {
+        while (it.hasNext()) {
+            Row row = it.nextRow();
+            Value[] values = row.getValues();
+            for (int i = 0; i < values.length; i++) {
+                if (i > 0) builder.append(TAB3);
+                builder.append(values[i]);
+            }
+            builder.append(EOL);
+        }
+    }
+}

--- a/modeshape-shell/src/main/java/org/modeshape/shell/cmd/jcrsession/RepositoryCommand.java
+++ b/modeshape-shell/src/main/java/org/modeshape/shell/cmd/jcrsession/RepositoryCommand.java
@@ -1,0 +1,114 @@
+/*
+ * ModeShape (http://www.modeshape.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.modeshape.shell.cmd.jcrsession;
+
+import org.modeshape.shell.cmd.ShellCommand;
+import java.io.File;
+import org.modeshape.jcr.api.BackupOptions;
+import org.modeshape.jcr.api.RepositoryManager;
+import org.modeshape.jcr.api.RestoreOptions;
+import org.modeshape.shell.ShellSession;
+import org.modeshape.shell.ShellI18n;
+
+/**
+ *
+ * @author kulikov
+ */
+public class RepositoryCommand extends ShellCommand {
+
+    public RepositoryCommand() {
+        super("repository");
+        addChild(new BackupCommand());
+        addChild(new RestoreCommand());
+    }
+    
+    private class BackupCommand extends ShellCommand {
+
+        public BackupCommand() {
+            super("backup", ShellI18n.repositoryBackupHelp);
+        }
+        
+        @Override
+        public String exec(ShellSession session) throws Exception {
+            String path = args(0);
+            
+            if (path == null) {
+                return help();
+            }
+            
+            BackupOptions opts = new BackupOptions() {
+                
+                @Override
+                public boolean includeBinaries() {
+                    return optionValue("--include-binaries") != null;
+                }
+                
+                @Override
+                public long documentsPerFile() {
+                    String s = optionValue("--documents-per-file");
+                    return s != null ? Long.parseLong(s) : super.documentsPerFile();
+                }
+            };
+            
+            org.modeshape.jcr.api.Session msSession = 
+                    (org.modeshape.jcr.api.Session)session.jcrSession();
+            RepositoryManager rm = msSession.getWorkspace().getRepositoryManager();
+            rm.backupRepository(new File(path), opts);
+            
+            return SILENCE;
+        }
+
+    }
+    
+    private class RestoreCommand extends ShellCommand {
+
+        public RestoreCommand() {
+            super("restore", ShellI18n.repositoryRestoreHelp);
+        }
+        
+        @Override
+        public String exec(ShellSession session) throws Exception {
+            String path = args(0);
+            
+            if (path == null) {
+                return help();
+            }
+            
+            RestoreOptions opts = new RestoreOptions() {
+                
+                @Override
+                public boolean includeBinaries() {
+                    return optionValue("--include-binaries") != null;
+                }
+                
+                @Override
+                public boolean reindexContentOnFinish() {
+                    return optionValue("--reindex-on-finish") != null;
+                }               
+                
+            };
+            
+            org.modeshape.jcr.api.Session msSession = 
+                    (org.modeshape.jcr.api.Session)session.jcrSession();
+            RepositoryManager rm = msSession.getWorkspace().getRepositoryManager();
+            rm.restoreRepository(new File(path), opts);
+            
+            return SILENCE;
+        }
+
+    }
+    
+}

--- a/modeshape-shell/src/main/java/org/modeshape/shell/cmd/jcrsession/ScriptCommand.java
+++ b/modeshape-shell/src/main/java/org/modeshape/shell/cmd/jcrsession/ScriptCommand.java
@@ -1,0 +1,31 @@
+/*
+ * ModeShape (http://www.modeshape.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.modeshape.shell.cmd.jcrsession;
+
+import org.modeshape.shell.cmd.ShellCommand;
+import org.modeshape.shell.ShellI18n;
+
+/**
+ *
+ * @author kulikov
+ */
+public class ScriptCommand extends ShellCommand {
+
+    public ScriptCommand() {
+        super("script", ShellI18n.scriptHelp);
+    }
+    
+}

--- a/modeshape-shell/src/main/java/org/modeshape/shell/cmd/jcrsession/SessionCommand.java
+++ b/modeshape-shell/src/main/java/org/modeshape/shell/cmd/jcrsession/SessionCommand.java
@@ -1,0 +1,345 @@
+/*
+ * ModeShape (http://www.modeshape.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.modeshape.shell.cmd.jcrsession;
+
+import org.modeshape.shell.cmd.ShellCommand;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import javax.jcr.Credentials;
+import javax.jcr.ImportUUIDBehavior;
+import javax.jcr.SimpleCredentials;
+import org.modeshape.shell.ShellSession;
+import org.modeshape.shell.ShellI18n;
+
+/**
+ *
+ * @author kulikov
+ */
+public class SessionCommand extends ShellCommand {
+    public SessionCommand() {
+        super("session");
+        addChild(new RefreshCmd());
+        addChild(new ExitCmd());
+        addChild(new SaveCmd());
+        addChild(new StatusCmd());
+        addChild(new ImpersonateCmd());
+        addChild(new MoveCmd());
+        addChild(new RemoveCmd());
+        addChild(new ImportCmd());
+        addChild(new ExportCmd());
+        addChild(new ShowCmd());
+    }
+    
+    private class RefreshCmd extends ShellCommand {
+
+        public RefreshCmd() {
+            super("refresh", ShellI18n.sessionRefreshHelp);
+        }
+        
+        @Override
+        public String exec(ShellSession session) throws Exception {
+            boolean keepChanges = false;
+            
+            String s = this.optionValue("--keep-changes");
+            if (s != null) keepChanges = Boolean.valueOf(s);
+            
+            session.jcrSession().refresh(keepChanges);
+            return SILENCE;
+        }
+                
+    }
+    
+    private class ExitCmd extends ShellCommand {
+
+        public ExitCmd() {
+            super("exit", ShellI18n.sessionExitHelp);
+        }
+
+        @Override
+        public String exec(ShellSession session) throws Exception {
+            session.jcrSession().logout();
+            session.setJcrSession(null);
+            return SILENCE;
+        }
+        
+    }
+
+    private class SaveCmd extends ShellCommand {
+
+        public SaveCmd() {
+            super("save", ShellI18n.sessionExitHelp);
+        }
+
+        @Override
+        public String exec(ShellSession session) throws Exception {
+            session.jcrSession().save();
+            return SILENCE;
+        }
+    }
+
+    private class StatusCmd extends ShellCommand {
+
+        public StatusCmd() {
+            super("status", ShellI18n.sessionStatusHelp);
+        }
+
+        @Override
+        public String exec(ShellSession session) throws Exception {
+            return (session.jcrSession() != null && session.jcrSession().isLive()) ?
+                    "alive" : "not alive";
+        }
+        
+    }
+
+    private class ImpersonateCmd extends ShellCommand {
+
+        public ImpersonateCmd() {
+            super("impersonate", ShellI18n.sessionImpersonateHelp);
+        }
+
+        @Override
+        public String exec(ShellSession session) throws Exception {
+            String uname = this.optionValue("--user");
+            String passwd = this.optionValue("--password");
+            
+            if (uname == null) {
+                session.jcrSession().impersonate(null);
+            } else if (passwd == null) {
+                Credentials creds = new SimpleCredentials(uname, null);
+                session.jcrSession().impersonate(creds);
+            } else {
+                Credentials creds = new SimpleCredentials(uname, passwd.toCharArray());
+                session.jcrSession().impersonate(creds);
+            }
+            return "";
+        }
+        
+    }
+
+    
+    private class MoveCmd extends ShellCommand {
+
+        public MoveCmd() {
+            super("move", ShellI18n.sessionMoveHelp);
+        }
+
+        @Override
+        public String exec(ShellSession session) throws Exception {
+            String src = this.args(0);
+            String dst = this.args(1);
+            
+            if (src == null) {
+                throw new IllegalArgumentException("source path should be specified");
+            }
+
+            if (dst == null) {
+                throw new IllegalArgumentException("destination path should be specified");
+            }
+            
+            session.jcrSession().move(src, dst);
+            return SILENCE;
+        }
+        
+    }
+
+    private class RemoveCmd extends ShellCommand {
+
+        public RemoveCmd() {
+            super("remove", ShellI18n.sessionRemoveHelp);
+        }
+
+        @Override
+        public String exec(ShellSession session) throws Exception {
+            String src = this.args(0);
+            
+            if (src == null) {
+                throw new IllegalArgumentException("path should be specified");
+            }
+            
+            session.jcrSession().removeItem(src);
+            return SILENCE;
+        }
+        
+    }
+
+    private class ImportCmd extends ShellCommand {
+
+        public ImportCmd() {
+            super("import", ShellI18n.sessionImportHelp);
+        }
+
+        @Override
+        public String exec(ShellSession session) throws Exception {
+            String sourceFile = this.args(0);            
+            FileInputStream fin = new FileInputStream(sourceFile);
+            
+            String parent = this.optionValue("--path");
+            String b = this.optionValue("--behaviour");
+            
+            int i = ImportUUIDBehavior.IMPORT_UUID_CREATE_NEW;
+            switch (b) {
+                case "create-new":
+                    i = ImportUUIDBehavior.IMPORT_UUID_CREATE_NEW;
+                    break;
+                case "remove-existing":
+                    i = ImportUUIDBehavior.IMPORT_UUID_COLLISION_REMOVE_EXISTING;
+                    break;
+                case "replace-existing":
+                    i = ImportUUIDBehavior.IMPORT_UUID_COLLISION_REPLACE_EXISTING;
+                    break;
+                case "collision-throw":
+                    i = ImportUUIDBehavior.IMPORT_UUID_COLLISION_THROW;
+                    break;
+            }
+            
+            session.jcrSession().importXML(parent, fin, i);
+            return "";
+        }
+        
+    }
+
+    private class ExportCmd extends ShellCommand {
+
+        public ExportCmd() {
+            super("export");
+        }
+
+        @Override
+        public String exec(ShellSession session) throws Exception {
+            String path = this.args(0);
+            String dst = this.optionValue("--destination-file");
+
+            
+            FileOutputStream fout = new FileOutputStream(dst);
+            
+            String v = this.optionValue("--view");
+            boolean skipBinary = this.optionValue("--skipBinary") != null;
+            boolean noRecurse = this.optionValue("--noRecurse") != null;
+            
+            switch (v) {
+                case "system":
+                    session.jcrSession().exportSystemView(path, fout, skipBinary, noRecurse);
+                    break;
+                case "document":
+                    session.jcrSession().exportDocumentView(path, fout, skipBinary, noRecurse);
+                    break;
+            }
+            return SILENCE;
+        }
+        
+    }
+
+    private class ShowCmd extends ShellCommand {
+
+        public ShowCmd() {
+            super("show");
+            addChild(new ShowAttributeNamesCmd());
+            addChild(new ShowPrefixesCmd());
+            addChild(new ShowAttributeCmd());
+            addChild(new ShowPrefixCmd());
+            addChild(new ShowUriCmd());
+        }
+
+    }
+
+    private class ShowAttributeNamesCmd extends ShellCommand {
+
+        public ShowAttributeNamesCmd() {
+            super("attributes", ShellI18n.sessionShowAttributesHelp);
+        }
+
+        @Override
+        public String exec(ShellSession session) throws Exception {
+            StringBuilder builder = new StringBuilder();
+            String[] names = session.jcrSession().getAttributeNames();
+            for (String name : names) {
+                builder.append(name).append(EOL);
+            }
+            return builder.toString();
+        }
+        
+    }
+
+    private class ShowPrefixesCmd extends ShellCommand {
+
+        public ShowPrefixesCmd() {
+            super("prefixes", ShellI18n.sessionShowPrefixesHelp);
+        }
+
+        @Override
+        public String exec(ShellSession session) throws Exception {
+            StringBuilder builder = new StringBuilder();
+            String[] names = session.jcrSession().getNamespacePrefixes();
+            for (String name : names) {
+                builder.append(name).append(EOL);
+            }
+            return builder.toString();
+        }
+        
+    }
+    
+    private class ShowAttributeCmd extends ShellCommand {
+
+        public ShowAttributeCmd() {
+            super("attribute", ShellI18n.sessionShowAttributeHelp);
+        }
+
+        @Override
+        public String exec(ShellSession session) throws Exception {
+            String aname = this.args(0);
+            assert aname != null : "Attribute name expected";
+            
+            Object value = session.jcrSession().getAttribute(aname);
+            return value == null ? "null" : value.toString();
+        }
+        
+    }
+
+    private class ShowPrefixCmd extends ShellCommand {
+
+        public ShowPrefixCmd() {
+            super("prefix", ShellI18n.sessionShowPrefixHelp);
+        }
+
+        @Override
+        public String exec(ShellSession session) throws Exception {
+            String aname = this.args(0);
+            assert aname != null : "uri expected";
+            
+            Object value = session.jcrSession().getNamespacePrefix(aname);
+            return value == null ? "null" : value.toString();
+        }
+        
+    }
+
+    private class ShowUriCmd extends ShellCommand {
+
+        public ShowUriCmd() {
+            super("uri", ShellI18n.sessionShowUriHelp);
+        }
+
+        @Override
+        public String exec(ShellSession session) throws Exception {
+            String aname = this.args(0);
+            assert aname != null : "Prefix name expected";
+            
+            Object value = session.jcrSession().getNamespaceURI(aname);
+            return value == null ? "null" : value.toString();
+        }
+        
+    }
+    
+}

--- a/modeshape-shell/src/main/java/org/modeshape/shell/cmd/jcrsession/ShowCommand.java
+++ b/modeshape-shell/src/main/java/org/modeshape/shell/cmd/jcrsession/ShowCommand.java
@@ -1,0 +1,210 @@
+/*
+ * ModeShape (http://www.modeshape.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.modeshape.shell.cmd.jcrsession;
+
+import org.modeshape.shell.cmd.ShellCommand;
+import javax.jcr.Node;
+import javax.jcr.NodeIterator;
+import javax.jcr.Property;
+import javax.jcr.PropertyIterator;
+import javax.jcr.nodetype.NodeType;
+import org.modeshape.jcr.api.PropertyType;
+import org.modeshape.shell.ShellSession;
+
+/**
+ *
+ * @author kulikov
+ */
+public class ShowCommand extends ShellCommand {
+
+    public ShowCommand() {
+        super("show");
+        addChild(new ShowChilds());
+        addChild(new ShowProperties());
+        addChild(new ShowProperty());
+        addChild(new ShowType());
+    }
+
+    private void printPropertyDefinition(StringBuilder builder, String name, boolean v) {
+        builder.append(name);
+        builder.append("\t\t\t");
+        builder.append(booleanValue(v));
+        builder.append("\n");
+    }
+
+    private String booleanValue(boolean a) {
+        return a ? "yes" : "no";
+    }
+
+    @Override
+    public String help() {
+        return "usage: list OPTIONS";
+    }
+
+    @Override
+    public String exec(ShellSession session) throws Exception {
+        return "";
+    }
+
+    private class ShowChilds extends ShellCommand {
+
+        public ShowChilds() {
+            super("nodes");
+        }
+
+        @Override
+        public String exec(ShellSession session) throws Exception {
+            Node node = session.jcrSession().getNode(session.getPath());
+            NodeIterator it = node.getNodes();
+
+            StringBuilder builder = new StringBuilder();
+            while (it.hasNext()) {
+                Node child = it.nextNode();
+                builder.append(child.getName().trim())
+                        .append("\t\t\t")
+                        .append(child.getPrimaryNodeType().getName().trim())
+                        .append("\n");
+            }
+            return builder.toString();
+        }
+
+        @Override
+        public String help() {
+            return "usage: show nodes";
+        }
+    }
+
+    private class ShowProperties extends ShellCommand {
+
+        public ShowProperties() {
+            super("properties");
+        }
+
+        @Override
+        public String exec(ShellSession session) throws Exception {
+            StringBuilder builder = new StringBuilder();
+            Node node = session.jcrSession().getNode(session.getPath());
+            PropertyIterator it = node.getProperties();
+            while (it.hasNext()) {
+                Property p = it.nextProperty();
+                builder.append(p.getName());
+                builder.append("\t\t\t");
+                builder.append(PropertyType.nameFromValue(p.getType()));
+                builder.append("\n");
+            }
+            return builder.toString();
+        }
+
+        @Override
+        public String help() {
+            return "usage: show properties";
+        }
+    }
+    
+    private class ShowProperty extends ShellCommand {
+
+        public ShowProperty() {
+            super("property");
+        }
+
+        @Override
+        public String exec(ShellSession session) throws Exception {
+            StringBuilder builder = new StringBuilder();
+            Node node = session.jcrSession().getNode(session.getPath());
+            Property p = node.getProperty(this.args(1));
+
+            printPropertyDefinition(builder, "auto created", p.getDefinition().isAutoCreated());
+            printPropertyDefinition(builder, "multiple", p.getDefinition().isMultiple());
+            printPropertyDefinition(builder, "mandatory", p.getDefinition().isMandatory());
+            printPropertyDefinition(builder, "protected", p.getDefinition().isProtected());
+            printPropertyDefinition(builder, "allow full text search", p.getDefinition().isFullTextSearchable());
+            printPropertyDefinition(builder, "allow query order", p.getDefinition().isQueryOrderable());
+
+            return builder.toString();
+        }
+
+        @Override
+        public String help() {
+            return "usage: show properties";
+        }
+    }
+
+    private class ShowType extends ShellCommand {
+
+        public ShowType() {
+            super("type");
+            addChild(new ShowPrimaryType());
+            addChild(new ShowMixinType());
+        }
+
+        @Override
+        public String help() {
+            return "usage: show type primary| mixin";
+        }
+
+        @Override
+        public String exec(ShellSession session) throws Exception {
+            return "";
+        }
+    }
+
+    private class ShowPrimaryType extends ShellCommand {
+
+        public ShowPrimaryType() {
+            super("primary");
+        }
+
+        @Override
+        public String exec(ShellSession session) throws Exception {
+            Node node = session.jcrSession().getNode(session.getPath());
+            return node.getPrimaryNodeType().getName();
+        }
+
+        @Override
+        public String help() {
+            return "usage: show type primary| mixin";
+        }
+    }
+    
+    private class ShowMixinType extends ShellCommand {
+
+        public ShowMixinType() {
+            super("mixin");
+        }
+
+        @Override
+        public String exec(ShellSession session) throws Exception {
+            final StringBuilder builder = new StringBuilder();
+            Node node = session.jcrSession().getNode(session.getPath());
+            NodeType[] mixin = node.getMixinNodeTypes();
+            if (mixin.length > 0) {
+                for (NodeType t : mixin) {
+                    builder.append(t.getName());
+                    builder.append("\n");
+                }
+            } else {
+                builder.append("[not assigned]");
+            }
+            return builder.toString();
+        }
+
+        @Override
+        public String help() {
+            return "usage: show type primary| mixin";
+        }
+    }
+    
+}

--- a/modeshape-shell/src/main/java/org/modeshape/shell/cmd/jcrsession/TypeCommand.java
+++ b/modeshape-shell/src/main/java/org/modeshape/shell/cmd/jcrsession/TypeCommand.java
@@ -1,0 +1,222 @@
+/*
+ * ModeShape (http://www.modeshape.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.modeshape.shell.cmd.jcrsession;
+
+import org.modeshape.shell.cmd.ShellCommand;
+import java.net.URL;
+import javax.jcr.PropertyType;
+import javax.jcr.nodetype.NodeDefinition;
+import javax.jcr.nodetype.NodeType;
+import javax.jcr.nodetype.NodeTypeIterator;
+import javax.jcr.nodetype.NodeTypeManager;
+import javax.jcr.nodetype.PropertyDefinition;
+import org.modeshape.jcr.JcrNodeTypeManager;
+import org.modeshape.shell.ShellSession;
+import org.modeshape.shell.ShellI18n;
+
+/**
+ *
+ * @author kulikov
+ */
+public class TypeCommand extends ShellCommand {
+
+    public TypeCommand() {
+        super("ntm");
+        addChild(new ShowCommand());
+        addChild(new RegisterCommand());
+        addChild(new UnregisterCommand());
+    }
+
+    private class RegisterCommand extends ShellCommand {
+
+        public RegisterCommand() {
+            super("register", ShellI18n.typeRegisterHelp);
+        }
+
+        @Override
+        public String exec(ShellSession session) throws Exception {
+            String url = optionValue("--url");
+            if (url == null || url.length() == 0) {
+                return help();
+            }
+
+            boolean allowUpdates = optionValue("--allow-updates") != null;
+            JcrNodeTypeManager ntm = (JcrNodeTypeManager) session.jcrSession().getWorkspace().getNodeTypeManager();
+            ntm.registerNodeTypes(new URL(url), allowUpdates);
+            
+            return SILENCE;
+        }
+
+    }
+
+    private class UnregisterCommand extends ShellCommand {
+
+        public UnregisterCommand() {
+            super("unregister", ShellI18n.typeUnregisterHelp);
+        }
+
+        @Override
+        public String exec(ShellSession session) throws Exception {
+            String name = optionValue("--type-name");
+            if (name == null || name.length() == 0) {
+                return help();
+            }
+
+            NodeTypeManager ntm = session.jcrSession().getWorkspace().getNodeTypeManager();
+            ntm.unregisterNodeType(name);
+            return SILENCE;
+        }
+
+    }
+
+    private class ShowCommand extends ShellCommand {
+
+        public ShowCommand() {
+            super("show");
+            addChild(new ShowTypesCommand());
+            addChild(new ShowPropertyDefsCommand());
+            addChild(new ShowChildNodeDefsCommand());
+        }
+
+    }
+
+    private class ShowTypesCommand extends ShellCommand {
+
+        public ShowTypesCommand() {
+            super("types", ShellI18n.typeShowTypesHelp);
+        }
+
+        @Override
+        public String exec(ShellSession session) throws Exception {
+            final String option = args(0);
+
+            if (option == null) {
+                return help();
+            }
+
+            final NodeTypeManager ntm = session.jcrSession().getWorkspace().getNodeTypeManager();
+            final NodeTypeIterator it;
+            switch (option.toLowerCase()) {
+                case "all":
+                    it = ntm.getAllNodeTypes();
+                    break;
+                case "primary":
+                    it = ntm.getPrimaryNodeTypes();
+                    break;
+                case "mixin":
+                    it = ntm.getMixinNodeTypes();
+                    break;
+                default:
+                    return help();
+            }
+
+            StringBuilder builder = new StringBuilder();
+            while (it.hasNext()) {
+                NodeType type = it.nextNodeType();
+                builder.append(type.getName());
+                builder.append(EOL);
+            }
+            return builder.toString();
+        }
+
+    }
+
+    private class ShowPropertyDefsCommand extends ShellCommand {
+
+        public ShowPropertyDefsCommand() {
+            super("property-definitions", ShellI18n.typeShowPropertyDefsHelp);
+        }
+
+        @Override
+        public String exec(ShellSession session) throws Exception {
+            String name = optionValue("--type-name");
+            if (name == null || name.length() == 0) {
+                return help();
+            }
+
+            NodeTypeManager ntm = session.jcrSession().getWorkspace().getNodeTypeManager();
+            NodeType t = ntm.getNodeType(name);
+
+            PropertyDefinition[] defs = t.getPropertyDefinitions();
+            StringBuilder builder = new StringBuilder();
+            for (PropertyDefinition d : defs) {
+                builder.append(d.getName());
+                builder.append("\t");
+                builder.append(PropertyType.nameFromValue(d.getRequiredType()));
+
+                if (d.isAutoCreated()) {
+                    builder.append("\tauto-created");
+                }
+                if (d.isMultiple()) {
+                    builder.append("\tmultiple");
+                }
+                if (d.isMandatory()) {
+                    builder.append("\tmandatory");
+                }
+                if (d.isProtected()) {
+                    builder.append("\tprotected");
+                }
+                if (d.isFullTextSearchable()) {
+                    builder.append("\tfull-text-search");
+                }
+
+                builder.append(EOL);
+            }
+            return builder.toString();
+        }
+
+    }
+
+    private class ShowChildNodeDefsCommand extends ShellCommand {
+
+        public ShowChildNodeDefsCommand() {
+            super("node-definitions", ShellI18n.typeShowNodeDefsHelp);
+        }
+
+        @Override
+        public String exec(ShellSession session) throws Exception {
+            String name = optionValue("--type-name");
+            if (name == null || name.length() == 0) {
+                return help();
+            }
+
+            NodeTypeManager ntm = session.jcrSession().getWorkspace().getNodeTypeManager();
+            NodeType t = ntm.getNodeType(name);
+
+            NodeDefinition[] defs = t.getChildNodeDefinitions();
+            StringBuilder builder = new StringBuilder();
+            for (NodeDefinition d : defs) {
+                builder.append(d.getName());
+                builder.append("\t");
+                builder.append(d.getDefaultPrimaryType());
+
+                if (d.isAutoCreated()) {
+                    builder.append("\tauto-created");
+                }
+                if (d.isMandatory()) {
+                    builder.append("\tmandatory");
+                }
+                if (d.isProtected()) {
+                    builder.append("\tprotected");
+                }
+
+                builder.append(EOL);
+            }
+            return builder.toString();
+        }
+
+    }
+}

--- a/modeshape-shell/src/main/java/org/modeshape/shell/cmd/jcrsession/VersionCommand.java
+++ b/modeshape-shell/src/main/java/org/modeshape/shell/cmd/jcrsession/VersionCommand.java
@@ -1,0 +1,222 @@
+/*
+ * ModeShape (http://www.modeshape.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.modeshape.shell.cmd.jcrsession;
+
+import org.modeshape.shell.cmd.ShellCommand;
+import javax.jcr.Node;
+import javax.jcr.NodeIterator;
+import javax.jcr.version.Version;
+import javax.jcr.version.VersionHistory;
+import javax.jcr.version.VersionIterator;
+import javax.jcr.version.VersionManager;
+import org.modeshape.shell.ShellSession;
+import org.modeshape.shell.ShellI18n;
+
+/**
+ *
+ * @author kulikov
+ */
+public class VersionCommand extends ShellCommand {
+
+    public VersionCommand() {
+        super("version");
+        addChild(new CheckinCommand());
+        addChild(new CheckoutCommand());
+        addChild(new MergeCommand());
+        addChild(new RestoreCommand());
+        addChild(new ShowCommand());
+    }
+    
+    private class CheckinCommand extends ShellCommand {
+
+        public CheckinCommand() {
+            super("checkin", ShellI18n.versionCheckinHelp);
+        }
+        
+        @Override
+        public String exec(ShellSession session) throws Exception {
+            String path = session.getPath();
+            VersionManager vm = session.jcrSession().getWorkspace().getVersionManager();
+            Version v = vm.checkin(path);
+            return v.getName();
+        }
+    }
+    
+    private class CheckoutCommand extends ShellCommand {
+
+        public CheckoutCommand() {
+            super("checkout", ShellI18n.versionCheckoutHelp);
+        }
+        
+        @Override
+        public String exec(ShellSession session) throws Exception {
+            String path = session.getPath();
+            session.jcrSession().getWorkspace().getVersionManager().checkout(path);
+            return SILENCE;
+        }
+
+    }
+
+    private class MergeCommand extends ShellCommand {
+
+        public MergeCommand() {
+            super("merge", ShellI18n.versionMergeHelp);
+        }
+        
+        @Override
+        public String exec(ShellSession session) throws Exception {
+            String path = session.getPath();
+            String workspace = session.jcrSession().getWorkspace().getName();
+            
+            boolean bestEffort = optionValue("--best-effort") != null && 
+                    Boolean.valueOf(optionValue("--best-effort"));
+            boolean shallow = optionValue("--shallow") != null && 
+                    Boolean.valueOf(optionValue("--shallow"));
+            
+            VersionManager vm = session.jcrSession().getWorkspace().getVersionManager();
+            NodeIterator it;
+            if (optionValue("--shallow") != null) {
+                it = vm.merge(path, workspace, bestEffort, shallow);
+            } else {
+                it = vm.merge(path, workspace, bestEffort);
+            }
+            
+            StringBuilder builder = new StringBuilder();
+            while (it.hasNext()) {
+                Node n = it.nextNode();
+                builder.append("Failure to merge ")
+                       .append(n.getPath())
+                       .append(EOL); 
+            }
+            return builder.toString();
+        }
+
+    }
+
+    
+    private class RestoreCommand extends ShellCommand {
+
+        public RestoreCommand() {
+            super("restore", ShellI18n.versionRestoreHelp);
+        }
+        
+        @Override
+        public String exec(ShellSession session) throws Exception {
+            String path = session.getPath();
+            
+            boolean removeExisting = optionValue("--remove-existing") != null && 
+                    Boolean.valueOf(optionValue("---remove-existing"));
+            String versionName = args(0);
+            
+            VersionManager vm = session.jcrSession().getWorkspace().getVersionManager();
+            vm.restore(path, versionName, removeExisting);
+            return SILENCE;
+        }
+
+    }
+
+    private class ShowCommand extends ShellCommand {
+
+        public ShowCommand() {
+            super("show");
+            addChild(new ShowBaseVersionCommand());
+            addChild(new ShowVersionHistoryCommand());
+            addChild(new ShowIsCheckedoutCommand());
+        }
+        
+    }
+
+    private class ShowBaseVersionCommand extends ShellCommand {
+
+        public ShowBaseVersionCommand() {
+            super("base-version", ShellI18n.versionShowBaseVersion);
+        }
+        
+        @Override
+        public String exec(ShellSession session) throws Exception {
+            String path = session.getPath();
+            Node node = session.jcrSession().getNode(path);
+            
+            if (!node.isNodeType("mix:versionable")) {
+                return "Node is not versionable";
+            }
+            
+            VersionManager vm = session.jcrSession().getWorkspace().getVersionManager();
+            return vm.getBaseVersion(path).getName();
+        }
+
+    }
+
+    private class ShowVersionHistoryCommand extends ShellCommand {
+
+        public ShowVersionHistoryCommand() {
+            super("history", ShellI18n.versionShowHistoryHelp);
+        }
+        
+        @Override
+        public String exec(ShellSession session) throws Exception {
+            String path = session.getPath();
+            Node node = session.jcrSession().getNode(path);
+            
+            if (!node.isNodeType("mix:versionable")) {
+                return "Node is not versionable";
+            }
+            
+            VersionManager vm = session.jcrSession().getWorkspace().getVersionManager();
+            VersionHistory h = vm.getVersionHistory(path);
+            
+            StringBuilder builder = new StringBuilder();
+            VersionIterator it = h.getAllVersions();
+            
+            if (it.getSize() == 0) {
+                return "<Up-to date>";
+            }
+            
+            while (it.hasNext()) {
+                Version v = it.nextVersion();
+                builder.append(v.getName());
+                builder.append(TAB3);
+                builder.append(v.getCreated().getTime());
+                builder.append(EOL);
+            }
+            
+            return builder.toString();
+        }
+
+    }
+
+    private class ShowIsCheckedoutCommand extends ShellCommand {
+
+        public ShowIsCheckedoutCommand() {
+            super("status", ShellI18n.versionShowStatusHelp);
+        }
+        
+        @Override
+        public String exec(ShellSession session) throws Exception {
+            String path = session.getPath();
+            Node node = session.jcrSession().getNode(path);
+            
+            if (!node.isNodeType("mix:versionable")) {
+                return "Node is not versionable";
+            }
+            
+            VersionManager vm = session.jcrSession().getWorkspace().getVersionManager();
+            return vm.isCheckedOut(path) ? "checked out" : "not checked out";
+        }
+
+    }
+    
+}

--- a/modeshape-shell/src/main/java/org/modeshape/shell/cmd/jcrsession/WorkspaceCommand.java
+++ b/modeshape-shell/src/main/java/org/modeshape/shell/cmd/jcrsession/WorkspaceCommand.java
@@ -1,0 +1,187 @@
+/*
+ * ModeShape (http://www.modeshape.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.modeshape.shell.cmd.jcrsession;
+
+import org.modeshape.shell.cmd.ShellCommand;
+import org.modeshape.shell.ShellSession;
+import org.modeshape.shell.ShellI18n;
+
+/**
+ *
+ * @author kulikov
+ */
+public class WorkspaceCommand extends ShellCommand {
+    
+    public WorkspaceCommand() {
+        super("workspace");
+        addChild(new CloneCmd());
+        addChild(new CopyCmd());
+        addChild(new CreateCmd());
+        addChild(new DeleteCmd());
+        addChild(new ImportCmd());
+        addChild(new ShowCmd());
+    }
+    
+    private class CloneCmd extends ShellCommand {
+
+        public CloneCmd() {
+            super("clone", ShellI18n.workspaceCloneHelp);
+        }
+        
+        @Override
+        public String exec(ShellSession session) throws Exception {
+            String srcWorkspace = args(0);
+            String srcPath = args(1);
+            String dstPath = args(2);
+            
+            assert srcWorkspace != null : "Source workspace not specified";
+            assert srcPath != null : "Source path not specified";
+            assert dstPath != null : "Destination not specified";
+            
+            assert srcPath.startsWith("/") : srcPath + " is not a valid absolute path";
+            assert dstPath.startsWith("/") : dstPath + " is not a valid absolute path";
+            
+            boolean removExisting = optionValue("-removeExisting") != null;
+            
+            session.jcrSession().getWorkspace().clone(dstPath, dstPath, dstPath, removExisting);
+            return SILENCE;
+        }
+
+    }
+
+    private class CopyCmd extends ShellCommand {
+
+        public CopyCmd() {
+            super("copy", ShellI18n.workspaceCopyHelp);
+        }
+        
+        @Override
+        public String exec(ShellSession session) throws Exception {
+            String srcWorkspace = optionValue("-w");
+            String srcPath = optionValue("-s");
+            String dstPath = optionValue("-d");
+            
+            assert srcPath != null : "Source path not specified";
+            assert dstPath != null : "Destination not specified";
+            
+            assert srcPath.startsWith("/") : srcPath + " is not a valid absolute path";
+            assert dstPath.startsWith("/") : dstPath + " is not a valid absolute path";
+
+            if (srcWorkspace == null) {
+                session.jcrSession().getWorkspace().copy(srcPath, dstPath);
+            } else {
+                session.jcrSession().getWorkspace().copy(srcWorkspace, srcPath, dstPath);
+            }
+            return SILENCE;
+        }
+
+    }
+
+    private class CreateCmd extends ShellCommand {
+
+        public CreateCmd() {
+            super("create", ShellI18n.workspaceCreateHelp);
+        }
+        
+        @Override
+        public String exec(ShellSession session) throws Exception {
+            String aname = args(0);
+            String srcWorkspace = optionValue("-clone");
+            
+            assert aname != null : "New name not specified";
+
+            if (srcWorkspace == null) {
+                session.jcrSession().getWorkspace().createWorkspace(aname);
+            } else {
+                session.jcrSession().getWorkspace().createWorkspace(aname, srcWorkspace);
+            }
+            return SILENCE;
+        }
+
+    }
+
+    private class DeleteCmd extends ShellCommand {
+
+        public DeleteCmd() {
+            super("delete", ShellI18n.workspaceDeleteHelp);
+        }
+        
+        @Override
+        public String exec(ShellSession session) throws Exception {
+            String aname = args(0);
+            assert aname != null : "Workspace name not specified";
+            session.jcrSession().getWorkspace().deleteWorkspace(aname);
+            return SILENCE;
+        }
+
+    }
+
+    private class ImportCmd extends ShellCommand {
+
+        public ImportCmd() {
+            super("import", ShellI18n.workspaceImport);
+        }
+        
+        @Override
+        public String exec(ShellSession session) throws Exception {
+            return "";//session.interpreter().onCommand(session, "session import", arguments(), options());
+        }
+
+    }
+
+    private class ShowCmd extends ShellCommand {
+
+        public ShowCmd() {
+            super("show");
+            addChild(new ShowNameCmd());
+            addChild(new ShowNamesCmd());
+        }
+        
+    }
+
+    private class ShowNameCmd extends ShellCommand {
+
+        public ShowNameCmd() {
+            super("name", ShellI18n.workspaceShowName);
+        }
+        
+        @Override
+        public String exec(ShellSession session) throws Exception {
+            return session.jcrSession().getWorkspace().getName();
+        }
+
+    }
+
+    private class ShowNamesCmd extends ShellCommand {
+
+        public ShowNamesCmd() {
+            super("names", ShellI18n.workspaceShowNames);
+        }
+        
+        @Override
+        public String exec(ShellSession session) throws Exception {
+            StringBuilder builder = new StringBuilder();
+            String[] list = session.jcrSession().getWorkspace().getAccessibleWorkspaceNames();
+            for (String n : list) {
+                builder.append(n).append("\n");
+            }
+            return builder.toString();
+        }
+
+    }
+    
+}
+

--- a/modeshape-shell/src/main/resources/org/modeshape/shell/ShellI18n.properties
+++ b/modeshape-shell/src/main/resources/org/modeshape/shell/ShellI18n.properties
@@ -1,0 +1,85 @@
+#
+# ModeShape (http://www.modeshape.org)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+sshUserNotSpecified = SSH user or password are not specified. SSH server won't start
+sshCouldNotStartServer = Error while starting SSH server {0}
+unknownCommand = Unknown command {0}
+connectHelp = Usage: connect [--user user-name] [--password password] [--workspace workspace-name] Repository
+changeNodeHelp = Usage: cd [relative-or-absolute-path]
+pwdHelp = Usage: pwd
+queryHelp = Usage: query --lang <query-language> 'query-string'
+nodeAddMixinHelp = Usage: node add mixin mixin-name
+nodeAddNodeHelp = Usage: node add node <relative-path> [--primary-type <node-type>]
+nodeShowIndexHelp = Usage: node show index
+nodeShowIdentifierHelp = Usage: node show identifier
+nodeShowPrimaryTypeHelp = Usage: node show primary-type
+nodeShowMixinsHelp = Usage: node show mixins
+nodeShowNodesHelp = Usage: node show nodes
+nodeShowPropertiesHelp = Usage: node show properties
+nodeShowPropertyHelp = Usage: node show property <property-name>
+nodeShowReferencesHelp = Usage: node show references
+nodeSetPrimaryTypeHelp = Usage: node set primary-type <type-name>
+nodeSetPropertyValueHelp = Usage: node set property-value --name <property-name> --value|--values <'property-value'>[,<property-value>]
+nodeUploadHelp = Usage: node upload --property-name <name> --file <binary-data-source>
+nodeDownloadHelp = Usage: node download --property-name <name> --file <binary-data-destination>
+repositoryBackupHelp = Usage: repository backup [--include-binaries] [--documents-per-file <num>] path
+repositoryRestoreHelp = Usage: repository restore [--include-binaries] [--reindex-on-finish] path
+scriptHelp = Usage: script -f file-name
+sessionRefreshHelp = Usage: session refresh [--keep-changes]
+sessionExitHelp = Usage: session exit
+sessionSaveHelp = Usage: session save
+sessionStatusHelp = Usage: session status
+sessionImpersonateHelp = Usage: session impersonate [--user <user-name> --password <user-password>]
+sessionMoveHelp = Usage: session move <source-abs-path> <destination-abs-path>
+sessionRemoveHelp = Usage: session remove <path>
+sessionImportHelp = Usage: session import <source-file> --path <node-path> --behaviour create-new|remove-existing|replace-existing|collision-throw
+sessionExportHelp = Usage: session export <node-path> --destination-file <path-to-file> --view system|document [--skipBinary] [--noRecurse]
+sessionShowAttributesHelp = Usage: session show attributes
+sessionShowAttributeHelp = Usage: session show attribute <attribute-name>
+sessionShowPrefixesHelp = Usage: session show prefixes
+sessionShowPrefixeHelp = Usage: session show prefix <prefix-name>
+sessionShowUriHelp = Usage: session show uri <uri>
+versionCheckinHelp = Usage: version checkin
+versionCheckoutHelp = Usage: version checkout
+versionMergeHelp = Usage: version merge [--best-effort --shallow]
+versionRestoreHelp = Usage: version restore version-name [--remove-existing]
+versionShowBaseVersion = Usage: version show base-version
+versionShowHistoryHelp = Usage: version show history
+versionShowStatusHelp = Usage: version show status
+workspaceCloneHelp = Usage: workspace clone <src-workspace> <src-abs-path> <dst-abs-path> [--remove-existing]
+workspaceCopyHelp = Usage: workspace copy [--workspace src-workspace]  <src-abs-path> <dst-abs-path>
+workspaceCreateHelp = Usage: workspace create <name> [--clone src-workspace]
+workspaceDeleteHelp = Usage: workspace delete <name>
+workspaceImport = Usage: workspace import <source-file> --path <node-path> --behaviour create-new|remove-existing|replace-existing|collision-throw
+workspaceShowName = Usage: workspace show name
+workspaceShowNames = Usage: workspace show names
+typeRegisterHelp = Usage: ntm register [--allow-updates] --url <url>
+typeUnregisterHelp = Usage: ntm unregister --type-name <type-name>
+typeShowTypesHelp = Usage: ntm show types <primary|mixins|all>
+typeShowPropertyDefsHelp = Usage: ntm show property-definitions --type-name <name>
+typeShowNodeDefsHelp = Usage: ntm show node-definitions --type-name <name>
+aclShowHelp = Usage: acl show
+aclSetHelp = Usage acl set --permissions <perm-list> --principal <name>
+aclRemoveHelp = Usage acl --principal <name>
+engineExitHelp = Exits from this session
+engineShowRepositoriesHelp = Usage show repositories
+engineShowRepositoryStateHelp = Usage show state --repository-name <name>
+engineStartRepositoryHelp = Usage start --repository-name <name>
+engineStopRepositoryHelp = Usage stop --repository-name <name>
+engineDeployRepositoryHelp = Usage deploy --config-file <path-to-configuration-file> 
+engineUndeployRepositoryHelp = Usage undeploy --repository-name <name> 
+engineConfigureRepositoryHelp = Usage configure <repository-name>
+configureSaveHelp = Usage save --destination <file-name>
+

--- a/modeshape-shell/src/test/java/org/modeshape/shell/cmd/CommandParserTest.java
+++ b/modeshape-shell/src/test/java/org/modeshape/shell/cmd/CommandParserTest.java
@@ -1,0 +1,72 @@
+/*
+ * ModeShape (http://www.modeshape.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.modeshape.shell.cmd;
+
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+
+/**
+ *
+ * @author kulikov
+ */
+public class CommandParserTest {
+    
+    public CommandParserTest() {
+    }
+    
+    @BeforeClass
+    public static void setUpClass() {
+    }
+    
+    @AfterClass
+    public static void tearDownClass() {
+    }
+    
+    @Before
+    public void setUp() {
+    }
+    
+    @After
+    public void tearDown() {
+    }
+
+    /**
+     * Test of getValue method, of class CommandParser.
+     */
+    @Test
+    public void testGetValue() {
+        String cmd = "connect -r My Repository -u anonymous";
+        String value = CommandParser.getOptionValue("-r", cmd);
+        assertEquals("My", value);
+        
+        cmd = "connect -r \"My Repository\" -u anonymous";
+        assertEquals("My Repository", CommandParser.getOptionValue("-r", cmd));
+
+        cmd = "connect -r \'My Repository\' -u anonymous";
+        assertEquals("My Repository", CommandParser.getOptionValue("-r", cmd));
+        
+        cmd = "connect -r \'My Repository\'";
+        assertEquals("My Repository", CommandParser.getOptionValue("-r", cmd));
+
+        cmd = "connect -r My Repository";
+        assertEquals("My", CommandParser.getOptionValue("-r", cmd));
+    }
+
+}

--- a/modeshape-shell/src/test/java/org/modeshape/shell/cmd/CommandTest.java
+++ b/modeshape-shell/src/test/java/org/modeshape/shell/cmd/CommandTest.java
@@ -1,0 +1,151 @@
+/*
+ * ModeShape (http://www.modeshape.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.modeshape.shell.cmd;
+
+import org.modeshape.shell.cmd.jcrsession.SessionCommand;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import org.modeshape.shell.ShellSession;
+
+/**
+ *
+ * @author kulikov
+ */
+public class CommandTest {
+    
+    private final ConnectCmd cmd = new ConnectCmd();
+    
+    public CommandTest() {
+    }
+    
+    @BeforeClass
+    public static void setUpClass() {
+    }
+    
+    @AfterClass
+    public static void tearDownClass() {
+    }
+    
+    @Before
+    public void setUp() {
+    }
+    
+    @After
+    public void tearDown() {
+    }
+
+    /**
+     * Test of findParameter method, of class Command.
+     */
+    @Test
+    public void testPrepare() throws Exception {
+        cmd.prepare("connect -u user -p password 'My Repository'");
+        assertEquals("My Repository", cmd.args(0));
+
+        cmd.prepare("connect 'My Repository'");
+        assertEquals("My Repository", cmd.args(0));
+        
+        cmd.prepare("connect My Repository");
+        assertEquals("My", cmd.args(0));
+        
+        AddCmd addCmd = new AddCmd();
+        addCmd.prepare("add node test");
+
+        SessionCommand c = new SessionCommand();
+        c.prepare("session refresh -help");
+
+        cmd.prepare("connect --user-name usr --password paswd 'My Repository'");
+        
+        System.out.println(cmd.optionValue("--user"));
+    }
+
+    public class ConnectCmd extends ShellCommand {
+
+        public ConnectCmd() {
+            super("connect");
+        }
+
+        @Override
+        public String exec(ShellSession session) throws Exception {
+            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        }
+
+        @Override
+        public String help() {
+            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        }
+    }
+
+
+    public class AddCmd extends ShellCommand {
+
+        public AddCmd() {
+            super("add");
+            addChild(new AddNodeCmd());
+            addChild(new AddPropertyCmd());            
+        }
+
+        @Override
+        public String exec(ShellSession session) throws Exception {
+            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        }
+
+        @Override
+        public String help() {
+            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        }
+        
+    }
+
+    public class AddNodeCmd extends ShellCommand {
+
+        public AddNodeCmd() {
+            super("node");
+        }
+
+        @Override
+        public String exec(ShellSession session) throws Exception {
+            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        }
+
+        @Override
+        public String help() {
+            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        }
+    }
+
+    public class AddPropertyCmd extends ShellCommand {
+
+        public AddPropertyCmd() {
+            super("property");
+        }
+
+        @Override
+        public String exec(ShellSession session) throws Exception {
+            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        }
+
+        @Override
+        public String help() {
+            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        }
+    }
+    
+}

--- a/modeshape-shell/src/test/java/org/modeshape/shell/cmd/JcrSessionInterpreterTest.java
+++ b/modeshape-shell/src/test/java/org/modeshape/shell/cmd/JcrSessionInterpreterTest.java
@@ -1,0 +1,367 @@
+/*
+ * ModeShape (http://www.modeshape.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.modeshape.shell.cmd;
+
+import org.modeshape.shell.cmd.jcrsession.JcrSessionInterpreter;
+import java.net.URL;
+import javax.jcr.Repository;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Test;
+import org.junit.BeforeClass;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import org.junit.Before;
+import org.modeshape.jcr.JcrRepository;
+import org.modeshape.jcr.ModeShapeEngine;
+import org.modeshape.jcr.RepositoryConfiguration;
+import org.modeshape.shell.ShellI18n;
+import org.modeshape.shell.ShellSession;
+
+/**
+ * Unit test for shell interpreter
+ *
+ * @author okulikov
+ */
+public class JcrSessionInterpreterTest {
+
+    private static ModeShapeEngine engine;
+    private static Repository repository;
+    private static ShellSession shellSession;
+   
+    private String sid;
+    private JcrSessionInterpreter interpreter = new JcrSessionInterpreter();
+    
+    @BeforeClass
+    public static void before() throws Exception {
+        engine = new ModeShapeEngine();
+        engine.start();
+
+        // Load the configuration for a repository via the classloader (can also use path to a file)...
+        repository = null;
+        String repositoryName = null;
+
+        URL url = JcrSessionInterpreterTest.class.getClassLoader().getResource("my-repository-config.json");
+        RepositoryConfiguration config = RepositoryConfiguration.read(url);
+
+        // Deploy the repository ...
+        repository = engine.deploy(config);
+        repositoryName = config.getName();
+
+        shellSession = new ShellSession(engine);
+        shellSession.setRepository((JcrRepository) repository);
+        
+        engine.startRepository(repositoryName);
+    }
+
+    @AfterClass
+    public static void stopRepository() throws Exception {
+        System.out.println("Shutting down engine ...");
+        engine.shutdown().get();
+        System.out.println("Success!");
+    }
+
+    @Before
+    public void connect() throws Exception{
+        shellSession.setJcrSession(shellSession.getRepository().login());
+        shellSession.setPath("/");
+    }
+
+    @After
+    public void disconnect() throws Exception{
+//        exec("session exit");
+    }
+    
+    @Test
+    public void testChangeNodeCommand() throws Exception {
+        String res = exec("cd --help");
+        assertEquals(ShellI18n.changeNodeHelp.text(), res);
+
+        res = exec("cd jcr:system");
+        assertEquals("", res);
+
+        res = exec("pwd");
+        assertEquals("/jcr:system", res);
+        System.out.println("Sid=" + sid);
+        
+        exec("cd ..");
+        res = exec("pwd");
+        assertEquals("/", res);
+    }
+
+    @Test
+    public void testPwdCommand() throws Exception {
+        String res = exec("pwd --help");
+        assertEquals(ShellI18n.pwdHelp.text(), res);
+
+        exec("cd jcr:system");
+        res = exec("pwd");
+        assertEquals("/jcr:system", res);
+    }
+
+    @Test
+    public void testQueryCommand() throws Exception {
+        String res = exec("query --help");
+        assertEquals(ShellI18n.queryHelp.text(), res);
+
+        res = exec("query --lang jcr-sql2 'select * from [nt:base]");
+        assertTrue(res.startsWith("nt:base.jcr:primaryType"));
+    }
+
+    @Test
+    public void testNodeAddMixinCommand() throws Exception {
+        String res = exec("node add mixin --help");
+        assertEquals(ShellI18n.nodeAddMixinHelp.text(), res);
+        
+        res = exec("node add node test-node");
+        assertEquals("", res);
+
+        res = exec("cd test-node");
+        assertEquals("", res);
+        
+        res = exec("pwd");
+        assertEquals("/test-node", res);
+        
+        res = exec("node add mixin mix:versionable");
+        assertEquals("", res);
+        
+        res = exec("show type mixin").trim();
+        assertEquals("mix:versionable", res);
+        
+    }
+
+    @Test
+    public void testNodeAddNodeCommand() throws Exception {
+        String res = exec("node add node --help");
+        assertEquals(ShellI18n.nodeAddNodeHelp.text(), res);
+
+        res = exec("node add node test-folder --primary-type nt:folder");
+
+        assertEquals("", res);
+        res = exec("cd test-folder");
+        assertEquals("", res);
+        
+        res = exec("pwd");
+        assertEquals("/test-folder", res);
+
+        res = exec("show type primary");
+        assertEquals("nt:folder", res);
+    }
+
+    @Test
+    public void testNodeShowIndexCommand() throws Exception {
+        String res = exec("node show index --help");
+        assertEquals(ShellI18n.nodeShowIndexHelp.text(), res);
+
+        res = exec("node show index");
+        assertEquals("1", res);
+    }
+
+    @Test
+    public void testNodeShowIdentifierCommand() throws Exception {
+        String res = exec("node show identifier --help");
+        assertEquals(ShellI18n.nodeShowIdentifierHelp.text(), res);
+
+        res = exec("node show identifier");
+        assertEquals("1", res);
+    }
+
+    @Test
+    public void testNodeShowPrimaryTypeCommand() throws Exception {
+        String res = exec("node show primary-type --help");
+        assertEquals("Usage: node show primary-type", res);
+
+        res = exec("node show primary-type");
+        assertEquals("mode:root", res);
+    }
+
+    @Test
+    public void testNodeShowMixinsCommand() throws Exception {
+        String res = exec("node show mixins --help");
+        assertEquals("Usage: node show mixins", res);
+
+        res = exec("node show mixins");
+        assertEquals("<empty set>", res);
+    }
+
+    @Test
+    public void testNodeShowNodesCommand() throws Exception {
+        String res = exec("node show nodes --help");
+        assertEquals("Usage: node show nodes", res);
+
+        res = exec("node show nodes");
+        assertTrue(res.contains("jcr:system"));
+    }
+
+    @Test
+    public void testNodeShowPropertiesCommand() throws Exception {
+        String res = exec("node show properties --help");
+        assertEquals("Usage: node show properties", res);
+
+        res = exec("node show properties");
+        assertTrue(res.contains("jcr:uuid"));
+    }
+
+    @Test
+    public void testNodeShowPropertyCommand() throws Exception {
+        String res = exec("node show property --help");
+        assertEquals("Usage: node show property <property-name>", res);
+
+        res = exec("node show property jcr:uuid");
+        assertTrue(res.length() > 0);
+    }
+
+    @Test
+    public void testNodeSetPrimaryTypeCommand() throws Exception {
+        String res = exec("node set primary-type --help");
+        assertEquals("Usage: node set primary-type <type-name>", res);
+
+        exec("node add node f1");
+        exec("cd f1");
+        exec("node set primary-type nt:folder");
+        res = exec("node show primary-type");
+        assertEquals("nt:folder", res);
+    }
+
+    @Test
+    public void testNodeSetPropertyValueCommand() throws Exception {
+        String res = exec("node set property-value --help");
+        assertEquals("Usage: node set property-value --name <property-name> --value|--values <'property-value'>[,<property-value>]", res);
+
+        exec("node add node f2 --primary-type nt:folder");
+        exec("cd f2");
+        exec("node add mixin mix:mimeType");
+        exec("node set property-value --name jcr:mimeType --value 'text/plain'");
+        res = exec("node show property jcr:mimeType");
+        assertEquals("text/plain", res);
+    }
+
+    @Test
+    public void testUploadCommand() throws Exception {
+        String res = exec("node upload --help");
+        assertEquals("Usage: node upload --property-name <name> --file <binary-data-source>", res);
+    }
+
+    @Test
+    public void testDownloadCommand() throws Exception {
+        String res = exec("node download --help");
+        assertEquals("Usage: node download --property-name <name> --file <binary-data-destination>", res);
+    }
+
+    @Test
+    public void testRepositoryBackupCommand() throws Exception {
+        String res = exec("repository backup --help");
+        assertEquals("Usage: repository backup [--include-binaries] [--documents-per-file <num>] path", res);
+
+        res = exec("repository backup target/repo.bak");
+        assertEquals("", res);        
+    }
+
+    @Test
+    public void testRepositoryRestoreCommand() throws Exception {
+        String res = exec("repository restore --help");
+        assertEquals("Usage: repository restore [--include-binaries] [--reindex-on-finish] path", res);
+
+        res = exec("repository backup target/repo-1.bak");
+        assertEquals("", res);        
+
+        res = exec("repository restore target/repo-1.bak");
+        assertEquals("", res);        
+    }
+
+    @Test
+    public void testScriptCommand() throws Exception {
+        String res = exec("script --help");
+        assertEquals("Usage: script -f file-name", res);
+    }
+
+    @Test
+    public void testSessionRefreshCommand() throws Exception {
+        String res = exec("session refresh --help");
+        assertEquals("Usage: session refresh [--keep-changes]", res);
+        
+        exec("node add node f3");
+        res = exec("node show nodes");
+        assertTrue(res.contains("f3"));
+        
+        exec("session refresh");
+        res = exec("node show nodes");
+        assertTrue(!res.contains("f3"));
+    }
+
+    @Test
+    public void testTypeRegisterCommand() throws Exception {
+        String res = exec("ntm register --help");
+        assertEquals("Usage: ntm register [--allow-updates] --url <url>", res);
+
+        URL url = JcrSessionInterpreterTest.class.getResource("/cars.cnd");
+        res = exec("ntm register --allow-updates --url " + url);
+        assertEquals("", res);
+        
+        res = exec("ntm show types primary");
+        assertTrue(res.contains("Car"));
+    }
+
+    @Test
+    public void testTypeUnregisterCommand() throws Exception {
+        String res = exec("ntm unregister --help");
+        assertEquals("Usage: ntm unregister --type-name <type-name>", res);
+
+        URL url = JcrSessionInterpreterTest.class.getResource("/cars.cnd");
+        res = exec("ntm register --allow-updates --url " + url);
+        assertEquals("", res);
+        
+        res = exec("ntm show types primary");
+        assertTrue(res.contains("Car"));
+        
+        res = exec("ntm unregister --type-name car:Car");
+        assertEquals("", res);
+        
+        res = exec("ntm show types primary");
+        assertTrue(!res.contains("Car"));
+    }
+    
+
+    @Test
+    public void testTypeShowPropertyDefsCommand() throws Exception {
+        String res = exec("ntm show property-definitions --help");
+        assertEquals("Usage: ntm show property-definitions --type-name <name>", res);
+
+        res = exec("ntm show property-definitions --type-name nt:folder");
+        assertTrue(res.contains("jcr:created"));
+    }
+
+    @Test
+    public void testTypeShowNodeDefsCommand() throws Exception {
+        String res = exec("ntm show node-definitions --help");
+        assertEquals("Usage: ntm show node-definitions --type-name <name>", res);
+
+        res = exec("ntm show node-definitions --type-name nt:folder");
+        assertTrue(res.contains("*"));
+    }
+
+    @Test
+    public void testTypeAcmCommand() throws Exception {
+        String res = exec("node add f-acl");
+        res = exec("cd f-acl");
+        res = exec("acl add --principal ms-user --permissions jcr:all");
+        res = exec("acl show");
+    }
+    
+    private String exec(String cmd) throws Exception {
+        return interpreter.execute(shellSession, cmd);
+    }
+}

--- a/modeshape-shell/src/test/java/org/modeshape/shell/cmd/config/ConfigCommandTest.java
+++ b/modeshape-shell/src/test/java/org/modeshape/shell/cmd/config/ConfigCommandTest.java
@@ -1,0 +1,128 @@
+/*
+ * ModeShape (http://www.modeshape.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.modeshape.shell.cmd.config;
+
+import java.lang.management.ManagementFactory;
+import java.net.URL;
+import javax.management.MBeanServer;
+import javax.management.ObjectName;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import org.modeshape.jcr.JcrRepository;
+import org.modeshape.jcr.ModeShapeEngine;
+import org.modeshape.jcr.RepositoryConfiguration;
+import org.modeshape.schematic.DocumentFactory;
+import org.modeshape.schematic.document.Document;
+import org.modeshape.schematic.document.EditableDocument;
+import org.modeshape.shell.ShellSession;
+import org.modeshape.shell.cmd.JcrSessionInterpreterTest;
+
+/**
+ *
+ * @author kulikov
+ */
+public class ConfigCommandTest {
+    
+    private static final MBeanServer SERVER = ManagementFactory.getPlatformMBeanServer();
+    private static ObjectName mBeanName;
+    private static ModeShapeEngine engine;
+    private static JcrRepository repository;
+    
+    public ConfigCommandTest() {
+    }
+    
+    @BeforeClass
+    public static void before() throws Exception {
+        engine = new ModeShapeEngine();
+        engine.start();
+
+        // Load the configuration for a repository via the classloader (can also use path to a file)...
+        repository = null;
+        String repositoryName = null;
+
+        URL url = JcrSessionInterpreterTest.class.getClassLoader().getResource("my-repository-config.json");
+        RepositoryConfiguration config = RepositoryConfiguration.read(url);
+
+        // Deploy the repository ...
+        repository = engine.deploy(config);
+        repositoryName = config.getName();
+
+    }
+
+    @AfterClass
+    public static void stopRepository() throws Exception {
+        System.out.println("Shutting down engine ...");
+        engine.shutdown().get();
+        System.out.println("Success!");
+    }
+    
+    @Before
+    public void setUp() {
+    }
+    
+    @After
+    public void tearDown() {
+    }
+
+    @Test
+    public void testConfigurationCommand() throws Exception {
+        ShellSession session = new ShellSession(engine);
+        session.setRepositoryConfiguration(repository.getConfiguration());
+        session.setInterpreter(ShellSession.CONFIGURATION_INTERPRETER);
+        String res = ShellSession.CONFIGURATION_INTERPRETER.execute(session, "show workspaces default");
+        assertEquals("default", res);
+        
+        ShellSession.CONFIGURATION_INTERPRETER.execute(session, "set workspaces default xxx");
+        res = ShellSession.CONFIGURATION_INTERPRETER.execute(session, "show workspaces default");
+        assertEquals("xxx", res);
+    }
+    
+//    @Test
+    public void testSomeMethod() throws Exception {
+        RepositoryConfiguration cfg = engine.getRepositoryConfiguration("My Repository");
+        System.out.println(cfg);
+/*        EditableDocument cfgEditor = cfg.edit().editable();
+        System.out.println(cfgEditor.get("name"));
+        System.out.println(cfgEditor.get("shell"));
+        
+        Object e2 = cfgEditor.get("workspaces");
+        EditableDocument ee2 = null;
+        if (e2 instanceof Document) {
+            ee2 = ((Document)e2).editable();
+        }
+  */      
+        String[] segments = new String[]{"workspaces", "predefined"};
+        EditableDocument doc0 = cfg.edit().editable();
+        EditableDocument doc = doc0;
+        for (int i = 0; i < segments.length - 1; i++) {
+            Object obj = doc.getDocument(segments[i]);
+            if (obj == null) {
+                obj = DocumentFactory.newDocument();
+            }
+            doc.set(segments[i], obj);
+            doc = ((Document) obj).editable();
+        }
+        
+//        doc.set(segments[segments.length - 1], "true");
+//        RepositoryConfiguration cfg1 = new RepositoryConfiguration(doc0, cfg.getName());
+        String s = doc.get(segments[segments.length - 1]).toString();
+        System.out.println(s);
+    }
+}

--- a/modeshape-shell/src/test/resources/cars.cnd
+++ b/modeshape-shell/src/test/resources/cars.cnd
@@ -1,0 +1,42 @@
+/*
+ * ModeShape (http://www.modeshape.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+ 
+//------------------------------------------------------------------------------
+// N A M E S P A C E S
+//------------------------------------------------------------------------------
+<jcr='http://www.jcp.org/jcr/1.0'>
+<nt='http://www.jcp.org/jcr/nt/1.0'>
+<mix='http://www.jcp.org/jcr/mix/1.0'>
+<car='http://www.modeshape.org/examples/cars/1.0'>
+
+//------------------------------------------------------------------------------
+// N O D E T Y P E S
+//------------------------------------------------------------------------------
+
+[car:Car] > nt:unstructured
+  - car:maker (string)
+  - car:model (string)
+  - car:year (string) < '(19|20)\d{2}'                     // any 4 digit number starting with '19' or '20'
+  - car:msrp (string) < '[$]\d{1,3}[,]?\d{3}([.]\d{2})?'   // of the form "$X,XXX.ZZ", "$XX,XXX.ZZ" or "$XXX,XXX.ZZ" 
+                                                           // where '.ZZ' is optional
+  - car:userRating (long) < '[1,5]'                        // any value from 1 to 5 (inclusive)
+  - car:valueRating (long) < '[1,5]'                       // any value from 1 to 5 (inclusive)
+  - car:mpgCity (long) < '(0,]'                            // any value greater than 0
+  - car:mpgHighway (long) < '(0,]'                         // any value greater than 0
+  - car:lengthInInches (double) < '(0,]'                   // any value greater than 0
+  - car:wheelbaseInInches (double) < '(0,]'                // any value greater than 0
+  - car:engine (string)
+

--- a/modeshape-shell/src/test/resources/log4j.properties
+++ b/modeshape-shell/src/test/resources/log4j.properties
@@ -1,0 +1,11 @@
+# Direct log messages to stdout
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.Target=System.out
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+log4j.appender.stdout.layout.ConversionPattern=%d{ABSOLUTE} %5p %m%n
+
+# Root logger option
+log4j.rootLogger=INFO, stdout
+
+# Set up the default logging to be INFO level, then override specific units
+log4j.logger.org.modeshape=INFO

--- a/modeshape-shell/src/test/resources/my-repository-config.json
+++ b/modeshape-shell/src/test/resources/my-repository-config.json
@@ -1,0 +1,14 @@
+{
+    "name" : "My Repository",
+    "workspaces" : {
+        "predefined" : ["otherWorkspace"],
+        "default" : "default",
+        "allowCreation" : true
+    },
+    "security" : {
+        "anonymous" : {
+            "roles" : ["readonly","readwrite","admin"],
+            "useOnFailedLogin" : false
+        }
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,9 @@
           JCA Resource adapter
     	-->
     	<module>modeshape-jca</module>
-
+        
+        <!-- Shell module -->
+        <module>modeshape-shell</module>
         <!--
           The JBoss AS7 subsystem needs the web components and (local) JDBC drivers.
         -->


### PR DESCRIPTION
This PR provides implementation of the command line shell for initial review.  Communication with repository is build using JMX. JMX remote port is 9999 and it is hard coded at this stage. 

Console main class: org.modeshape.jcr.shell.ShellConsole. 
Immediately after start the only available command is 'list' which shows reachable repositories (MBeans). 
Command connect [-u user -p password -w workspace] Repository_name joins console with repository.
<Tab> - lists available commands for the current context.  


