### PR TITLE
MODE-2623 Fixes the loading of documents from the persistent store after exclusive locks are obtained

### DIFF
--- a/modeshape-schematic/src/main/java/org/modeshape/schematic/SchematicDb.java
+++ b/modeshape-schematic/src/main/java/org/modeshape/schematic/SchematicDb.java
@@ -69,8 +69,8 @@ public interface SchematicDb extends TransactionListener, Lifecycle, Lockable {
      * Loads a set of documents from the DB returning the corresponding schematic entries.
      * 
      * <p>
-     * If this method is called within an existing transaction, it should <b>not take into account</b> the transient transactional 
-     * context (i.e. any local but not yet committed changes) and should always return the latest persisted information.
+     * If this method is called within an existing transaction, it should <b>take into account</b> the transient transactional 
+     * context (i.e. any local but not yet committed changes) and either use that (if it exists) or the persisted information.
      * </p>
      * 
      * @param keys an {@link Collection} of keys; never {@code null}
@@ -184,7 +184,7 @@ public interface SchematicDb extends TransactionListener, Lifecycle, Lockable {
      */
     @RequiresTransaction
     default void putEntry(Document entryDocument) {
-        SchematicEntry entry = () -> entryDocument;
+        SchematicEntry entry = SchematicEntry.fromDocument(entryDocument);
         put(entry.id(), entry);
     }
 }

--- a/modeshape-schematic/src/main/java/org/modeshape/schematic/SchematicEntry.java
+++ b/modeshape-schematic/src/main/java/org/modeshape/schematic/SchematicEntry.java
@@ -139,4 +139,15 @@ public interface SchematicEntry {
     static Document content(Document entryDocument) {
         return entryDocument.getDocument(FieldName.CONTENT);
     }
+    
+    /**
+     * Creates a new schematic entry instance based on the given document.
+     * 
+     * @param entryDocument a {@link Document} instance; may not be {@code null}
+     * @return a {@link SchematicEntry} instance which wraps the underlying document; never {@code null}
+     */
+    static SchematicEntry fromDocument(Document entryDocument) {
+        Objects.requireNonNull(entryDocument, "document cannot be null");
+        return () -> entryDocument;
+    }
 }

--- a/persistence/modeshape-persistence-file/src/main/java/org/modeshape/persistence/file/FileDb.java
+++ b/persistence/modeshape-persistence-file/src/main/java/org/modeshape/persistence/file/FileDb.java
@@ -102,13 +102,13 @@ public class FileDb implements SchematicDb {
 
     @Override
     public List<SchematicEntry> load( Collection<String> keys ) {
+        final TransactionStore.TransactionMap<String, Document> txContent = transactionalContent(false);
+        final TransactionStore.TransactionMap<String, Document> actualContent = txContent != null ? txContent : persistedContent; 
         return keys.stream()
-                   .map(persistedContent::get)
+                   .map(actualContent::get)
                    .filter(Objects::nonNull)
-                   .map(document -> {
-                       SchematicEntry schematicEntry = () -> document;
-                       return schematicEntry;
-                   }).collect(Collectors.toList()); 
+                   .map(SchematicEntry::fromDocument)
+                   .collect(Collectors.toList()); 
     }
 
     @Override

--- a/persistence/modeshape-persistence-relational/src/main/java/org/modeshape/persistence/relational/TransactionalCaches.java
+++ b/persistence/modeshape-persistence-relational/src/main/java/org/modeshape/persistence/relational/TransactionalCaches.java
@@ -67,6 +67,9 @@ public final class TransactionalCaches {
     }
     
     protected void putForReading(String key, Document doc) {
+        if (!TransactionsHolder.hasActiveTransaction()) {
+            return;
+        }
         cacheForTransaction().putForReading(key, doc);    
     }
 
@@ -100,10 +103,16 @@ public final class TransactionalCaches {
     }
     
     protected void putNew(String key) {
+        if (!TransactionsHolder.hasActiveTransaction()) {
+            return;
+        }
         cacheForTransaction().putNew(key);
     }
 
     protected void putNew(Collection<String> keys) {
+        if (!TransactionsHolder.hasActiveTransaction()) {
+            return;
+        }
         cacheForTransaction().putNew(keys);
     }
     


### PR DESCRIPTION
The previous code always loaded a fresh copy of the latest persisted (i.e. successfully committed) information and did not take into account the fact that a user transaction might span multiple workspace cache usages. 

This is particularly evident when dealing with the `jcr:system` area and `SystemContent` in general, via multiple `session.save()` calls coming from different API methods.