### PR TITLE
Mode-2620-b Method node.getParent() throws NullPointerException

### DIFF
--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrSession.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrSession.java
@@ -60,6 +60,8 @@ import javax.jcr.security.AccessControlManager;
 import javax.jcr.version.Version;
 import javax.jcr.version.VersionException;
 import javax.jcr.version.VersionIterator;
+import javax.transaction.SystemException;
+import org.modeshape.common.SystemFailureException;
 import org.modeshape.common.i18n.I18n;
 import org.modeshape.common.logging.Logger;
 import org.modeshape.common.text.TextDecoder;
@@ -2496,7 +2498,11 @@ public class JcrSession implements org.modeshape.jcr.api.Session {
          * created) can persist changes (via their SessionCache.save())
          */
         private void signalSaveOfSystemChanges() {
-            cache().checkForTransaction();
+            try {
+                cache().checkForTransaction();
+            } catch (SystemException e) {
+                throw new SystemFailureException(e);
+            }
         }
 
         @Override

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/ModeShapeFederationManager.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/ModeShapeFederationManager.java
@@ -69,11 +69,13 @@ public class ModeShapeFederationManager implements FederationManager {
 
 
         SessionCache sessionCache = this.session.spawnSessionCache(false);
+        SessionCache systemSession = session.repository.createSystemSession(session.context(), false);
+
         String externalNodeKey = documentStore.createExternalProjection(parentNodeToBecomeFederatedKey.toString(), sourceName,
-                                                                        externalPath, projectionAlias);
+                                                                        externalPath, projectionAlias, systemSession);
         MutableCachedNode mutable = sessionCache.mutable(parentNodeToBecomeFederatedKey);
         mutable.addFederatedSegment(externalNodeKey, projectionAlias);
-        sessionCache.save();
+        systemSession.save(sessionCache, null);
     }
 
     @Override

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/SessionCache.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/SessionCache.java
@@ -16,6 +16,7 @@
 package org.modeshape.jcr.cache;
 
 import java.util.Set;
+import javax.transaction.SystemException;
 import org.modeshape.jcr.ExecutionContext;
 import org.modeshape.jcr.api.value.DateTime;
 import org.modeshape.jcr.cache.document.WorkspaceCache;
