### PR TITLE
Resolves https://issues.jboss.org/browse/MODE-2622:

### DIFF
--- a/modeshape-jcr/src/test/java/org/modeshape/jcr/ClusteringHelper.java
+++ b/modeshape-jcr/src/test/java/org/modeshape/jcr/ClusteringHelper.java
@@ -51,11 +51,18 @@ public final class ClusteringHelper {
             if (preferIpv6 && localAddress instanceof Inet6Address) {
                 localHost = localAddress;
                 break;
-            } else if (!preferIpv6 && !(localAddress instanceof Inet6Address)) {
-                localHost = localAddress;
-                break;
             }
         }
+
+        if(localHost == null){
+            for (InetAddress localAddress : localHostAddresses) {
+                if (!(localAddress instanceof Inet6Address)) {
+                    localHost = localAddress;
+                    break;
+                }
+            }
+        }
+
         assert localHost != null;
         return localHost;
     }


### PR DESCRIPTION
 unit tests in modeshape-jcr breaking on OSX + java 1.8.0_20