### PR TITLE
MODE-2642 Removes the RepositoryFeaturesDetector optimization for #isCheckedOut and #isLocked

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,9 +27,13 @@ jdk:
   
 # We use docker for the persistence integration tests
 services:
-    - docker
-    
+  - docker
+
+before_script:
+  - sudo docker ps -a 
+  
 # We have to use our local `settings.xml`, and the clustering tests require IPv4 on the Travis infrastructure
 # We're also changing the Maven default logging to avoid printing out all the 'Downloading' messages which can cause the Travis
 # build to fail when the log size exceeds 4MB
-script: mvn -s settings.xml clean install -Pintegration -Ppersistence-integration -DpreferIpv4 -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer=warn -B
+script: 
+  - mvn -s settings.xml clean install -Pintegration -Ppersistence-integration -DpreferIpv4 -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer=warn -B

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/AbstractJcrNode.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/AbstractJcrNode.java
@@ -3211,10 +3211,6 @@ abstract class AbstractJcrNode extends AbstractJcrItem implements Node {
 
     @Override
     public boolean isCheckedOut() throws RepositoryException {
-        if (!session().repository().versioningUsed()) {
-            //we can bypass this altogether is versioning is not being used....
-            return true;
-        }
         AbstractJcrNode node = this;
         SessionCache cache = sessionCache();
         ValueFactory<Boolean> booleanFactory = session.context().getValueFactories().getBooleanFactory();

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrLockManager.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrLockManager.java
@@ -181,10 +181,7 @@ class JcrLockManager implements LockManager {
     private ModeShapeLock getLowestLockAlongPath(final AbstractJcrNode node, boolean skipExpiredLocks)
         throws PathNotFoundException, AccessDeniedException, RepositoryException {
         session.checkLive();
-        if (!this.session.repository().lockingUsed()) {
-            //if locking hasn't been used at all, there's nothing to check
-            return null;
-        }
+       
         SessionCache sessionCache = session.cache();
         NodeCache cache = sessionCache;
         NodeKey nodeKey = node.key();

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrRepository.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrRepository.java
@@ -500,14 +500,6 @@ public class JcrRepository implements org.modeshape.jcr.api.Repository {
     protected final ChangeJournal journal() {
         return runningState().journal();
     }
-
-    protected final boolean versioningUsed() {
-        return runningState().repositoryCache().versioningUsed();
-    }
-
-    protected final boolean lockingUsed() {
-        return runningState().repositoryCache().lockingUsed();
-    }
     
     protected final boolean mimeTypeDetectionEnabled() {
         return runningState().mimeTypeDetector() != NullMimeTypeDetector.INSTANCE;

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/RepositoryCache.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/RepositoryCache.java
@@ -123,7 +123,6 @@ public class RepositoryCache {
     private int lastUpgradeId;
     private final LockingService startupLockingService;
     private volatile boolean isHoldingClusterLock = false;
-    private final RepositoryFeaturesDetector repositoryFeaturesDetector;
     private final int workspaceCacheSize;
 
     public RepositoryCache( ExecutionContext context,
@@ -310,9 +309,6 @@ public class RepositoryCache {
 
         // set the local source key in the document store
         this.documentStore.setLocalSourceKey(this.sourceKey);
-
-        // init the features detector (must be done only after the system area has been fully initialized)
-        this.repositoryFeaturesDetector = new RepositoryFeaturesDetector(systemSession, systemRef.getKey());
     }
 
     protected boolean waitUntil( Callable<Boolean> condition,
@@ -375,15 +371,7 @@ public class RepositoryCache {
             }
         }
     }
-
-    public final boolean versioningUsed() {
-        return repositoryFeaturesDetector.versioningUsed();
-    }
-
-    public final boolean lockingUsed() {
-        return repositoryFeaturesDetector.lockingUsed();
-    }
-
+    
     public final ChangeBus changeBus() {
         return changeBus;
     }
@@ -624,59 +612,7 @@ public class RepositoryCache {
         ChildReference systemRef = systemRoot.getChildReferences(systemSession).getChild(JcrLexicon.SYSTEM);
         return systemSession.mutable(systemRef.getKey());
     }
-
-    protected class RepositoryFeaturesDetector implements ChangeSetListener {
-        private final AtomicBoolean versioningUsed;
-        private final NodeKey versionStorageKey;
-        private final AtomicBoolean lockingUsed;
-        private final NodeKey locksContainerKey;
-
-        protected RepositoryFeaturesDetector( SessionCache systemSession,
-                                              NodeKey systemNodeKey ) {
-            CachedNode systemNode = systemSession.getNode(systemNodeKey);
-
-            this.versionStorageKey = systemNode.getChildReferences(systemSession).getChild(JcrLexicon.VERSION_STORAGE).getKey();
-            CachedNode versionStorage = systemSession.getNode(versionStorageKey);
-            boolean versioningUsed = !versionStorage.getChildReferences(systemSession).isEmpty();
-            this.versioningUsed = new AtomicBoolean(versioningUsed);
-
-            this.locksContainerKey = systemNode.getChildReferences(systemSession).getChild(ModeShapeLexicon.LOCKS).getKey();
-            CachedNode locksContainer = systemSession.getNode(locksContainerKey);
-            boolean lockingUsed = !locksContainer.getChildReferences(systemSession).isEmpty();
-            this.lockingUsed = new AtomicBoolean(lockingUsed);
-
-            if (!versioningUsed || !lockingUsed) {
-                // register with the change bus to be able to detect the changes in the usage of the various features
-                RepositoryCache.this.changeBus.registerInThread(this);
-            }
-        }
-
-        protected boolean lockingUsed() {
-            return lockingUsed.get();
-        }
-
-        protected boolean versioningUsed() {
-            return versioningUsed.get();
-        }
-
-        @Override
-        public void notify( ChangeSet changeSet ) {
-            if (!systemWorkspaceName.equals(changeSet.getWorkspaceName())) {
-                return;
-            }
-            Set<NodeKey> nodeKeys = changeSet.changedNodes();
-            if (!versioningUsed() && nodeKeys.contains(this.versionStorageKey)) {
-                this.versioningUsed.set(true);
-            }
-            if (!lockingUsed() && nodeKeys.contains(this.locksContainerKey)) {
-                this.lockingUsed.set(true);
-            }
-            if (versioningUsed() && lockingUsed()) {
-                RepositoryCache.this.changeBus.unregister(this);
-            }
-        }
-    }
-
+    
     protected class ChangesToWorkspacesListener implements ChangeSetListener {
         @Override
         public void notify( ChangeSet changeSet ) {

--- a/modeshape-jcr/src/test/java/org/modeshape/jcr/JcrRepositoryTest.java
+++ b/modeshape-jcr/src/test/java/org/modeshape/jcr/JcrRepositoryTest.java
@@ -29,6 +29,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -1425,35 +1426,7 @@ public class JcrRepositoryTest {
             session.logout();
         }
     }
-
-    @Test
-    @FixFor( "MODE-2277" )
-    public void shouldUpdateVersioningUsageFlag() throws Exception {
-        assertFalse(repository.repositoryCache().versioningUsed());
-        session = createSession();
-        session.getRootNode().addNode("node");
-        session.save();
-
-        Node nod2 = session.getRootNode().addNode("versionableNode");
-        nod2.addMixin("mix:versionable");
-        session.save();
-        //pre-save should already have initialized the version history
-        assertTrue(repository.repositoryCache().versioningUsed());
-    }
-
-    @Test
-    @FixFor( "MODE-2277" )
-    public void shouldUpdateLockingUsageFlag() throws Exception {
-        assertFalse(repository.repositoryCache().lockingUsed());
-        session = createSession();
-        Node node1 = session.getRootNode().addNode("node");
-        node1.addMixin("mix:lockable");
-        session.save();
-        assertFalse(repository.repositoryCache().lockingUsed());
-        session.lockManager().lock("/node", false, true, -1, null);
-        assertTrue(repository.repositoryCache().lockingUsed());
-    }
-
+    
     @Test
     @FixFor( "MODE-2343" )
     public void shouldReleaseObservationManagerThreadsOnLogout() throws Exception {

--- a/modeshape-parent/pom.xml
+++ b/modeshape-parent/pom.xml
@@ -215,6 +215,7 @@
         <version.bundle.plugin>3.0.0</version.bundle.plugin>
         <version.gwt.maven.plugin>2.5.1</version.gwt.maven.plugin>
         <version.org.wildfly.plugings.wildfly-maven-plugin>1.0.2.Final</version.org.wildfly.plugings.wildfly-maven-plugin>
+        <version.fabric8.docker.plugin>0.18.1</version.fabric8.docker.plugin>
         <version.org.elasticsearch>2.1.0</version.org.elasticsearch>
         <version.jna>4.1.0</version.jna>
         <!--The name of the modeshape-client artifact used by tools-->
@@ -306,7 +307,7 @@
                 <database.url>jdbc:h2:file:./target/db</database.url>
                 <database.username>sa</database.username>
                 <database.password/>
-                <docker.image/>
+                <docker.filter/>
             </properties>
         </profile>
 
@@ -324,8 +325,9 @@
                 <database.username>mysql</database.username>
                 <database.password>mysql</database.password>
                 <database.driver>com.mysql.jdbc.Driver</database.driver>
-                <database.url>jdbc:mysql://${docker.host.address}:3306/${database.name}?autoReconnect=true&amp;useSSL=false</database.url>
-                <docker.image>modeshape-mysql</docker.image>
+                <database.port>3306</database.port>
+                <database.url>jdbc:mysql://${docker.host.address}:${database.port}/${database.name}?autoReconnect=true&amp;useSSL=false</database.url>
+                <docker.filter>mysql/mysql-server:${version.docker.mysql}</docker.filter>
             </properties>
             <dependencies>
                 <dependency>
@@ -350,8 +352,9 @@
                 <database.username>postgres</database.username>
                 <database.password>postgres</database.password>
                 <database.driver>org.postgresql.Driver</database.driver>
-                <database.url>jdbc:postgresql://${docker.host.address}:5432/${database.name}</database.url>
-                <docker.image>modeshape-postgres</docker.image>
+                <database.port>5432</database.port>
+                <database.url>jdbc:postgresql://${docker.host.address}:${database.port}/${database.name}</database.url>
+                <docker.filter>postgres:${version.docker.postgresql}</docker.filter>
             </properties>
             <dependencies>
                 <dependency>
@@ -376,8 +379,10 @@
                 <database.username>system</database.username>
                 <database.password>oracle</database.password>
                 <database.driver>oracle.jdbc.OracleDriver</database.driver>
-                <database.url>jdbc:oracle:thin:@${docker.host.address}:49161:xe</database.url>
-                <docker.image>modeshape-oracle</docker.image>
+                <database.port1>49161</database.port1>
+                <database.port2>49160</database.port2>
+                <database.url>jdbc:oracle:thin:@${docker.host.address}:${database.port1}:xe</database.url>
+                <docker.filter>wnameless/oracle-xe-11g:${version.docker.oracle}</docker.filter>
             </properties>
             <dependencies>
                 <dependency>
@@ -535,7 +540,7 @@
                 <plugin>
                     <groupId>io.fabric8</groupId>
                     <artifactId>docker-maven-plugin</artifactId>
-                    <version>0.14.1</version>
+                    <version>${version.fabric8.docker.plugin}</version>
                     <configuration>
                         <watchInterval>500</watchInterval>
                         <logDate>default</logDate>
@@ -544,16 +549,15 @@
                         <images>
                             <image>
                                 <name>postgres:${version.docker.postgresql}</name>
-                                <alias>modeshape-postgres</alias>
                                 <run>
-                                    <namingStrategy>alias</namingStrategy>
+                                    <namingStrategy>none</namingStrategy>
                                     <env>
                                         <POSTGRES_DB>${database.name}</POSTGRES_DB>
                                         <POSTGRES_USER>${database.username}</POSTGRES_USER>
                                         <POSTGRES_PASSWORD>${database.password}</POSTGRES_PASSWORD>
                                     </env>
                                     <ports>
-                                        <port>5432:5432</port>
+                                        <port>${database.port}:5432</port>
                                     </ports>
                                     <log>
                                         <prefix>postgress</prefix>
@@ -568,9 +572,8 @@
                             </image>
                             <image>
                                 <name>mysql/mysql-server:${version.docker.mysql}</name>
-                                <alias>modeshape-mysql</alias>
                                 <run>
-                                    <namingStrategy>alias</namingStrategy>
+                                    <namingStrategy>none</namingStrategy>
                                     <env>
                                         <MYSQL_ROOT_PASSWORD>modeshape</MYSQL_ROOT_PASSWORD>
                                         <MYSQL_DATABASE>${database.name}</MYSQL_DATABASE>
@@ -578,7 +581,7 @@
                                         <MYSQL_PASSWORD>${database.password}</MYSQL_PASSWORD>
                                     </env>
                                     <ports>
-                                        <port>3306:3306</port>
+                                        <port>${database.port}:3306</port>
                                     </ports>
                                     <log>
                                         <prefix>mysql</prefix>
@@ -593,15 +596,14 @@
                             </image>
                             <image>
                                 <name>wnameless/oracle-xe-11g:${version.docker.oracle}</name>
-                                <alias>modeshape-oracle</alias>
                                 <run>
-                                    <namingStrategy>alias</namingStrategy>
+                                    <namingStrategy>none</namingStrategy>
                                     <env>
                                         <ORACLE_ALLOW_REMOTE>true</ORACLE_ALLOW_REMOTE>
                                     </env>
                                     <ports>
-                                        <port>49160:22</port>
-                                        <port>49161:1521</port>
+                                        <port>${database.port2}:22</port>
+                                        <port>${database.port1}:1521</port>
                                     </ports>
                                     <log>
                                         <prefix>oracle</prefix>

--- a/modeshape-persistence-tests/pom.xml
+++ b/modeshape-persistence-tests/pom.xml
@@ -187,8 +187,9 @@
                 <database.username>mysql</database.username>
                 <database.password>mysql</database.password>
                 <database.driver>com.mysql.jdbc.Driver</database.driver>
-                <database.url>jdbc:mysql://${docker.host.address}:3306/${database.name}?autoReconnect=true&amp;useSSL=false</database.url>
-                <docker.image>modeshape-mysql</docker.image>
+                <database.port>6603</database.port>
+                <database.url>jdbc:mysql://${docker.host.address}:${database.port}/${database.name}?autoReconnect=true&amp;useSSL=false</database.url>
+                <docker.filter>mysql/mysql-server:${version.docker.mysql}</docker.filter>
             </properties>
             <dependencies>
                 <dependency>
@@ -214,19 +215,23 @@
                 <oracle.database.username>system</oracle.database.username>
                 <oracle.database.password>oracle</oracle.database.password>
                 <oracle.database.driver>oracle.jdbc.OracleDriver</oracle.database.driver>
-                <oracle.database.url>jdbc:oracle:thin:@${docker.host.address}:49161:xe</oracle.database.url>
+                <oracle.database.port1>49161</oracle.database.port1>
+                <oracle.database.port2>49160</oracle.database.port2>
+                <oracle.database.url>jdbc:oracle:thin:@${docker.host.address}:${oracle.database.port1}:xe</oracle.database.url>
 
                 <postgres.database.name>modeshape_db</postgres.database.name>
                 <postgres.database.username>ms_user</postgres.database.username>
                 <postgres.database.password>ms_password</postgres.database.password>
                 <postgres.database.driver>org.postgresql.Driver</postgres.database.driver>
-                <postgres.database.url>jdbc:postgresql://${docker.host.address}:5432/${postgres.database.name}</postgres.database.url>
+                <postgres.database.port>5432</postgres.database.port>
+                <postgres.database.url>jdbc:postgresql://${docker.host.address}:${postgres.database.port}/${postgres.database.name}</postgres.database.url>
 
                 <mysql.database.name>modeshape_db</mysql.database.name>
                 <mysql.database.username>ms_user</mysql.database.username>
                 <mysql.database.password>ms_password</mysql.database.password>
                 <mysql.database.driver>com.mysql.jdbc.Driver</mysql.database.driver>
-                <mysql.database.url>jdbc:mysql://${docker.host.address}:3306/${mysql.database.name}?autoReconnect=true&amp;useSSL=false</mysql.database.url>
+                <mysql.database.port>3306</mysql.database.port>
+                <mysql.database.url>jdbc:mysql://${docker.host.address}:${mysql.database.port}/${mysql.database.name}?autoReconnect=true&amp;useSSL=false</mysql.database.url>
             </properties>
             <dependencies>
                 <dependency>
@@ -262,16 +267,15 @@
                             <images>
                                 <image>
                                     <name>postgres:${version.docker.postgresql}</name>
-                                    <alias>modeshape-postgres</alias>
                                     <run>
-                                        <namingStrategy>alias</namingStrategy>
+                                        <namingStrategy>none</namingStrategy>
                                         <env>
                                             <POSTGRES_DB>${postgres.database.name}</POSTGRES_DB>
                                             <POSTGRES_USER>${postgres.database.username}</POSTGRES_USER>
                                             <POSTGRES_PASSWORD>${postgres.database.password}</POSTGRES_PASSWORD>
                                         </env>
                                         <ports>
-                                            <port>5432:5432</port>
+                                            <port>${postgres.database.port}:5432</port>
                                         </ports>
                                         <log>
                                             <prefix>postgress</prefix>
@@ -296,7 +300,7 @@
                                             <MYSQL_PASSWORD>${mysql.database.password}</MYSQL_PASSWORD>
                                         </env>
                                         <ports>
-                                            <port>3306:3306</port>
+                                            <port>${mysql.database.port}:3306</port>
                                         </ports>
                                         <log>
                                             <prefix>mysql</prefix>
@@ -318,8 +322,8 @@
                                             <ORACLE_ALLOW_REMOTE>true</ORACLE_ALLOW_REMOTE>
                                         </env>
                                         <ports>
-                                            <port>49160:22</port>
-                                            <port>49161:1521</port>
+                                            <port>${oracle.database.port2}:22</port>
+                                            <port>${oracle.database.port1}:1521</port>
                                         </ports>
                                         <log>
                                             <prefix>oracle</prefix>


### PR DESCRIPTION
This was introduced as part of https://issues.jboss.org/browse/MODE-2277 to optimize the read access of the `node#isCheckedOut` method, but the entire concept is flawed when user transactions are used. User transactions are isolated from the repository and do not trigger any notifications until the transaction is committed.