### PR TITLE
MODE-2607 Fixes incorrect behaviour when using user transactions

### DIFF
--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/document/WorkspaceCache.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/document/WorkspaceCache.java
@@ -332,7 +332,6 @@ public class WorkspaceCache implements DocumentCache {
     }
 
     protected void loadFromDocumentStore(Set<String> keys) {
-        this.nodesByKey.clear();
         this.documentStore.load(keys).forEach(entry -> {
             String key = entry.id();
             Document document = entry.content();

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/document/WritableSessionCache.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/document/WritableSessionCache.java
@@ -437,6 +437,7 @@ public class WritableSessionCache extends AbstractSessionCache {
      * should no longer use a transaction-specific workspace cache.
      */
     private void completeTransaction(final String txId) {
+        getWorkspace().clear();
         // reset the ws cache to the shared (global one)
         setWorkspaceCache(sharedWorkspaceCache());
         // and clear some tx specific data


### PR DESCRIPTION
The bug was caused by the fact that the transactional ws cache was being cleared after each `session.save()` call, even if  the user transaction might still not have been committed. This meant that subsequent `session.save()` calls could get/see transient changes as the "latest persisted information".