### PR TITLE
MODE-2587 Updates backup and restore to perform the two operations in batches

### DIFF
--- a/modeshape-jcr-api/src/main/java/org/modeshape/jcr/api/BackupOptions.java
+++ b/modeshape-jcr-api/src/main/java/org/modeshape/jcr/api/BackupOptions.java
@@ -27,6 +27,11 @@ public abstract class BackupOptions {
      * So, if each node requires about 200 bytes (compressed), the resulting files will be about 19 MB in size.
      */
     public static final long DEFAULT_DOCUMENTS_PER_FILE = 100000L;
+
+    /**
+     * The number of documents read form the persistent store and written in a backup file in one unit
+     */
+    public static final int DEFAULT_BATCH_SIZE = 10000;
     
     /**
      * Default backup options which will be used when a backup is performed without an explicit set of options.
@@ -46,10 +51,24 @@ public abstract class BackupOptions {
     /**
      * Return the number of documents which should be backed up in a single file. 
      *
-     * @return the number documents; defaults to {@code 100000}
+     * @return the number documents; defaults to {@@value #DEFAULT_DOCUMENTS_PER_FILE}
      */
     public long documentsPerFile() {
         return DEFAULT_DOCUMENTS_PER_FILE;    
+    }
+
+    /**
+     * Return the number of documents that should be read and written to the backup file in one unit.
+     * 
+     * <p>
+     *     This is a setting that can be used to influence the memory and throughout of the backup process.
+     * </p>
+     * 
+     * @return the number of documents; defaults to {@value #DEFAULT_BATCH_SIZE}
+     * @since 5.0
+     */
+    public int batchSize() {
+        return DEFAULT_BATCH_SIZE;
     }
 
     /**
@@ -64,8 +83,9 @@ public abstract class BackupOptions {
     @Override
     public String toString() {
         StringBuilder builder = new StringBuilder("[backup_options: ");
-        builder.append("include_binaries=").append(includeBinaries());
-        builder.append(", documents_per_file=").append(documentsPerFile());
+        builder.append("include binaries=").append(includeBinaries());
+        builder.append(", batch size=").append(batchSize());
+        builder.append(", documents per file=").append(documentsPerFile());
         builder.append(", compress=").append(compress());
         builder.append("]");
         return builder.toString();

--- a/modeshape-jcr-api/src/main/java/org/modeshape/jcr/api/RestoreOptions.java
+++ b/modeshape-jcr-api/src/main/java/org/modeshape/jcr/api/RestoreOptions.java
@@ -21,6 +21,11 @@ package org.modeshape.jcr.api;
  * @author Horia Chiorean (hchiorea@redhat.com)
  */
 public abstract class RestoreOptions {
+
+    /**
+     * The number of documents written in one unit (i.e. transaction) from the backup files into the persistent storage.
+     */
+    public static final int DEFAULT_BATCH_SIZE = 1000;
     
     /**
      * The default options used during restore, if no explicit ones are given.
@@ -37,6 +42,20 @@ public abstract class RestoreOptions {
     }
 
     /**
+     * Return the number of documents that are written to the persistent store in one unit of work (transaction)
+     *
+     * <p>
+     *     This is a setting that can be used to influence the memory and throughout of the restore process.
+     * </p>
+     *
+     * @return the number of documents; defaults to {@value #DEFAULT_BATCH_SIZE}
+     * @since 5.0
+     */
+    public int batchSize() {
+        return DEFAULT_BATCH_SIZE;
+    }
+
+    /**
      * Whether binaries should be restored or not. ModeShape uses references between documents and binary values, so 
      * depending on the context it may not always be desired for binary values to be restored. 
      * 
@@ -49,8 +68,9 @@ public abstract class RestoreOptions {
     @Override
     public String toString() {
         StringBuilder builder = new StringBuilder("[restore_options: ");
-        builder.append("include_binaries=").append(includeBinaries());
-        builder.append(", reindex_content_on_finish=").append(reindexContentOnFinish());
+        builder.append("batch size=").append(batchSize());
+        builder.append(", include binaries=").append(includeBinaries());
+        builder.append(", reindex content on finish=").append(reindexContentOnFinish());
         builder.append("]");
         return builder.toString();
     }

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrI18n.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrI18n.java
@@ -72,6 +72,7 @@ public final class JcrI18n {
     public static I18n problemsWritingBinaryToBackup;
     public static I18n problemsReadingBinaryFromBackup;
     public static I18n problemsGettingBinaryKeysFromBinaryStore;
+    public static I18n unexpectedProblemDuringRestore;
     public static I18n interruptedWhilePerformingBackup;
     public static I18n problemObtainingDocumentsToBackup;
     public static I18n backupOperationWasCancelled;

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/document/DocumentStore.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/document/DocumentStore.java
@@ -49,9 +49,9 @@ public interface DocumentStore {
      * Loads a set of entries from the document store. This should always return the latest persisted view of the entries.
      * 
      * @param keys a {@link Set} of document keys; may not be null
-     * @return a {@link Set} of {@link SchematicEntry entries}; never {@code null} 
+     * @return a {@link Collection} of {@link SchematicEntry entries}; never {@code null} 
      */
-    public List<SchematicEntry> load(Set<String> keys);
+    public List<SchematicEntry> load(Collection<String> keys);
 
     /**
      * Store the supplied document at the given key.

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/document/LocalDocumentStore.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/document/LocalDocumentStore.java
@@ -73,12 +73,12 @@ public class LocalDocumentStore implements DocumentStore {
      * 
      * @return a {@link Set} of keys, never {@code null}
      */
-    public Set<String> keys() {
+    public List<String> keys() {
         return database.keys();    
     }
 
     @Override
-    public List<SchematicEntry> load(Set<String> keys) {
+    public List<SchematicEntry> load(Collection<String> keys) {
         return database.load(keys);
     }
     

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/federation/FederatedDocumentStore.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/federation/FederatedDocumentStore.java
@@ -272,10 +272,10 @@ public class FederatedDocumentStore implements DocumentStore {
     }
 
     @Override
-    public List<SchematicEntry> load(Set<String> keys) {
+    public List<SchematicEntry> load(Collection<String> keys) {
         Map<Boolean, List<String>> keysByLocality = keys.stream().collect(Collectors.groupingBy(this::isLocalSource));
         List<String> localKeys = keysByLocality.get(Boolean.TRUE);
-        List<SchematicEntry> docsByKey = localKeys == null ? new ArrayList<>() : localStore().load(new HashSet<>(localKeys));
+        List<SchematicEntry> docsByKey = localKeys == null ? new ArrayList<>() : localStore().load(localKeys);
         List<String> externalKeys = keysByLocality.get(Boolean.FALSE);
         if (externalKeys != null) {
             docsByKey.addAll(externalKeys.stream()

--- a/modeshape-jcr/src/main/resources/org/modeshape/jcr/JcrI18n.properties
+++ b/modeshape-jcr/src/main/resources/org/modeshape/jcr/JcrI18n.properties
@@ -59,6 +59,7 @@ problemInitializingBackupArea = Error while initializing the backup area "{0}": 
 problemsWritingDocumentToBackup = Problems writing document "{0}" to backup: {1}
 problemsWritingBinaryToBackup = Problems writing binary value with SHA-1 "{0}" to backup {1}: {2}
 problemsGettingBinaryKeysFromBinaryStore = Problem getting the binary keys from the binary store in the "{0}" repository for the backup {1}: {2}
+unexpectedProblemDuringRestore = There was un expected problem during the restore operations: {0}
 problemsReadingBinaryFromBackup = Unable to read binary value {0} from backup for repository '{1}' at {2} - check permissions
 interruptedWhilePerformingBackup = Backup of '{0}' to {1} was interrupted and has been aborted: {2}
 problemObtainingDocumentsToBackup = Problem obtaining the set of documents to backup repository '{0}' to {1}: {2}

--- a/modeshape-jcr/src/test/resources/log4j.properties
+++ b/modeshape-jcr/src/test/resources/log4j.properties
@@ -9,7 +9,7 @@ log4j.rootLogger=INFO, stdout
 
 # Set up the default logging to be INFO level, then override specific units
 log4j.logger.org.modeshape=INFO
-
+#log4j.logger.org.modeshape.jcr.BackupService=TRACE
 log4j.logger.org.jgroups.protocols=ERROR
 log4j.logger.com.mchange=WARN
 log4j.logger.com.zaxxer.hikari=WARN

--- a/modeshape-performance-tests/src/test/java/org/modeshape/test/performance/FSPerformanceTest.java
+++ b/modeshape-performance-tests/src/test/java/org/modeshape/test/performance/FSPerformanceTest.java
@@ -21,7 +21,7 @@ import org.modeshape.jcr.TestingUtil;
 public class FSPerformanceTest extends InMemoryPerformanceTest {
     @Override
     protected void cleanUpFileSystem() {
-        TestingUtil.waitUntilFolderCleanedUp("target/perf-test");
+        TestingUtil.waitUntilFolderCleanedUp("target/perf_test");
     }
 
     @Override

--- a/modeshape-schematic/src/main/java/org/modeshape/schematic/SchematicDb.java
+++ b/modeshape-schematic/src/main/java/org/modeshape/schematic/SchematicDb.java
@@ -15,9 +15,8 @@
  */
 package org.modeshape.schematic;
 
+import java.util.Collection;
 import java.util.List;
-import java.util.Set;
-import java.util.stream.Stream;
 import org.modeshape.schematic.annotation.RequiresTransaction;
 import org.modeshape.schematic.document.Document;
 import org.modeshape.schematic.document.EditableDocument;
@@ -50,9 +49,9 @@ public interface SchematicDb extends TransactionListener, Lifecycle {
      * (i.e. any local but not yet committed changes)
      * </p>
      * 
-     * @return a {@link Stream} instance, never {@code null}
+     * @return a {@link List} instance, never {@code null}
      */
-    Set<String> keys();
+    List<String> keys();
     
     /**
      * Get the document with the supplied key. This will represent the full {@link SchematicEntry} document if one exists. 
@@ -74,10 +73,10 @@ public interface SchematicDb extends TransactionListener, Lifecycle {
      * context (i.e. any local but not yet committed changes) and should always return the latest persisted information.
      * </p>
      * 
-     * @param keys a {@link Set} of keys; never {@code null}
+     * @param keys an {@link Collection} of keys; never {@code null}
      * @return a {@link List} of {@link SchematicEntry entries}; never {@code null} 
      */
-    List<SchematicEntry> load(Set<String> keys);
+    List<SchematicEntry> load(Collection<String> keys);
     
     /**
      * Stores the supplied schematic entry under the given key. If an entry already exists with the same key, it should be

--- a/persistence/modeshape-persistence-file/src/main/java/org/modeshape/persistence/file/FileDb.java
+++ b/persistence/modeshape-persistence-file/src/main/java/org/modeshape/persistence/file/FileDb.java
@@ -19,10 +19,10 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
-import java.util.HashSet;
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
-import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.stream.Collectors;
@@ -79,8 +79,8 @@ public class FileDb implements SchematicDb {
     }
 
     @Override
-    public Set<String> keys() {
-        Set<String> keys = new HashSet<>();
+    public List<String> keys() {
+        List<String> keys = new ArrayList<>();
         persistedContent.keyIterator(persistedContent.firstKey()).forEachRemaining(keys::add);        
         TransactionStore.TransactionMap<String, Document> txContent = transactionalContent(false);
         if (txContent != null) {
@@ -96,7 +96,7 @@ public class FileDb implements SchematicDb {
     }
 
     @Override
-    public List<SchematicEntry> load( Set<String> keys ) {
+    public List<SchematicEntry> load( Collection<String> keys ) {
         return keys.stream()
                    .map(persistedContent::get)
                    .filter(Objects::nonNull)

--- a/persistence/modeshape-persistence-relational/src/main/java/org/modeshape/persistence/relational/DefaultStatements.java
+++ b/persistence/modeshape-persistence-relational/src/main/java/org/modeshape/persistence/relational/DefaultStatements.java
@@ -24,10 +24,8 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -83,10 +81,10 @@ public class DefaultStatements implements Statements {
     }
 
     @Override
-    public Set<String> getAllIds( Connection connection ) throws SQLException {
+    public List<String> getAllIds(Connection connection) throws SQLException {
         logTableInfo("Returning all ids from {0}");
         try (PreparedStatement ps = connection.prepareStatement(statements.get(GET_ALL_IDS))) {
-            Set<String> result = new HashSet<>();
+            List<String> result = new ArrayList<>();
             ps.setFetchSize(config.fetchSize());
             try (ResultSet rs = ps.executeQuery()) {
                 while (rs.next()) {

--- a/persistence/modeshape-persistence-relational/src/main/java/org/modeshape/persistence/relational/RelationalDb.java
+++ b/persistence/modeshape-persistence-relational/src/main/java/org/modeshape/persistence/relational/RelationalDb.java
@@ -20,12 +20,12 @@ import java.io.InputStream;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Properties;
-import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.function.Function;
@@ -128,9 +128,9 @@ public class RelationalDb implements SchematicDb {
     }
 
     @Override
-    public Set<String> keys() {
+    public List<String> keys() {
         //first read everything from the db
-        Set<String> persistedKeys = runWithConnection(statements::getAllIds, true);
+        List<String> persistedKeys = runWithConnection(statements::getAllIds, true);
       
         if (!TransactionsHolder.hasActiveTransaction()) {
             // there is no active tx for just return the persistent view
@@ -138,7 +138,7 @@ public class RelationalDb implements SchematicDb {
         }
         // there is an active transaction, so just filter out the keys which have been removed
         persistedKeys.addAll(transactionalCaches.documentKeys());
-        return persistedKeys.stream().filter(id -> !transactionalCaches.isRemoved(id)).collect(Collectors.toSet());
+        return persistedKeys.stream().filter(id -> !transactionalCaches.isRemoved(id)).collect(Collectors.toList());
     }
     
     @Override
@@ -172,7 +172,7 @@ public class RelationalDb implements SchematicDb {
     }
 
     @Override
-    public List<SchematicEntry> load(Set<String> keys) {
+    public List<SchematicEntry> load(Collection<String> keys) {
         boolean hasActiveTransaction = TransactionsHolder.hasActiveTransaction();
         Function<Document, SchematicEntry> documentParser = document -> {
             SchematicEntry entry = () -> document;

--- a/persistence/modeshape-persistence-relational/src/main/java/org/modeshape/persistence/relational/Statements.java
+++ b/persistence/modeshape-persistence-relational/src/main/java/org/modeshape/persistence/relational/Statements.java
@@ -19,7 +19,6 @@ import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.function.Function;
 import org.modeshape.schematic.document.Document;
 
@@ -67,10 +66,10 @@ public interface Statements {
      * Returns all the ids from a table.
      *
      * @param connection a {@link Connection} instance; may not be null
-     * @return a {@link Set} of ids; never {@code null}
+     * @return a {@link List} of ids; never {@code null}
      * @throws SQLException if the operation fails.
      */
-    Set<String> getAllIds( Connection connection ) throws SQLException;
+    List<String> getAllIds(Connection connection) throws SQLException;
 
     /**
      * Searches for a document with a certain id.


### PR DESCRIPTION
This should fix any memory issues caused by the previous implementation, where everything was loaded and written to in one big batch.