### PR TITLE
MODE-2654 Fixes the behavior of copying locked nodes

### DIFF
--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/document/DocumentTranslator.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/document/DocumentTranslator.java
@@ -1446,7 +1446,7 @@ public class DocumentTranslator implements DocumentConstants {
      * @param doc the document
      * @return true if the change was made successfully, or false otherwise
      */
-    public boolean isLocked( EditableDocument doc ) {
+    protected boolean isLocked( EditableDocument doc ) {
         return hasProperty(doc, JcrLexicon.LOCK_OWNER) || hasProperty(doc, JcrLexicon.LOCK_IS_DEEP);
     }
 

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/document/SessionNode.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/document/SessionNode.java
@@ -2968,6 +2968,13 @@ public class SessionNode implements MutableCachedNode {
                 if (isVersionProperty && !includeVersionProperties) {
                     continue;
                 }
+                
+                if (JcrLexicon.LOCK_OWNER.equals(propertyName) || JcrLexicon.LOCK_IS_DEEP.equals(propertyName)) {
+                    // as per JCR 17.7 locked nodes can always be copied, but should not appear as locked 
+                    // note that we're not removing the entire mixin, just these properties
+                    continue;
+                }
+                
                 if (property.isReference() || property.isSimpleReference()) {
                     // reference properties are not copied directly because that would cause incorrect back-pointers
                     // they are processed at the end of the clone/copy operation.
@@ -2977,7 +2984,7 @@ public class SessionNode implements MutableCachedNode {
                         sourceKeyToReferenceProperties.put(sourceNodeKey, referenceProperties);
                     }
                     referenceProperties.add(property);
-                } else if (property.getName().equals(JcrLexicon.UUID)) {
+                } else if (propertyName.equals(JcrLexicon.UUID)) {
                     // UUIDs need to be handled differently
                     copyUUIDProperty(property, targetNode, sourceNode);
                 } else {

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/document/WritableSessionCache.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/document/WritableSessionCache.java
@@ -1093,7 +1093,7 @@ public class WritableSessionCache extends AbstractSessionCache {
                     switch (lockChange) {
                         case LOCK_FOR_SESSION:
                         case LOCK_FOR_NON_SESSION:
-                            // check is another session has already locked the document
+                            // check if another session has already locked the document
                             if (translator.isLocked(doc)) {
                                 throw new LockFailureException(key);
                             }


### PR DESCRIPTION
As per `JCR #17.7` locked nodes should be copied without any special restriction