### PR TITLE
Revert "MODE-2620: Method node.getParent() throws NullPointerException"

### DIFF
--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/Connectors.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/Connectors.java
@@ -294,10 +294,11 @@ public final class Connectors {
         }
     }
 
-    private void storeProjection( Projection projection, SessionCache systemSession ) {
+    private void storeProjection( Projection projection ) {
         PropertyFactory propertyFactory = repository.context().getPropertyFactory();
 
         // we need to store the projection mappings so that we don't loose that information
+        SessionCache systemSession = repository.createSystemSession(repository.context(), false);
         NodeKey systemNodeKey = getSystemNode(systemSession).getKey();
         MutableCachedNode systemNode = systemSession.mutable(systemNodeKey);
         ChildReference federationNodeRef = systemNode.getChildReferences(systemSession).getChild(ModeShapeLexicon.FEDERATION);
@@ -308,6 +309,7 @@ public final class Connectors {
                 Property primaryType = propertyFactory.create(JcrLexicon.PRIMARY_TYPE, ModeShapeLexicon.FEDERATION);
                 systemNode.createChild(systemSession, systemNodeKey.withId("mode:federation"), ModeShapeLexicon.FEDERATION,
                                        primaryType);
+                systemSession.save();
                 federationNodeRef = systemNode.getChildReferences(systemSession).getChild(ModeShapeLexicon.FEDERATION);
             } catch (Exception e) {
                 throw new RuntimeException(e);
@@ -326,6 +328,7 @@ public final class Connectors {
         federationNode.createChild(systemSession, federationNodeKey.withRandomId(), ModeShapeLexicon.PROJECTION, primaryType,
                                    externalNodeKeyProp, projectedNodeKeyProp, alias);
 
+        systemSession.save();
     }
 
     /**
@@ -352,10 +355,9 @@ public final class Connectors {
      */
     public synchronized void addProjection( String externalNodeKey,
                                             String projectedNodeKey,
-                                            String alias,
-                                            SessionCache systemSession) {
+                                            String alias ) {
         Projection projection = new Projection(externalNodeKey, projectedNodeKey, alias);
-        storeProjection(projection, systemSession);
+        storeProjection(projection);
         Snapshot current = this.snapshot.get();
         Snapshot updated = current.withProjection(projection);
         this.snapshot.compareAndSet(current, updated);

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/ModeShapeFederationManager.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/ModeShapeFederationManager.java
@@ -69,17 +69,11 @@ public class ModeShapeFederationManager implements FederationManager {
 
 
         SessionCache sessionCache = this.session.spawnSessionCache(false);
-        SessionCache systemSession = session.repository.createSystemSession(
-                session.context(), false);
-        String externalNodeKey = documentStore.createExternalProjection(
-                parentNodeToBecomeFederatedKey.toString(), 
-                sourceName,
-                externalPath, 
-                projectionAlias,
-                systemSession);
+        String externalNodeKey = documentStore.createExternalProjection(parentNodeToBecomeFederatedKey.toString(), sourceName,
+                                                                        externalPath, projectionAlias);
         MutableCachedNode mutable = sessionCache.mutable(parentNodeToBecomeFederatedKey);
         mutable.addFederatedSegment(externalNodeKey, projectionAlias);
-        systemSession.save(sessionCache, null);
+        sessionCache.save();
     }
 
     @Override
@@ -95,9 +89,6 @@ public class ModeShapeFederationManager implements FederationManager {
         NodeKey externalNodeKey = session.getNode(path.getString()).key();
 
         SessionCache sessionCache = session.spawnSessionCache(false);
-        SessionCache systemSession = session.repository.createSystemSession(
-                session.context(), false);
-        
         MutableCachedNode federatedNode = sessionCache.mutable(federatedNodeKey);
         federatedNode.removeFederatedSegment(externalNodeKey.toString());
         sessionCache.save();

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/document/DocumentStore.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/document/DocumentStore.java
@@ -20,7 +20,6 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 import org.modeshape.jcr.cache.DocumentStoreException;
-import org.modeshape.jcr.cache.SessionCache;
 import org.modeshape.jcr.value.Name;
 import org.modeshape.jcr.value.binary.ExternalBinaryValue;
 import org.modeshape.schematic.SchematicEntry;
@@ -203,8 +202,7 @@ public interface DocumentStore {
     public String createExternalProjection( String projectedNodeKey,
                                             String sourceName,
                                             String externalPath,
-                                            String alias,
-                                            SessionCache systemSession );
+                                            String alias );
     /**
      * Returns a document representing a block of children, that has the given key.
      *

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/document/LocalDocumentStore.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/document/LocalDocumentStore.java
@@ -29,7 +29,6 @@ import javax.transaction.Transaction;
 import org.modeshape.common.SystemFailureException;
 import org.modeshape.common.util.CheckArg;
 import org.modeshape.jcr.RepositoryEnvironment;
-import org.modeshape.jcr.cache.SessionCache;
 import org.modeshape.jcr.locking.LockingService;
 import org.modeshape.jcr.txn.Transactions;
 import org.modeshape.jcr.value.Name;
@@ -198,8 +197,7 @@ public class LocalDocumentStore implements DocumentStore {
     public String createExternalProjection( String projectedNodeKey,
                                             String sourceName,
                                             String externalPath,
-                                            String alias,
-                                            SessionCache systemSession ) {
+                                            String alias ) {
         throw new UnsupportedOperationException("External projections are not supported in the local document store");
     }
 

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/document/WritableSessionCache.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/document/WritableSessionCache.java
@@ -571,14 +571,15 @@ public class WritableSessionCache extends AbstractSessionCache {
                 } catch (IllegalStateException err) {
                     // Not associated with a txn??
                     throw new SystemFailureException(err);
-                } catch (RollbackException | HeuristicMixedException | HeuristicRollbackException err) {
+                } catch (RollbackException err) {
                     // Couldn't be committed, but the txn is already rolled back ...
-                    txn = null;
-                    if (err.getCause() != null) {
-                        throw err.getCause();
-                    } else {
-                        throw new SystemFailureException(err);
-                    }
+                    return;
+                } catch (HeuristicMixedException err) {
+                    // Rollback has occurred ...
+                    return;
+                } catch (HeuristicRollbackException err) {
+                    // Rollback has occurred ...
+                    return;
                 } catch (SystemException err) {
                     // System failed unexpectedly ...
                     throw new SystemFailureException(err);
@@ -767,15 +768,13 @@ public class WritableSessionCache extends AbstractSessionCache {
                 } catch (IllegalStateException err) {
                     // Not associated with a txn??
                     throw new SystemFailureException(err);
-                } catch (RollbackException | HeuristicMixedException | HeuristicRollbackException err) {
+                } catch (RollbackException err) {
                     // Couldn't be committed, but the txn is already rolled back ...
-                    txn = null;
-                    if (err.getCause() != null) {
-                        throw err.getCause();
-                    } else {
-                        throw new SystemFailureException(err);
-                    }
-                    //throw new SystemFailureException(err);
+                    return;
+                } catch (HeuristicMixedException err) {
+                } catch (HeuristicRollbackException err) {
+                    // Rollback has occurred ...
+                    return;
                 } catch (SystemException err) {
                     // System failed unexpectedly ...
                     throw new SystemFailureException(err);
@@ -787,8 +786,8 @@ public class WritableSessionCache extends AbstractSessionCache {
 
         } catch (RuntimeException e) {
             throw e;
-        } catch (Throwable t) {
-            throw new WrappedException(t);
+        } catch (Exception e) {
+            throw new WrappedException(e);
         } finally {
             try {
                 thatLock.unlock();
@@ -915,14 +914,13 @@ public class WritableSessionCache extends AbstractSessionCache {
                 } catch (IllegalStateException err) {
                     // Not associated with a txn??
                     throw new SystemFailureException(err);
-                } catch (RollbackException | HeuristicMixedException | HeuristicRollbackException err) {
+                } catch (RollbackException err) {
                     // Couldn't be committed, but the txn is already rolled back ...
-                    txn = null;
-                    if (err.getCause() != null) {
-                        throw err.getCause();
-                    } else {
-                        throw new SystemFailureException(err);
-                    }
+                    return;
+                } catch (HeuristicMixedException err) {
+                } catch (HeuristicRollbackException err) {
+                    // Rollback has occurred ...
+                    return;
                 } catch (SystemException err) {
                     // System failed unexpectedly ...
                     throw new SystemFailureException(err);
@@ -934,8 +932,8 @@ public class WritableSessionCache extends AbstractSessionCache {
 
         } catch (RuntimeException e) {
             throw e;
-        } catch (Throwable t) {
-            throw new WrappedException(t);
+        } catch (Exception e) {
+            throw new WrappedException(e);
         } finally {
             try {
                 thatLock.unlock();

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/federation/FederatedDocumentStore.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/federation/FederatedDocumentStore.java
@@ -33,7 +33,6 @@ import org.modeshape.jcr.Connectors;
 import org.modeshape.jcr.JcrI18n;
 import org.modeshape.jcr.cache.MutableCachedNode;
 import org.modeshape.jcr.cache.NodeKey;
-import org.modeshape.jcr.cache.SessionCache;
 import org.modeshape.jcr.cache.document.DocumentStore;
 import org.modeshape.jcr.cache.document.DocumentTranslator;
 import org.modeshape.jcr.cache.document.LocalDocumentStore;
@@ -367,15 +366,14 @@ public class FederatedDocumentStore implements DocumentStore {
     public String createExternalProjection( String projectedNodeKey,
                                             String sourceName,
                                             String externalPath,
-                                            String alias,
-                                            SessionCache systemSession ) {
+                                            String alias ) {
         String sourceKey = NodeKey.keyForSourceName(sourceName);
         Connector connector = connectors.getConnectorForSourceKey(sourceKey);
         if (connector != null) {
             String externalNodeId = connector.getDocumentId(externalPath);
             if (externalNodeId != null) {
                 String externalNodeKey = documentIdToNodeKeyString(sourceName, externalNodeId);
-                connectors.addProjection(externalNodeKey, projectedNodeKey, alias, systemSession);
+                connectors.addProjection(externalNodeKey, projectedNodeKey, alias);
                 return externalNodeKey;
             }
         }


### PR DESCRIPTION
Reverts ModeShape/modeshape#1595.

Reverted because of this build fail: https://travis-ci.org/ModeShape/modeshape/builds/162997333