### PR TITLE
MODE-2665 Changes the RepositoryLockManager#unlock method so that it saves the system session first

### DIFF
--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/RepositoryLockManager.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/RepositoryLockManager.java
@@ -475,7 +475,8 @@ class RepositoryLockManager implements ChangeSetListener {
         }
 
         // Now save the two sessions ...
-        lockingSession.save(systemSession, null);
+        // save the system session first so that the system change is reflected first in the ws caches
+        systemSession.save(lockingSession, null);
     }
 
     /**


### PR DESCRIPTION
This addresses potential multi-threaded deadlocks (in a cluster) in the sense that the same order of node keys should be used when locking nodes internally across the JCR `lock` and `unlock` operations, as a whole.