### PR TITLE
MODE-2615 Fixes the handling of multi-byte UTF-8 characters by the BSON reader

### DIFF
--- a/modeshape-schematic/src/main/java/org/modeshape/schematic/internal/io/BsonDataInput.java
+++ b/modeshape-schematic/src/main/java/org/modeshape/schematic/internal/io/BsonDataInput.java
@@ -256,11 +256,12 @@ public class BsonDataInput implements DataInput {
                     byteBuf.flip();
                 } else {
                     // We know exactly how much we should read ...
-                    int amountToRead = Math.min(len, byteBuf.remaining());
-                    amountToRead = Math.min(amountToRead, charBuf.remaining());
+                    int amountToRead = Math.min(len, Math.min(byteBuf.remaining(), charBuf.remaining()));
                     int offset = byteBuf.position(); // may have already read some bytes ...
                     dis.readFully(bytes, offset, amountToRead);
-                    byteBuf.limit(amountToRead);
+                    // take into account the offset because we might have carry-over bytes from a previous compaction 
+                    // this happens when decoding multi-byte UTF8 chars
+                    byteBuf.limit(amountToRead + offset); 
                     byteBuf.rewind();
                     // Adjust the number of bytes to read ...
                     len -= amountToRead;

--- a/modeshape-schematic/src/test/java/org/modeshape/schematic/internal/document/BsonReadingAndWritingTest.java
+++ b/modeshape-schematic/src/test/java/org/modeshape/schematic/internal/document/BsonReadingAndWritingTest.java
@@ -61,6 +61,7 @@ import org.modeshape.schematic.document.ObjectId;
 import org.modeshape.schematic.document.Symbol;
 import org.modeshape.schematic.document.Timestamp;
 import org.modeshape.schematic.internal.annotation.FixFor;
+import org.modeshape.schematic.internal.io.BufferCache;
 
 public class BsonReadingAndWritingTest {
 
@@ -331,6 +332,30 @@ public class BsonReadingAndWritingTest {
             Document document = new BasicDocument("largeString", str);
             assertRoundtrip(document, false);
         }
+    }
+
+    @Test
+    @FixFor( "MODE-2615" )
+    public void shouldRoundTripDocumentWithMultiByteUTF8Chars() throws Exception{
+        char[] chars = new char[BufferCache.MINIMUM_SIZE];
+        Arrays.fill(chars, 'a');
+        chars[BufferCache.MINIMUM_SIZE - 1] = '\u00A3'; // 2 bytes UTF-8
+        Document document = new BasicDocument("string", new String(chars));
+        assertRoundtrip(document);
+
+        chars[BufferCache.MINIMUM_SIZE - 1] = '\uFFFF'; // 3 bytes UTF-8
+        document = new BasicDocument("string", new String(chars));
+        assertRoundtrip(document);
+
+        chars[BufferCache.MINIMUM_SIZE - 1] = '\u00A3'; // 2 bytes UTF-8
+        chars[BufferCache.MINIMUM_SIZE - 2] = '\uFFFF'; // 3 bytes UTF-8
+        document = new BasicDocument("string", new String(chars));
+        assertRoundtrip(document);
+
+        chars[BufferCache.MINIMUM_SIZE - 1] = '\uFFFF'; // 3 bytes UTF-8
+        chars[BufferCache.MINIMUM_SIZE - 2] = '\u00A3'; // 2 bytes UTF-8
+        document = new BasicDocument("string", new String(chars));
+        assertRoundtrip(document);
     }
 
     protected String readFile(String filePath) throws IOException {


### PR DESCRIPTION
supersedes https://github.com/ModeShape/modeshape/pull/1578 containing the same fix but with additional test cases and fewer commits.