### PR TITLE
MODE-2077 Adds the ability to use DB locking when running in a cluster instead of JGroups locking

### DIFF
--- a/deploy/jbossas/modeshape-jbossas-subsystem/src/main/java/org/modeshape/jboss/subsystem/AddRepository.java
+++ b/deploy/jbossas/modeshape-jbossas-subsystem/src/main/java/org/modeshape/jboss/subsystem/AddRepository.java
@@ -225,7 +225,8 @@ public class AddRepository extends AbstractAddStepHandler {
         
         if (!StringUtil.isBlank(clusterName)) {
             final String clusterConfig = attribute(context, model, ModelAttributes.CLUSTER_CONFIG, null);
-            parseClustering(clusterName, clusterConfig, configDoc);
+            final String clusterLocking = attribute(context, model, ModelAttributes.CLUSTER_LOCKING, null);
+            parseClustering(clusterName, clusterConfig, clusterLocking, configDoc);
             final String clusterStackName = attribute(context, model, ModelAttributes.CLUSTER_STACK, null);
             if (!StringUtil.isBlank(clusterStackName)) {
                 repositoryServiceBuilder.addDependency(ServiceName.JBOSS.append("jgroups", "factory", clusterStackName),
@@ -302,11 +303,14 @@ public class AddRepository extends AbstractAddStepHandler {
         monitorBuilder.install();
     }
 
-    private void parseClustering(String clusterName, String clusterConfig, EditableDocument configDoc)  {
+    private void parseClustering(String clusterName, String clusterConfig, String clusterLocking, EditableDocument configDoc)  {
         EditableDocument clustering = configDoc.getOrCreateDocument(FieldName.CLUSTERING);
         clustering.setString(FieldName.CLUSTER_NAME, clusterName);
         if (!StringUtil.isBlank(clusterConfig)) {
             clustering.setString(FieldName.CLUSTER_CONFIGURATION, clusterConfig);                        
+        }
+        if (!StringUtil.isBlank(clusterLocking)) {
+            clustering.setString(FieldName.CLUSTER_LOCKING, clusterLocking);
         }
     }
 

--- a/deploy/jbossas/modeshape-jbossas-subsystem/src/main/java/org/modeshape/jboss/subsystem/Attribute.java
+++ b/deploy/jbossas/modeshape-jbossas-subsystem/src/main/java/org/modeshape/jboss/subsystem/Attribute.java
@@ -59,6 +59,7 @@ public enum Attribute {
     CLUSTER_NAME("cluster-name"),
     CLUSTER_STACK("cluster-stack"),
     CLUSTER_CONFIG("cluster-config"),
+    CLUSTER_LOCKING("cluster-locking"),
     GARBAGE_COLLECTION_THREAD_POOL("garbage-collection-thread-pool"),
     GARBAGE_COLLECTION_INITIAL_TIME("garbage-collection-initial-time"),
     GARBAGE_COLLECTION_INTERVAL("garbage-collection-interval"),

--- a/deploy/jbossas/modeshape-jbossas-subsystem/src/main/java/org/modeshape/jboss/subsystem/ModeShapeSubsystemXMLReader_3_0.java
+++ b/deploy/jbossas/modeshape-jbossas-subsystem/src/main/java/org/modeshape/jboss/subsystem/ModeShapeSubsystemXMLReader_3_0.java
@@ -149,6 +149,9 @@ public class ModeShapeSubsystemXMLReader_3_0 implements XMLStreamConstants, XMLE
                         break;   
                     case CLUSTER_CONFIG:
                         ModelAttributes.CLUSTER_CONFIG.parseAndSetParameter(attrValue, repository, reader);
+                        break; 
+                    case CLUSTER_LOCKING:
+                        ModelAttributes.CLUSTER_LOCKING.parseAndSetParameter(attrValue, repository, reader);
                         break;
                     case SECURITY_DOMAIN:
                         ModelAttributes.SECURITY_DOMAIN.parseAndSetParameter(attrValue, repository, reader);

--- a/deploy/jbossas/modeshape-jbossas-subsystem/src/main/java/org/modeshape/jboss/subsystem/ModeShapeSubsystemXMLWriter.java
+++ b/deploy/jbossas/modeshape-jbossas-subsystem/src/main/java/org/modeshape/jboss/subsystem/ModeShapeSubsystemXMLWriter.java
@@ -83,6 +83,7 @@ public class ModeShapeSubsystemXMLWriter implements XMLStreamConstants, XMLEleme
         ModelAttributes.CLUSTER_NAME.marshallAsAttribute(repository, false, writer);
         ModelAttributes.CLUSTER_STACK.marshallAsAttribute(repository, false, writer);
         ModelAttributes.CLUSTER_CONFIG.marshallAsAttribute(repository, false, writer);
+        ModelAttributes.CLUSTER_LOCKING.marshallAsAttribute(repository, false, writer);
         writeAttributeAsList(writer, repository, ModelAttributes.ANONYMOUS_ROLES);
         ModelAttributes.ANONYMOUS_USERNAME.marshallAsAttribute(repository, false, writer);
         ModelAttributes.USE_ANONYMOUS_IF_AUTH_FAILED.marshallAsAttribute(repository, false, writer);

--- a/deploy/jbossas/modeshape-jbossas-subsystem/src/main/java/org/modeshape/jboss/subsystem/ModelAttributes.java
+++ b/deploy/jbossas/modeshape-jbossas-subsystem/src/main/java/org/modeshape/jboss/subsystem/ModelAttributes.java
@@ -67,6 +67,10 @@ public class ModelAttributes {
                                                                                           RepositoryConfiguration.FieldValue.KIND_TEXT,
                                                                                           RepositoryConfiguration.FieldValue.KIND_UNIQUE,
                                                                                           RepositoryConfiguration.FieldValue.KIND_VALUE);
+    private static final ParameterValidator CLUSTER_LOCKING_VALIDATOR = new StringSetValidator(true,
+                                                                                               true,
+                                                                                               RepositoryConfiguration.FieldValue.LOCKING_JGROUPS,
+                                                                                               RepositoryConfiguration.FieldValue.LOCKING_DB);
     private static final ParameterValidator REINDEXING_MODE_VALIDATOR = new StringSetValidator(true,
                                                                                           true,
                                                                                           RepositoryConfiguration.ReindexingMode.IF_MISSING.name(),
@@ -208,6 +212,15 @@ public class ModelAttributes {
                     .setAllowExpression(true)
                     .setAllowNull(true)
                     .setFlags(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
+                    .build();
+    
+    public static final SimpleAttributeDefinition CLUSTER_LOCKING =
+            new SimpleAttributeDefinitionBuilder(ModelKeys.CLUSTER_LOCKING, ModelType.STRING)
+                    .setXmlName(Attribute.CLUSTER_LOCKING.getLocalName())
+                    .setAllowExpression(true)
+                    .setAllowNull(true)
+                    .setFlags(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
+                    .setValidator(CLUSTER_LOCKING_VALIDATOR)
                     .build();
 
     public static final MappedSimpleAttributeDefinition GARBAGE_COLLECTION_THREAD_POOL =
@@ -939,7 +952,7 @@ public class ModelAttributes {
     public static final AttributeDefinition[] WEBAPP_ATTRIBUTES = {EXPLODED};
 
     public static final AttributeDefinition[] REPOSITORY_ATTRIBUTES = {JNDI_NAME, ENABLE_MONITORING,
-        CLUSTER_NAME, CLUSTER_STACK, CLUSTER_CONFIG, REPOSITORY_MODULE_DEPENDENCIES,
+        CLUSTER_NAME, CLUSTER_STACK, CLUSTER_CONFIG, CLUSTER_LOCKING, REPOSITORY_MODULE_DEPENDENCIES,
         SECURITY_DOMAIN, ANONYMOUS_ROLES, ANONYMOUS_USERNAME, USE_ANONYMOUS_IF_AUTH_FAILED, NODE_TYPES, DEFAULT_WORKSPACE,
         PREDEFINED_WORKSPACE_NAMES, ALLOW_WORKSPACE_CREATION, WORKSPACES_CACHE_SIZE, DEFAULT_INITIAL_CONTENT,
         WORKSPACES_INITIAL_CONTENT, GARBAGE_COLLECTION_THREAD_POOL,

--- a/deploy/jbossas/modeshape-jbossas-subsystem/src/main/java/org/modeshape/jboss/subsystem/ModelKeys.java
+++ b/deploy/jbossas/modeshape-jbossas-subsystem/src/main/java/org/modeshape/jboss/subsystem/ModelKeys.java
@@ -47,6 +47,7 @@ public class ModelKeys {
     static final String CLUSTER_NAME = "cluster-name";
     static final String CLUSTER_STACK = "cluster-stack";
     static final String CLUSTER_CONFIG = "cluster-config";
+    static final String CLUSTER_LOCKING = "cluster-locking";
     static final String GARBAGE_COLLECTION_THREAD_POOL = "garbage-collection-thread-pool";
     static final String GARBAGE_COLLECTION_INITIAL_TIME = "garbage-collection-initial-time";
     static final String GARBAGE_COLLECTION_INTERVAL = "garbage-collection-interval";

--- a/deploy/jbossas/modeshape-jbossas-subsystem/src/main/resources/org/modeshape/jboss/subsystem/LocalDescriptions.properties
+++ b/deploy/jbossas/modeshape-jbossas-subsystem/src/main/resources/org/modeshape/jboss/subsystem/LocalDescriptions.properties
@@ -84,6 +84,7 @@ modeshape.repository.journal-gc-initial-time = The local time that the first gar
 modeshape.repository.cluster-name = Defines the name of the communication channel used by this and other clustered repositories.
 modeshape.repository.cluster-stack = Defines the JGroups stack used by the repository when clustered.
 modeshape.repository.cluster-config = Defines the JGroups configuration file that can be used alternatively to the cluster-stack param
+modeshape.repository.cluster-locking = Defines the configuration for exclusive locking when running in a cluster
 
 #Persistence
 modeshape.repository.db-persistence = ModeShape db persistence configuration

--- a/deploy/jbossas/modeshape-jbossas-subsystem/src/main/resources/schema/modeshape_3_0.xsd
+++ b/deploy/jbossas/modeshape-jbossas-subsystem/src/main/resources/schema/modeshape_3_0.xsd
@@ -263,6 +263,14 @@
                     For example: ${jboss.server.config.dir}/modeshape/jgroups.xml
                 </xs:documentation>
             </xs:annotation>
+        </xs:attribute>  
+        <xs:attribute name="cluster-locking" type="cluster-locking-enum">
+            <xs:annotation>
+                <xs:documentation>
+                    Configures how ModeShape should obtain exclusive locks when running in a cluster. Defaults to JGroups 
+                    (using JGroups' LockService) but can also be configured to use DB exclusive locks.
+                </xs:documentation>
+            </xs:annotation>
         </xs:attribute>
         <xs:attribute name="garbage-collection-thread-pool" type="xs:string" use="optional" default="modeshape-gc">
             <xs:annotation>
@@ -1086,6 +1094,12 @@
             <xs:enumeration value="enumerated"/>
             <xs:enumeration value="text"/>
             <xs:enumeration value="nodetype"/>
+        </xs:restriction>
+    </xs:simpleType> 
+    <xs:simpleType name="cluster-locking-enum">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="jgroups"/>
+            <xs:enumeration value="db"/>
         </xs:restriction>
     </xs:simpleType>
     <xs:simpleType name="reindexing-mode">

--- a/deploy/jbossas/modeshape-jbossas-subsystem/src/test/resources/org/modeshape/jboss/subsystem/modeshape-clustered-config.xml
+++ b/deploy/jbossas/modeshape-jbossas-subsystem/src/test/resources/org/modeshape/jboss/subsystem/modeshape-clustered-config.xml
@@ -1,9 +1,9 @@
 <subsystem xmlns="urn:jboss:domain:modeshape:3.0">
   <repository name="sample1" jndi-name="jcr/local/modeshape_repo1" cluster-name="cluster1" cluster-stack="tcp"/>
   <repository name="sample2" jndi-name="jcr/local/modeshape_repo2" cluster-name="cluster2" 
-              cluster-config="${jboss.server.config.dir}/modeshape/jgroups.xml"/>
+              cluster-config="${jboss.server.config.dir}/modeshape/jgroups.xml" cluster-locking="jgroups"/>
   <repository name="sample3" jndi-name="jcr/local/modeshape_repo3" cluster-name="cluster3" cluster-stack="udp" 
-              cluster-config="${jboss.server.config.dir}/modeshape/jgroups.xml"/>
+              cluster-config="${jboss.server.config.dir}/modeshape/jgroups.xml" cluster-locking="db"/>
 </subsystem>
 
 

--- a/integration/modeshape-jbossas-integration-tests/src/main/resources/standalone/configuration/standalone-modeshape.xml
+++ b/integration/modeshape-jbossas-integration-tests/src/main/resources/standalone/configuration/standalone-modeshape.xml
@@ -520,13 +520,15 @@
             <repository name="repo-clustered3"
                         anonymous-roles="admin"
                         cluster-name="modeshape-wf-it2"
-                        cluster-stack="tcp">
+                        cluster-stack="tcp"
+                        cluster-locking="db">
                 <db-persistence data-source-jndi-name="java:jboss/datasources/ModeshapeClusterDS2"/>
             </repository>
             <repository name="repo-clustered4" 
                         anonymous-roles="admin"
                         cluster-name="modeshape-wf-it2"
-                        cluster-stack="tcp">
+                        cluster-stack="tcp"
+                        cluster-locking="db">
                 <db-persistence data-source-jndi-name="java:jboss/datasources/ModeshapeClusterDS2"/>
             </repository>
             <repository name="compositeBinaryStoreRepository" anonymous-roles="admin">

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/RepositoryConfiguration.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/RepositoryConfiguration.java
@@ -263,9 +263,14 @@ public class RepositoryConfiguration {
         public static final String CLUSTER_NAME = "clusterName";
         
         /**
-         * The the path to the JGroups configuration file
+         * The path to the JGroups configuration file
          */
         public static final String CLUSTER_CONFIGURATION = "configuration";
+
+        /**
+         * The type of locking to use when clustering
+         */
+        public static final String CLUSTER_LOCKING = "locking";
 
         /**
          * The size threshold that dictates whether binary values should be stored in the binary store. Binary values smaller than
@@ -580,6 +585,9 @@ public class RepositoryConfiguration {
         public static final String MIMETYPE_DETECTION_NONE = "none";
         public static final String MIMETYPE_DETECTION_NAME = "name";
         public static final String MIMETYPE_DETECTION_CONTENT = "content";
+        
+        public static final String LOCKING_JGROUPS  = "jgroups";
+        public static final String LOCKING_DB  = "db";
     }
 
     protected static final Set<List<String>> DEPRECATED_FIELDS = Collections.emptySet();
@@ -2288,6 +2296,14 @@ public class RepositoryConfiguration {
 
         public String getConfiguration() {
             return clusteringDoc.getString(FieldName.CLUSTER_CONFIGURATION, Default.CLUSTER_CONFIG);
+        }
+        
+        protected String getLocking() {
+            return clusteringDoc.getString(FieldName.CLUSTER_LOCKING, FieldValue.LOCKING_JGROUPS);
+        }
+        
+        public boolean useDbLocking() {
+            return getLocking().equals(FieldValue.LOCKING_DB);
         }
     }
 

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/RepositoryCache.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/RepositoryCache.java
@@ -120,14 +120,14 @@ public class RepositoryCache {
     private volatile boolean initializingRepository = false;
     private volatile boolean upgradingRepository = false;
     private int lastUpgradeId;
-    private final LockingService lockingService;
+    private final LockingService startupLockingService;
     private volatile boolean isHoldingClusterLock = false;
     private final RepositoryFeaturesDetector repositoryFeaturesDetector;
     private final int workspaceCacheSize;
 
     public RepositoryCache( ExecutionContext context,
                             DocumentStore documentStore,
-                            LockingService lockingService,
+                            LockingService startupLockingService,
                             RepositoryConfiguration configuration,
                             ContentInitializer initializer,
                             RepositoryEnvironment repositoryEnvironment,
@@ -137,7 +137,7 @@ public class RepositoryCache {
         this.context = context;
         this.configuration = configuration;
         this.documentStore = documentStore;
-        this.lockingService = lockingService;
+        this.startupLockingService = startupLockingService;
         this.minimumStringLengthForBinaryStorage.set(configuration.getBinaryStorage().getMinimumStringSize());
         this.translator = new DocumentTranslator(this.context, this.documentStore, this.minimumStringLengthForBinaryStorage.get());
         this.repositoryEnvironment = repositoryEnvironment;
@@ -154,11 +154,11 @@ public class RepositoryCache {
         
         // if we're running in a cluster, try to acquire a global cluster lock to perform initialization or to force multiple 
         // nodes to wait for the one performing the initialization
-        if (lockingService != null) {
+        if (startupLockingService != null) {
             int minutesToWait = 10;
             LOGGER.debug("Waiting at most for {0} minutes while verifying the status of the '{1}' repository", minutesToWait,
                          name);
-            waitUntil(() -> lockingService.tryLock(0, TimeUnit.MILLISECONDS, INITIALIZATION_LOCK), minutesToWait, TimeUnit.MINUTES,
+            waitUntil(() -> startupLockingService.tryLock(0, TimeUnit.MILLISECONDS, INITIALIZATION_LOCK), minutesToWait, TimeUnit.MINUTES,
                       JcrI18n.repositoryWasNeverInitializedAfterMinutes);
             LOGGER.debug("Repository '{0}' acquired clustered-wide lock for performing initialization or verifying status", name);
             // at this point we should have a global cluster-wide lock
@@ -368,7 +368,7 @@ public class RepositoryCache {
         } finally {
             // if we have a global cluster-wide lock, make sure its released
             if (isHoldingClusterLock) {
-                lockingService.unlock(INITIALIZATION_LOCK);
+                startupLockingService.unlock(INITIALIZATION_LOCK);
                 isHoldingClusterLock = false;
                 LOGGER.debug("Repository '{0}' released clustered-wide lock after failing to start up ", name);
             }
@@ -454,7 +454,7 @@ public class RepositoryCache {
         } finally {
             // if we have a global cluster-wide lock, make sure its released
             if (isHoldingClusterLock) {
-                lockingService.unlock(INITIALIZATION_LOCK);
+                startupLockingService.unlock(INITIALIZATION_LOCK);
                 isHoldingClusterLock = false;
                 LOGGER.debug("Repository '{0}' released clustered-wide lock after successful startup", name);
             }

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/RepositoryCache.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/RepositoryCache.java
@@ -79,7 +79,8 @@ import com.googlecode.concurrentlinkedhashmap.ConcurrentLinkedHashMap;
 public class RepositoryCache {
 
     public static final String REPOSITORY_INFO_KEY = "repository:info";
-    
+    public static final String INITIALIZATION_LOCK = "modeshape-init-lock";
+
     private static final Logger LOGGER = Logger.getLogger(RepositoryCache.class);
 
     private static final String SYSTEM_METADATA_IDENTIFIER = "jcr:system/mode:metadata";
@@ -94,8 +95,7 @@ public class RepositoryCache {
     private static final String REPOSITORY_UPGRADE_ID_FIELD_NAME = "lastUpgradeId";
     private static final String REPOSITORY_UPGRADED_AT_FIELD_NAME = "lastUpgradedAt";
     private static final String REPOSITORY_UPGRADER_FIELD_NAME = "upgrader";
-    private static final String INITIALIZATION_LOCK = "modeshape-init-lock";
-
+    
     private final ExecutionContext context;
     private final RepositoryConfiguration configuration;
     private final DocumentStore documentStore;
@@ -580,7 +580,7 @@ public class RepositoryCache {
                 translator.setProperty(doc, propFactory.create(name("accessControl"), accessControlEnabled), null, null);
 
                 return null;
-            }, 2, systemMetadataKeyStr);
+            }, 2, REPOSITORY_INFO_KEY);
         } catch (RuntimeException re) {
             LOGGER.error(JcrI18n.errorUpdatingRepositoryMetadata, name, re.getMessage());
             throw re;
@@ -820,7 +820,7 @@ public class RepositoryCache {
               }
             } 
             return result;
-        }, 0, rootKey.toString());
+        }, 0, REPOSITORY_INFO_KEY);
     }
     
     protected ConcurrentMap<NodeKey, CachedNode> cacheForWorkspace() {

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/document/LocalDocumentStore.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/document/LocalDocumentStore.java
@@ -280,6 +280,7 @@ public class LocalDocumentStore implements DocumentStore {
     public  <V> V runInTransaction( Callable<V> operation, int retryCountOnLockTimeout, String... keysToLock ) {
         // Start a transaction ...
         Transactions txns = repoEnv.getTransactions();
+        int retryCount = retryCountOnLockTimeout;
         try {
             Transactions.Transaction txn = txns.begin();
             if (keysToLock.length > 0) {
@@ -291,7 +292,7 @@ public class LocalDocumentStore implements DocumentStore {
                 if (!locksAcquired) {
                     txn.rollback();
                     throw new org.modeshape.jcr.TimeoutException(
-                            "Cannot acquire locks on: " + Arrays.toString(keysToLock) + " after " + retryCountOnLockTimeout + " attempts");
+                            "Cannot acquire locks on: " + Arrays.toString(keysToLock) + " after " + retryCount + " attempts");
                 }
             }
             try {

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/locking/AbstractLockingService.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/locking/AbstractLockingService.java
@@ -171,6 +171,10 @@ public abstract class AbstractLockingService<T extends Lock> implements LockingS
         return time > 0 ? lock.tryLock(time, timeUnit) : lock.tryLock();
     }
 
+    protected long getLockTimeoutMillis() {
+        return lockTimeoutMillis;
+    }
+
     protected abstract T createLock(String name);
     protected abstract void validateLock(T lock);
     protected abstract boolean releaseLock(T lock);

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/locking/DbLockingService.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/locking/DbLockingService.java
@@ -1,0 +1,86 @@
+/*
+ * ModeShape (http://www.modeshape.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.modeshape.jcr.locking;
+
+import java.util.concurrent.TimeUnit;
+import org.modeshape.schematic.Lockable;
+
+/**
+ * {@link LockingService} implementation which uses DB locking, via a {@link Lockable} instance.
+ * 
+ * @author Horia Chiorean (hchiorea@redhat.com)
+ * @since 5.2
+ */
+public class DbLockingService implements LockingService {
+    
+    private final JGroupsLockingService jgroupsLockingService;
+    private final String initializationLockName;
+    private final Lockable db;
+
+    /**
+     * Creates a new db locking service instance.
+     * 
+     * @param jgroupsLockingService the {@link JGroupsLockingService} instance to which some locking may be delegated; never {@code null}
+     * @param initializationLockName the name of the lock used for cluster-wide initialization, which cannot be handled by this 
+     * service; never {@code null}
+     * @param db a {@link Lockable} instance; never {@code null}
+     */
+    public DbLockingService(JGroupsLockingService jgroupsLockingService, String initializationLockName, Lockable db) {
+        this.jgroupsLockingService = jgroupsLockingService;
+        this.initializationLockName = initializationLockName;
+        this.db = db;
+    }
+
+    @Override
+    public boolean tryLock(long time, TimeUnit unit, String... names) throws InterruptedException {
+        if (isInitializationLock(names)) {
+            // the db cannot handle the initialization lock, so delegate to JG
+            return jgroupsLockingService.tryLock(time, unit, names[0]);
+        }
+        
+        long start = System.nanoTime();
+        boolean result = false;
+        while (!(result = db.lockForWriting(names)) && 
+               TimeUnit.MILLISECONDS.convert((System.nanoTime() - start), TimeUnit.NANOSECONDS) < time) {
+            //wait a bit
+            Thread.sleep(1000);
+        }
+        return result;        
+    }
+
+    private boolean isInitializationLock(String... names) {
+        return names.length == 1 && names[0].equals(initializationLockName);
+    }
+
+    @Override
+    public boolean tryLock(String... names) throws InterruptedException {
+        return tryLock(jgroupsLockingService.getLockTimeoutMillis(), TimeUnit.MILLISECONDS, names);
+    }
+
+    @Override
+    public boolean unlock(String... names) {
+        if (isInitializationLock(names)) {
+            return jgroupsLockingService.unlock(names);
+        }
+        // the DB should automatically release locks at the end of each transaction
+        return true;
+    }
+
+    @Override
+    public boolean shutdown() {
+        return jgroupsLockingService.shutdown();
+    }
+}

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/locking/JGroupsLockingService.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/locking/JGroupsLockingService.java
@@ -30,7 +30,7 @@ import org.modeshape.common.annotation.ThreadSafe;
  * @since 5.0
  */
 @ThreadSafe
-public class ClusteredLockingService extends AbstractLockingService<Lock> {
+public class JGroupsLockingService extends AbstractLockingService<Lock> {
 
     /**
      * The service used for cluster-wide locking
@@ -46,7 +46,7 @@ public class ClusteredLockingService extends AbstractLockingService<Lock> {
      * @param channel a {@link Channel} instance; may not be null
      * @param lockTimeoutMillis the number of millis to wait before timing out when attempting to obtain a lock
      */
-    public ClusteredLockingService(Channel channel, long lockTimeoutMillis) {
+    public JGroupsLockingService(Channel channel, long lockTimeoutMillis) {
         super(lockTimeoutMillis);
         
         ProtocolStack protocolStack = channel.getProtocolStack();

--- a/modeshape-jcr/src/main/resources/org/modeshape/jcr/repository-config-schema.json
+++ b/modeshape-jcr/src/main/resources/org/modeshape/jcr/repository-config-schema.json
@@ -695,6 +695,12 @@
                     "default" : "org/modeshape/jcr/clustering/jgroups-config.xml",
                     "description": "The path to the JGroups configuration file that should be used"
                 },
+                "locking" : {
+                    "type" : "string",
+                    "enum" : ["jgroups", "db"],
+                    "default" : "jgroups",
+                    "description" : "The locking mechanism to use while clustering. Defaults to JGroups"
+                },
                 "description": {
                     "type": "string",
                     "description": "The optional description of this section of the configuration. It is unused by ModeShape."

--- a/modeshape-jcr/src/test/java/org/modeshape/jcr/ClusteredRepositoryTest.java
+++ b/modeshape-jcr/src/test/java/org/modeshape/jcr/ClusteredRepositoryTest.java
@@ -164,6 +164,28 @@ public class ClusteredRepositoryTest {
             TestingUtil.killRepositories(repository1, repository2);
         }
     }
+    
+    @Test
+    @FixFor( {"MODE-2077"} )
+    public void shouldPropagateNodeChangesInClusterWithDBLocking() throws Exception {
+        JcrRepository repository1 = TestingUtil.startClusteredRepositoryWithConfig("config/cluster/repo-config-clustered-db-locking.json",
+                                                                                   node1Id);
+        JcrSession session1 = repository1.login();
+        assertInitialContentPersisted(session1);
+
+        JcrRepository repository2 = TestingUtil.startClusteredRepositoryWithConfig("config/cluster/repo-config-clustered-db-locking.json",
+                                                                                   node2Id);
+        JcrSession session2 = repository2.login();
+        assertInitialContentPersisted(session2);
+
+        try {
+            assertChangesVisibleViaListener(session1, session2);
+            assertChangesArePropagatedInCluster(session1, session2, "node1");
+            assertChangesArePropagatedInCluster(session2, session1, "node2");
+        } finally {
+            TestingUtil.killRepositories(repository1, repository2);
+        }
+    }
 
     private void assertChangesVisibleViaListener(JcrSession session1,
                                                 JcrSession session2) throws RepositoryException, InterruptedException {

--- a/modeshape-jcr/src/test/java/org/modeshape/jcr/locking/JGroupsLockingServiceTest.java
+++ b/modeshape-jcr/src/test/java/org/modeshape/jcr/locking/JGroupsLockingServiceTest.java
@@ -35,7 +35,7 @@ import org.modeshape.jcr.clustering.ClusteringService;
  * 
  * @author Horia Chiorean (hchiorea@redhat.com)
  */
-public class ClusteredLockingServiceTest extends StandaloneLockingServiceTest {
+public class JGroupsLockingServiceTest extends StandaloneLockingServiceTest {
     
     private static final int SERVICES_COUNT = 4;      
     
@@ -150,15 +150,15 @@ public class ClusteredLockingServiceTest extends StandaloneLockingServiceTest {
         assertFalse(service4.tryLock("lock4"));
     }
 
-    protected ClusteredLockingService newLockingService(int clusteredServiceIdx) {
+    protected JGroupsLockingService newLockingService(int clusteredServiceIdx) {
         ClusteringService service = clusteringServices.get(clusteredServiceIdx);  
-        ClusteredLockingService lockingService = new ClusteredLockingService(service.getChannel(), 100);
+        JGroupsLockingService lockingService = new JGroupsLockingService(service.getChannel(), 100);
         lockingServices.add(lockingService);        
         return lockingService;
     }
 
     @Override
     protected LockingService newLockingService() {
-        return new ClusteredLockingService(clusteringServices.get(0).getChannel(), 100);
+        return new JGroupsLockingService(clusteringServices.get(0).getChannel(), 100);
     }
 }

--- a/modeshape-jcr/src/test/resources/config/cluster/repo-config-clustered-db-locking.json
+++ b/modeshape-jcr/src/test/resources/config/cluster/repo-config-clustered-db-locking.json
@@ -1,0 +1,37 @@
+{
+    "name" : "Clustered Repository",
+    "node-types" : ["cnd/cars.cnd", "cnd/aircraft.cnd"],
+    "workspaces" : {
+        "predefined" : ["otherWorkspace"],
+        "default" : "default",
+        "allowCreation" : true,
+        "initialContent" : {
+            "default" : "carsInitialContent.xml"
+        }
+    },
+    "monitoring" : {
+        "enabled" : false
+    },
+    "storage": {
+        "persistence": {
+            "type": "db",
+            "connectionUrl": "jdbc:h2:file:./target/clustered/db;AUTO_SERVER=TRUE"
+        },
+        "binaryStorage": {
+            "type": "file",
+            "directory": "target/clustered/binaries",
+            "minimumBinarySizeInBytes": 4096
+        }
+    },
+    "clustering" : {
+        "clusterName" : "Test cluster",
+        "configuration" : "config/cluster/jgroups-test-config.xml",
+        "locking" : "db"
+    },
+    "security" : {
+        "anonymous" : {
+            "roles" : ["readonly","readwrite","admin"],
+            "useOnFailedLogin" : false
+        }
+    }
+}

--- a/modeshape-schematic/src/main/java/org/modeshape/schematic/Lockable.java
+++ b/modeshape-schematic/src/main/java/org/modeshape/schematic/Lockable.java
@@ -15,21 +15,28 @@
  */
 package org.modeshape.schematic;
 
+import java.util.Arrays;
+import java.util.List;
+
 /**
- * Interface for handling the lifecycle of a component.
+ * A {@link SchematicDb} which has the ability to lock.
  * 
  * @author Horia Chiorean (hchiorea@redhat.com)
- * @since 5.0
  */
-public interface Lifecycle {
+public interface Lockable {
 
     /**
-     * Announces that the repository is about to start using this DB.
+     * Locks a list of keys exclusively, for writing.
+     * 
+     * @param locks a list of locks
+     * @return {@code true} if the operation was successful and the locks were obtained, false otherwise
      */
-    void start();
+    boolean lockForWriting( List<String> locks );
 
     /**
-     * Announces that the repository is shutting down and will stop using this DB.
+     * @see Lockable#lockForWriting(List) 
      */
-    void stop();
+    default boolean lockForWriting( String...locks ) {
+        return lockForWriting(Arrays.asList(locks));        
+    }
 }

--- a/modeshape-schematic/src/main/java/org/modeshape/schematic/SchematicDb.java
+++ b/modeshape-schematic/src/main/java/org/modeshape/schematic/SchematicDb.java
@@ -28,7 +28,7 @@ import org.modeshape.schematic.document.EditableDocument;
  * @author Horia Chiorean <hchiorea@redhat.com>
  * @since 5.0
  */
-public interface SchematicDb extends TransactionListener, Lifecycle {
+public interface SchematicDb extends TransactionListener, Lifecycle, Lockable {
 
     /**
      * Returns a unique identifier for this schematic DB. 
@@ -138,6 +138,12 @@ public interface SchematicDb extends TransactionListener, Lifecycle {
     @RequiresTransaction
     default void put( String key, Document content ) {
         put(key, SchematicEntry.create(key, content));
+    }
+
+    @Override
+    @RequiresTransaction
+    default boolean lockForWriting( List<String> locks ) {
+        throw new UnsupportedOperationException(getClass() +  " does not support exclusive locking");
     }
 
     /**

--- a/persistence/modeshape-persistence-relational/src/main/java/org/modeshape/persistence/relational/DefaultStatements.java
+++ b/persistence/modeshape-persistence-relational/src/main/java/org/modeshape/persistence/relational/DefaultStatements.java
@@ -128,8 +128,7 @@ public class DefaultStatements implements Statements {
                     
     private <R> List<R> loadIDs( Connection connection, String statement, List<String> ids, Function<Document, R> parser) 
             throws SQLException {
-        String params = ids.stream().map(id -> "?").collect(Collectors.joining(","));
-        String statementString = statement.replaceAll("#", params);
+        String statementString = formatStatementWithMultipleParams(statement, ids);
         try (PreparedStatement ps = connection.prepareStatement(statementString)) {
             int paramIdx = 1;
             for (String id : ids) {
@@ -147,6 +146,11 @@ public class DefaultStatements implements Statements {
         }
     }
 
+    private String formatStatementWithMultipleParams(String statement, List<String> ids) {
+        String params = ids.stream().map(id -> "?").collect(Collectors.joining(","));
+        return statement.replaceAll("#", params);
+    }
+
     @Override
     public boolean lockForWriting( Connection connection, List<String> ids ) throws SQLException {
         if (logger.isDebugEnabled()) {
@@ -159,8 +163,7 @@ public class DefaultStatements implements Statements {
     }
 
     private boolean lockIDs( Connection connection, String statement, List<String> ids ) throws SQLException {
-        String params = ids.stream().map(id -> "?").collect(Collectors.joining(","));
-        String statementString = statement.replaceAll("#", params);
+        String statementString = formatStatementWithMultipleParams(statement, ids);
         try (PreparedStatement ps = connection.prepareStatement(statementString)) {
             int paramIdx = 1;
             for (String id : ids) {
@@ -333,8 +336,7 @@ public class DefaultStatements implements Statements {
         }
 
         private boolean batchRemove( Connection connection, String statement, List<String> ids ) throws SQLException {
-            String params = ids.stream().map(id -> "?").collect(Collectors.joining(","));
-            String statementString = statement.replaceAll("#", params);
+            String statementString = formatStatementWithMultipleParams(statement, ids);
             if (logger.isDebugEnabled()) {
                 logger.debug("running statement: {0}", statementString);
             }

--- a/persistence/modeshape-persistence-relational/src/main/java/org/modeshape/persistence/relational/RelationalDb.java
+++ b/persistence/modeshape-persistence-relational/src/main/java/org/modeshape/persistence/relational/RelationalDb.java
@@ -197,6 +197,15 @@ public class RelationalDb implements SchematicDb {
     }
 
     @Override
+    public boolean lockForWriting( List<String> locks ) {
+        TransactionsHolder.requireActiveTransaction();
+        if (locks.isEmpty()) {
+            return false;
+        }
+        return runWithConnection(connection -> statements.lockForWriting(connection, locks), true);
+    }
+
+    @Override
     public void put(String key, SchematicEntry entry) {
         // simply store the put into the cache
         transactionalCaches.putForWriting(key, entry.source());
@@ -363,8 +372,8 @@ public class RelationalDb implements SchematicDb {
     }
 
     protected Connection connectionForActiveTx() {
-        return connectionsByTxId.computeIfAbsent(TransactionsHolder.requireActiveTransaction(), 
-                                                    transactionId -> dsManager.newConnection(false, false));
+        return connectionsByTxId.computeIfAbsent(TransactionsHolder.requireActiveTransaction(),
+                                                 transactionId -> dsManager.newConnection(false, false));
     }
     
     protected RelationalDbConfig config() {

--- a/persistence/modeshape-persistence-relational/src/main/java/org/modeshape/persistence/relational/RelationalDb.java
+++ b/persistence/modeshape-persistence-relational/src/main/java/org/modeshape/persistence/relational/RelationalDb.java
@@ -198,10 +198,10 @@ public class RelationalDb implements SchematicDb {
 
     @Override
     public boolean lockForWriting( List<String> locks ) {
-        TransactionsHolder.requireActiveTransaction();
         if (locks.isEmpty()) {
             return false;
         }
+        TransactionsHolder.requireActiveTransaction();
         return runWithConnection(connection -> statements.lockForWriting(connection, locks), true);
     }
 

--- a/persistence/modeshape-persistence-relational/src/main/java/org/modeshape/persistence/relational/Statements.java
+++ b/persistence/modeshape-persistence-relational/src/main/java/org/modeshape/persistence/relational/Statements.java
@@ -43,6 +43,7 @@ public interface Statements {
     String REMOVE_CONTENT = "remove_content";
     String REMOVE_ALL_CONTENT = "remove_all_content";
     String GET_MULTIPLE = "get_multiple";
+    String LOCK_CONTENT = "lock_content";
 
     /**
      * Create a new table.
@@ -128,6 +129,19 @@ public interface Statements {
      * @throws SQLException if the operation fails.
      */
     Void removeAll( Connection connection ) throws SQLException;
+
+    /**
+     * Locks for writing the given list of ids. 
+     * <p>
+     * Note that if any of the ids are not present in the DB, they should not be taken into account and should simply be ignored 
+     * as opposed to causing the operation to fail.
+     * </p>
+     * @param connection a {@link Connection} instance, never {@code null}
+     * @param ids a {@link List} of IDs, never {@code null}
+     * @return {@code true} if locks were successfully obtained, false otherwise
+     * @throws SQLException if anything unexpected fails
+     */
+    boolean lockForWriting( Connection connection, List<String> ids ) throws SQLException;
 
     /**
      * A batch of table update operations.

--- a/persistence/modeshape-persistence-relational/src/main/resources/org/modeshape/persistence/relational/h2_database.properties
+++ b/persistence/modeshape-persistence-relational/src/main/resources/org/modeshape/persistence/relational/h2_database.properties
@@ -32,3 +32,6 @@ remove_content = DELETE FROM {0} WHERE ID IN (#)
 
 # Remove all documents
 remove_all_content = DELETE FROM {0}
+
+# Lock documents
+lock_content = SELECT ID FROM {0} WHERE ID IN (#) FOR UPDATE

--- a/persistence/modeshape-persistence-relational/src/main/resources/org/modeshape/persistence/relational/mysql_database.properties
+++ b/persistence/modeshape-persistence-relational/src/main/resources/org/modeshape/persistence/relational/mysql_database.properties
@@ -35,3 +35,6 @@ remove_content = DELETE FROM {0} WHERE ID IN (#)
 
 # Remove all documents
 remove_all_content = DELETE FROM {0}
+
+# Lock documents
+lock_content = SELECT ID FROM {0} WHERE ID IN (#) FOR UPDATE

--- a/persistence/modeshape-persistence-relational/src/main/resources/org/modeshape/persistence/relational/oracle_database.properties
+++ b/persistence/modeshape-persistence-relational/src/main/resources/org/modeshape/persistence/relational/oracle_database.properties
@@ -31,3 +31,6 @@ remove_content = DELETE FROM {0} WHERE ID IN (#)
 
 # Remove all documents
 remove_all_content = DELETE FROM {0}
+
+# Lock documents
+lock_content = SELECT ID FROM {0} WHERE ID IN (#) FOR UPDATE

--- a/persistence/modeshape-persistence-relational/src/main/resources/org/modeshape/persistence/relational/postgres_database.properties
+++ b/persistence/modeshape-persistence-relational/src/main/resources/org/modeshape/persistence/relational/postgres_database.properties
@@ -32,3 +32,6 @@ remove_content = DELETE FROM {0} WHERE ID IN (#)
 
 # Remove all documents
 remove_all_content = DELETE FROM {0}
+
+# Lock documents
+lock_content = SELECT ID FROM {0} WHERE ID IN (#) FOR UPDATE

--- a/persistence/modeshape-persistence-relational/src/main/resources/org/modeshape/persistence/relational/sqlserver_database.properties
+++ b/persistence/modeshape-persistence-relational/src/main/resources/org/modeshape/persistence/relational/sqlserver_database.properties
@@ -33,4 +33,4 @@ remove_content = DELETE FROM {0} WHERE ID IN (#)
 remove_all_content = DELETE FROM {0}
 
 # Lock documents
-lock_content = SELECT ID FROM {0} WHERE ID IN (#) WITH (UPDLOCK) 
+lock_content = SELECT ID FROM {0} WHERE ID IN (#) WITH (UPDLOCK, ROWLOCK)

--- a/persistence/modeshape-persistence-relational/src/main/resources/org/modeshape/persistence/relational/sqlserver_database.properties
+++ b/persistence/modeshape-persistence-relational/src/main/resources/org/modeshape/persistence/relational/sqlserver_database.properties
@@ -31,3 +31,6 @@ remove_content = DELETE FROM {0} WHERE ID IN (#)
 
 # Remove all documents
 remove_all_content = DELETE FROM {0}
+
+# Lock documents
+lock_content = SELECT ID FROM {0} WHERE ID IN (#) WITH (UPDLOCK) 


### PR DESCRIPTION
This can be configured in JSON like so:
```
"clustering" : {
        "clusterName" : "Test cluster",
        "configuration" : "config/cluster/jgroups-test-config.xml",
        "locking" : "db"
    },
```
or in Wildfly:

```
<repository name="repo-clustered3 cluster-name="modeshape-wf-it2" cluster-stack="tcp" cluster-locking="db">
```