@@ -260,8 +261,9 @@ public interface SessionCache extends NodeCache {
     /**
      * Check whether this session is running within a transaction. This is commonly called by components that change persistent
      * state. Such persistent state might not be noticed by this session cache.
+     * @throws javax.transaction.SystemException - unexpected error conditions encountered by transaction manager.
      */
-    public void checkForTransaction();
+    public void checkForTransaction() throws SystemException;
 
     @Override
     public SessionCache unwrap();

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/SessionCacheWrapper.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/SessionCacheWrapper.java
@@ -17,6 +17,7 @@ package org.modeshape.jcr.cache;
 
 import java.util.Iterator;
 import java.util.Set;
+import javax.transaction.SystemException;
 import org.modeshape.jcr.ExecutionContext;
 import org.modeshape.jcr.cache.document.WorkspaceCache;
 
@@ -168,7 +169,7 @@ public class SessionCacheWrapper implements SessionCache {
     }
 
     @Override
-    public void checkForTransaction() {
+    public void checkForTransaction() throws SystemException {
         delegate.checkForTransaction();
     }
 

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/document/DocumentStore.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/document/DocumentStore.java
@@ -20,6 +20,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 import org.modeshape.jcr.cache.DocumentStoreException;
+import org.modeshape.jcr.cache.SessionCache;
 import org.modeshape.jcr.value.Name;
 import org.modeshape.jcr.value.binary.ExternalBinaryValue;
 import org.modeshape.schematic.SchematicEntry;
@@ -202,7 +203,8 @@ public interface DocumentStore {
     public String createExternalProjection( String projectedNodeKey,
                                             String sourceName,
                                             String externalPath,
-                                            String alias );
+                                            String alias,
+                                            SessionCache systemSession);
     /**
      * Returns a document representing a block of children, that has the given key.
      *

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/document/LocalDocumentStore.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/document/LocalDocumentStore.java
@@ -29,6 +29,7 @@ import javax.transaction.Transaction;
 import org.modeshape.common.SystemFailureException;
 import org.modeshape.common.util.CheckArg;
 import org.modeshape.jcr.RepositoryEnvironment;
+import org.modeshape.jcr.cache.SessionCache;
 import org.modeshape.jcr.locking.LockingService;
 import org.modeshape.jcr.txn.Transactions;
 import org.modeshape.jcr.value.Name;
@@ -197,7 +198,8 @@ public class LocalDocumentStore implements DocumentStore {
     public String createExternalProjection( String projectedNodeKey,
                                             String sourceName,
                                             String externalPath,
-                                            String alias ) {
+                                            String alias,
+                                            SessionCache systemSession) {
         throw new UnsupportedOperationException("External projections are not supported in the local document store");
     }
 

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/document/TransactionalWorkspaceCaches.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/document/TransactionalWorkspaceCaches.java
@@ -46,7 +46,7 @@ public class TransactionalWorkspaceCaches {
         this.txnMgr = transactions.getTransactionManager();
     }
     
-    protected WorkspaceCache getTransactionalCache(WorkspaceCache globalWorkspaceCache) throws Exception {
+    protected WorkspaceCache getTransactionalCache(WorkspaceCache globalWorkspaceCache) throws SystemException  {
         // Get the current transaction ...
         Transaction txn = txnMgr.getTransaction();
         if (txn == null || txn.getStatus() != Status.STATUS_ACTIVE) return globalWorkspaceCache;

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/federation/FederatedDocumentStore.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/federation/FederatedDocumentStore.java
@@ -33,6 +33,7 @@ import org.modeshape.jcr.Connectors;
 import org.modeshape.jcr.JcrI18n;
 import org.modeshape.jcr.cache.MutableCachedNode;
 import org.modeshape.jcr.cache.NodeKey;
+import org.modeshape.jcr.cache.SessionCache;
 import org.modeshape.jcr.cache.document.DocumentStore;
 import org.modeshape.jcr.cache.document.DocumentTranslator;
 import org.modeshape.jcr.cache.document.LocalDocumentStore;
@@ -366,14 +367,15 @@ public class FederatedDocumentStore implements DocumentStore {
     public String createExternalProjection( String projectedNodeKey,
                                             String sourceName,
                                             String externalPath,
-                                            String alias ) {
+                                            String alias,
+                                            SessionCache systemSession) {
         String sourceKey = NodeKey.keyForSourceName(sourceName);
         Connector connector = connectors.getConnectorForSourceKey(sourceKey);
         if (connector != null) {
             String externalNodeId = connector.getDocumentId(externalPath);
             if (externalNodeId != null) {
                 String externalNodeKey = documentIdToNodeKeyString(sourceName, externalNodeId);
-                connectors.addProjection(externalNodeKey, projectedNodeKey, alias);
+                connectors.addProjection(externalNodeKey, projectedNodeKey, alias, systemSession);
                 return externalNodeKey;
             }
         }

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/txn/Transactions.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/txn/Transactions.java
@@ -492,7 +492,7 @@ public class Transactions {
 
         @Override
         public void commit()
-                throws RollbackException, HeuristicMixedException, HeuristicRollbackException, SecurityException,
+                throws RollbackException, SecurityException,
                        IllegalStateException, SystemException {
             try {
                 // commit first
@@ -501,6 +501,12 @@ public class Transactions {
                 listener.txCommitted(id);
                 // run the ModeShape commit functions after we've notified the listener
                 executeFunctionsUponCommit();
+            } catch (RollbackException | HeuristicMixedException | HeuristicRollbackException e) {
+                listener.txRolledback(id);
+                throw new RollbackException(e.getMessage());
+            } catch (SystemException e) {
+                listener.txRolledback(id);
+                throw e;
             } finally {
                 // even if commit fails, we want to execute the complete functions to try and leave the repository into a consistent state
                 executeFunctionsUponCompletion();    
@@ -542,7 +548,7 @@ public class Transactions {
 
         @Override
         public void commit()
-                throws RollbackException, HeuristicMixedException, HeuristicRollbackException, SecurityException,
+                throws RollbackException, SecurityException,
                        IllegalStateException, SystemException {
             if (logger.isTraceEnabled()) {
                 super.commit();
@@ -571,7 +577,7 @@ public class Transactions {
         }
 
         @Override
-        public void commit() throws RollbackException, HeuristicMixedException, HeuristicRollbackException, SecurityException, 
+        public void commit() throws RollbackException,  SecurityException, 
                                     IllegalStateException, SystemException {
             if (nestedLevel.getAndDecrement() == 1) {
                 try {

--- a/modeshape-persistence-tests/src/test/java/org/modeshape/jcr/ModeshapePersistenceIT.java
+++ b/modeshape-persistence-tests/src/test/java/org/modeshape/jcr/ModeshapePersistenceIT.java
@@ -30,6 +30,10 @@ import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -112,6 +116,7 @@ public class ModeshapePersistenceIT {
     public void afterEach() throws Exception {
         testRepository.setDropOnExit(true);
         testRepository.shutdown();
+        this.cleanDatabase();
     }
 
     @Test
@@ -2285,5 +2290,27 @@ public class ModeshapePersistenceIT {
     
     private void importInitialContent(String resourceName, Session session) throws RepositoryException, IOException {
         testRepository.loadInitialContent(resourceName, session);
+    }
+    
+    private void cleanDatabase() {
+        Connection conn = null;
+        try {
+            String driverName = System.getProperty("db.driver");
+            String username = System.getProperty("db.username");
+            String password = System.getProperty("db.password");
+            String url = System.getProperty("db.url");
+            
+            Class.forName(driverName);
+            conn = DriverManager.getConnection(url, username, password);
+            Statement deleteQuery = conn.createStatement();
+            deleteQuery.executeQuery("drop table MODESHAPE_REPOSITORY");
+        } catch (ClassNotFoundException | SQLException e) {
+        } finally {
+            if (conn != null) 
+                try {
+                    conn.close();
+                } catch (SQLException e) {
+                }
+        }
     }
 }


### PR DESCRIPTION
This PR contains following changes:
- Pure JDBC database clean up between persistence integration tests;
- Transaction failure handling causing data lost or corruption;
- Makes creating projection atomic.