### PR TITLE
MODE-2668 Fixes the handling of JCR operations within non-active user transactions

### DIFF
--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrI18n.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrI18n.java
@@ -451,7 +451,7 @@ public final class JcrI18n {
     public static I18n localIndexProviderDoesNotSupportTextIndexes;
     public static I18n localIndexProviderDoesNotSupportMultiColumnIndexes;
 
-    public static I18n warnRogueTransaction;
+    public static I18n errorInvalidUserTransaction;
     public static I18n warnAttemptingToUnlockAnotherLock;
     private JcrI18n() {
     }

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/document/AbstractSessionCache.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/document/AbstractSessionCache.java
@@ -59,16 +59,20 @@ public abstract class AbstractSessionCache implements SessionCache, DocumentCach
             return userId;
         }
     }
-
+    
+    protected final Logger logger;
+    
     private final WorkspaceCache sharedWorkspaceCache;
     private final AtomicReference<WorkspaceCache> workspaceCache = new AtomicReference<>();
     private final NameFactory nameFactory;
     private final PathFactory pathFactory;
     private final Path rootPath;
+    
     private ExecutionContext context;
 
     protected AbstractSessionCache(ExecutionContext context,
                                    WorkspaceCache sharedWorkspaceCache) {
+        this.logger = Logger.getLogger(getClass());
         this.context = context;
         this.sharedWorkspaceCache = sharedWorkspaceCache;
         this.workspaceCache.set(sharedWorkspaceCache);
@@ -77,9 +81,7 @@ public abstract class AbstractSessionCache implements SessionCache, DocumentCach
         this.pathFactory = factories.getPathFactory();
         this.rootPath = this.pathFactory.createRootPath();
     }
-
-    protected abstract Logger logger();
-
+    
     @Override
     public final SessionCache unwrap() {
         return this;

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/document/ReadOnlySessionCache.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/document/ReadOnlySessionCache.java
@@ -18,7 +18,6 @@ package org.modeshape.jcr.cache.document;
 import java.util.Collections;
 import java.util.Set;
 import org.modeshape.common.annotation.ThreadSafe;
-import org.modeshape.common.logging.Logger;
 import org.modeshape.jcr.ExecutionContext;
 import org.modeshape.jcr.cache.CachedNode;
 import org.modeshape.jcr.cache.NodeKey;
@@ -30,18 +29,11 @@ import org.modeshape.jcr.cache.SessionCache;
 @ThreadSafe
 public class ReadOnlySessionCache extends AbstractSessionCache {
 
-    private static final Logger LOGGER = Logger.getLogger(ReadOnlySessionCache.class);
-
     public ReadOnlySessionCache(ExecutionContext context,
                                 WorkspaceCache workspaceCache) {
         super(context, workspaceCache);
     }
-
-    @Override
-    protected Logger logger() {
-        return LOGGER;
-    }
-
+    
     @Override
     public boolean hasChanges() {
         return false;

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/txn/LocalTransaction.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/txn/LocalTransaction.java
@@ -60,9 +60,9 @@ public class LocalTransaction implements Transaction {
             if (!isActive()) {
                throw new SystemException("Illegal transaction status:" + status); 
             }
-            synchronizations.stream().forEach(Synchronization::beforeCompletion);
-            status.compareAndSet(Status.STATUS_ACTIVE, Status.STATUS_COMMITTED);
-            synchronizations.stream().forEach((sync)->sync.afterCompletion(status.get()));
+            synchronizations.forEach(Synchronization::beforeCompletion);
+            status.set(Status.STATUS_COMMITTED);
+            synchronizations.forEach((sync)->sync.afterCompletion(Status.STATUS_COMMITTED));
         } finally {
             LocalTransactionManager.clear();
         }
@@ -92,9 +92,9 @@ public class LocalTransaction implements Transaction {
             if (!isActive() && !markedForRollback()) {
                 throw new SystemException("Illegal transaction status:" + status);
             }
-            synchronizations.stream().forEach(Synchronization::beforeCompletion);
+            synchronizations.forEach(Synchronization::beforeCompletion);
             status.set(Status.STATUS_ROLLEDBACK);
-            synchronizations.stream().forEach((sync)->sync.afterCompletion(status.get()));
+            synchronizations.forEach((sync)->sync.afterCompletion(Status.STATUS_ROLLEDBACK));
         } finally {
             LocalTransactionManager.clear();
         }

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/txn/Transactions.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/txn/Transactions.java
@@ -151,10 +151,9 @@ public class Transactions {
 
         // Get the transaction currently associated with this thread (if there is one) ...
         javax.transaction.Transaction txn = txnMgr.getTransaction();
-        if (txn != null && txn.getStatus() != Status.STATUS_ACTIVE) {
-            logger.warn(JcrI18n.warnRogueTransaction,txn);
-            txnMgr.suspend(); 
-            txn = null;
+        if (txn != null && Status.STATUS_ACTIVE != txn.getStatus()) {
+            // there is a user transaction which is not valid, so abort everything
+            throw new IllegalStateException(JcrI18n.errorInvalidUserTransaction.text(txn));
         }
         
         if (txn == null) {

--- a/modeshape-jcr/src/main/resources/org/modeshape/jcr/JcrI18n.properties
+++ b/modeshape-jcr/src/main/resources/org/modeshape/jcr/JcrI18n.properties
@@ -430,5 +430,5 @@ localIndexProviderDirectoryMustBeWritable = The directory for local indexes at '
 localIndexProviderDoesNotSupportTextIndexes = The '{0}' index definition is not valid because the local index provider '{1}' does not support TEXT indexes.
 localIndexProviderDoesNotSupportMultiColumnIndexes = The '{0}' index definition is not valid because the local index provider '{1}' does not support multi-column indexes.
 
-warnRogueTransaction = Suspending non active transaction {0}. This may indicate a problem with the transaction manager.
+errorInvalidUserTransaction = Non-active user transaction {0} detected; aborting current operation. Note that any transient changes are still present in the their corresponding sessions
 warnAttemptingToUnlockAnotherLock = Thread '{0}' is attempting to unlock '{1}' which belongs to another thread.


### PR DESCRIPTION
Any JCR session operation attempted within a non active user transaction will raise an exception and will leave the transient state of the session unchanged (as per the docs of the session.save method)