### PR TITLE
MODE-2668, MODE-2669 Fixes some more issues around user transactions

### DIFF
--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/txn/Transactions.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/txn/Transactions.java
@@ -228,6 +228,10 @@ public class Transactions {
                 // no active transaction
                 return null;
             }
+            if (Status.STATUS_ACTIVE != txn.getStatus()) {
+                // there is a user transaction which is not valid, so abort everything
+                throw new IllegalStateException(JcrI18n.errorInvalidUserTransaction.text(txn));
+            }
             return transactionTable.get(txn);
         } catch (SystemException e) {
             logger.debug(e, "Cannot determine if there is an active transaction or not");
@@ -649,6 +653,14 @@ public class Transactions {
                     transactionTable.remove(this.transaction);
                 }
             }
+        }
+    
+        @Override
+        public String toString() {
+            final StringBuilder sb = new StringBuilder(getClass().getSimpleName()).append("[local ").append("txId='")
+                                                                                  .append(id).append("', original tx='")
+                                                                                  .append(transaction).append("']");
+            return sb.toString();
         }
     }
 

--- a/modeshape-jcr/src/main/resources/org/modeshape/jcr/JcrI18n.properties
+++ b/modeshape-jcr/src/main/resources/org/modeshape/jcr/JcrI18n.properties
@@ -430,5 +430,5 @@ localIndexProviderDirectoryMustBeWritable = The directory for local indexes at '
 localIndexProviderDoesNotSupportTextIndexes = The '{0}' index definition is not valid because the local index provider '{1}' does not support TEXT indexes.
 localIndexProviderDoesNotSupportMultiColumnIndexes = The '{0}' index definition is not valid because the local index provider '{1}' does not support multi-column indexes.
 
-errorInvalidUserTransaction = Non-active user transaction {0} detected; aborting current operation. Note that any transient changes are still present in the their corresponding sessions
+errorInvalidUserTransaction = Detected non-active user transaction '{0}'; aborting current operation. Note that any transient changes are still present in the their corresponding sessions
 warnAttemptingToUnlockAnotherLock = Thread '{0}' is attempting to unlock '{1}' which belongs to another thread.

--- a/persistence/modeshape-persistence-relational/src/main/java/org/modeshape/persistence/relational/TransactionalCaches.java
+++ b/persistence/modeshape-persistence-relational/src/main/java/org/modeshape/persistence/relational/TransactionalCaches.java
@@ -50,7 +50,7 @@ public final class TransactionalCaches {
     }    
 
     protected Document search(String key) {
-        TransactionalCache cache = cacheForTransaction();
+        TransactionalCache cache = cacheForActiveTransaction();
         Document doc = cache.getFromWriteCache(key);
         if (doc != null) {
             return doc;
@@ -59,26 +59,26 @@ public final class TransactionalCaches {
     }
     
     protected boolean hasBeenRead(String key) {
-        return cacheForTransaction().readCache().containsKey(key);
+        return cacheForActiveTransaction().readCache().containsKey(key);
     }
 
     protected Document getForWriting(String key) {
-        return cacheForTransaction().getFromWriteCache(key);                     
+        return cacheForActiveTransaction().getFromWriteCache(key);                     
     }
     
     protected void putForReading(String key, Document doc) {
         if (!TransactionsHolder.hasActiveTransaction()) {
             return;
         }
-        cacheForTransaction().putForReading(key, doc);    
+        cacheForActiveTransaction().putForReading(key, doc);    
     }
 
     protected Document putForWriting(String key, Document doc) {
-        return cacheForTransaction().putForWriting(key, doc);
+        return cacheForActiveTransaction().putForWriting(key, doc);
     }
     
     protected Set<String> documentKeys() {
-        TransactionalCache transactionalCache = cacheForTransaction();
+        TransactionalCache transactionalCache = cacheForActiveTransaction();
         return transactionalCache.writeCache().entrySet()
                              .stream()
                              .filter(entry -> !transactionalCache.isRemoved(entry.getKey()))
@@ -87,48 +87,46 @@ public final class TransactionalCaches {
     }
     
     protected ConcurrentMap<String, Document> writeCache() {
-        return cacheForTransaction().writeCache();
+        return cacheForActiveTransaction().writeCache();
     }
     
     protected  boolean isRemoved(String key) {
-        return cacheForTransaction().isRemoved(key);
+        return cacheForActiveTransaction().isRemoved(key);
     }
 
     protected void remove(String key) {
-        cacheForTransaction().remove(key);
+        cacheForActiveTransaction().remove(key);
     }
     
     protected boolean isNew(String key) {
-        return cacheForTransaction().isNew(key);
+        return cacheForActiveTransaction().isNew(key);
     }
     
     protected void putNew(String key) {
         if (!TransactionsHolder.hasActiveTransaction()) {
             return;
         }
-        cacheForTransaction().putNew(key);
+        cacheForActiveTransaction().putNew(key);
     }
 
     protected void putNew(Collection<String> keys) {
         if (!TransactionsHolder.hasActiveTransaction()) {
             return;
         }
-        cacheForTransaction().putNew(keys);
+        cacheForActiveTransaction().putNew(keys);
     }
     
-    protected void clearCache() {
-        cachesByTxId.computeIfPresent(TransactionsHolder.requireActiveTransaction(), (id, readWriteCache) -> {
-            readWriteCache.clear();
-            return null;
-        });
+    protected void clearCache(String txId) {  
+        cachesByTxId.remove(txId);
     }
     
     protected void stop() {
         cachesByTxId.clear();
     }
 
-    private TransactionalCache cacheForTransaction() {
-        return cachesByTxId.computeIfAbsent(TransactionsHolder.requireActiveTransaction(), TransactionalCache::new);
+    private TransactionalCache cacheForActiveTransaction() {
+        String activeTxId = TransactionsHolder.requireActiveTransaction();
+        return cachesByTxId.computeIfAbsent(activeTxId, TransactionalCache::new);
     }
 
     private static class TransactionalCache {

--- a/persistence/modeshape-persistence-relational/src/main/java/org/modeshape/persistence/relational/TransactionsHolder.java
+++ b/persistence/modeshape-persistence-relational/src/main/java/org/modeshape/persistence/relational/TransactionsHolder.java
@@ -48,13 +48,12 @@ public final class TransactionsHolder {
                 Thread.currentThread().getName()));
     }
     
-    protected static String validateTransaction(String actualTxId) {
-        String expectedTxId = requireActiveTransaction();
-        if (!expectedTxId.equals(actualTxId)) {
+    protected static void validateAgainstActiveTransaction(String otherTxId) {
+        String expectedTxId = ACTIVE_TX_ID.get();
+        if (!otherTxId.equals(ACTIVE_TX_ID.get())) {
             throw new RelationalProviderException(RelationalProviderI18n.threadAssociatedWithAnotherTransaction, 
-                                                  Thread.currentThread().getName(), expectedTxId, actualTxId);
+                                                  Thread.currentThread().getName(), expectedTxId, otherTxId);
         }
-        return expectedTxId;
     }
     
     protected static void setActiveTxId(String txId) {


### PR DESCRIPTION
The change for https://issues.jboss.org/browse/MODE-2668 detects aborted user transactions when the equivalent ModeShape transaction is being searched

The change for https://issues.jboss.org/browse/MODE-2669 allows the relational DB provider to correctly clean up resources even if commit or rollback are called from different threads