### PR TITLE
MODE-2620: Method node.getParent() throws NullPointerException

### DIFF
--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/ModeShapeFederationManager.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/ModeShapeFederationManager.java
@@ -69,11 +69,17 @@ public class ModeShapeFederationManager implements FederationManager {
 
 
         SessionCache sessionCache = this.session.spawnSessionCache(false);
-        String externalNodeKey = documentStore.createExternalProjection(parentNodeToBecomeFederatedKey.toString(), sourceName,
-                                                                        externalPath, projectionAlias);
+        SessionCache systemSession = session.repository.createSystemSession(
+                session.context(), false);
+        String externalNodeKey = documentStore.createExternalProjection(
+                parentNodeToBecomeFederatedKey.toString(), 
+                sourceName,
+                externalPath, 
+                projectionAlias,
+                systemSession);
         MutableCachedNode mutable = sessionCache.mutable(parentNodeToBecomeFederatedKey);
         mutable.addFederatedSegment(externalNodeKey, projectionAlias);
-        sessionCache.save();
+        systemSession.save(sessionCache, null);
     }
 
     @Override
@@ -89,6 +95,9 @@ public class ModeShapeFederationManager implements FederationManager {
         NodeKey externalNodeKey = session.getNode(path.getString()).key();
 
         SessionCache sessionCache = session.spawnSessionCache(false);
+        SessionCache systemSession = session.repository.createSystemSession(
+                session.context(), false);
+        
         MutableCachedNode federatedNode = sessionCache.mutable(federatedNodeKey);
         federatedNode.removeFederatedSegment(externalNodeKey.toString());
         sessionCache.save();

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/document/DocumentStore.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/document/DocumentStore.java
@@ -20,6 +20,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 import org.modeshape.jcr.cache.DocumentStoreException;
+import org.modeshape.jcr.cache.SessionCache;
 import org.modeshape.jcr.value.Name;
 import org.modeshape.jcr.value.binary.ExternalBinaryValue;
 import org.modeshape.schematic.SchematicEntry;
@@ -202,7 +203,8 @@ public interface DocumentStore {
     public String createExternalProjection( String projectedNodeKey,
                                             String sourceName,
                                             String externalPath,
-                                            String alias );
+                                            String alias,
+                                            SessionCache systemSession );
     /**
      * Returns a document representing a block of children, that has the given key.
      *

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/document/LocalDocumentStore.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/document/LocalDocumentStore.java
@@ -29,6 +29,7 @@ import javax.transaction.Transaction;
 import org.modeshape.common.SystemFailureException;
 import org.modeshape.common.util.CheckArg;
 import org.modeshape.jcr.RepositoryEnvironment;
+import org.modeshape.jcr.cache.SessionCache;
 import org.modeshape.jcr.locking.LockingService;
 import org.modeshape.jcr.txn.Transactions;
 import org.modeshape.jcr.value.Name;
@@ -197,7 +198,8 @@ public class LocalDocumentStore implements DocumentStore {
     public String createExternalProjection( String projectedNodeKey,
                                             String sourceName,
                                             String externalPath,
-                                            String alias ) {
+                                            String alias,
+                                            SessionCache systemSession ) {
         throw new UnsupportedOperationException("External projections are not supported in the local document store");
     }
 

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/document/WritableSessionCache.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/document/WritableSessionCache.java
@@ -570,15 +570,14 @@ public class WritableSessionCache extends AbstractSessionCache {
                 } catch (IllegalStateException err) {
                     // Not associated with a txn??
                     throw new SystemFailureException(err);
-                } catch (RollbackException err) {
+                } catch (RollbackException | HeuristicMixedException | HeuristicRollbackException err) {
                     // Couldn't be committed, but the txn is already rolled back ...
-                    return;
-                } catch (HeuristicMixedException err) {
-                    // Rollback has occurred ...
-                    return;
-                } catch (HeuristicRollbackException err) {
-                    // Rollback has occurred ...
-                    return;
+                    txn = null;
+                    if (err.getCause() != null) {
+                        throw err.getCause();
+                    } else {
+                        throw new SystemFailureException(err);
+                    }
                 } catch (SystemException err) {
                     // System failed unexpectedly ...
                     throw new SystemFailureException(err);
@@ -767,13 +766,15 @@ public class WritableSessionCache extends AbstractSessionCache {
                 } catch (IllegalStateException err) {
                     // Not associated with a txn??
                     throw new SystemFailureException(err);
-                } catch (RollbackException err) {
+                } catch (RollbackException | HeuristicMixedException | HeuristicRollbackException err) {
                     // Couldn't be committed, but the txn is already rolled back ...
-                    return;
-                } catch (HeuristicMixedException err) {
-                } catch (HeuristicRollbackException err) {
-                    // Rollback has occurred ...
-                    return;
+                    txn = null;
+                    if (err.getCause() != null) {
+                        throw err.getCause();
+                    } else {
+                        throw new SystemFailureException(err);
+                    }
+                    //throw new SystemFailureException(err);
                 } catch (SystemException err) {
                     // System failed unexpectedly ...
                     throw new SystemFailureException(err);
@@ -785,8 +786,8 @@ public class WritableSessionCache extends AbstractSessionCache {
 
         } catch (RuntimeException e) {
             throw e;
-        } catch (Exception e) {
-            throw new WrappedException(e);
+        } catch (Throwable t) {
+            throw new WrappedException(t);
         } finally {
             try {
                 thatLock.unlock();
@@ -913,13 +914,14 @@ public class WritableSessionCache extends AbstractSessionCache {
                 } catch (IllegalStateException err) {
                     // Not associated with a txn??
                     throw new SystemFailureException(err);
-                } catch (RollbackException err) {
+                } catch (RollbackException | HeuristicMixedException | HeuristicRollbackException err) {
                     // Couldn't be committed, but the txn is already rolled back ...
-                    return;
-                } catch (HeuristicMixedException err) {
-                } catch (HeuristicRollbackException err) {
-                    // Rollback has occurred ...
-                    return;
+                    txn = null;
+                    if (err.getCause() != null) {
+                        throw err.getCause();
+                    } else {
+                        throw new SystemFailureException(err);
+                    }
                 } catch (SystemException err) {
                     // System failed unexpectedly ...
                     throw new SystemFailureException(err);
@@ -931,8 +933,8 @@ public class WritableSessionCache extends AbstractSessionCache {
 
         } catch (RuntimeException e) {
             throw e;
-        } catch (Exception e) {
-            throw new WrappedException(e);
+        } catch (Throwable t) {
+            throw new WrappedException(t);
         } finally {
             try {
                 thatLock.unlock();

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/federation/FederatedDocumentStore.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/federation/FederatedDocumentStore.java
@@ -33,6 +33,7 @@ import org.modeshape.jcr.Connectors;
 import org.modeshape.jcr.JcrI18n;
 import org.modeshape.jcr.cache.MutableCachedNode;
 import org.modeshape.jcr.cache.NodeKey;
+import org.modeshape.jcr.cache.SessionCache;
 import org.modeshape.jcr.cache.document.DocumentStore;
 import org.modeshape.jcr.cache.document.DocumentTranslator;
 import org.modeshape.jcr.cache.document.LocalDocumentStore;
@@ -366,14 +367,15 @@ public class FederatedDocumentStore implements DocumentStore {
     public String createExternalProjection( String projectedNodeKey,
                                             String sourceName,
                                             String externalPath,
-                                            String alias ) {
+                                            String alias,
+                                            SessionCache systemSession ) {
         String sourceKey = NodeKey.keyForSourceName(sourceName);
         Connector connector = connectors.getConnectorForSourceKey(sourceKey);
         if (connector != null) {
             String externalNodeId = connector.getDocumentId(externalPath);
             if (externalNodeId != null) {
                 String externalNodeKey = documentIdToNodeKeyString(sourceName, externalNodeId);
-                connectors.addProjection(externalNodeKey, projectedNodeKey, alias);
+                connectors.addProjection(externalNodeKey, projectedNodeKey, alias, systemSession);
                 return externalNodeKey;
             }
         }


### PR DESCRIPTION
This PR fixes silent exception handling of the failed transactions what causes repository inconsistency. 