### PR TITLE
MODE-2574, MODE-2575 Adds configuration support for the Cassandra and MongoDB binary stores

### DIFF
--- a/deploy/jbossas/modeshape-jbossas-subsystem/src/main/java/org/modeshape/jboss/subsystem/AddCassandraBinaryStorage.java
+++ b/deploy/jbossas/modeshape-jbossas-subsystem/src/main/java/org/modeshape/jboss/subsystem/AddCassandraBinaryStorage.java
@@ -1,0 +1,51 @@
+/*
+ * ModeShape (http://www.modeshape.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.modeshape.jboss.subsystem;
+
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.OperationFailedException;
+import org.jboss.dmr.ModelNode;
+import org.modeshape.jcr.RepositoryConfiguration.FieldName;
+import org.modeshape.jcr.RepositoryConfiguration.FieldValue;
+import org.modeshape.schematic.document.EditableDocument;
+
+/**
+ * 
+ */
+public class AddCassandraBinaryStorage extends AbstractAddBinaryStorage {
+
+    public static final AddCassandraBinaryStorage INSTANCE = new AddCassandraBinaryStorage();
+
+    private AddCassandraBinaryStorage() {
+    }
+
+    @Override
+    protected void writeBinaryStorageConfiguration( String repositoryName,
+                                                    OperationContext context,
+                                                    ModelNode model,
+                                                    EditableDocument binaries ) throws OperationFailedException {
+        binaries.set(FieldName.TYPE, FieldValue.BINARY_STORAGE_TYPE_CASSANDRA);
+        String address = ModelAttributes.CASSANDRA_HOST.resolveModelAttribute(context, model).asString();
+        binaries.setString(FieldName.ADDRESS, address);
+    }
+
+    @Override
+    protected void populateModel( ModelNode operation,
+                                  ModelNode model ) throws OperationFailedException {
+        populate(operation, model, ModelAttributes.CASSANDRA_BINARY_STORAGE_ATTRIBUTES);
+    }
+
+}

--- a/deploy/jbossas/modeshape-jbossas-subsystem/src/main/java/org/modeshape/jboss/subsystem/AddMongoBinaryStorage.java
+++ b/deploy/jbossas/modeshape-jbossas-subsystem/src/main/java/org/modeshape/jboss/subsystem/AddMongoBinaryStorage.java
@@ -1,0 +1,59 @@
+/*
+ * ModeShape (http://www.modeshape.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.modeshape.jboss.subsystem;
+
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.OperationFailedException;
+import org.jboss.dmr.ModelNode;
+import org.modeshape.jcr.RepositoryConfiguration.FieldName;
+import org.modeshape.jcr.RepositoryConfiguration.FieldValue;
+import org.modeshape.schematic.document.EditableDocument;
+
+/**
+ * 
+ */
+public class AddMongoBinaryStorage extends AbstractAddBinaryStorage {
+
+    public static final AddMongoBinaryStorage INSTANCE = new AddMongoBinaryStorage();
+
+    private AddMongoBinaryStorage() {
+    }
+
+    @Override
+    protected void writeBinaryStorageConfiguration( String repositoryName,
+                                                    OperationContext context,
+                                                    ModelNode model,
+                                                    EditableDocument binaries ) throws OperationFailedException {
+        binaries.set(FieldName.TYPE, FieldValue.BINARY_STORAGE_TYPE_CASSANDRA);
+        String host = ModelAttributes.MONGO_HOST.resolveModelAttribute(context, model).asString();
+        binaries.setString(FieldName.HOST, host);
+        int port = ModelAttributes.MONGO_PORT.resolveModelAttribute(context, model).asInt();
+        binaries.setNumber(FieldName.PORT, port);
+        String database = ModelAttributes.MONGO_DATABASE.resolveModelAttribute(context, model).asString();
+        binaries.setString(FieldName.DATABASE, database);
+        String username = ModelAttributes.MONGO_USERNAME.resolveModelAttribute(context, model).asString();
+        binaries.setString(FieldName.USER_NAME, username);
+        String password = ModelAttributes.MONGO_PASSWORD.resolveModelAttribute(context, model).asString();
+        binaries.setString(FieldName.USER_PASSWORD, password);
+    }
+
+    @Override
+    protected void populateModel( ModelNode operation,
+                                  ModelNode model ) throws OperationFailedException {
+        populate(operation, model, ModelAttributes.MONGO_BINARY_STORAGE_ATTRIBUTES);
+    }
+
+}

