### PR TITLE
MODE-2615 Fixes the BsonDataInput to handle multi-byte UTF-8 characters

### DIFF
--- a/modeshape-schematic/src/main/java/org/modeshape/schematic/internal/io/BsonDataInput.java
+++ b/modeshape-schematic/src/main/java/org/modeshape/schematic/internal/io/BsonDataInput.java
@@ -260,7 +260,7 @@ public class BsonDataInput implements DataInput {
                     amountToRead = Math.min(amountToRead, charBuf.remaining());
                     int offset = byteBuf.position(); // may have already read some bytes ...
                     dis.readFully(bytes, offset, amountToRead);
-                    byteBuf.limit(amountToRead);
+                    byteBuf.limit(amountToRead + offset);
                     byteBuf.rewind();
                     // Adjust the number of bytes to read ...
                     len -= amountToRead;

--- a/modeshape-schematic/src/test/java/org/modeshape/schematic/internal/document/BsonReadingAndWritingTest.java
+++ b/modeshape-schematic/src/test/java/org/modeshape/schematic/internal/document/BsonReadingAndWritingTest.java
@@ -61,6 +61,7 @@ import org.modeshape.schematic.document.ObjectId;
 import org.modeshape.schematic.document.Symbol;
 import org.modeshape.schematic.document.Timestamp;
 import org.modeshape.schematic.internal.annotation.FixFor;
+import org.modeshape.schematic.internal.io.BufferCache;
 
 public class BsonReadingAndWritingTest {
 
@@ -331,6 +332,16 @@ public class BsonReadingAndWritingTest {
             Document document = new BasicDocument("largeString", str);
             assertRoundtrip(document, false);
         }
+    }
+
+    @Test
+    @FixFor( "MODE-2615" )
+    public void shouldHandleMultiByteCharactersAcrossBufferBoundaries() throws Exception{
+        char[] chars = new char[BufferCache.MINIMUM_SIZE * 2];
+        Arrays.fill(chars, 'a');
+        chars[BufferCache.MINIMUM_SIZE - 1]='\u00A3';
+        Document document = new BasicDocument("string", new String(chars));
+        assertRoundtrip(document);
     }
 
     protected String readFile(String filePath) throws IOException {


### PR DESCRIPTION
This fix ensures that the `limit` is set correctly when there is already data in the `ByteBuffer` from a previous decode operation. This happens when a multi-byte UTF-8 character could not be consumed by the decoder and is left in the buffer for the next iteration.
