### PR TITLE
MODE-2645 : Elasticsearch index provider always recreates index even if they exist upon engine restart

### DIFF
--- a/index-providers/modeshape-elasticsearch-index-provider/src/main/java/org/modeshape/jcr/index/elasticsearch/client/EsClient.java
+++ b/index-providers/modeshape-elasticsearch-index-provider/src/main/java/org/modeshape/jcr/index/elasticsearch/client/EsClient.java
@@ -79,7 +79,7 @@ public class EsClient {
      */
     public boolean createIndex(String name, String type, EsRequest mappings) throws IOException {
         if (indexExists(name)) {
-            deleteIndex(name);
+            return true;
         }
 
         CloseableHttpClient client = HttpClients.createDefault();

--- a/index-providers/modeshape-elasticsearch-index-provider/src/test/resources/config/repo-config1.json
+++ b/index-providers/modeshape-elasticsearch-index-provider/src/test/resources/config/repo-config1.json
@@ -1,6 +1,10 @@
 {
     "name": "Persistent repo no indexes",
     "storage": {
+        "persistence" : {
+            "type" : "file",
+            "path": "target/persistent_repository/db"
+        },        
         "binaryStorage": {
             "type": "file",
             "directory": "target/persistent_repository/binaries",


### PR DESCRIPTION
This PR provides the fix which does not delete and the re-create existing index.