### PR TITLE
MODE-2593 Adds datasource support to the Database Binary Store

### DIFF
--- a/deploy/jbossas/kit/jboss-wf/com/zaxxer/hikari/2.4.3/module.xml
+++ b/deploy/jbossas/kit/jboss-wf/com/zaxxer/hikari/2.4.3/module.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
 <!--
   ~
   ~ ModeShape (http://www.modeshape.org)
@@ -16,19 +15,11 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
 -->
-<module xmlns="urn:jboss:module:1.3" name="org.modeshape.persistence.relational">
+<module xmlns="urn:jboss:module:1.3" name="com.zaxxer.hikari" slot="2.4.3">
     <resources>
-        <resource-root path="modeshape-persistence-relational-${project.version}.jar" />
+        <resource-root path="HikariCP-${version.com.zaxxer.HikariCP}.jar" />
     </resources>
-
     <dependencies>
         <module name="javax.api" export="true"/>
-        <module name="org.modeshape.schematic" export="true"/>
-        <module name="org.modeshape.common" export="true"/>
-        <module name="com.zaxxer.hikari" slot="${version.com.zaxxer.HikariCP}"/>
-        <!-- For logging ... -->
-        <module name="org.slf4j"/>
-        <module name="org.slf4j.impl"/>
-        <module name="org.jboss.logging"/>
     </dependencies>
 </module>

--- a/deploy/jbossas/kit/jboss-wf/org/modeshape/connector/jdbc/metadata/main/module.xml
+++ b/deploy/jbossas/kit/jboss-wf/org/modeshape/connector/jdbc/metadata/main/module.xml
@@ -18,11 +18,11 @@
 <module xmlns="urn:jboss:module:1.3" name="org.modeshape.connector.jdbc.metadata">
     <resources>
         <resource-root path="modeshape-connector-jdbc-metadata-${project.version}.jar" />
-        <resource-root path="HikariCP-${version.com.zaxxer.HikariCP}.jar" />
     </resources>
 
     <dependencies>
         <module name="org.modeshape"/>
+        <module name="com.zaxxer.hikari" slot="${version.com.zaxxer.HikariCP}"/>
     </dependencies>
 
 </module>

--- a/deploy/jbossas/kit/jboss-wf/org/modeshape/main/module.xml
+++ b/deploy/jbossas/kit/jboss-wf/org/modeshape/main/module.xml
@@ -33,7 +33,8 @@
         <module name="org.modeshape.schematic" export="true"/>
         <module name="org.modeshape.persistence.relational" export="true" services="export"/>
         <module name="org.modeshape.persistence.file" export="true" services="export"/>
-
+        <!-- for the DB binary store -->
+        <module name="com.zaxxer.hikari" slot="${version.com.zaxxer.HikariCP}"/> 
         <module name="org.jgroups" slot="${jgroups.module.slot}"/>
 
         <module name="org.apache.tika" slot="${version.org.apache.tika}" services="import"/>

--- a/modeshape-assembly-descriptors/src/main/resources/assemblies/jboss-wf-dist.xml
+++ b/modeshape-assembly-descriptors/src/main/resources/assemblies/jboss-wf-dist.xml
@@ -104,7 +104,6 @@
             <outputDirectory>modules/org/modeshape/persistence/relational/main</outputDirectory>
             <includes>
                 <include>org.modeshape:modeshape-persistence-relational:jar</include>
-                <include>com.zaxxer:HikariCP:jar</include>
             </includes>
         </dependencySet>
 
@@ -151,6 +150,15 @@
             <unpack>false</unpack>
         </dependencySet>
 
+        <!--Module for Hikari connection pool -->
+        <dependencySet>
+            <useProjectArtifact>false</useProjectArtifact>
+            <outputDirectory>modules/com/zaxxer/hikari/${version.com.zaxxer.HikariCP}</outputDirectory>
+            <includes>
+                <include>com.zaxxer:HikariCP:jar</include>
+            </includes>
+        </dependencySet>
+        
         <!-- Module for Tika (self-contained) -->
         <dependencySet>
             <useProjectArtifact>false</useProjectArtifact>
@@ -207,7 +215,6 @@
             <outputDirectory>modules/org/modeshape/connector/jdbc/metadata/main</outputDirectory>
             <includes>
                 <include>org.modeshape:modeshape-connector-jdbc-metadata:jar</include>
-                <include>com.zaxxer:HikariCP:jar</include>
             </includes>
         </dependencySet>
 

--- a/modeshape-jcr/pom.xml
+++ b/modeshape-jcr/pom.xml
@@ -262,6 +262,12 @@
             <groupId>org.apache.cassandra</groupId>
             <artifactId>cassandra-all</artifactId>
         </dependency>
+
+        <!-- Database binary storage -->
+        <dependency>
+            <groupId>com.zaxxer</groupId>
+            <artifactId>HikariCP</artifactId>
+        </dependency>
     </dependencies>
     <build>
         <resources>


### PR DESCRIPTION
This uses the same datasource implementation (Hikari) that is being used by the relational persistent storage. This artifact has also been promoted as a top-level artifact in the WF kit.