### PR TITLE
MODE-2670 Changes the implementation of the internal repository locking

### DIFF
--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/InitialContentImporter.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/InitialContentImporter.java
@@ -25,6 +25,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Set;
 import javax.jcr.Node;
 import javax.jcr.RepositoryException;
 import javax.jcr.Value;
@@ -60,6 +61,23 @@ public final class InitialContentImporter {
                             JcrRepository.RunningState repository ) {
         this.initialContentConfig = initialContentConfig;
         this.repository = repository;
+    }
+    
+    protected void initialize() {
+        RepositoryCache repositoryCache = repository.repositoryCache();
+        if (!repositoryCache.isInitializingRepository()) {
+            return;
+        }
+        Set<String> workspaceNames = repositoryCache.getWorkspaceNames();
+        if (workspaceNames.isEmpty()) {
+            return;   
+        }
+        repository.localDocumentStore().runInTransaction(() -> {
+            for (String workspace : workspaceNames) {
+                importInitialContent(workspace);       
+            }
+            return null;
+        }, 0, RepositoryCache.REPOSITORY_INFO_KEY);
     }
 
     protected void importInitialContent( String workspaceName ) throws RepositoryException {

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/ModeShapeLexicon.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/ModeShapeLexicon.java
@@ -70,11 +70,6 @@ public class ModeShapeLexicon {
     public static final Name LOCALNAME = new BasicName(Namespace.URI, "localName");
 
     /**
-     * The name of the node which is used for running 1-time operations
-     */
-    public static final Name REPOSITORY = new BasicName(Namespace.URI, "repository");
-
-    /**
      * Federation related items
      */
     public static final Name FEDERATION = new BasicName(Namespace.URI, "federation");

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/document/LocalDocumentStore.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/document/LocalDocumentStore.java
@@ -25,7 +25,6 @@ import java.util.concurrent.Callable;
 import java.util.function.BiFunction;
 import javax.transaction.NotSupportedException;
 import javax.transaction.SystemException;
-import javax.transaction.Transaction;
 import org.modeshape.common.SystemFailureException;
 import org.modeshape.common.util.CheckArg;
 import org.modeshape.jcr.RepositoryEnvironment;
@@ -313,26 +312,6 @@ public class LocalDocumentStore implements DocumentStore {
             throw re;
         } catch (Exception e) {
             throw new RuntimeException(e);
-        }
-    }
-  
-    /**
-     * Runs the given operation within a local transaction, after optionally suspending any existing transaction.
-     *
-     * @see #runInTransaction(Callable, int, String...) 
-     */
-    public  <V> V runInLocalTransaction( Callable<V> operation, int retryCountOnLockTimeout, String... keysToLock ) {
-        // Start a transaction ...
-        Transactions txns = repoEnv.getTransactions();
-        try {
-            Transaction activeTransaction = txns.suspend();
-            V result = runInTransaction(operation, retryCountOnLockTimeout, keysToLock);
-            if (activeTransaction != null) {
-                txns.resume(activeTransaction);
-            }
-            return result;
-        } catch (SystemException e) {
-            throw new SystemFailureException(e);
         }
     }
 

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/locking/JGroupsLockingService.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/locking/JGroupsLockingService.java
@@ -28,8 +28,10 @@ import org.modeshape.common.annotation.ThreadSafe;
  *
  * @author Horia Chiorean (hchiorea@redhat.com)
  * @since 5.0
+ * @deprecated this is not reliable when running in a cluster and will be removed in the next major version.
  */
 @ThreadSafe
+@Deprecated
 public class JGroupsLockingService extends AbstractLockingService<Lock> {
 
     /**
@@ -61,12 +63,7 @@ public class JGroupsLockingService extends AbstractLockingService<Lock> {
     protected Lock createLock(String name) {
         return lockService.getLock(name);
     }
-
-    @Override
-    protected void validateLock(Lock lock) {
-        //nothing to validate here
-    }
-
+    
     @Override
     protected boolean releaseLock(Lock lock) {
         // the only way to tell if JG has a lock is to try locking it from the current thread (which should be a no-op if the lock 

--- a/modeshape-jcr/src/test/java/org/modeshape/jcr/JcrQueryManagerTest.java
+++ b/modeshape-jcr/src/test/java/org/modeshape/jcr/JcrQueryManagerTest.java
@@ -120,7 +120,7 @@ import org.modeshape.jcr.value.Path.Segment;
 public class JcrQueryManagerTest extends MultiUseAbstractTest {
 
     private static final String[] INDEXED_SYSTEM_NODES_PATHS = new String[] {"/jcr:system/jcr:nodeTypes",
-        "/jcr:system/mode:namespaces", "/jcr:system/mode:repository"};
+        "/jcr:system/mode:namespaces"};
 
     /** The total number of nodes excluding '/jcr:system' */
     protected static final int TOTAL_NON_SYSTEM_NODE_COUNT = 25;

--- a/modeshape-jcr/src/test/java/org/modeshape/jcr/TestingUtil.java
+++ b/modeshape-jcr/src/test/java/org/modeshape/jcr/TestingUtil.java
@@ -20,6 +20,9 @@ import java.net.URL;
 import java.util.Arrays;
 import java.util.Properties;
 import javax.jcr.Repository;
+import javax.transaction.Status;
+import javax.transaction.SystemException;
+import javax.transaction.Transaction;
 import javax.transaction.TransactionManager;
 import org.junit.Assert;
 import org.modeshape.common.SystemFailureException;
@@ -83,9 +86,16 @@ public class TestingUtil {
     public static void killTransaction( TransactionManager txManager ) {
         if (txManager != null) {
             try {
-                txManager.rollback();
-            } catch (Exception e) {
-                // ignore
+                Transaction transaction = txManager.getTransaction();
+                if (transaction != null) {
+                    if (Status.STATUS_ACTIVE == transaction.getStatus()) {
+                        txManager.rollback();
+                    } else {
+                        txManager.suspend();
+                    }
+                }
+            } catch (SystemException e) {
+                //ignore
             }
         }
     }

--- a/modeshape-jcr/src/test/resources/config/repo-config-db-txn.json
+++ b/modeshape-jcr/src/test/resources/config/repo-config-db-txn.json
@@ -1,0 +1,20 @@
+{
+    "name" : "DB File Repository",
+    "workspaces" : {
+        "default" : "default",
+        "predefined" : ["otherWorkspace"],
+        "allowCreation" : true
+    },
+    "storage" : {
+        "persistence" : {
+            "type" : "db",
+            "connectionUrl": "jdbc:h2:file:./target/txn/db"
+        }
+    },
+    "security" : {
+        "anonymous" : {
+            "roles" : ["readonly","readwrite","admin"],
+            "useOnFailedLogin" : false
+        }
+    }
+}

--- a/persistence/modeshape-persistence-relational/src/main/java/org/modeshape/persistence/relational/RelationalProviderException.java
+++ b/persistence/modeshape-persistence-relational/src/main/java/org/modeshape/persistence/relational/RelationalProviderException.java
@@ -32,4 +32,8 @@ public class RelationalProviderException extends RuntimeException {
     protected RelationalProviderException(I18n msgResource, Object... params) {
         super(msgResource.text(params));
     }
+    
+    protected RelationalProviderException(String message) {
+        super(message);
+    }
 }

--- a/persistence/modeshape-persistence-relational/src/main/java/org/modeshape/persistence/relational/TransactionalCaches.java
+++ b/persistence/modeshape-persistence-relational/src/main/java/org/modeshape/persistence/relational/TransactionalCaches.java
@@ -57,11 +57,7 @@ public final class TransactionalCaches {
         }
         return cache.getFromReadCache(key); 
     }
-    
-    protected boolean hasBeenRead(String key) {
-        return cacheForActiveTransaction().readCache().containsKey(key);
-    }
-
+ 
     protected Document getForWriting(String key) {
         return cacheForActiveTransaction().getFromWriteCache(key);                     
     }
@@ -84,10 +80,6 @@ public final class TransactionalCaches {
                              .filter(entry -> !transactionalCache.isRemoved(entry.getKey()))
                              .map(Map.Entry::getKey)
                              .collect(Collectors.toSet());
-    }
-    
-    protected ConcurrentMap<String, Document> writeCache() {
-        return cacheForActiveTransaction().writeCache();
     }
     
     protected  boolean isRemoved(String key) {
@@ -123,13 +115,17 @@ public final class TransactionalCaches {
     protected void stop() {
         cachesByTxId.clear();
     }
-
+    
     private TransactionalCache cacheForActiveTransaction() {
         String activeTxId = TransactionsHolder.requireActiveTransaction();
         return cachesByTxId.computeIfAbsent(activeTxId, TransactionalCache::new);
     }
+    
+    protected TransactionalCache cacheForTransaction(String txId) {
+        return cachesByTxId.get(txId);
+    }
 
-    private static class TransactionalCache {
+    protected static class TransactionalCache {
         private final ConcurrentMap<String, Document> read = new ConcurrentHashMap<>();
         private final ConcurrentMap<String, Document> write = new ConcurrentHashMap<>();
         private final Set<String> newIds = Collections.newSetFromMap(new ConcurrentHashMap<>());

--- a/persistence/modeshape-persistence-relational/src/main/java/org/modeshape/persistence/relational/TransactionsHolder.java
+++ b/persistence/modeshape-persistence-relational/src/main/java/org/modeshape/persistence/relational/TransactionsHolder.java
@@ -33,7 +33,7 @@ public final class TransactionsHolder {
     }
     
     protected static boolean hasActiveTransaction() {
-        return ACTIVE_TX_ID.get() != null;
+        return activeTransaction() != null;
     }
     
     /**
@@ -47,17 +47,13 @@ public final class TransactionsHolder {
                 RelationalProviderI18n.threadNotAssociatedWithTransaction,
                 Thread.currentThread().getName()));
     }
-    
-    protected static void validateAgainstActiveTransaction(String otherTxId) {
-        String expectedTxId = ACTIVE_TX_ID.get();
-        if (!otherTxId.equals(ACTIVE_TX_ID.get())) {
-            throw new RelationalProviderException(RelationalProviderI18n.threadAssociatedWithAnotherTransaction, 
-                                                  Thread.currentThread().getName(), expectedTxId, otherTxId);
-        }
-    }
-    
+   
     protected static void setActiveTxId(String txId) {
         ACTIVE_TX_ID.set(txId);
+    }
+    
+    protected static String activeTransaction() {
+        return ACTIVE_TX_ID.get();
     }
     
     protected static void clearActiveTransaction() {

--- a/persistence/modeshape-persistence-relational/src/main/resources/org/modeshape/persistence/relational/RelationalProviderI18n.properties
+++ b/persistence/modeshape-persistence-relational/src/main/resources/org/modeshape/persistence/relational/RelationalProviderI18n.properties
@@ -2,6 +2,6 @@ jndiError = Unexpected error while trying to read the '{0}' datasource from JNDI
 unsupportedDBError = Unsupported database type: '{0}'
 warnCannotCloseConnection = Cannot close DB connection for table '{0}' and transaction '{1}' because '{2}'. Turn on DEBUG logging for more information
 threadNotAssociatedWithTransaction = The current thread '{0}' does not have an active transaction.
-threadAssociatedWithAnotherTransaction = The current thread '{0}' is associated with transaction '{1}' instead of '{2}'. Make sure your transactions are confined within the originator thread !
+threadAssociatedWithAnotherTransaction = The current thread '{0}' is already associated with transaction '{1}' instead of '{2}'; this may indicate a rollback was performed off another thread
 errorPersistingChanges = Unexpected error while persisting changes for transaction '{0}'
 warnConnectionsNeedCleanup = There are '{0}' active connections which have not been released. This indicates a possible transactional issue preventing proper cleanup.


### PR DESCRIPTION
The new lock implementation uses a bare-bone `AbstractQueuedSynchronizer` implementation because in ModeShape's case locks have to be able to be unlocked from other threads than the owning threads (transaction rollbacks). The previous `ReentrantLock` implementation would obviously not work.

 This commit also changes the way the persistence stores deal with transactions: instead of holding onto the "current" transaction via a `ThreadLocal` variable, they will now rely on their internal mapping of tx ids. This is provided by ModeShape for each transaction. Therefore, thread-locality is no longer an issue.

The commit further changes some of the ways in which internal transactions are used during repository startup, making sure some operations are grouped and some - the preconfigured workspaces - are created up-front within a single transaction.