### PR TITLE
MODE-2610 Fixes another transactional issue

### DIFF
--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/document/TransactionalWorkspaceCache.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/document/TransactionalWorkspaceCache.java
@@ -72,12 +72,12 @@ public class TransactionalWorkspaceCache extends WorkspaceCache {
      * @see Transactions#updateCache(WorkspaceCache, ChangeSet, org.modeshape.jcr.txn.Transactions.Transaction)
      */
     public void changedWithinTransaction( final ChangeSet changes ) {
-        txWorkspaceCaches.workspaceCachesFor(txn).forEach(cache -> cache.internalChangedWithinTransaction(changes));
+        txWorkspaceCaches.dispatchChangesForTransaction(txn, changes);
     }
 
     @Override
     public void clear() {
-        txWorkspaceCaches.workspaceCachesFor(txn).forEach(TransactionalWorkspaceCache::internalClear);
+        txWorkspaceCaches.clearAllCachesForTransaction(txn);
     }
 
    protected void internalClear() {

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/document/WorkspaceCache.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/document/WorkspaceCache.java
@@ -336,6 +336,7 @@ public class WorkspaceCache implements DocumentCache {
             String key = entry.id();
             Document document = entry.content();
             NodeKey nodeKey = new NodeKey(key);
+            // in some cases (user transactions) we may be replacing a node, but it's important to do so
             this.nodesByKey.put(nodeKey, new LazyCachedNode(nodeKey, document));
             if (LOGGER.isDebugEnabled()) {
                 LOGGER.debug("Read a fresh copy from the document store for '{0}' and stored it in the tx ws cache as '{1}'",


### PR DESCRIPTION
The bug was caused by the fact that not all the nodes were refreshed from the document store (i.e. the latest persisted version) on successive `session.save()` calls made from the same ongoing transaction