### PR TITLE
MODE-2609 Fixes the type of the jcr:childVersionHistory property

### DIFF
--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/AbstractJcrProperty.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/AbstractJcrProperty.java
@@ -385,6 +385,12 @@ abstract class AbstractJcrProperty extends AbstractJcrItem implements org.modesh
                     throw new IllegalArgumentException("Unknown reference type: " + value.getClass().getSimpleName());
                 }
                 return session().node(key, null);
+            } else if (value instanceof String ) {
+                String valueString = (String) value;
+                // see MODE-2609 - some reference properties may have been incorrectly stored as strings, so try to resolve them
+                if (NodeKey.isValidFormat(valueString)) {
+                    return session().node(new NodeKey(valueString), null);
+                }                 
             }
             // STRING, PATH and NAME values will be convertable to a Path object ...
             Path path = factories.getPathFactory().create(value);

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrVersionManager.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrVersionManager.java
@@ -414,15 +414,17 @@ final class JcrVersionManager implements org.modeshape.jcr.api.version.VersionMa
                     JcrVersionHistoryNode history = node.getVersionHistory();
                     org.modeshape.jcr.value.Property primaryType = propertyFactory().create(JcrLexicon.PRIMARY_TYPE,
                                                                                             JcrNtLexicon.VERSIONED_CHILD);
-                    org.modeshape.jcr.value.Property childVersionHistory = propertyFactory().create(JcrLexicon.CHILD_VERSION_HISTORY,
-                                                                                                    history.key().toString());
+                    Reference childVersionHistoryValue = session.referenceFactory().create(history.key(), true);                    
+                    org.modeshape.jcr.value.Property childVersionHistory = propertyFactory().create(
+                            JcrLexicon.CHILD_VERSION_HISTORY,
+                            childVersionHistoryValue);
                     parentInVersionHistory.createChild(versionHistoryCache, key, nodeName, primaryType, childVersionHistory);
                     return;
                 }
 
                 // Otherwise, treat it as a copy, as per section 3.13.9 bullet item 5 in JSR-283, so DO NOT break ...
             case OnParentVersionAction.COPY:
-                // Per section 3.13.9 item 5 in JSR-283, an OPV of COPY or VERSION (iff not versionable)
+                // Per section 3.13.9 item 5 in JSR-283, an OPV of COPY or VERSION (if not versionable)
                 // results in COPY behavior "regardless of the OPV values of the sub-items".
                 // We can achieve this by making the onParentVersionAction always COPY for the
                 // recursive call ...


### PR DESCRIPTION
The property should be a REFERENCE, not a STRING. The code was changed so that if the value for the property was stored as a STRING, the node to which it points can still be read back.