### PR TITLE
MODE-2596 Fixes the concurrent initialization of the same workspace cache with user transactions

### DIFF
--- a/integration/modeshape-jbossas-integration-tests/src/main/java/org/modeshape/test/integration/StartupRepositoryProvider1.java
+++ b/integration/modeshape-jbossas-integration-tests/src/main/java/org/modeshape/test/integration/StartupRepositoryProvider1.java
@@ -1,0 +1,40 @@
+/*
+ * ModeShape (http://www.modeshape.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.modeshape.test.integration;
+
+import javax.annotation.PostConstruct;
+import javax.ejb.Singleton;
+import javax.ejb.Startup;
+import javax.ejb.TransactionAttribute;
+import javax.ejb.TransactionAttributeType;
+
+/**
+ * EJB which reads a repository from JNDI (also initializing it) and checks for the existence of some dummy node.
+ * 
+ * @author Horia Chiorean (hchiorea@redhat.com)
+ */
+@Singleton
+@Startup
+public class StartupRepositoryProvider1 extends RepositoryProvider {
+    
+    @PostConstruct
+    @TransactionAttribute( TransactionAttributeType.REQUIRED )
+    public void run() throws Exception {
+        org.modeshape.jcr.api.Repository repository = (org.modeshape.jcr.api.Repository)getRepositoryFromJndi("java:/jcr/sample");
+        javax.jcr.Session session = repository.login();
+        session.nodeExists("/DUMMY");
+    }
+}

--- a/integration/modeshape-jbossas-integration-tests/src/main/java/org/modeshape/test/integration/StartupRepositoryProvider2.java
+++ b/integration/modeshape-jbossas-integration-tests/src/main/java/org/modeshape/test/integration/StartupRepositoryProvider2.java
@@ -1,0 +1,40 @@
+/*
+ * ModeShape (http://www.modeshape.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.modeshape.test.integration;
+
+import javax.annotation.PostConstruct;
+import javax.ejb.Singleton;
+import javax.ejb.Startup;
+import javax.ejb.TransactionAttribute;
+import javax.ejb.TransactionAttributeType;
+
+/**
+ * EJB which reads a repository from JNDI (also initializing it) and checks for the existence of some dummy node.
+ * 
+ * @author Horia Chiorean (hchiorea@redhat.com)
+ */
+@Singleton
+@Startup
+public class StartupRepositoryProvider2 extends RepositoryProvider {
+    
+    @PostConstruct
+    @TransactionAttribute( TransactionAttributeType.REQUIRED )
+    public void run() throws Exception {
+        org.modeshape.jcr.api.Repository repository = (org.modeshape.jcr.api.Repository)getRepositoryFromJndi("java:/jcr/sample");
+        javax.jcr.Session session = repository.login();
+        session.nodeExists("/DUMMY");
+    }
+}

--- a/integration/modeshape-jbossas-integration-tests/src/test/java/org/modeshape/test/integration/TransactionsTest.java
+++ b/integration/modeshape-jbossas-integration-tests/src/test/java/org/modeshape/test/integration/TransactionsTest.java
@@ -23,6 +23,7 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Resource;
+import javax.ejb.EJB;
 import javax.enterprise.concurrent.ManagedExecutorService;
 import javax.inject.Inject;
 import javax.jcr.Session;
@@ -49,9 +50,12 @@ public class TransactionsTest {
     public static WebArchive createWarDeployment() {
         WebArchive archive = ShrinkWrap.create(WebArchive.class, "transactions-test.war")
                                        .addAsWebInfResource(EmptyAsset.INSTANCE, ArchivePaths.create("beans.xml"))
-                                       .addClass(RepositoryOperation.class)
-                                       .addClass(TransactionalOperationExecutor.class);
-
+                                       .addClasses(RepositoryProvider.class,
+                                                   StartupRepositoryProvider1.class,
+                                                   StartupRepositoryProvider2.class,
+                                                   RepositoryOperation.class,
+                                                   TransactionalOperationExecutor.class);
+                                    
         // Add our custom Manifest, which has the additional Dependencies entry ...
         archive.setManifest(new File("src/main/webapp/META-INF/MANIFEST.MF"));
         return archive;
@@ -65,6 +69,13 @@ public class TransactionsTest {
 
     @Resource( mappedName = "java:/jcr/sample" )
     protected JcrRepository repository;
+
+
+    @EJB//@FixFor( "MODE-2596" ) at startup this bean will run its post-construct code
+    private StartupRepositoryProvider1 startupBean1;
+
+    @EJB//@FixFor( "MODE-2596" ) at startup this bean will run its post-construct code
+    private StartupRepositoryProvider2 startupBean2;
 
     @Test
     @FixFor( "MODE-2352" )

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/document/DocumentTranslator.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/document/DocumentTranslator.java
@@ -971,10 +971,13 @@ public class DocumentTranslator implements DocumentConstants {
     }
 
     public EditableDocument fromChildReference( ChildReference ref ) {
-        // We don't write the
-        return Schematic.newDocument(KEY, valueToDocument(ref.getKey(), null, null), NAME, strings.create(ref.getName()));
+        return childReferenceDocument(ref.getKey(), ref.getName());
     }
-
+    
+    public EditableDocument childReferenceDocument(NodeKey key, Name name) {
+        return Schematic.newDocument(KEY, valueToDocument(key, null, null), NAME, strings.create(name)); 
+    }
+    
     public Set<NodeKey> getReferrers( Document document,
                                       ReferenceType type ) {
         // Get the properties container ...

--- a/modeshape-jcr/src/test/java/org/modeshape/jcr/ClusteredRepositoryTest.java
+++ b/modeshape-jcr/src/test/java/org/modeshape/jcr/ClusteredRepositoryTest.java
@@ -249,7 +249,7 @@ public class ClusteredRepositoryTest {
     
     @Test
     @FixFor( "MODE-1903" )
-    public void shouldReindexContentInClusterBasedOnTimestsamp() throws Exception {
+    public void shouldReindexContentInClusterBasedOnTimestamp() throws Exception {
         JcrRepository repository1 = null;
         JcrRepository repository2 = null;
         try {

--- a/modeshape-jcr/src/test/resources/config/local-index-provider-with-custom-settings.json
+++ b/modeshape-jcr/src/test/resources/config/local-index-provider-with-custom-settings.json
@@ -18,5 +18,8 @@
             "nodeType" : "mix:title",
             "columns" : "jcr:title(STRING)"
         }
+    },
+    "reindexing" : {
+        "async" : false
     }
 }


### PR DESCRIPTION
The problem in this particular case was the fact that a user transaction off a certain thread might not have been committed while  another thread was seeing the ws cache as already initialized. 

The solution was to make sure ws cache initialization takes place inside local transactions by suspending/resuming any potential outside transactions.