### PR TITLE
MODE-2634 Replaces ConcurrentLinkedHashmap with Caffeine 2.3.3

### DIFF
--- a/boms/modeshape-bom-embedded/pom.xml
+++ b/boms/modeshape-bom-embedded/pom.xml
@@ -52,7 +52,7 @@
         <version.org.jgroups>3.6.8.Final</version.org.jgroups>
         <version.com.h2>1.4.191</version.com.h2>
         <version.com.zaxxer.HikariCP>2.4.3</version.com.zaxxer.HikariCP>
-        <version.com.googlecode.concurrentlinkedhashmap>1.4.2</version.com.googlecode.concurrentlinkedhashmap>
+        <version.com.github.ben-manes.caffeine>2.3.3</version.com.github.ben-manes.caffeine>
         <version.org.mapdb>1.0.9</version.org.mapdb>
         <version.org.slf4j>1.7.7</version.org.slf4j>
         <version.log4j>1.2.17</version.log4j>
@@ -365,10 +365,11 @@
             <!-- 
                 Cache used by modeshape-jcr
             -->
+
             <dependency>
-                <groupId>com.googlecode.concurrentlinkedhashmap</groupId>
-                <artifactId>concurrentlinkedhashmap-lru</artifactId>
-                <version>${version.com.googlecode.concurrentlinkedhashmap}</version>
+                <groupId>com.github.ben-manes.caffeine</groupId>
+                <artifactId>caffeine</artifactId>
+                <version>${version.com.github.ben-manes.caffeine}</version>
             </dependency>
 
             <!--

--- a/deploy/jbossas/kit/jboss-wf/org/modeshape/main/module.xml
+++ b/deploy/jbossas/kit/jboss-wf/org/modeshape/main/module.xml
@@ -21,7 +21,7 @@
         <resource-root path="modeshape-jcr-${project.version}.jar"/>
         <resource-root path="modeshape-jbossas-subsystem-${project.version}.jar"/>
         <resource-root path="mapdb-${version.org.mapdb}.jar"/>
-        <resource-root path="concurrentlinkedhashmap-lru-${version.com.googlecode.concurrentlinkedhashmap}.jar"/>
+        <resource-root path="caffeine-${version.com.github.ben-manes.caffeine}.jar"/>
         <resource-root path="res"/>
         <resource-root path="deployments"/>
     </resources>

--- a/modeshape-assembly-descriptors/src/main/resources/assemblies/jboss-wf-dist.xml
+++ b/modeshape-assembly-descriptors/src/main/resources/assemblies/jboss-wf-dist.xml
@@ -145,7 +145,7 @@
                 <include>org.modeshape:modeshape-jcr:jar</include>
                 <include>org.modeshape:modeshape-jbossas-subsystem:jar</include>
                 <include>org.mapdb:mapdb:jar</include>
-                <include>com.googlecode.concurrentlinkedhashmap:concurrentlinkedhashmap-lru:jar</include>
+                <include>com.github.ben-manes.caffeine:caffeine:jar</include>
             </includes>
             <unpack>false</unpack>
         </dependencySet>

--- a/modeshape-jcr/pom.xml
+++ b/modeshape-jcr/pom.xml
@@ -54,10 +54,12 @@
             <artifactId>mapdb</artifactId>
         </dependency>
         <!-- Workspace cache -->
+
         <dependency>
-            <groupId>com.googlecode.concurrentlinkedhashmap</groupId>
-            <artifactId>concurrentlinkedhashmap-lru</artifactId>
+            <groupId>com.github.ben-manes.caffeine</groupId>
+            <artifactId>caffeine</artifactId>
         </dependency>
+        
         <!-- MIME-type detection. This can be excluded in applications and components that depend on ModeShape
              if MIME type detection is to be disabled in ModeShape. -->
         <dependency>

--- a/modeshape-parent/pom.xml
+++ b/modeshape-parent/pom.xml
@@ -130,7 +130,7 @@
         <version.com.zaxxer.HikariCP>2.4.3</version.com.zaxxer.HikariCP>
         
         <version.org.jboss.spec.javax.transaction.jboss-transaction-api_1.2_spec>1.0.1.Final</version.org.jboss.spec.javax.transaction.jboss-transaction-api_1.2_spec>
-        <version.com.googlecode.concurrentlinkedhashmap>1.4.2</version.com.googlecode.concurrentlinkedhashmap>
+        <version.com.github.ben-manes.caffeine>2.3.3</version.com.github.ben-manes.caffeine>
         <!--Make sure the jgroups version is the same as the one used by ISPN -->
         <version.org.jgroups>3.6.8.Final</version.org.jgroups>
         <jgroups.module.slot>main</jgroups.module.slot>
@@ -1097,11 +1097,11 @@
             </dependency>
 
             <dependency>
-                <groupId>com.googlecode.concurrentlinkedhashmap</groupId>
-                <artifactId>concurrentlinkedhashmap-lru</artifactId>
-                <version>${version.com.googlecode.concurrentlinkedhashmap}</version>
+                <groupId>com.github.ben-manes.caffeine</groupId>
+                <artifactId>caffeine</artifactId>
+                <version>${version.com.github.ben-manes.caffeine}</version>
             </dependency>
-
+          
             <dependency>
                 <groupId>org.jboss.spec.javax.transaction</groupId>
                 <artifactId>jboss-transaction-api_1.2_spec</artifactId>


### PR DESCRIPTION
The former is dormant and was designed for pre JDK 8 while the latter is the current active project which uses JDK 8