### PR TITLE
MODE-2617 Fixes the cache retrieval of new versions

### DIFF
--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrSession.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrSession.java
@@ -519,7 +519,7 @@ public class JcrSession implements org.modeshape.jcr.api.Session {
     }
 
     /**
-     * Obtain the {@link Node JCR Node} object for the node with the supplied key.
+     * Obtain the {@link Node JCR Node} object for the cached node and this session's cache
      *
      * @param cachedNode the cached node; may not be null
      * @param expectedType the expected implementation type for the node, or null if it is not known
@@ -529,12 +529,27 @@ public class JcrSession implements org.modeshape.jcr.api.Session {
     AbstractJcrNode node( CachedNode cachedNode,
                           AbstractJcrNode.Type expectedType,
                           NodeKey parentKey ) {
+        return node(cachedNode, cache, expectedType, parentKey);
+    }
+    
+    /**
+     * Obtain the {@link Node JCR Node} object for the cached node and cache instance
+     *
+     * @param cachedNode the cached node; may not be null
+     * @param cache the cache where {@code cachedNode} resides; may not be null
+     * @param expectedType the expected implementation type for the node, or null if it is not known
+     * @param parentKey the node key for the parent node, or null if the parent is not known
+     * @return the JCR node; never null
+     */
+    AbstractJcrNode node( CachedNode cachedNode,
+                          SessionCache cache,
+                          AbstractJcrNode.Type expectedType,
+                          NodeKey parentKey ) {
         assert cachedNode != null;
         NodeKey nodeKey = cachedNode.getKey();
         AbstractJcrNode node = jcrNodes.get(nodeKey);
         boolean mightBeShared = true;
         if (node == null) {
-
             if (expectedType == null) {
                 Name primaryType = cachedNode.getPrimaryType(cache);
                 expectedType = Type.typeForPrimaryType(primaryType);

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrVersionManager.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrVersionManager.java
@@ -374,8 +374,9 @@ final class JcrVersionManager implements org.modeshape.jcr.api.version.VersionMa
         } finally {
             // TODO: Versioning: may want to catch this block and retry, if the new version name couldn't be created
         }
-
-        return (JcrVersionNode)session.node(version, Type.VERSION);
+        // return the version node from the system cache, not this session's cache because this session is asynchronously 
+        // notified of system ws changes and may not always get the latest data immediately
+        return (JcrVersionNode)session.node(version, systemSession, Type.VERSION, null);
     }
 
     /**

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/clustering/ClusteringService.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/clustering/ClusteringService.java
@@ -153,7 +153,7 @@ public abstract class ClusteringService {
             return false;
         }
         Address address = channel.getAddress();
-        LOGGER.debug("{0} Shutting down clustering service...", address);
+        LOGGER.debug("{0} shutting down clustering service...", address);
         consumers.clear();
 
         // Mark this as not accepting any more ...
@@ -165,7 +165,7 @@ public abstract class ClusteringService {
             channel.removeChannelListener(listener);
             channel.setReceiver(null);
             channel.close();
-            LOGGER.debug("{0} Successfully closed main channel", address);
+            LOGGER.debug("{0} successfully closed main channel", address);
         } finally {
             channel = null;
         }
@@ -230,7 +230,7 @@ public abstract class ClusteringService {
         }
 
         if (LOGGER.isDebugEnabled()) {
-            LOGGER.debug("{0} sending payload {1} in cluster {2} ", channel.getAddress(), payload, clusterName());
+            LOGGER.debug("{0} SENDING {1} ", toString(), payload);
         }
         try {
             byte[] messageData = toByteArray(payload);
@@ -337,7 +337,7 @@ public abstract class ClusteringService {
                 Serializable payload = fromByteArray(message.getBuffer(), getClass().getClassLoader());
 
                 if (LOGGER.isDebugEnabled()) {
-                    LOGGER.debug("{0} from cluster {1} received payload {2}", channel.getAddress(), clusterName(), payload);
+                    LOGGER.debug("{0} RECEIVED {1}", ClusteringService.this.toString(), payload);
                 }
 
                 for (MessageConsumer<Serializable> consumer : consumers) {
@@ -359,17 +359,19 @@ public abstract class ClusteringService {
 
         @Override
         public void viewAccepted( View newView ) {
-            LOGGER.trace("{0} Members of '{1}' cluster have changed: {2}, total count: {3}", channel.getAddress(), clusterName(), 
-                         newView, newView.getMembers().size());
-            membersInCluster.set(newView.getMembers().size());
+            int membersCount = newView.getMembers().size();
+            membersInCluster.set(membersCount);
             if (LOGGER.isDebugEnabled()) {
+                String clusterServiceInfo = ClusteringService.this.toString();
+                LOGGER.debug("{0}: new cluster member joined: {1}, total count: {2}", clusterServiceInfo, newView, membersCount);
+
                 if (membersInCluster.get() > 1) {
                     LOGGER.debug(
-                            "{0} There are now multiple members of cluster '{1}'; changes will be propagated throughout the cluster",
-                            channel.getAddress(), clusterName());
+                            "{0}: there are now multiple members in cluster; changes will be propagated throughout the cluster",
+                            clusterServiceInfo);
                 } else if (membersInCluster.get() == 1) {
-                    LOGGER.debug("{0} There is only one member of cluster '{1}'; changes will be propagated locally only",
-                                 channel.getAddress(), clusterName());
+                    LOGGER.debug("{0}: there is only one member in cluster; changes will be propagated only locally",
+                                 clusterServiceInfo);
                 }
             }
         }


### PR DESCRIPTION
Under certain timing conditions (visible especially when running in a cluster) a newly created version could be reported as not found since the events used to clear the cache are async