--- a/deploy/jbossas/modeshape-jbossas-subsystem/src/main/java/org/modeshape/jboss/subsystem/Attribute.java
+++ b/deploy/jbossas/modeshape-jbossas-subsystem/src/main/java/org/modeshape/jboss/subsystem/Attribute.java
@@ -104,6 +104,9 @@ public enum Attribute {
     MAX_POOL_SIZE("max-pool-size"),
     COLUMNS("columns"),
     REINDEXING_ASNC("async"),
+    HOST("host"),
+    PORT("port"),
+    DATABASE("database"),
     REINDEXING_MODE("mode");
 
     private final String name;

--- a/deploy/jbossas/modeshape-jbossas-subsystem/src/main/java/org/modeshape/jboss/subsystem/BinaryStorageWriteAttributeHandler.java
+++ b/deploy/jbossas/modeshape-jbossas-subsystem/src/main/java/org/modeshape/jboss/subsystem/BinaryStorageWriteAttributeHandler.java
@@ -36,6 +36,12 @@ public class BinaryStorageWriteAttributeHandler extends AbstractRepositoryConfig
     static final BinaryStorageWriteAttributeHandler DATABASE_BINARY_STORAGE_INSTANCE = new BinaryStorageWriteAttributeHandler(
             ModelAttributes.DATABASE_BINARY_STORAGE_ATTRIBUTES);
 
+    static final BinaryStorageWriteAttributeHandler CASSANDRA_BINARY_STORAGE_INSTANCE = new BinaryStorageWriteAttributeHandler(
+            ModelAttributes.CASSANDRA_BINARY_STORAGE_ATTRIBUTES);
+
+    static final BinaryStorageWriteAttributeHandler MONGO_BINARY_STORAGE_INSTANCE = new BinaryStorageWriteAttributeHandler(
+            ModelAttributes.MONGO_BINARY_STORAGE_ATTRIBUTES);
+
     static final BinaryStorageWriteAttributeHandler COMPOSITE_BINARY_STORAGE_INSTANCE = new BinaryStorageWriteAttributeHandler(
             ModelAttributes.COMPOSITE_BINARY_STORAGE_ATTRIBUTES);
 

--- a/deploy/jbossas/modeshape-jbossas-subsystem/src/main/java/org/modeshape/jboss/subsystem/Element.java
+++ b/deploy/jbossas/modeshape-jbossas-subsystem/src/main/java/org/modeshape/jboss/subsystem/Element.java
@@ -30,6 +30,8 @@ public enum Element {
     COMPOSITE_BINARY_STORAGE("composite-binary-storage"),
     CUSTOM_BINARY_STORAGE("custom-binary-storage"),
     DB_BINARY_STORAGE("db-binary-storage"),
+    CASSANDRA_BINARY_STORAGE("cassandra-binary-storage"),
+    MONGO_BINARY_STORAGE("mongo-binary-storage"),
     FILE_BINARY_STORAGE("file-binary-storage"),
     TRANSIENT_BINARY_STORAGE("transient-binary-storage"),
     INDEX_PROVIDER("index-provider"),

--- a/deploy/jbossas/modeshape-jbossas-subsystem/src/main/java/org/modeshape/jboss/subsystem/MappedListAttributeDefinition.java
+++ b/deploy/jbossas/modeshape-jbossas-subsystem/src/main/java/org/modeshape/jboss/subsystem/MappedListAttributeDefinition.java
@@ -138,6 +138,11 @@ public class MappedListAttributeDefinition extends SimpleListAttributeDefinition
             return this;
         }
 
+        protected Builder setAllowExpression( final boolean allowExpression ) {
+            builder.setAllowExpression(allowExpression);
+            return this;
+        }
+
         protected Builder setFieldPathInRepositoryConfiguration( String... pathToField ) {
             configPath = Collections.unmodifiableList(Arrays.asList(pathToField));
             return this;

--- a/deploy/jbossas/modeshape-jbossas-subsystem/src/main/java/org/modeshape/jboss/subsystem/ModeShapeCassandraBinaryStorageResource.java
+++ b/deploy/jbossas/modeshape-jbossas-subsystem/src/main/java/org/modeshape/jboss/subsystem/ModeShapeCassandraBinaryStorageResource.java
@@ -1,0 +1,39 @@
+/*
+ * ModeShape (http://www.modeshape.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.modeshape.jboss.subsystem;
+
+import org.jboss.as.controller.PathElement;
+import org.jboss.as.controller.SimpleResourceDefinition;
+import org.jboss.as.controller.registry.ManagementResourceRegistration;
+
+/**
+ * {@link SimpleResourceDefinition} which handles <cassandra-binary-storage/> elements.
+ */
+public class ModeShapeCassandraBinaryStorageResource extends SimpleResourceDefinition {
+    protected final static ModeShapeCassandraBinaryStorageResource DEFAULT = new ModeShapeCassandraBinaryStorageResource(
+            PathElement.pathElement(ModelKeys.STORAGE_TYPE, ModelKeys.CASSANDRA_BINARY_STORAGE));
+
+    private ModeShapeCassandraBinaryStorageResource(PathElement pathElement) {
+        super(pathElement,
+              ModeShapeExtension.getResourceDescriptionResolver(ModelKeys.REPOSITORY, ModelKeys.CASSANDRA_BINARY_STORAGE),
+              AddCassandraBinaryStorage.INSTANCE, RemoveBinaryStorage.INSTANCE);
+    }
+
+    @Override
+    public void registerAttributes( ManagementResourceRegistration resourceRegistration ) {
+        BinaryStorageWriteAttributeHandler.CASSANDRA_BINARY_STORAGE_INSTANCE.registerAttributes(resourceRegistration);
+    }
+}

--- a/deploy/jbossas/modeshape-jbossas-subsystem/src/main/java/org/modeshape/jboss/subsystem/ModeShapeExtension.java
+++ b/deploy/jbossas/modeshape-jbossas-subsystem/src/main/java/org/modeshape/jboss/subsystem/ModeShapeExtension.java
@@ -107,6 +107,8 @@ public class ModeShapeExtension implements Extension {
         binaryStorageSubmodel.registerSubModel(ModeShapeDatabaseBinaryStorageResource.DEFAULT);
         binaryStorageSubmodel.registerSubModel(ModeShapeCustomBinaryStorageResource.DEFAULT);
         binaryStorageSubmodel.registerSubModel(ModeShapeTransientBinaryStorageResource.DEFAULT);
+        binaryStorageSubmodel.registerSubModel(ModeShapeCassandraBinaryStorageResource.DEFAULT);
+        binaryStorageSubmodel.registerSubModel(ModeShapeMongoBinaryStorageResource.DEFAULT);
 
         ManagementResourceRegistration compositeStorageSubmodel = binaryStorageSubmodel.registerSubModel(ModeShapeCompositeBinaryStorageResource.INSTANCE);
         compositeStorageSubmodel.registerSubModel(ModeShapeFileBinaryStorageResource.NESTED);

--- a/deploy/jbossas/modeshape-jbossas-subsystem/src/main/java/org/modeshape/jboss/subsystem/ModeShapeMongoBinaryStorageResource.java
+++ b/deploy/jbossas/modeshape-jbossas-subsystem/src/main/java/org/modeshape/jboss/subsystem/ModeShapeMongoBinaryStorageResource.java
@@ -1,0 +1,39 @@
+/*
+ * ModeShape (http://www.modeshape.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.modeshape.jboss.subsystem;
+
+import org.jboss.as.controller.PathElement;
+import org.jboss.as.controller.SimpleResourceDefinition;
+import org.jboss.as.controller.registry.ManagementResourceRegistration;
+
+/**
+ * {@link SimpleResourceDefinition} which handles <mongo-binary-storage/> elements.
+ */
+public class ModeShapeMongoBinaryStorageResource extends SimpleResourceDefinition {
+    protected final static ModeShapeMongoBinaryStorageResource DEFAULT = new ModeShapeMongoBinaryStorageResource(
+            PathElement.pathElement(ModelKeys.STORAGE_TYPE, ModelKeys.MONGO_BINARY_STORAGE));
+
+    private ModeShapeMongoBinaryStorageResource(PathElement pathElement) {
+        super(pathElement,
+              ModeShapeExtension.getResourceDescriptionResolver(ModelKeys.REPOSITORY, ModelKeys.MONGO_BINARY_STORAGE),
+              AddMongoBinaryStorage.INSTANCE, RemoveBinaryStorage.INSTANCE);
+    }
+
+    @Override
+    public void registerAttributes( ManagementResourceRegistration resourceRegistration ) {
+        BinaryStorageWriteAttributeHandler.MONGO_BINARY_STORAGE_INSTANCE.registerAttributes(resourceRegistration);
+    }
+}

--- a/deploy/jbossas/modeshape-jbossas-subsystem/src/main/java/org/modeshape/jboss/subsystem/ModeShapeSubsystemXMLWriter.java
+++ b/deploy/jbossas/modeshape-jbossas-subsystem/src/main/java/org/modeshape/jboss/subsystem/ModeShapeSubsystemXMLWriter.java
@@ -15,6 +15,7 @@
  */
 package org.modeshape.jboss.subsystem;
 
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -291,9 +292,9 @@ public class ModeShapeSubsystemXMLWriter implements XMLStreamConstants, XMLEleme
         }
     }
 
-    private void writeBinaryStorageModel( XMLExtendedStreamWriter writer,
-                                          String storageType,
-                                          ModelNode storage ) throws XMLStreamException {
+    private void writeBinaryStorageModel(XMLExtendedStreamWriter writer,
+                                         String storageType,
+                                         ModelNode storage) throws XMLStreamException {
         if (ModelKeys.TRANSIENT_BINARY_STORAGE.equals(storageType)) {
             writer.writeStartElement(Element.TRANSIENT_BINARY_STORAGE.getLocalName());
             ModelAttributes.MINIMUM_BINARY_SIZE.marshallAsAttribute(storage, false, writer);
@@ -321,6 +322,24 @@ public class ModeShapeSubsystemXMLWriter implements XMLStreamConstants, XMLEleme
             ModelAttributes.STORE_NAME.marshallAsAttribute(storage, false, writer);
             ModelAttributes.MIME_TYPE_DETECTION.marshallAsAttribute(storage, false, writer);
             writer.writeEndElement();
+        } else if (ModelKeys.CASSANDRA_BINARY_STORAGE.equals(storageType)) {
+            writer.writeStartElement(Element.CASSANDRA_BINARY_STORAGE.getLocalName());
+            ModelAttributes.MINIMUM_BINARY_SIZE.marshallAsAttribute(storage, false, writer);
+            ModelAttributes.MINIMUM_STRING_SIZE.marshallAsAttribute(storage, false, writer);
+            ModelAttributes.MIME_TYPE_DETECTION.marshallAsAttribute(storage, false, writer);
+            ModelAttributes.CASSANDRA_HOST.marshallAsAttribute(storage, false, writer);
+            writer.writeEndElement();
+        } else if (ModelKeys.MONGO_BINARY_STORAGE.equals(storageType)) {
+            writer.writeStartElement(Element.MONGO_BINARY_STORAGE.getLocalName());
+            ModelAttributes.MINIMUM_BINARY_SIZE.marshallAsAttribute(storage, false, writer);
+            ModelAttributes.MINIMUM_STRING_SIZE.marshallAsAttribute(storage, false, writer);
+            ModelAttributes.MIME_TYPE_DETECTION.marshallAsAttribute(storage, false, writer);
+            ModelAttributes.MONGO_HOST.marshallAsAttribute(storage, false, writer);
+            ModelAttributes.MONGO_PORT.marshallAsAttribute(storage, false, writer);
+            ModelAttributes.MONGO_DATABASE.marshallAsAttribute(storage, false, writer);
+            ModelAttributes.MONGO_USERNAME.marshallAsAttribute(storage, false, writer);
+            ModelAttributes.MONGO_PASSWORD.marshallAsAttribute(storage, false, writer);
+            writer.writeEndElement();
         } else if (ModelKeys.COMPOSITE_BINARY_STORAGE.equals(storageType)) {
             writer.writeStartElement(Element.COMPOSITE_BINARY_STORAGE.getLocalName());
             ModelAttributes.MINIMUM_BINARY_SIZE.marshallAsAttribute(storage, false, writer);
@@ -339,15 +358,25 @@ public class ModeShapeSubsystemXMLWriter implements XMLStreamConstants, XMLEleme
             ModelAttributes.MINIMUM_STRING_SIZE.marshallAsAttribute(storage, false, writer);
             ModelAttributes.STORE_NAME.marshallAsAttribute(storage, false, writer);
             ModelAttributes.MIME_TYPE_DETECTION.marshallAsAttribute(storage, false, writer);
-            for (String key : storage.keys()) {
-                if (key.equals(ModelKeys.CLASSNAME)) {
-                    ModelAttributes.CLASSNAME.marshallAsAttribute(storage, false, writer);
-                } else if (key.equals(ModelKeys.MODULE)) {
-                    ModelAttributes.MODULE.marshallAsAttribute(storage, false, writer);
-                } else {
-                    writer.writeAttribute(key, storage.get(key).asString());
+            List<String> toSkip = Arrays.asList(ModelKeys.MINIMUM_BINARY_SIZE, ModelKeys.MINIMUM_STRING_SIZE,
+                                                ModelKeys.STORE_NAME, ModelKeys.MIME_TYPE_DETECTION); 
+            storage.keys().stream().filter(key -> !toSkip.contains(key)).forEach(key -> {
+                try {
+                    switch (key) {
+                        case ModelKeys.CLASSNAME:
+                            ModelAttributes.CLASSNAME.marshallAsAttribute(storage, false, writer);
+                            break;
+                        case ModelKeys.MODULE:
+                            ModelAttributes.MODULE.marshallAsAttribute(storage, false, writer);
+                            break;
+                        default:
+                            writer.writeAttribute(key, storage.get(key).asString());
+                            break;
+                    }
+                } catch (XMLStreamException e) {
+                    throw new RuntimeException(e);
                 }
-            }
+            });
             writer.writeEndElement();
         }
     }

--- a/deploy/jbossas/modeshape-jbossas-subsystem/src/main/java/org/modeshape/jboss/subsystem/ModelAttributes.java
+++ b/deploy/jbossas/modeshape-jbossas-subsystem/src/main/java/org/modeshape/jboss/subsystem/ModelAttributes.java
@@ -411,7 +411,8 @@ public class ModelAttributes {
             new SimpleAttributeDefinitionBuilder(ModelKeys.NODE_TYPE_NAME, ModelType.STRING)
                     .setXmlName(Attribute.NODE_TYPE.getLocalName())
                     .setAllowExpression(true)
-                    .setAllowNull(false)
+                    .setAllowNull(true)
+                    .setDefaultValue(new ModelNode("nt:base"))
                     .setValidator(NODE_TYPE_VALIDATOR)
                     .setFlags(AttributeAccess.Flag.RESTART_NONE)
                     .build();
@@ -564,6 +565,7 @@ public class ModelAttributes {
                                                              .setFlags(AttributeAccess.Flag.RESTART_NONE)
                                                              .build())
                                                  .setAllowNull(true)
+                                                 .setAllowExpression(true)
                                                  .setMinSize(0)
                                                  .build();
 
@@ -875,6 +877,55 @@ public class ModelAttributes {
                     .setFlags(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
                     .build();
 
+    public static final MappedSimpleAttributeDefinition CASSANDRA_HOST =
+            new MappedAttributeDefinitionBuilder(Attribute.HOST.getLocalName(), ModelType.STRING,
+                                                 FieldName.STORAGE, FieldName.BINARY_STORAGE, FieldName.ADDRESS)
+                    .setAllowExpression(true)
+                    .setAllowNull(false)
+                    .setFlags(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
+                    .build();
+    
+    public static final MappedSimpleAttributeDefinition MONGO_HOST =
+            new MappedAttributeDefinitionBuilder(Attribute.HOST.getLocalName(), ModelType.STRING,
+                                                 FieldName.STORAGE, FieldName.BINARY_STORAGE, FieldName.HOST)
+                    .setAllowExpression(true)
+                    .setAllowNull(false)
+                    .setFlags(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
+                    .build();
+    
+    public static final MappedSimpleAttributeDefinition MONGO_PORT =
+            new MappedAttributeDefinitionBuilder(Attribute.PORT.getLocalName(), ModelType.INT,
+                                                 FieldName.STORAGE, FieldName.BINARY_STORAGE, FieldName.PORT)
+                    .setAllowExpression(true)
+                    .setAllowNull(false)
+                    .setFlags(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
+                    .build();
+    
+    public static final MappedSimpleAttributeDefinition MONGO_DATABASE =
+            new MappedAttributeDefinitionBuilder(Attribute.DATABASE.getLocalName(), ModelType.STRING,
+                                                 FieldName.STORAGE, FieldName.BINARY_STORAGE, FieldName.DATABASE)
+                    .setAllowExpression(true)
+                    .setAllowNull(true)
+                    .setFlags(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
+                    .build();
+    
+    public static final MappedSimpleAttributeDefinition MONGO_USERNAME =
+            new MappedAttributeDefinitionBuilder(Attribute.USERNAME.getLocalName(), ModelType.STRING,
+                                                 FieldName.STORAGE, FieldName.BINARY_STORAGE, FieldName.USER_NAME)
+                    .setAllowExpression(true)
+                    .setAllowNull(true)
+                    .setFlags(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
+                    .build();
+
+    public static final MappedSimpleAttributeDefinition MONGO_PASSWORD =
+            new MappedAttributeDefinitionBuilder(Attribute.PASSWORD.getLocalName(), ModelType.STRING,
+                                                 FieldName.STORAGE, FieldName.BINARY_STORAGE, FieldName.USER_PASSWORD)
+                    .setAllowExpression(true)
+                    .setAllowNull(true)
+                    .setFlags(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
+                    .build();
+    
+    
     public static final AttributeDefinition[] SUBSYSTEM_ATTRIBUTES = {};
 
     public static final AttributeDefinition[] WEBAPP_ATTRIBUTES = {EXPLODED};
@@ -898,7 +949,13 @@ public class ModelAttributes {
         TRASH, RELATIVE_TO, STORE_NAME, MIME_TYPE_DETECTION};
 
     public static final AttributeDefinition[] DATABASE_BINARY_STORAGE_ATTRIBUTES = {MINIMUM_BINARY_SIZE, MINIMUM_STRING_SIZE,
-        DATA_SOURCE_JNDI_NAME, STORE_NAME, MIME_TYPE_DETECTION};
+        DATA_SOURCE_JNDI_NAME, STORE_NAME, MIME_TYPE_DETECTION};  
+    
+    public static final AttributeDefinition[] CASSANDRA_BINARY_STORAGE_ATTRIBUTES = {MINIMUM_BINARY_SIZE, MINIMUM_STRING_SIZE,
+        MIME_TYPE_DETECTION, CASSANDRA_HOST };
+
+    public static final AttributeDefinition[] MONGO_BINARY_STORAGE_ATTRIBUTES = {MINIMUM_BINARY_SIZE, MINIMUM_STRING_SIZE,
+        MIME_TYPE_DETECTION, MONGO_HOST, MONGO_PORT, MONGO_DATABASE, MONGO_USERNAME, MONGO_PASSWORD};
 
     public static final AttributeDefinition[] COMPOSITE_BINARY_STORAGE_ATTRIBUTES = {MINIMUM_BINARY_SIZE, MINIMUM_STRING_SIZE,
         NESTED_STORES, MIME_TYPE_DETECTION};

--- a/deploy/jbossas/modeshape-jbossas-subsystem/src/main/java/org/modeshape/jboss/subsystem/ModelKeys.java
+++ b/deploy/jbossas/modeshape-jbossas-subsystem/src/main/java/org/modeshape/jboss/subsystem/ModelKeys.java
@@ -85,6 +85,8 @@ public class ModelKeys {
     static final String TRANSIENT_BINARY_STORAGE = "transient-binary-storage";
     static final String FILE_BINARY_STORAGE = "file-binary-storage";
     static final String DB_BINARY_STORAGE = "db-binary-storage";
+    static final String CASSANDRA_BINARY_STORAGE = "cassandra-binary-storage";
+    static final String MONGO_BINARY_STORAGE = "mongo-binary-storage";
     static final String COMPOSITE_BINARY_STORAGE = "composite-binary-storage";
     static final String CUSTOM_BINARY_STORAGE = "custom-binary-storage";
 

--- a/deploy/jbossas/modeshape-jbossas-subsystem/src/main/resources/org/modeshape/jboss/subsystem/LocalDescriptions.properties
+++ b/deploy/jbossas/modeshape-jbossas-subsystem/src/main/resources/org/modeshape/jboss/subsystem/LocalDescriptions.properties
@@ -220,6 +220,28 @@ modeshape.repository.file-binary-storage.trash = The path to the directory where
 modeshape.repository.file-binary-storage.relative-to = The (optional) path to the directory that the 'path' parameter is relative to
 modeshape.repository.file-binary-storage.store-name = An implementation-supplied name for this binary store
 
+modeshape.repository.cassandra-binary-storage = Store binary values in Cassandra
+modeshape.repository.cassandra-binary-storage.add = Store binary values in Cassandra
+modeshape.repository.cassandra-binary-storage.remove = Remove the Cassandra binary storage configuration
+modeshape.repository.cassandra-binary-storage.binary-storage-type = The type of binary storage 
+modeshape.repository.cassandra-binary-storage.minimum-binary-size = The size threshold that dictates whether binary values should be stored in the binary store. Binary values smaller than this value are stored with the node, whereas binary values with a size equal to or greater than this limit will be stored separately from the node and in the binary store, keyed by the SHA-1 hash of the value. This is a space and performance optimization that stores each unique large value only once.
+modeshape.repository.cassandra-binary-storage.minimum-string-size = The size threshold that dictates whether string values should be stored in the binary store. String values smaller than this value are stored with the node, whereas string values with a size equal to or greater than this limit will be stored separately from the node and in the binary store, keyed by the SHA-1 hash of the value. This is a space and performance optimization that stores each unique large value only once.
+modeshape.repository.cassandra-binary-storage.mime-type-detection = The type of mime-type detector to use 
+modeshape.repository.cassandra-binary-storage.host = The Cassandra cluster address
+
+modeshape.repository.mongo-binary-storage = Store binary values in MongoDB
+modeshape.repository.mongo-binary-storage.add = Store binary values in MongoDB
+modeshape.repository.mongo-binary-storage.remove = Remove the MongoDB binary storage configuration
+modeshape.repository.mongo-binary-storage.binary-storage-type = The type of binary storage 
+modeshape.repository.mongo-binary-storage.minimum-binary-size = The size threshold that dictates whether binary values should be stored in the binary store. Binary values smaller than this value are stored with the node, whereas binary values with a size equal to or greater than this limit will be stored separately from the node and in the binary store, keyed by the SHA-1 hash of the value. This is a space and performance optimization that stores each unique large value only once.
+modeshape.repository.mongo-binary-storage.minimum-string-size = The size threshold that dictates whether string values should be stored in the binary store. String values smaller than this value are stored with the node, whereas string values with a size equal to or greater than this limit will be stored separately from the node and in the binary store, keyed by the SHA-1 hash of the value. This is a space and performance optimization that stores each unique large value only once.
+modeshape.repository.mongo-binary-storage.mime-type-detection = The type of mime-type detector to use 
+modeshape.repository.mongo-binary-storage.host = The MongoDB host name
+modeshape.repository.mongo-binary-storage.port = The MongoDB port
+modeshape.repository.mongo-binary-storage.database = The name of the Mongo database used to store the binary values
+modeshape.repository.mongo-binary-storage.username = The Mongo user name
+modeshape.repository.mongo-binary-storage.password = The Mongo password
+
 modeshape.repository.transient-binary-storage = Store binary values in a temporary location
 modeshape.repository.transient-binary-storage.describe = Specify that the repository binary values are to be stored on the file system in a temporary location
 modeshape.repository.transient-binary-storage.add = Store binary values in a temporary location

--- a/deploy/jbossas/modeshape-jbossas-subsystem/src/main/resources/schema/modeshape_3_0.xsd
+++ b/deploy/jbossas/modeshape-jbossas-subsystem/src/main/resources/schema/modeshape_3_0.xsd
@@ -158,6 +158,16 @@
                         <xs:documentation>The binary files are stored in a relational database.</xs:documentation>
                     </xs:annotation>
                 </xs:element>
+                <xs:element name="cassandra-binary-storage" type="cassandra-binary-storage">
+                    <xs:annotation>
+                        <xs:documentation>The binary files are stored in Cassandra.</xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+                <xs:element name="mongo-binary-storage" type="mongo-binary-storage">
+                    <xs:annotation>
+                        <xs:documentation>The binary files are stored in MongoDB.</xs:documentation>
+                    </xs:annotation>
+                </xs:element>
                 <xs:element name="composite-binary-storage" type="composite-binary-storage">
                     <xs:annotation>
                         <xs:documentation>The binary files are stored in a one of any number of named binary stores.
@@ -837,6 +847,16 @@
         <xs:attributeGroup ref="file-storage-attributes"/>
         <xs:attributeGroup ref="binary-storage-attributes"/>
     </xs:complexType>
+   
+     <xs:complexType name="cassandra-binary-storage">
+        <xs:attributeGroup ref="cassandra-storage-attributes"/>
+        <xs:attributeGroup ref="binary-storage-attributes"/>
+    </xs:complexType>
+
+    <xs:complexType name="mongo-binary-storage">
+        <xs:attributeGroup ref="mongo-storage-attributes"/>
+        <xs:attributeGroup ref="binary-storage-attributes"/>
+    </xs:complexType>
 
     <xs:complexType name="nested-file-binary-storage">
         <xs:attributeGroup ref="file-storage-attributes"/>
@@ -994,6 +1014,40 @@
                     generate an exception when the repository is created.
                     If undefined, the path defaults to 'modeshape/{repositoryName}/binaries/trash'.
                 </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:attributeGroup>
+    <xs:attributeGroup name="cassandra-storage-attributes">
+        <xs:attribute name="host" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>The address of the Cassandra server to connect to</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:attributeGroup> 
+    <xs:attributeGroup name="mongo-storage-attributes">
+        <xs:attribute name="host" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>The MongoDB host name</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="port" type="xs:integer" use="required">
+            <xs:annotation>
+                <xs:documentation>The MongoDB port number</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="database" type="xs:string" default="ModeShape_BinaryStore" use="optional">
+            <xs:annotation>
+                <xs:documentation>The MongoDB database name where binaries will be stored</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="username" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>The DB user name</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="password" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>The DB user password</xs:documentation>
             </xs:annotation>
         </xs:attribute>
     </xs:attributeGroup>

--- a/deploy/jbossas/modeshape-jbossas-subsystem/src/test/java/org/modeshape/jboss/subsystem/ModeShapeConfigurationTest.java
+++ b/deploy/jbossas/modeshape-jbossas-subsystem/src/test/java/org/modeshape/jboss/subsystem/ModeShapeConfigurationTest.java
@@ -68,7 +68,14 @@ public class ModeShapeConfigurationTest extends AbstractSubsystemBaseTest {
 
     @Override
     protected String getSubsystemXml( String configId ) throws IOException {
-        return configId != null ? readResource("modeshape-" + configId + "-config.xml") : getSubsystemXml();
+        if (configId == null) {
+            return getSubsystemXml();
+        }
+        String config = "modeshape-" + configId + "-config.xml";
+        if (ModeShapeConfigurationTest.class.getResource(config) != null) {
+            return readResource(config); 
+        }
+        return readResource(configId);
     }
 
     @Test
@@ -83,108 +90,123 @@ public class ModeShapeConfigurationTest extends AbstractSubsystemBaseTest {
 
     @Test
     public void testConfigurationWithIndexStorage() throws Exception {
-        parse(readResource("modeshape-index-storage.xml"));
+        standardSubsystemTest("modeshape-index-storage.xml", false);
     }
 
     @Test
     public void testConfigurationWithAllIndexTypes() throws Exception {
         // fix for MODE-2348
-        parse(readResource("modeshape-index-types.xml"));
+        standardSubsystemTest("modeshape-index-types.xml");
     }
 
     @Test
     public void testConfigurationWithFileBinaryStorage() throws Exception {
-        parse(readResource("modeshape-file-binary-storage.xml"));
+        standardSubsystemTest("modeshape-file-binary-storage.xml", false);
     }  
     
     @Test
     public void testConfigurationWithTransientBinaryStorage() throws Exception {
-        parse(readResource("modeshape-transient-binary-storage.xml"));
+        standardSubsystemTest("modeshape-transient-binary-storage.xml");
+    }   
+    
+    @Test
+    public void testConfigurationWithDBBinaryStorage() throws Exception {
+        standardSubsystemTest("modeshape-db-binary-storage.xml");
+    }  
+
+    @Test
+    public void testConfigurationWithCassandraBinaryStorage() throws Exception {
+        standardSubsystemTest("modeshape-cassandra-binary-storage.xml");
+    }  
+    
+    @Test
+    public void testConfigurationWithMongoBinaryStorage() throws Exception {
+        standardSubsystemTest("modeshape-mongo-binary-storage.xml");
     }  
     
     @Test(expected = XMLStreamException.class)
     public void shouldValidateFileBinaryStoreAttributesAgainstSchema() throws Exception {
-        parse(readResource("modeshape-invalid-file-binary-storage.xml"));
+        standardSubsystemTest("modeshape-invalid-file-binary-storage.xml");
     }
 
     @Test
     public void testConfigurationWithCompositeBinaryStores() throws Exception {
-        parse(readResource("modeshape-composite-binary-storage-config.xml"));
+        standardSubsystemTest("modeshape-composite-binary-storage-config.xml", false);
     }
 
     @Test( expected = XMLStreamException.class )
     public void shouldRejectInvalidCompositeBinaryStoreConfiguration() throws Exception {
-        parse(readResource("modeshape-invalid-composite-binary-storage.xml"));
+        standardSubsystemTest("modeshape-invalid-composite-binary-storage.xml");
     }
 
     @Test
     public void testConfigurationWithWorkspaceInitialContent() throws Exception {
-        parse(readResource("modeshape-initial-content-config.xml"));
+        standardSubsystemTest("modeshape-initial-content-config.xml", false);
     }
     
     @Test
     public void testConfigurationWithClustering() throws Exception {
-        parse(readResource("modeshape-clustered-config.xml"));
+        standardSubsystemTest("modeshape-clustered-config.xml");
     }
 
     @Test
     public void testConfigurationWithNodeTypes() throws Exception {
-        parse(readResource("modeshape-node-types-config.xml"));
+        standardSubsystemTest("modeshape-node-types-config.xml");
     }
 
     @Test
     public void testConfigurationWithCustomAuthenticators() throws Exception {
-        parse(readResource("modeshape-custom-authenticators-config.xml"));
+        standardSubsystemTest("modeshape-custom-authenticators-config.xml", false);
     }
 
     @Test
     public void testConfigurationWithWorkspacesCacheContainer() throws Exception {
-        parse(readResource("modeshape-workspaces-cache-config.xml"));
+        standardSubsystemTest("modeshape-workspaces-cache-config.xml", false);
     }
 
     @Test
     public void testConfigurationWithExternalSources() throws Exception {
-        parse(readResource("modeshape-federation-config.xml"));
+        standardSubsystemTest("modeshape-federation-config.xml", false);
     }
 
     @Test
     public void testConfigurationWithGarbageCollectionSpecified() throws Exception {
-        parse(readResource("modeshape-garbage-collection.xml"));
+        standardSubsystemTest("modeshape-garbage-collection.xml", false);
     }
 
     @Test
     public void testConfigurationWithWebapps() throws Exception {
-        parse(readResource("modeshape-webapp-config.xml"));
+        standardSubsystemTest("modeshape-webapp-config.xml", false);
     }
 
     @Test
     public void testConfigurationWithJournaling() throws Exception {
-        parse(readResource("modeshape-journaling.xml"));
+        standardSubsystemTest("modeshape-journaling.xml");
     }
     
     @Test
     public void testConfigurationWithOptimization() throws Exception {
-        parse(readResource("modeshape-optimiziation-config.xml"));
+        standardSubsystemTest("modeshape-optimiziation-config.xml", false);
     }
     
     @Test
     public void testConfigurationWithMimeTypeDetection() throws Exception {
-        parse(readResource("modeshape-mime-type-detection.xml"));
+        standardSubsystemTest("modeshape-mime-type-detection.xml");
     } 
     
     @Test
     public void testConfigurationWithReindexing() throws Exception {
-        parse(readResource("modeshape-reindexing.xml"));
+        standardSubsystemTest("modeshape-reindexing.xml");
     }
     
     @Test
     public void testConfigurationWithPersistence() throws Exception {
-        parse(readResource("modeshape-persistence-config.xml"));
+        standardSubsystemTest("modeshape-persistence-config.xml");
     }  
     
     @Test
     public void testConfigurationWithCustomDependencies() throws Exception {
-        parse(readResource("modeshape-repository-dependencies-config.xml"));
+        standardSubsystemTest("modeshape-repository-dependencies-config.xml");
     }
 
     @Test

--- a/deploy/jbossas/modeshape-jbossas-subsystem/src/test/resources/org/modeshape/jboss/subsystem/modeshape-cassandra-binary-storage.xml
+++ b/deploy/jbossas/modeshape-jbossas-subsystem/src/test/resources/org/modeshape/jboss/subsystem/modeshape-cassandra-binary-storage.xml
@@ -1,0 +1,5 @@
+<subsystem xmlns="urn:jboss:domain:modeshape:3.0">
+  <repository name="sample">
+    <cassandra-binary-storage mime-type-detection="content" min-string-size="10" min-value-size="4096" host="localhost"/>  
+  </repository>
+</subsystem>

--- a/deploy/jbossas/modeshape-jbossas-subsystem/src/test/resources/org/modeshape/jboss/subsystem/modeshape-clustered-config.xml
+++ b/deploy/jbossas/modeshape-jbossas-subsystem/src/test/resources/org/modeshape/jboss/subsystem/modeshape-clustered-config.xml
@@ -1,8 +1,8 @@
 <subsystem xmlns="urn:jboss:domain:modeshape:3.0">
-  <repository name="sample1" jndi-name="java:jcr/local/modeshape_repo1" cluster-name="cluster1" cluster-stack="tcp"/>
-  <repository name="sample2" jndi-name="java:jcr/local/modeshape_repo2" cluster-name="cluster2" 
+  <repository name="sample1" jndi-name="jcr/local/modeshape_repo1" cluster-name="cluster1" cluster-stack="tcp"/>
+  <repository name="sample2" jndi-name="jcr/local/modeshape_repo2" cluster-name="cluster2" 
               cluster-config="${jboss.server.config.dir}/modeshape/jgroups.xml"/>
-  <repository name="sample3" jndi-name="java:jcr/local/modeshape_repo3" cluster-name="cluster3" cluster-stack="udp" 
+  <repository name="sample3" jndi-name="jcr/local/modeshape_repo3" cluster-name="cluster3" cluster-stack="udp" 
               cluster-config="${jboss.server.config.dir}/modeshape/jgroups.xml"/>
 </subsystem>
 

--- a/deploy/jbossas/modeshape-jbossas-subsystem/src/test/resources/org/modeshape/jboss/subsystem/modeshape-composite-binary-storage-config.xml
+++ b/deploy/jbossas/modeshape-jbossas-subsystem/src/test/resources/org/modeshape/jboss/subsystem/modeshape-composite-binary-storage-config.xml
@@ -7,8 +7,8 @@
             <file-binary-storage store-name="another-fsbs"
                                  path="modeshape/sample/somewhere-else"
                                  relative-to="jboss.server.data.dir"/>
-            <custom-binary-storage classname="someclass" store-name="customBinary"/>
             <db-binary-storage data-source-jndi-name="jndiName" store-name="dbBinary"/>
+            <custom-binary-storage classname="someclass" store-name="customBinary"/>
         </composite-binary-storage>
     </repository>
 </subsystem>

--- a/deploy/jbossas/modeshape-jbossas-subsystem/src/test/resources/org/modeshape/jboss/subsystem/modeshape-custom-authenticators-config.xml
+++ b/deploy/jbossas/modeshape-jbossas-subsystem/src/test/resources/org/modeshape/jboss/subsystem/modeshape-custom-authenticators-config.xml
@@ -3,7 +3,7 @@
               jndi-name="jcr/local/sample"
               enable-monitoring="true"
               security-domain="modeshape-security"
-              anonymous-roles="readonly readwrite admin connect" 
+              anonymous-roles="readonly readwrite admin" 
               anonymous-username="&lt;anonymous&gt;" 
               use-anonymous-upon-failed-authentication="false">
     <workspaces default-workspace="default" allow-workspace-creation="true">

--- a/deploy/jbossas/modeshape-jbossas-subsystem/src/test/resources/org/modeshape/jboss/subsystem/modeshape-db-binary-storage.xml
+++ b/deploy/jbossas/modeshape-jbossas-subsystem/src/test/resources/org/modeshape/jboss/subsystem/modeshape-db-binary-storage.xml
@@ -1,0 +1,5 @@
+<subsystem xmlns="urn:jboss:domain:modeshape:3.0">
+  <repository name="sample">
+    <db-binary-storage mime-type-detection="content" min-string-size="10" min-value-size="4096" data-source-jndi-name="test"/>  
+  </repository>
+</subsystem>

--- a/deploy/jbossas/modeshape-jbossas-subsystem/src/test/resources/org/modeshape/jboss/subsystem/modeshape-federation-config.xml
+++ b/deploy/jbossas/modeshape-jbossas-subsystem/src/test/resources/org/modeshape/jboss/subsystem/modeshape-federation-config.xml
@@ -3,7 +3,7 @@
               jndi-name="jcr/local/sample"
               enable-monitoring="true"
               security-domain="modeshape-security"
-              anonymous-roles="readonly readwrite admin connect" 
+              anonymous-roles="admin readwrite" 
               anonymous-username="&lt;anonymous&gt;" 
               use-anonymous-upon-failed-authentication="false">
     <workspaces default-workspace="default" allow-workspace-creation="true">

--- a/deploy/jbossas/modeshape-jbossas-subsystem/src/test/resources/org/modeshape/jboss/subsystem/modeshape-file-binary-storage.xml
+++ b/deploy/jbossas/modeshape-jbossas-subsystem/src/test/resources/org/modeshape/jboss/subsystem/modeshape-file-binary-storage.xml
@@ -3,7 +3,7 @@
               jndi-name="jcr/local/sample"
               enable-monitoring="true"
               security-domain="modeshape-security"
-              anonymous-roles="readonly readwrite admin connect" 
+              anonymous-roles="readonly readwrite admin" 
               anonymous-username="&lt;anonymous&gt;" 
               use-anonymous-upon-failed-authentication="false">
     <workspaces default-workspace="default" allow-workspace-creation="true">

--- a/deploy/jbossas/modeshape-jbossas-subsystem/src/test/resources/org/modeshape/jboss/subsystem/modeshape-garbage-collection.xml
+++ b/deploy/jbossas/modeshape-jbossas-subsystem/src/test/resources/org/modeshape/jboss/subsystem/modeshape-garbage-collection.xml
@@ -3,7 +3,7 @@
               jndi-name="jcr/local/sample"
               enable-monitoring="true"
               security-domain="modeshape-security"
-              anonymous-roles="readonly readwrite admin connect" 
+              anonymous-roles="readonly readwrite admin" 
               anonymous-username="&lt;anonymous&gt;" 
               use-anonymous-upon-failed-authentication="false"
               garbage-collection-thread-pool="something"

--- a/deploy/jbossas/modeshape-jbossas-subsystem/src/test/resources/org/modeshape/jboss/subsystem/modeshape-index-storage.xml
+++ b/deploy/jbossas/modeshape-jbossas-subsystem/src/test/resources/org/modeshape/jboss/subsystem/modeshape-index-storage.xml
@@ -3,7 +3,7 @@
               jndi-name="jcr/local/sample"
               enable-monitoring="true"
               security-domain="modeshape-security"
-              anonymous-roles="readonly readwrite admin connect" 
+              anonymous-roles="readonly readwrite admin" 
               anonymous-username="&lt;anonymous&gt;" 
               use-anonymous-upon-failed-authentication="false">
     <workspaces default-workspace="default" allow-workspace-creation="true">
@@ -28,7 +28,7 @@
                         analyzerClass="org.apache.lucene.analysis.ro.RomanianAnalyzer" codec="Lucene53"/>
     </index-providers>
     <indexes>
-      <index name="primaryTypes" provider-name="local" index-kind="value" node-type="nt:base" columns="jcr:primaryType(NAME)" />
+      <index name="primaryTypes" provider-name="local" kind="value" node-type="nt:base" columns="jcr:primaryType(NAME)" />
       <index name="names" provider-name="local" kind="value" node-type="nt:resource" columns="jcr:name(NAME)" />
     </indexes>
     <sequencers>

--- a/deploy/jbossas/modeshape-jbossas-subsystem/src/test/resources/org/modeshape/jboss/subsystem/modeshape-mongo-binary-storage.xml
+++ b/deploy/jbossas/modeshape-jbossas-subsystem/src/test/resources/org/modeshape/jboss/subsystem/modeshape-mongo-binary-storage.xml
@@ -1,0 +1,6 @@
+<subsystem xmlns="urn:jboss:domain:modeshape:3.0">
+  <repository name="sample">
+    <mongo-binary-storage mime-type-detection="content" min-string-size="10" min-value-size="4096" database="test"
+            host="localhost" port="100" password="test" username="test"/>  
+  </repository>
+</subsystem>

--- a/deploy/jbossas/modeshape-jbossas-subsystem/src/test/resources/org/modeshape/jboss/subsystem/modeshape-workspaces-cache-config.xml
+++ b/deploy/jbossas/modeshape-jbossas-subsystem/src/test/resources/org/modeshape/jboss/subsystem/modeshape-workspaces-cache-config.xml
@@ -3,7 +3,7 @@
               jndi-name="jcr/local/sample"
               enable-monitoring="true"
               security-domain="modeshape-security"
-              anonymous-roles="readonly readwrite admin connect" 
+              anonymous-roles="readonly readwrite admin" 
               anonymous-username="&lt;anonymous&gt;" 
               use-anonymous-upon-failed-authentication="false">
       <workspaces default-workspace="default" allow-workspace-creation="true" cache-size="10"/>

--- a/integration/modeshape-jbossas-integration-tests/src/test/java/org/modeshape/test/integration/DataSourceIntegrationTest.java
+++ b/integration/modeshape-jbossas-integration-tests/src/test/java/org/modeshape/test/integration/DataSourceIntegrationTest.java
@@ -16,6 +16,7 @@
 package org.modeshape.test.integration;
 
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 import java.io.File;
 import java.sql.Connection;
 import javax.annotation.Resource;
@@ -34,6 +35,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.modeshape.common.util.FileUtil;
 import org.modeshape.jcr.JcrRepository;
 import org.modeshape.jdbc.ConnectionResultsComparator;
 
@@ -78,6 +80,10 @@ public class DataSourceIntegrationTest {
 
     @Before
     public void before() throws Exception {
+        File serverDataDir = new File(System.getProperty("jboss.server.data.dir"));
+        assertTrue("Cannot read server data dir !", serverDataDir.exists() && serverDataDir.canRead());
+        FileUtil.delete(new File(serverDataDir, "modeshape/store/artifacts"));
+        
         assertNotNull(modeshapeDS);
         connection = modeshapeDS.getConnection();
         assertNotNull(connection);

--- a/integration/modeshape-jbossas-integration-tests/src/test/java/org/modeshape/test/integration/QueryIntegrationTest.java
+++ b/integration/modeshape-jbossas-integration-tests/src/test/java/org/modeshape/test/integration/QueryIntegrationTest.java
@@ -15,6 +15,7 @@
  */
 package org.modeshape.test.integration;
 
+import static org.junit.Assert.assertTrue;
 import java.io.File;
 import java.io.InputStream;
 import javax.annotation.Resource;
@@ -32,6 +33,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.modeshape.common.util.FileUtil;
 import org.modeshape.jcr.JcrRepository;
 import org.modeshape.jcr.ValidateQuery;
 import org.modeshape.jcr.ValidateQuery.ValidationBuilder;
@@ -66,6 +68,10 @@ public class QueryIntegrationTest {
 
     @Before
     public void beforeEach() throws Exception {
+        File serverDataDir = new File(System.getProperty("jboss.server.data.dir"));
+        assertTrue("Cannot read server data dir !", serverDataDir.exists() && serverDataDir.canRead());
+        FileUtil.delete(new File(serverDataDir, "modeshape/store/artifacts"));
+        
         session = repository.login("default");
         print = false;
         tools = new JcrTools();

--- a/integration/modeshape-jbossas-integration-tests/src/test/java/org/modeshape/test/integration/SequencersIntegrationTest.java
+++ b/integration/modeshape-jbossas-integration-tests/src/test/java/org/modeshape/test/integration/SequencersIntegrationTest.java
@@ -40,9 +40,11 @@ import org.jboss.shrinkwrap.api.ArchivePaths;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.modeshape.common.FixFor;
+import org.modeshape.common.util.FileUtil;
 import org.modeshape.jcr.JcrRepository;
 import org.modeshape.jcr.JcrSession;
 import org.modeshape.jcr.RepositoryConfiguration;
@@ -75,6 +77,13 @@ public class SequencersIntegrationTest {
                          .setManifest(new File("src/main/webapp/META-INF/MANIFEST.MF"));
     }
 
+    @Before
+    public void before() {
+        File serverDataDir = new File(System.getProperty("jboss.server.data.dir"));
+        assertTrue("Cannot read server data dir !", serverDataDir.exists() && serverDataDir.canRead());
+        FileUtil.delete(new File(serverDataDir, "modeshape/store/artifacts"));        
+    }
+    
     @Test
     public void shouldSequenceImage() throws Exception {
         uploadFileAndAssertSequenced("/image_file.jpg", "/derived/image", "org.modeshape.sequencer.image.ImageMetadataSequencer");

--- a/integration/modeshape-jbossas-integration-tests/src/test/java/org/modeshape/test/integration/TikaTextExtractorIntegrationTest.java
+++ b/integration/modeshape-jbossas-integration-tests/src/test/java/org/modeshape/test/integration/TikaTextExtractorIntegrationTest.java
@@ -16,6 +16,7 @@
 package org.modeshape.test.integration;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import java.io.File;
 import java.io.InputStream;
 import javax.annotation.Resource;
@@ -33,6 +34,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.modeshape.common.FixFor;
+import org.modeshape.common.util.FileUtil;
 import org.modeshape.jcr.JcrRepository;
 import org.modeshape.jcr.api.JcrTools;
 import org.modeshape.jcr.query.JcrQuery;
@@ -61,6 +63,9 @@ public class TikaTextExtractorIntegrationTest {
 
     @Before
     public void beforeEach() throws Exception {
+        File serverDataDir = new File(System.getProperty("jboss.server.data.dir"));
+        assertTrue("Cannot read server data dir !", serverDataDir.exists() && serverDataDir.canRead());
+        FileUtil.delete(new File(serverDataDir, "modeshape/store/artifacts"));
         session = repository.login("default");
     }
 

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/RepositoryConfiguration.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/RepositoryConfiguration.java
@@ -65,9 +65,11 @@ import org.modeshape.jcr.value.PropertyType;
 import org.modeshape.jcr.value.binary.AbstractBinaryStore;
 import org.modeshape.jcr.value.binary.BinaryStore;
 import org.modeshape.jcr.value.binary.BinaryStoreException;
+import org.modeshape.jcr.value.binary.CassandraBinaryStore;
 import org.modeshape.jcr.value.binary.CompositeBinaryStore;
 import org.modeshape.jcr.value.binary.DatabaseBinaryStore;
 import org.modeshape.jcr.value.binary.FileSystemBinaryStore;
+import org.modeshape.jcr.value.binary.MongodbBinaryStore;
 import org.modeshape.jcr.value.binary.TransientBinaryStore;
 import org.modeshape.schematic.SchemaLibrary;
 import org.modeshape.schematic.SchemaLibrary.Problem;
@@ -426,6 +428,10 @@ public class RepositoryConfiguration {
         public static final String REINDEXING = "reindexing";
         public static final String REINDEXING_ASYNC = "async";
         public static final String REINDEXING_MODE = "mode";
+        public static final String ADDRESS = "address";
+        public static final String DATABASE = "database";
+        public static final String HOST = "host";
+        public static final String PORT = "port";
 
         public static final String GARBAGE_COLLECTION = "garbageCollection";
         public static final String INITIAL_TIME = "initialTime";
@@ -561,6 +567,8 @@ public class RepositoryConfiguration {
         public static final String BINARY_STORAGE_TYPE_FILE = "file";
         public static final String BINARY_STORAGE_TYPE_DATABASE = "database";
         public static final String BINARY_STORAGE_TYPE_COMPOSITE = "composite";
+        public static final String BINARY_STORAGE_TYPE_CASSANDRA = "cassandra";
+        public static final String BINARY_STORAGE_TYPE_MONGO = "mongo";
         public static final String BINARY_STORAGE_TYPE_CUSTOM = "custom";
 
         public static final String KIND_VALUE = "value";
@@ -1146,6 +1154,16 @@ public class RepositoryConfiguration {
 
                 store = createInstance();
                 setTypeFields(store, binaryStorage);
+            } else if (type.equalsIgnoreCase(FieldValue.BINARY_STORAGE_TYPE_CASSANDRA)) {
+                String address = binaryStorage.getString(FieldName.ADDRESS);
+                store = new CassandraBinaryStore(address);
+            } else if (type.equalsIgnoreCase(FieldValue.BINARY_STORAGE_TYPE_MONGO)) {
+                String host = binaryStorage.getString(FieldName.HOST);
+                Integer port = binaryStorage.getInteger(FieldName.PORT);
+                String database = binaryStorage.getString(FieldName.DATABASE);
+                String username = binaryStorage.getString(FieldName.USER_NAME);
+                String password = binaryStorage.getString(FieldName.USER_PASSWORD);
+                store = new MongodbBinaryStore(host, port, database, username, password, null);                
             }
             if (store == null) store = TransientBinaryStore.get();
             store.setMinimumBinarySizeInBytes(getMinimumBinarySizeInBytes());

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/value/binary/MongodbBinaryStore.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/value/binary/MongodbBinaryStore.java
@@ -19,8 +19,10 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.UnknownHostException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import org.modeshape.common.util.IoUtil;
@@ -78,55 +80,14 @@ public class MongodbBinaryStore extends AbstractBinaryStore {
     private String password;
 
     // server address(es)
-    private Set<String> replicaSet = new HashSet<String>();
+    private Set<String> replicaSet = new HashSet<>();
 
     // database instance
     private DB db;
 
     // chunk size in bytes
     protected int chunkSize = 1024;
-
-    public MongodbBinaryStore() {
-        this.cache = TransientBinaryStore.get();
-        this.database = DEFAULT_DB_NAME;
-    }
-
-    /**
-     * Creates new store.
-     *
-     * @param database database name
-     * @param replicaSet list of server addresses in the form 'host:port' or null for localhost
-     */
-    public MongodbBinaryStore( String database,
-                               Set<String> replicaSet ) {
-        this.cache = TransientBinaryStore.get();
-        this.database = database;
-        if (replicaSet != null) {
-            this.replicaSet.addAll(replicaSet);
-        }
-    }
-
-    /**
-     * Creates new store.
-     *
-     * @param database database name
-     * @param username database user
-     * @param password user's password
-     * @param replicaSet list of server addresses in the form 'host:port' or null for localhost
-     */
-    public MongodbBinaryStore( String database,
-                               String username,
-                               String password,
-                               Set<String> replicaSet ) {
-        this.cache = TransientBinaryStore.get();
-        this.database = database;
-        this.username = username;
-        this.password = password;
-        if (replicaSet != null) {
-            this.replicaSet.addAll(replicaSet);
-        }
-    }
-
+    
     /**
      * Creates a new instance of the store, using a single MongoDB.
      *
@@ -137,10 +98,27 @@ public class MongodbBinaryStore extends AbstractBinaryStore {
     public MongodbBinaryStore( String host,
                                int port,
                                String database ) {
+        this(host, port, database, null, null, null);
+    }
+
+    /**
+     * Creates a new mongo binary store instance using the supplied params.
+     * 
+     * @param host the mongo host; may not be null
+     * @param port the port 
+     * @param database the name of the database; may be null in which case a default will be used
+     * @param username the username; may be null 
+     * @param password the password; may be null
+     * @param replicaSet a {@link Set} of (host:port) pairs representing multiple server addresses; may be null
+     */
+    public MongodbBinaryStore(String host, int port, String database, String username, String password, Set<String> replicaSet) {
         this.cache = TransientBinaryStore.get();
-        this.host = host;
+        this.host = Objects.requireNonNull(host);
         this.port = port;
-        this.database = database;
+        this.database = !StringUtil.isBlank(database) ? database : DEFAULT_DB_NAME;
+        this.username = username;
+        this.password = password;
+        this.replicaSet = replicaSet == null ? Collections.emptySet() : replicaSet;
     }
 
     /**

--- a/modeshape-jcr/src/main/resources/org/modeshape/jcr/repository-config-schema.json
+++ b/modeshape-jcr/src/main/resources/org/modeshape/jcr/repository-config-schema.json
@@ -375,6 +375,94 @@
                         },
                         {
                             "type" : "object",
+                            "additionalProperties" : true,
+                            "properties" : {
+                                "type" : {
+                                    "type" : "string",
+                                    "description" : "The specification of the Cassandra binary store",
+                                    "enum" : [ "cassandra" ]
+                                },
+                                "address" : {
+                                    "type" : "string",
+                                    "description" : "The address of a Cassandra Node",
+                                    "required" : true,
+                                },
+                                "minimumBinarySizeInBytes" : {
+                                    "type" : "integer",
+                                    "default" : 4096,
+                                    "description" : "The size threshold that dictates whether binary values should be stored in the binary store. Binary values smaller than this value are stored with the node, whereas binary values with a size equal to or greater than this limit will be stored separately from the node and in the binary store, keyed by the SHA-1 hash of the value. This is a space and performance optimization that stores each unique large value only once. The default value is '4096' bytes, or 4 kilobytes."
+                                },
+                                "minimumStringSize" : {
+                                    "type" : "integer",
+                                    "description" : "The size threshold that dictates whether string values should be stored in the binary store. String values shorter than this length are stored with the node, whereas strings with a length equal to or greater than this limit will be stored separately from the node and in the binary store, keyed by the SHA-1 hash of the value. This is a space and performance optimization that stores each unique large value only once. The default value is to match the 'minimumBinarySizeInBytes' value."
+                                },
+                                "mimeTypeDetection" : {
+                                    "type" : "string",
+                                    "description" : "What type of mime-type detection should be performed when uploading binary values. Defaults to 'content' - i.e. reading the binary content (at least the headers) to determine the mime type",
+                                    "default" : "content",
+                                    "enum" : [ "none", "content", "name" ]
+                                },
+                                "description" : {
+                                    "type" : "string",
+                                    "description" : "The optional description of this section of the configuration. It is unused by ModeShape."
+                                },
+                            }
+                        }, 
+                        {
+                            "type" : "object",
+                            "additionalProperties" : true,
+                            "properties" : {
+                                "type" : {
+                                    "type" : "string",
+                                    "description" : "The specification of the Cassandra binary store",
+                                    "enum" : [ "mongo" ]
+                                },
+                                "host" : {
+                                    "type" : "string",
+                                    "description" : "The name of the MongoDB host",
+                                    "required" : true,
+                                },
+                                "port" : {
+                                    "type" : "integer",
+                                    "description" : "The MongoDB port",
+                                    "required" : true,
+                                },
+                                "database" : {
+                                    "type" : "string",
+                                    "description" : "The name of the database where to store the binary content",
+                                    "default" : "ModeShape_BinaryStore",
+                                },
+                                "username" : {
+                                    "type" : "string",
+                                    "description" : "The username to use when connecting to MongoDB",
+                                },
+                                "password" : {
+                                    "type" : "string",
+                                    "description" : "The password to use when connecting to MongoDB",
+                                },
+                                "minimumBinarySizeInBytes" : {
+                                    "type" : "integer",
+                                    "default" : 4096,
+                                    "description" : "The size threshold that dictates whether binary values should be stored in the binary store. Binary values smaller than this value are stored with the node, whereas binary values with a size equal to or greater than this limit will be stored separately from the node and in the binary store, keyed by the SHA-1 hash of the value. This is a space and performance optimization that stores each unique large value only once. The default value is '4096' bytes, or 4 kilobytes."
+                                },
+                                "minimumStringSize" : {
+                                    "type" : "integer",
+                                    "description" : "The size threshold that dictates whether string values should be stored in the binary store. String values shorter than this length are stored with the node, whereas strings with a length equal to or greater than this limit will be stored separately from the node and in the binary store, keyed by the SHA-1 hash of the value. This is a space and performance optimization that stores each unique large value only once. The default value is to match the 'minimumBinarySizeInBytes' value."
+                                },
+                                "mimeTypeDetection" : {
+                                    "type" : "string",
+                                    "description" : "What type of mime-type detection should be performed when uploading binary values. Defaults to 'content' - i.e. reading the binary content (at least the headers) to determine the mime type",
+                                    "default" : "content",
+                                    "enum" : [ "none", "content", "name" ]
+                                },
+                                "description" : {
+                                    "type" : "string",
+                                    "description" : "The optional description of this section of the configuration. It is unused by ModeShape."
+                                }
+                            }
+                        },
+                        {
+                            "type" : "object",
                             "additionalProperties" : false,
                             "properties" : {
                                 "type" : {

--- a/modeshape-jcr/src/test/java/org/modeshape/jcr/BinaryStorageIntegrationTest.java
+++ b/modeshape-jcr/src/test/java/org/modeshape/jcr/BinaryStorageIntegrationTest.java
@@ -51,6 +51,7 @@ import org.modeshape.jcr.api.Binary;
 import org.modeshape.jcr.value.BinaryKey;
 import org.modeshape.jcr.value.BinaryValue;
 import org.modeshape.jcr.value.binary.BinaryStore;
+import com.datastax.driver.core.exceptions.NoHostAvailableException;
 
 /**
  * Test suite that should include test cases which verify that a repository configured with various binary stores, correctly
@@ -325,6 +326,18 @@ public class BinaryStorageIntegrationTest extends SingleUseAbstractTest {
         Node content2 = session.getNode("/file2.txt").getNode("jcr:content");
         // because the name of the file doe have an extension, we're expecting a specific mime type here
         assertEquals("text/plain", content2.getProperty("jcr:mimeType").getString());
+    }
+    
+    @Test(expected = NoHostAvailableException.class)
+    public void shouldStartWithCassandraBinaryStore() throws Exception {
+        // we expect cassandra to fail because we're not starting a cassandra server, but we want to check that we get that far ;)
+        startRepositoryWithConfigurationFrom("config/cassandra-binary-storage.json");        
+    }
+   
+    @Test
+    public void shouldStartWithMongoBinaryStore() throws Exception {
+        // even though we don't start mongo in this test, the binary store is initialized ;)
+        startRepositoryWithConfigurationFrom("config/mongo-binary-storage.json");        
     }
 
     private String randomString(long size) {

--- a/modeshape-jcr/src/test/java/org/modeshape/jcr/RepositoryConfigurationTest.java
+++ b/modeshape-jcr/src/test/java/org/modeshape/jcr/RepositoryConfigurationTest.java
@@ -136,6 +136,18 @@ public class RepositoryConfigurationTest {
     public void shouldSuccessfullyValidateDriverBasedBinaryStorageConfiguration() {
         assertValid("config/database-url-binary-storage.json");
     }
+   
+    @Test
+    @FixFor( "MODE-2574" )
+    public void shouldSuccessfullyValidateCassandraBinaryStorageConfiguration() {
+        assertValid("config/cassandra-binary-storage.json");
+    }
+ 
+    @Test
+    @FixFor( "MODE-2575" )
+    public void shouldSuccessfullyValidateMongoBinaryStorageConfiguration() {
+        assertValid("config/mongo-binary-storage.json");
+    }
 
     @Test
     public void shouldSuccessfullyValidateCompositeBinaryStorageConfiguration() {

--- a/modeshape-jcr/src/test/resources/config/cassandra-binary-storage.json
+++ b/modeshape-jcr/src/test/resources/config/cassandra-binary-storage.json
@@ -1,0 +1,12 @@
+{
+    "name" : "Test Repository",
+    "storage" : {
+        "binaryStorage" : {
+            "type"  : "cassandra",
+            "address" : "::1",
+            "minimumBinarySizeInBytes" : 4096,
+            "minimumStringSize" : 1025,
+            "mimeTypeDetection" : "none"
+        }
+    }
+}

--- a/modeshape-jcr/src/test/resources/config/mongo-binary-storage.json
+++ b/modeshape-jcr/src/test/resources/config/mongo-binary-storage.json
@@ -1,0 +1,16 @@
+{
+    "name" : "Test Repository",
+    "storage" : {
+        "binaryStorage" : {
+            "type"  : "mongo",
+            "host" : "localhost",
+            "port" : 100,
+            "username" : "test",
+            "password" : "test",
+            "database" : "test",
+            "minimumBinarySizeInBytes" : 4096,
+            "minimumStringSize" : 1025,
+            "mimeTypeDetection" : "none"
+        }
+    }
+}


### PR DESCRIPTION
The support is added both in the JSON and the Wildfly kit, based on the current code (i.e. in terms of configuration options). This also fixes a number of other JBoss AS kit issues, exposed by the enhancement of the JBoss AS subsystem tests.