### PR TITLE
MODE-2667, MODE-2667 Added S3 endpoint support

### DIFF
--- a/deploy/jbossas/modeshape-jbossas-subsystem/src/main/java/org/modeshape/jboss/subsystem/AddS3BinaryStorage.java
+++ b/deploy/jbossas/modeshape-jbossas-subsystem/src/main/java/org/modeshape/jboss/subsystem/AddS3BinaryStorage.java
@@ -41,6 +41,8 @@ public class AddS3BinaryStorage extends AbstractAddBinaryStorage {
         binaries.setString(FieldName.USER_PASSWORD, password);
         String bucketName = ModelAttributes.S3_BUCKET_NAME.resolveModelAttribute(context, model).asString();
         binaries.setString(FieldName.BUCKET_NAME, bucketName);
+        String endPoint = ModelAttributes.S3_ENDPOINT_URL.resolveModelAttribute(context, model).asString();
+        binaries.setString(FieldName.ENDPOINT_URL, endPoint);
     }
 
     @Override

--- a/deploy/jbossas/modeshape-jbossas-subsystem/src/main/java/org/modeshape/jboss/subsystem/Attribute.java
+++ b/deploy/jbossas/modeshape-jbossas-subsystem/src/main/java/org/modeshape/jboss/subsystem/Attribute.java
@@ -110,6 +110,7 @@ public enum Attribute {
     DATABASE("database"),
     REINDEXING_MODE("mode"),
     BUCKET_NAME("bucket-name"),
+    ENDPOINT_URL("endpoint-url"),
     HOST_ADDRESSES("host-addresses");
 
     private final String name;

--- a/deploy/jbossas/modeshape-jbossas-subsystem/src/main/java/org/modeshape/jboss/subsystem/ModeShapeSubsystemXMLReader_3_0.java
+++ b/deploy/jbossas/modeshape-jbossas-subsystem/src/main/java/org/modeshape/jboss/subsystem/ModeShapeSubsystemXMLReader_3_0.java
@@ -858,9 +858,12 @@ public class ModeShapeSubsystemXMLReader_3_0 implements XMLStreamConstants, XMLE
                         break;
                     case USERNAME:
                         ModelAttributes.S3_USERNAME.parseAndSetParameter(attrValue, storageType, reader);
-                        break;
+                    break;
                     case PASSWORD:
                         ModelAttributes.S3_PASSWORD.parseAndSetParameter(attrValue, storageType, reader);
+                    break;
+                    case ENDPOINT_URL:
+                        ModelAttributes.S3_ENDPOINT_URL.parseAndSetParameter(attrValue, storageType, reader);
                         break;
                     case MIN_VALUE_SIZE:
                         ModelAttributes.MINIMUM_BINARY_SIZE.parseAndSetParameter(attrValue, storageType, reader);

--- a/deploy/jbossas/modeshape-jbossas-subsystem/src/main/java/org/modeshape/jboss/subsystem/ModeShapeSubsystemXMLWriter.java
+++ b/deploy/jbossas/modeshape-jbossas-subsystem/src/main/java/org/modeshape/jboss/subsystem/ModeShapeSubsystemXMLWriter.java
@@ -350,6 +350,7 @@ public class ModeShapeSubsystemXMLWriter implements XMLStreamConstants, XMLEleme
             ModelAttributes.S3_BUCKET_NAME.marshallAsAttribute(storage, false, writer);
             ModelAttributes.S3_USERNAME.marshallAsAttribute(storage, false, writer);
             ModelAttributes.S3_PASSWORD.marshallAsAttribute(storage, false, writer);
+            ModelAttributes.S3_ENDPOINT_URL.marshallAsAttribute(storage, false, writer);
             writer.writeEndElement();
         } else if (ModelKeys.COMPOSITE_BINARY_STORAGE.equals(storageType)) {
             writer.writeStartElement(Element.COMPOSITE_BINARY_STORAGE.getLocalName());

--- a/deploy/jbossas/modeshape-jbossas-subsystem/src/main/java/org/modeshape/jboss/subsystem/ModelAttributes.java
+++ b/deploy/jbossas/modeshape-jbossas-subsystem/src/main/java/org/modeshape/jboss/subsystem/ModelAttributes.java
@@ -981,6 +981,14 @@ public class ModelAttributes {
             .setFlags(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
             .build();
 
+    public static final MappedSimpleAttributeDefinition S3_ENDPOINT_URL =
+        new MappedAttributeDefinitionBuilder(Attribute.ENDPOINT_URL.getLocalName(), ModelType.STRING,
+                                             FieldName.STORAGE, FieldName.BINARY_STORAGE, FieldName.ENDPOINT_URL)
+                .setAllowExpression(true)
+                .setAllowNull(true)
+                .setFlags(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
+                .build();
+
     public static final AttributeDefinition[] SUBSYSTEM_ATTRIBUTES = {};
 
     public static final AttributeDefinition[] WEBAPP_ATTRIBUTES = {EXPLODED};
@@ -1010,7 +1018,7 @@ public class ModelAttributes {
         MIME_TYPE_DETECTION, CASSANDRA_HOST };
 
     public static final AttributeDefinition[] S3_BINARY_STORAGE_ATTRIBUTES = {MINIMUM_BINARY_SIZE, MINIMUM_STRING_SIZE,
-        MIME_TYPE_DETECTION, S3_USERNAME, S3_PASSWORD, S3_BUCKET_NAME};
+        MIME_TYPE_DETECTION, S3_USERNAME, S3_PASSWORD, S3_BUCKET_NAME, S3_ENDPOINT_URL};
 
     public static final AttributeDefinition[] MONGO_BINARY_STORAGE_ATTRIBUTES = { MINIMUM_BINARY_SIZE, MINIMUM_STRING_SIZE,
                                                                                   MIME_TYPE_DETECTION, MONGO_HOST, MONGO_PORT, MONGO_DATABASE, MONGO_USERNAME, MONGO_PASSWORD, MONGO_HOST_ADDRESSES };

--- a/deploy/jbossas/modeshape-jbossas-subsystem/src/main/resources/schema/modeshape_3_0.xsd
+++ b/deploy/jbossas/modeshape-jbossas-subsystem/src/main/resources/schema/modeshape_3_0.xsd
@@ -1101,6 +1101,11 @@
                 <xs:documentation>The bucket name</xs:documentation>
             </xs:annotation>
         </xs:attribute>
+        <xs:attribute name="endpoint-url" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>The bucket name</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
     </xs:attributeGroup>
     <!-- Global simple types -->
     <xs:simpleType name="garbage-collection-initial-time-type">

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/RepositoryConfiguration.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/RepositoryConfiguration.java
@@ -439,6 +439,7 @@ public class RepositoryConfiguration {
         public static final String HOST = "host";
         public static final String PORT = "port";
         public static final String BUCKET_NAME = "bucketName";
+        public static final String ENDPOINT_URL = "endPoint";
 
         public static final String GARBAGE_COLLECTION = "garbageCollection";
         public static final String INITIAL_TIME = "initialTime";
@@ -1211,8 +1212,17 @@ public class RepositoryConfiguration {
                 String username = binaryStorage.getString(FieldName.USER_NAME);
                 String password = binaryStorage.getString(FieldName.USER_PASSWORD);
                 String bucketName = binaryStorage.getString(FieldName.BUCKET_NAME);
-                store = new S3BinaryStore(username, password, bucketName);
+
+                //Use S3 provided endpoints
+                if (FieldName.ENDPOINT_URL != null) {
+                    String endPoint = binaryStorage.getString(FieldName.ENDPOINT_URL);
+                    store = new S3BinaryStore(username, password, bucketName, endPoint);
+                }
+                else { //Use default AWS endpoint
+                    store = new S3BinaryStore(username, password, bucketName);
+                }
             }
+
             if (store == null) store = TransientBinaryStore.get();
             store.setMinimumBinarySizeInBytes(getMinimumBinarySizeInBytes());
             return store;

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/value/binary/S3BinaryStore.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/value/binary/S3BinaryStore.java
@@ -79,8 +79,26 @@ public class S3BinaryStore extends AbstractBinaryStore {
      * @throws BinaryStoreException if S3 connection cannot be made to verify bucket
      */
     public S3BinaryStore(String accessKey, String secretKey, String bucketName) throws BinaryStoreException {
+        this(accessKey, secretKey, bucketName, null);
+    }
+
+    /**
+     * Creates a binary store with a connection to Amazon S3
+     *
+     * @param accessKey AWS access key credential
+     * @param secretKey AWS secret key credential
+     * @param bucketName Name of the S3 bucket in which binary content will be stored
+     * @param endPoint The S3 endpoint URL where the bucket will be accessed
+     * @throws BinaryStoreException if S3 connection cannot be made to verify bucket
+     */
+    public S3BinaryStore(String accessKey, String secretKey, String bucketName, String endPoint) throws BinaryStoreException {
         this.bucketName = bucketName;
         this.s3Client = new AmazonS3Client(new BasicAWSCredentials(accessKey, secretKey));
+
+        // Support for compatible S3 storage systems
+        if(endPoint != null)
+            this.s3Client.setEndpoint(endPoint);
+
         this.fileSystemCache = TransientBinaryStore.get();
         this.fileSystemCache.setMinimumBinarySizeInBytes(1L);
 

--- a/modeshape-jcr/src/main/resources/org/modeshape/jcr/repository-config-schema.json
+++ b/modeshape-jcr/src/main/resources/org/modeshape/jcr/repository-config-schema.json
@@ -488,6 +488,11 @@
                                     "description" : "The S3 bucket name in which binary values will be stored.",
                                     "required" : true
                                 },
+                                "endPoint" : {
+                                    "type" : "string",
+                                    "description" : "The S3 bucket name in which binary values will be stored.",
+                                    "required" : false
+                                },
                                 "minimumBinarySizeInBytes" : {
                                     "type" : "integer",
                                     "default" : 4096,


### PR DESCRIPTION
Added changes to:

-Added additional overloaded  constructor to take 'endpoint' as an parameter
-Updated schema file to support this additional parameter (as optional to keep backward compatibility).
-Repository config files so it uses endpoint
{
  "name": "Test Repository",
  "storage": {
    "binaryStorage": {
      "type": "s3",
      "username": "access_key",
      "password": "secrey",
      "bucketName": "modeshape_bucket",
      "endPoint": "https://some3scompatiblestorage"
    }
  }
}