### PR TITLE
MODE-2631: allow for better granularity when configuring JCR lock cleanup process.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,6 @@ ObjectStore
 # Atomikos
 *.lck
 *.epoch
+
+# ignore checkstyle files
+*.checkstyle

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrRepository.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrRepository.java
@@ -1317,13 +1317,17 @@ public class JcrRepository implements org.modeshape.jcr.api.Repository {
                 String threadPoolName = gcConfig.getThreadPoolName();
                 long gcInitialTimeInMillis = determineInitialDelay(gcConfig.getInitialTimeExpression());
                 long gcIntervalInMillis = gcConfig.getIntervalInMillis();
-             
+                
                 assert gcInitialTimeInMillis >= 0;
+                
+                long lockCleanupInitialDelayInMillis = gcConfig.getLockCleanup().getLockCleanupInitialDelayInMillis().orElse(gcInitialTimeInMillis);
+                long lockCleanupIntervalInMillis = gcConfig.getLockCleanup().getLockCleanupIntervalInMillis().orElse(gcIntervalInMillis);
+                
                 ScheduledExecutorService garbageCollectionService = this.context.getScheduledThreadPool(threadPoolName);
                 backgroundProcesses.add(garbageCollectionService.scheduleAtFixedRate(new LockGarbageCollectionTask(
                                                                                                                    JcrRepository.this),
-                                                                                     gcInitialTimeInMillis,
-                                                                                     gcIntervalInMillis,
+                                                                                     lockCleanupInitialDelayInMillis,
+                                                                                     lockCleanupIntervalInMillis,
                                                                                      TimeUnit.MILLISECONDS));
                 backgroundProcesses.add(garbageCollectionService.scheduleAtFixedRate(new BinaryValueGarbageCollectionTask(
                                                                                                                           JcrRepository.this),

--- a/modeshape-jcr/src/main/resources/org/modeshape/jcr/repository-config-schema.json
+++ b/modeshape-jcr/src/main/resources/org/modeshape/jcr/repository-config-schema.json
@@ -65,6 +65,21 @@
                     "default" : "24",
                     "description" : "The number of hours between garbage collection runs. By default the interval is 24 hours (meaning it runs once per day)."
                 },
+                "lockCleanup" : {
+                    "type" : "object",
+                    "description" : "The (optional) lock cleanup configuration.",
+                    "additionalProperties" : false,
+                    "properties" : {
+                        "lockCleanupInitialDelayInMinutes" : {
+                            "type" : "integer",
+                            "description" : "The (optional) time to wait before scheduling the lock cleanup process. At runtime, defaults to the converted value of 'initialTime'."
+                        },
+                        "lockCleanupIntervalInMinutes" : {
+                            "type" : "integer",
+                            "description" : "The (optional) number of minutes between lock cleanup runs. At runtime, defaults to the converted value of 'intervalInHours'."
+                        }
+                    }
+                }
             }
         },
         "storage" : {

--- a/modeshape-jcr/src/test/java/org/modeshape/jcr/LockCleanupTest.java
+++ b/modeshape-jcr/src/test/java/org/modeshape/jcr/LockCleanupTest.java
@@ -1,0 +1,63 @@
+/*
+ * ModeShape (http://www.modeshape.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.modeshape.jcr;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.concurrent.TimeUnit;
+
+import javax.jcr.Node;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * Unit tests for garbage collection process related to lock cleanup.
+ * 
+ * @author Illia Khokholkov
+ *
+ */
+public class LockCleanupTest extends MultiUseAbstractTest {
+
+    @BeforeClass
+    public static void beforeAll() throws Exception {
+        startRepository(RepositoryConfiguration.read(LockCleanupTest.class
+                .getResource("/config/repo-config-garbage-collection.json")));
+    }
+    
+    /**
+     * Checks scheduled lock cleanup. The repository is configured to start lock cleanup process
+     * right away, i.e. no initial delay, and run it every minute. The node used for testing is
+     * locked for one second. After approximately a minute, the node should be automatically
+     * unlocked by the background garbage collection process.
+     * 
+     * @throws Exception
+     *             if an error occurred
+     */
+    @Test
+    public void checkScheduledLockCleanup() throws Exception {
+        Node node = session.getRootNode().addNode("toLock");
+        
+        node.addMixin("mix:lockable");
+        node.getSession().save();
+        node.getSession().getWorkspace().getLockManager().lock(node.getPath(), false, false, 1, null);
+        
+        assertTrue("The node should be locked", node.isLocked());
+        Thread.sleep(TimeUnit.SECONDS.toMillis(75));
+        assertFalse("The node should not be locked", node.isLocked());
+    }
+}

--- a/modeshape-jcr/src/test/java/org/modeshape/jcr/RepositoryConfigurationTest.java
+++ b/modeshape-jcr/src/test/java/org/modeshape/jcr/RepositoryConfigurationTest.java
@@ -24,6 +24,8 @@ import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import java.util.EnumSet;
+import java.util.concurrent.TimeUnit;
+
 import org.modeshape.schematic.Schematic;
 import org.modeshape.schematic.document.Document;
 import org.junit.Before;
@@ -36,6 +38,7 @@ import org.modeshape.jcr.RepositoryConfiguration.DocumentOptimization;
 import org.modeshape.jcr.RepositoryConfiguration.FieldName;
 import org.modeshape.jcr.RepositoryConfiguration.Indexes;
 import org.modeshape.jcr.RepositoryConfiguration.JaasSecurity;
+import org.modeshape.jcr.RepositoryConfiguration.LockCleanup;
 import org.modeshape.jcr.RepositoryConfiguration.Security;
 import org.modeshape.jcr.api.index.IndexDefinition;
 import org.modeshape.jcr.api.index.IndexDefinition.IndexKind;
@@ -193,7 +196,18 @@ public class RepositoryConfigurationTest {
     public void shouldSuccessfullyValidateConfigurationWithGarbageCollection() {
         assertValid("config/repo-config-garbage-collection.json");
     }
-
+    
+    @Test
+    public void shouldSuccessfullyReadGarbageCollectionLockCleanupConfiguration() throws Exception {
+        RepositoryConfiguration repositoryConfiguration = RepositoryConfiguration.read(
+                "config/repo-config-garbage-collection.json");
+        
+        LockCleanup lockCleanup = repositoryConfiguration.getGarbageCollection().getLockCleanup();
+        
+        assertEquals(0, lockCleanup.getLockCleanupInitialDelayInMillis().get().longValue());
+        assertEquals(TimeUnit.MINUTES.toMillis(1), lockCleanup.getLockCleanupIntervalInMillis().get().longValue());
+    }
+    
     @Test
     public void shouldAlwaysReturnNonNullSecurityComponent() {
         RepositoryConfiguration config = new RepositoryConfiguration("repoName");

--- a/modeshape-jcr/src/test/resources/config/repo-config-garbage-collection.json
+++ b/modeshape-jcr/src/test/resources/config/repo-config-garbage-collection.json
@@ -1,13 +1,21 @@
 {
     "name" : "Garbage collecting repository",
     "workspaces" : {
-        "predefined" : ["ws1", "ws2"],
         "default" : "default",
         "allowCreation" : true
     },
+    "security" : {
+        "anonymous" : {
+            "roles" : ["readonly","readwrite","admin"],
+            "useOnFailedLogin" : true
+        },
+    },
     "garbageCollection" : {
-        "threadPool" : "modeshape-gc-pool",
-        "initialTime" : "04:01",
+        "initialTime" : "05:00",
         "intervalInHours" : 5,
+        "lockCleanup" : {
+            "lockCleanupInitialDelayInMinutes" : 0,
+            "lockCleanupIntervalInMinutes" : 1
+        }
     }
 }

--- a/modeshape-schematic/src/test/resources/json/schema/repository-config-schema.json
+++ b/modeshape-schematic/src/test/resources/json/schema/repository-config-schema.json
@@ -65,6 +65,21 @@
                     "default" : "24",
                     "description" : "The number of hours between garbage collection runs. By default the interval is 24 hours (meaning it runs once per day)."
                 },
+                "lockCleanup" : {
+                    "type" : "object",
+                    "description" : "The (optional) lock cleanup configuration.",
+                    "additionalProperties" : false,
+                    "properties" : {
+                        "lockCleanupInitialDelayInMinutes" : {
+                            "type" : "integer",
+                            "description" : "The (optional) time to wait before scheduling the lock cleanup process. At runtime, defaults to the converted value of 'initialTime'."
+                        },
+                        "lockCleanupIntervalInMinutes" : {
+                            "type" : "integer",
+                            "description" : "The (optional) number of minutes between lock cleanup runs. At runtime, defaults to the converted value of 'intervalInHours'."
+                        }
+                    }
+                }
             }
         },
         "storage" : {


### PR DESCRIPTION
The garbage collection process should now have new properties exposed (the property values are provided as an example):
```json
"garbageCollection" : {
    "lockCleanup" : {
        "lockCleanupInitialDelayInMinutes" : 60,
        "lockCleanupIntervalInMinutes" : 180
    }
}
```