### PR TITLE
MODE-2637 : NullPointerException in IndexChangeAdapter

### DIFF
--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/spi/index/provider/IndexChangeAdapters.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/spi/index/provider/IndexChangeAdapters.java
@@ -834,9 +834,13 @@ public class IndexChangeAdapters {
                     newValues.addAll(Arrays.asList(newProperty.getValuesAsArray()));
                 }
             } else if (mixinsTypeChange instanceof PropertyAdded) {
-                newValues.addAll(Arrays.asList(mixinsTypeChange.getProperty().getValuesAsArray()));
+                if (!mixinsTypeChange.getProperty().isEmpty()) {
+                    newValues.addAll(Arrays.asList(mixinsTypeChange.getProperty().getValuesAsArray()));
+                }
             } else if (mixinsTypeChange instanceof PropertyRemoved) {
-                oldValues.addAll(Arrays.asList(mixinsTypeChange.getProperty().getValuesAsArray()));
+                if (!mixinsTypeChange.getProperty().isEmpty()) {
+                    oldValues.addAll(Arrays.asList(mixinsTypeChange.getProperty().getValuesAsArray()));
+                }
             }
 
             if (primaryTypeChange == null && mixinsTypeChange == null) {

--- a/modeshape-jcr/src/test/java/org/modeshape/jcr/JcrWorkspaceTest.java
+++ b/modeshape-jcr/src/test/java/org/modeshape/jcr/JcrWorkspaceTest.java
@@ -804,6 +804,24 @@ public class JcrWorkspaceTest extends SingleUseAbstractTest {
 
     }
 
+    
+    @Test
+    @FixFor("MODE-2637")
+    public void copyNodeWithEmptyMultiValueProperty() throws Exception {
+        // start a repository with some indexes
+        startRepositoryWithConfigurationFrom("config/repo-config-local-provider-and-nodetype-index.json");
+        session.getRootNode().addNode("a");
+        Node node = session.getNode("/a");
+        node.addMixin("mix:referenceable");
+        session.save();
+        node.removeMixin("mix:referenceable");
+        session.save();
+        assertTrue(node.hasProperty("jcr:mixinTypes"));
+        assertThat(node.getProperty("jcr:mixinTypes").getValues().length, is(0));
+        session.getWorkspace().copy(session.getNode("/a").getPath(), "/a2");
+        session.save();
+    } 
+    
     protected void checkCorrespondingPaths( String workspace,
                                             final String... otherWorkspaces ) throws Exception {
         final Session session = repository.login(workspace);

--- a/modeshape-jcr/src/test/resources/config/repo-config-local-provider-and-nodetype-index.json
+++ b/modeshape-jcr/src/test/resources/config/repo-config-local-provider-and-nodetype-index.json
@@ -1,0 +1,18 @@
+{
+    "name": "QueryableRepo",
+    "indexProviders": {
+        "local": {
+            "classname": "org.modeshape.jcr.index.local.LocalIndexProvider",
+            "directory": "target/local_index_test_repository"
+        },
+    },
+    "indexes": {
+        "nodeTypes": {
+            "kind": "nodeType",
+            "provider": "local",
+            "synchronous": true,
+            "nodeType": "nt:base",
+            "columns": "jcr:primaryType(STRING)"
+        }
+    }
+}


### PR DESCRIPTION
PR provides fix which substitutes empty array instead of `null` as value for not assigned multiple-value property.