### PR TITLE
MODE-2629: mitigate Oracle 11g query syntax errors.

### DIFF
--- a/persistence/modeshape-persistence-relational/pom.xml
+++ b/persistence/modeshape-persistence-relational/pom.xml
@@ -32,5 +32,19 @@
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
         </dependency>
+        
+        <!-- Testing (note the scope) -->
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-library</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+        </dependency>
     </dependencies>
 </project>

--- a/persistence/modeshape-persistence-relational/src/main/java/org/modeshape/persistence/relational/DefaultStatements.java
+++ b/persistence/modeshape-persistence-relational/src/main/java/org/modeshape/persistence/relational/DefaultStatements.java
@@ -146,7 +146,7 @@ public class DefaultStatements implements Statements {
         }
     }
 
-    private String formatStatementWithMultipleParams(String statement, List<String> ids) {
+    String formatStatementWithMultipleParams(String statement, List<String> ids) {
         String params = ids.stream().map(id -> "?").collect(Collectors.joining(","));
         return statement.replaceAll("#", params);
     }

--- a/persistence/modeshape-persistence-relational/src/main/java/org/modeshape/persistence/relational/Statements.java
+++ b/persistence/modeshape-persistence-relational/src/main/java/org/modeshape/persistence/relational/Statements.java
@@ -44,6 +44,7 @@ public interface Statements {
     String REMOVE_ALL_CONTENT = "remove_all_content";
     String GET_MULTIPLE = "get_multiple";
     String LOCK_CONTENT = "lock_content";
+    String ID_IN_CLAUSE = "id_in_clause";
 
     /**
      * Create a new table.

--- a/persistence/modeshape-persistence-relational/src/main/resources/org/modeshape/persistence/relational/oracle_database.properties
+++ b/persistence/modeshape-persistence-relational/src/main/resources/org/modeshape/persistence/relational/oracle_database.properties
@@ -15,7 +15,7 @@ get_all_ids = SELECT ID FROM {0}
 get_by_id = SELECT CONTENT FROM {0} WHERE ID = ?
 
 # Load multiple contents by id
-get_multiple = SELECT CONTENT FROM {0} WHERE ID IN (#)
+get_multiple = SELECT CONTENT FROM {0} WHERE #
 
 # Check if a row exists
 content_exists = SELECT 1 FROM {0} WHERE ID = ?
@@ -27,10 +27,13 @@ insert_content = INSERT INTO {0} (ID, CONTENT) VALUES (?, ?)
 update_content = UPDATE {0} SET LAST_CHANGED=CURRENT_TIMESTAMP, CONTENT = ? WHERE ID = ?
 
 # Remove an existing document
-remove_content = DELETE FROM {0} WHERE ID IN (#)
+remove_content = DELETE FROM {0} WHERE #
 
 # Remove all documents
 remove_all_content = DELETE FROM {0}
 
 # Lock documents
-lock_content = SELECT ID FROM {0} WHERE ID IN (#) FOR UPDATE
+lock_content = SELECT ID FROM {0} WHERE # FOR UPDATE
+
+# The IN clause for the ID column
+id_in_clause = ID IN (#)

--- a/persistence/modeshape-persistence-relational/src/test/java/org/modeshape/persistence/relational/OracleStatementsTest.java
+++ b/persistence/modeshape-persistence-relational/src/test/java/org/modeshape/persistence/relational/OracleStatementsTest.java
@@ -1,0 +1,80 @@
+/*
+ * ModeShape (http://www.modeshape.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.modeshape.persistence.relational;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.modeshape.schematic.document.Document;
+
+/**
+ * Unit tests for {@link OracleStatements}. 
+ * 
+ * @author Illia Khokholkov
+ *
+ */
+public class OracleStatementsTest {
+    
+    private static final String SELECT_STATEMENT_PATTERN = "SELECT CONTENT FROM MODESHAPE WHERE #";
+    private static final String ID_IN_CLAUSE_PATTERN = "ID IN (#)";
+    
+    private OracleStatements oracleStatements;
+    
+    @Before
+    public void setUp() {
+        Map<String, String> statements = new HashMap<>();
+        statements.put(Statements.ID_IN_CLAUSE, ID_IN_CLAUSE_PATTERN);
+        
+        RelationalDbConfig dbConfig = new RelationalDbConfig(mock(Document.class));
+        oracleStatements = new OracleStatements(dbConfig, statements);
+    }
+    
+    @Test
+    public void formatStatementParamsWithinLimit() {
+        List<String> ids = IntStream.range(0, 1000).mapToObj(i -> Integer.toString(i))
+                .collect(Collectors.toList());
+        
+        String expectedParams = ids.stream().map(entry -> "?")
+                .collect(Collectors.joining(","));
+        
+        assertEquals(
+                String.format("SELECT CONTENT FROM MODESHAPE WHERE ID IN (%s)", expectedParams),
+                oracleStatements.formatStatementWithMultipleParams(SELECT_STATEMENT_PATTERN, ids));
+    }
+    
+    @Test
+    public void formatStatementMaxParamsReached() {
+        List<String> ids = IntStream.range(0, 2100).mapToObj(i -> Integer.toString(i))
+                .collect(Collectors.toList());
+        
+        String partitionOne = IntStream.range(0, 1000).mapToObj(i -> "?").collect(Collectors.joining(","));
+        String partitionTwo = partitionOne;
+        String partitionThree = IntStream.range(0, 100).mapToObj(i -> "?").collect(Collectors.joining(","));
+        
+        assertEquals(
+                String.format("SELECT CONTENT FROM MODESHAPE WHERE ID IN (%s) OR ID IN (%s) OR ID IN (%s)",
+                        partitionOne, partitionTwo, partitionThree),
+                oracleStatements.formatStatementWithMultipleParams(SELECT_STATEMENT_PATTERN, ids));
+    }
+}


### PR DESCRIPTION
- mitigate the problem where Oracle 11g refuses to execute a query that has more than
  1,000 parameters passed into the IN clause; the problem is mitigated, but not fixed;
  it may still be possible to run into problems if Oracle 11g has limitations as to how
  many OR clauses a query can have