### PR TITLE
MODE-2670 Changes the logic of initializing in a cluster, removing redundant locking

### DIFF
--- a/integration/modeshape-jbossas-integration-tests/src/test/java/org/modeshape/test/integration/ClusteredConfigurationIntegrationTest.java
+++ b/integration/modeshape-jbossas-integration-tests/src/test/java/org/modeshape/test/integration/ClusteredConfigurationIntegrationTest.java
@@ -77,8 +77,8 @@ public class ClusteredConfigurationIntegrationTest {
     @Test
     @FixFor({"MODE-1923", "MODE-1929", "MODE-2226"})
     public void clusteredRepositoryShouldHaveStartedUpUsingExternalJGroupsConfigFile() throws Exception {
-        checkRepoConfiguration(clusteredRepository1, "modeshape-wf-it1", true, false);
-        checkRepoConfiguration(clusteredRepository2, "modeshape-wf-it1", true, false);
+        checkRepoConfiguration(clusteredRepository1, "modeshape-wf-it1", true, true);
+        checkRepoConfiguration(clusteredRepository2, "modeshape-wf-it1", true, true);
         checkRepoStarted(clusteredRepository1, clusteredRepository2);
     }
     

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrI18n.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrI18n.java
@@ -37,7 +37,6 @@ public final class JcrI18n {
     public static I18n repositoryCannotBeStartedWithoutTransactionalSupport;
     public static I18n unableToInitializeSystemWorkspace;
     public static I18n repositoryWasNeverInitializedAfterMinutes;
-    public static I18n repositoryWasInitializedByOtherProcess;
     public static I18n repositoryWasNeverUpgradedAfterMinutes;
     public static I18n failureDuringUpgradeOperation;
     public static I18n errorShuttingDownIndexProvider;

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/RepositoryConfiguration.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/RepositoryConfiguration.java
@@ -2321,7 +2321,7 @@ public class RepositoryConfiguration {
         }
         
         protected String getLocking() {
-            return clusteringDoc.getString(FieldName.CLUSTER_LOCKING, FieldValue.LOCKING_JGROUPS);
+            return clusteringDoc.getString(FieldName.CLUSTER_LOCKING, FieldValue.LOCKING_DB);
         }
         
         public boolean useDbLocking() {

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/RepositoryCache.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/RepositoryCache.java
@@ -15,6 +15,7 @@
  */
 package org.modeshape.jcr.cache;
 
+import java.util.Date;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
@@ -60,7 +61,6 @@ import org.modeshape.jcr.cache.document.TransactionalWorkspaceCaches;
 import org.modeshape.jcr.cache.document.WorkspaceCache;
 import org.modeshape.jcr.cache.document.WritableSessionCache;
 import org.modeshape.jcr.federation.FederatedDocumentStore;
-import org.modeshape.jcr.locking.LockingService;
 import org.modeshape.jcr.spi.federation.Connector;
 import org.modeshape.jcr.value.Name;
 import org.modeshape.jcr.value.Property;
@@ -80,7 +80,6 @@ import com.github.benmanes.caffeine.cache.Caffeine;
 public class RepositoryCache {
 
     public static final String REPOSITORY_INFO_KEY = "repository:info";
-    public static final String INITIALIZATION_LOCK = "modeshape-init-lock";
 
     private static final Logger LOGGER = Logger.getLogger(RepositoryCache.class);
 
@@ -121,23 +120,19 @@ public class RepositoryCache {
     private volatile boolean initializingRepository = false;
     private volatile boolean upgradingRepository = false;
     private int lastUpgradeId;
-    private final LockingService startupLockingService;
-    private volatile boolean isHoldingClusterLock = false;
     private final int workspaceCacheSize;
 
-    public RepositoryCache( ExecutionContext context,
-                            DocumentStore documentStore,
-                            LockingService startupLockingService,
-                            RepositoryConfiguration configuration,
-                            ContentInitializer initializer,
-                            RepositoryEnvironment repositoryEnvironment,
-                            ChangeBus changeBus,
-                            Upgrades upgradeFunctions ) {
+    public RepositoryCache(ExecutionContext context,
+                           DocumentStore documentStore,
+                           RepositoryConfiguration configuration,
+                           ContentInitializer initializer,
+                           RepositoryEnvironment repositoryEnvironment,
+                           ChangeBus changeBus,
+                           Upgrades upgradeFunctions) {
         assert initializer != null;
         this.context = context;
         this.configuration = configuration;
         this.documentStore = documentStore;
-        this.startupLockingService = startupLockingService;
         this.minimumStringLengthForBinaryStorage.set(configuration.getBinaryStorage().getMinimumStringSize());
         this.translator = new DocumentTranslator(this.context, this.documentStore, this.minimumStringLengthForBinaryStorage.get());
         this.repositoryEnvironment = repositoryEnvironment;
@@ -152,26 +147,13 @@ public class RepositoryCache {
         this.workspaceCacheSize = configuration.getWorkspaceCacheSize();
         CheckArg.isPositive(workspaceCacheSize, "workspaceCacheSize");
         
-        // if we're running in a cluster, try to acquire a global cluster lock to perform initialization or to force multiple 
-        // nodes to wait for the one performing the initialization
-        if (startupLockingService != null) {
-            int minutesToWait = 10;
-            LOGGER.debug("Waiting at most for {0} minutes while verifying the status of the '{1}' repository", minutesToWait,
-                         name);
-            waitUntil(() -> startupLockingService.tryLock(0, TimeUnit.MILLISECONDS, INITIALIZATION_LOCK), minutesToWait, TimeUnit.MINUTES,
-                      JcrI18n.repositoryWasNeverInitializedAfterMinutes);
-            LOGGER.debug("Repository '{0}' acquired clustered-wide lock for performing initialization or verifying status", name);
-            // at this point we should have a global cluster-wide lock
-            isHoldingClusterLock = true;
-        }
-
         SchematicEntry repositoryInfo = this.documentStore.localStore().get(REPOSITORY_INFO_KEY);
         boolean upgradeRequired = false;
         String databaseId = documentStore.localStore().databaseId();
         if (repositoryInfo == null) {
             // Create a UUID that we'll use as the string specifying who is doing the initialization ...
             String initializerId = UUID.randomUUID().toString();
-
+    
             // Must be a new repository (or one created before 3.0.0.Final) ...
             this.repoKey = NodeKey.keyForSourceName(this.name);
             this.sourceKey = NodeKey.keyForSourceName(databaseId);
@@ -182,24 +164,56 @@ public class RepositoryCache {
             doc.setString(REPOSITORY_KEY_FIELD_NAME, this.repoKey);
             doc.setString(REPOSITORY_SOURCE_NAME_FIELD_NAME, databaseId);
             doc.setString(REPOSITORY_SOURCE_KEY_FIELD_NAME, this.sourceKey);
-            doc.setDate(REPOSITORY_CREATED_AT_FIELD_NAME, now.toDate());
+            Date creationDate = now.toDate();
+            doc.setDate(REPOSITORY_CREATED_AT_FIELD_NAME, creationDate);
             doc.setString(REPOSITORY_INITIALIZER_FIELD_NAME, initializerId);
             doc.setString(REPOSITORY_CREATED_WITH_MODESHAPE_VERSION_FIELD_NAME, ModeShape.getVersion());
             doc.setNumber(REPOSITORY_UPGRADE_ID_FIELD_NAME, upgrades.getLatestAvailableUpgradeId());
-
-            SchematicEntry entryWrittenBySomeOtherProcess = localStore().runInTransaction(
-                    () -> this.documentStore.storeIfAbsent(REPOSITORY_INFO_KEY, doc), 0);
-            // store the repository info
-            if (entryWrittenBySomeOtherProcess != null) {
-                // if clustered, we should be holding a cluster-wide lock, so if some other process managed to write under this
-                // key smth is seriously wrong. If not clustered, only 1 thread will always perform repository initialization.
-                // in either case, this should not happen
-                throw new SystemFailureException(JcrI18n.repositoryWasInitializedByOtherProcess.text(name));
+    
+            // loop until we know for sure someone is initializing a repository
+            boolean initializerDecided = false;
+            while (!initializerDecided) {
+                LOGGER.debug("Initializer '{0}' is determining who should be initializing repository '{1}'", initializerId,
+                             name);
+                // run a transaction which writes the repository info to the DB. Note that it's possible in a cluster for someone
+                // else to have successfully written something else first
+                localStore().runInTransaction(
+                        () -> this.documentStore.storeIfAbsent(REPOSITORY_INFO_KEY, doc), 0);
+                // re-read the entry which was persisted (may be ours but may also belong to another process)
+                // note that we're not relying on the outcome of the previous method intentionally to avoid any potential DB transaction
+                // isolation issues, which could give us back our own entry even though someone else may've persisted something else
+                SchematicEntry initializerInfo = this.documentStore.get(REPOSITORY_INFO_KEY);
+                if (initializerInfo != null) {
+                    Document content = initializerInfo.content();
+                    initializingRepository = initializerId.equals(content.getString(REPOSITORY_INITIALIZER_FIELD_NAME)) &&
+                                             creationDate.equals(content.getDate(REPOSITORY_CREATED_AT_FIELD_NAME));
+                    if (initializingRepository || content.containsField(REPOSITORY_INITIALIZED_AT_FIELD_NAME)) {
+                        // we're the ones initializing or someone else has already finished
+                        initializerDecided = true;
+                    } else {
+                        // someone else is doing the initialization so wait until that completes or is rolled back
+                        AtomicBoolean isRolledBack = new AtomicBoolean(false);
+                        waitUntil(() -> {
+                            LOGGER.debug("Repository '{0}' is being initialized by another process; waiting until that finished or is rolled back");
+                            SchematicEntry persistedInitializerInfo = this.documentStore.get(REPOSITORY_INFO_KEY);
+                            if (persistedInitializerInfo == null) {
+                                isRolledBack.set(true);
+                            }
+                            return isRolledBack.get() || 
+                                   persistedInitializerInfo.content().containsField(REPOSITORY_INITIALIZED_AT_FIELD_NAME);
+                        }, 10, TimeUnit.MINUTES, JcrI18n.repositoryWasNeverInitializedAfterMinutes);
+                        // it may have been rolled back, in which case we'll try ourselves again
+                        initializerDecided = !isRolledBack.get();
+                    }
+                }
             }
-            repositoryInfo = this.documentStore.get(REPOSITORY_INFO_KEY);
-            // We're doing the initialization ...
-            initializingRepository = true;
-            LOGGER.debug("Initializing the '{0}' repository", name);
+            if (!initializingRepository) {
+                // some other process (local or in a cluster) has gotten ahead of us...
+                LOGGER.debug("Repository '{0}' has been initialized by another initializer: '{1}'", name, initializerId);
+            } else {
+                // We're doing the initialization ...
+                LOGGER.debug("Initializer '{0}' is initializing repository '{1}'", initializerId, name);
+            }
         } else {
             // Get the repository key and source key from the repository info document ...
             Document info = repositoryInfo.content();
@@ -356,27 +370,18 @@ public class RepositoryCache {
      * error occurs.
      */
     public final void rollbackRepositoryInfo() {
-        try {
-            SchematicEntry repositoryInfoEntry = this.documentStore.localStore().get(REPOSITORY_INFO_KEY);
-            if (repositoryInfoEntry != null && isInitializingRepository()) {
-                localStore().runInTransaction(() -> {
-                    Document repoInfoDoc = repositoryInfoEntry.content();
-                    // we should only remove the repository info if it wasn't initialized successfully previously
-                    // in a cluster, it may happen that another node finished initialization while this node crashed (in which case we
-                    // should not remove the entry)
-                    if (!repoInfoDoc.containsField(REPOSITORY_INITIALIZED_AT_FIELD_NAME)) {
-                        this.documentStore.localStore().remove(REPOSITORY_INFO_KEY);
-                    }
-                    return null;
-                }, 0, REPOSITORY_INFO_KEY); 
-            }
-        } finally {
-            // if we have a global cluster-wide lock, make sure its released
-            if (isHoldingClusterLock) {
-                startupLockingService.unlock(INITIALIZATION_LOCK);
-                isHoldingClusterLock = false;
-                LOGGER.debug("Repository '{0}' released clustered-wide lock after failing to start up ", name);
-            }
+        SchematicEntry repositoryInfoEntry = this.documentStore.localStore().get(REPOSITORY_INFO_KEY);
+        if (repositoryInfoEntry != null && initializingRepository) {
+            localStore().runInTransaction(() -> {
+                Document repoInfoDoc = repositoryInfoEntry.content();
+                // we should only remove the repository info if it wasn't initialized successfully previously
+                // in a cluster, it may happen that another node finished initialization while this node crashed (in which case we
+                // should not remove the entry)
+                if (!repoInfoDoc.containsField(REPOSITORY_INITIALIZED_AT_FIELD_NAME)) {
+                    this.documentStore.localStore().remove(REPOSITORY_INFO_KEY);
+                }
+                return null;
+            }, 0, REPOSITORY_INFO_KEY);
         }
     }
     
@@ -447,23 +452,14 @@ public class RepositoryCache {
     }
     
     private void writeInitializedAt() {
-        try {
-            LOGGER.debug("Marking repository '{0}' as fully initialized", name);
-            LocalDocumentStore store = documentStore().localStore();
-            EditableDocument repositoryInfo = store.edit(REPOSITORY_INFO_KEY, true);
-            if (repositoryInfo.get(REPOSITORY_INITIALIZED_AT_FIELD_NAME) == null) {
-                DateTime now = context().getValueFactories().getDateFactory().create();
-                repositoryInfo.setDate(REPOSITORY_INITIALIZED_AT_FIELD_NAME, now.toDate());
-            }
-            LOGGER.debug("Repository '{0}' is fully initialized", name);
-        } finally {
-            // if we have a global cluster-wide lock, make sure its released
-            if (isHoldingClusterLock) {
-                startupLockingService.unlock(INITIALIZATION_LOCK);
-                isHoldingClusterLock = false;
-                LOGGER.debug("Repository '{0}' released clustered-wide lock after successful startup", name);
-            }
+        LOGGER.debug("Marking repository '{0}' as fully initialized", name);
+        LocalDocumentStore store = documentStore().localStore();
+        EditableDocument repositoryInfo = store.edit(REPOSITORY_INFO_KEY, true);
+        if (repositoryInfo.get(REPOSITORY_INITIALIZED_AT_FIELD_NAME) == null) {
+            DateTime now = context().getValueFactories().getDateFactory().create();
+            repositoryInfo.setDate(REPOSITORY_INITIALIZED_AT_FIELD_NAME, now.toDate());
         }
+        LOGGER.debug("Repository '{0}' is fully initialized", name);
     }
     
     private void doUpgrade(final Upgrades.Context resources) {

--- a/modeshape-jcr/src/main/resources/org/modeshape/jcr/JcrI18n.properties
+++ b/modeshape-jcr/src/main/resources/org/modeshape/jcr/JcrI18n.properties
@@ -25,7 +25,6 @@ repositoryIsCurrentlyBeingRestored = The '{0}' repository is currently being res
 repositoryCannotBeStartedWithoutTransactionalSupport = The '{0}' repository cannot be started because no transaction manager was found in the runtime classpath. Enable DEBUG logging for more information. 
 unableToInitializeSystemWorkspace = Unable to initialize the '/jcr:system' content in repository '{0}'
 repositoryWasNeverInitializedAfterMinutes = Repository '{0}' is still not fully initialized after {1} minutes. Aborting.
-repositoryWasInitializedByOtherProcess = Repository '{0}' has been initialized by another process while holding a cluster-wide lock. Cluster seems corrupt, aborting.
 repositoryWasNeverUpgradedAfterMinutes = Repository '{0}' is still not fully upgraded after {1} minutes. SOME PROBLEMS MAY EXIST BECAUSE OF THIS.
 failureDuringUpgradeOperation = Repository '{0}' could not be upgrade due to a failure of the upgrade steps: {1}
 errorShuttingDownIndexProvider = Error while shutting down the '{1}' index provider for repository '{0}': {2}

--- a/modeshape-jcr/src/test/java/org/modeshape/jcr/TransactionsTest.java
+++ b/modeshape-jcr/src/test/java/org/modeshape/jcr/TransactionsTest.java
@@ -62,6 +62,7 @@ import javax.transaction.Status;
 import javax.transaction.SystemException;
 import javax.transaction.Transaction;
 import javax.transaction.TransactionManager;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.modeshape.common.FixFor;
 import org.modeshape.common.util.FileUtil;
@@ -490,6 +491,7 @@ public class TransactionsTest extends SingleUseAbstractTest {
 
     @Test
     @FixFor( "MODE-2495" )
+    @Ignore( "ModeShape 5 requires thread confinement" )
     public void shouldSupportMultipleThreadsChangingTheSameUserTransaction() throws Exception {
         startRepositoryWithConfigurationFrom("config/repo-config-inmemory-txn.json");
 

--- a/modeshape-jcr/src/test/java/org/modeshape/jcr/bus/AbstractChangeBusTest.java
+++ b/modeshape-jcr/src/test/java/org/modeshape/jcr/bus/AbstractChangeBusTest.java
@@ -20,16 +20,20 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentLinkedDeque;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Ignore;
@@ -218,11 +222,7 @@ public abstract class AbstractChangeBusTest {
 
         for (TestChangeSet changeSet : receivedChanges) {
             String wsName = changeSet.getWorkspaceName();
-            List<Long> receivedTimes = changeSetsPerWs.get(wsName);
-            if (receivedTimes == null) {
-                receivedTimes = new ArrayList<>();
-                changeSetsPerWs.put(wsName, receivedTimes);
-            }
+            List<Long> receivedTimes = changeSetsPerWs.computeIfAbsent(wsName, k -> new ArrayList<>());
             for (Long receivedTime : receivedTimes) {
                 assertTrue(receivedTime <= changeSet.time());
             }
@@ -327,33 +327,41 @@ public abstract class AbstractChangeBusTest {
         public String getUUID() {
             return uuid;
         }
-
+    
         @Override
-        public boolean equals( Object o ) {
+        public boolean equals(Object o) {
             if (this == o) {
                 return true;
             }
-            if (!(o instanceof TestChangeSet)) {
+            if (o == null || getClass() != o.getClass()) {
                 return false;
             }
-
-            TestChangeSet other = (TestChangeSet)o;
-            return this.uuid.equals(other.uuid); 
+            TestChangeSet changes = (TestChangeSet) o;
+            return Objects.equals(workspaceName, changes.workspaceName) &&
+                   Objects.equals(uuid, changes.uuid);
         }
-
+    
         @Override
         public int hashCode() {
-            int result = workspaceName.hashCode();
-            result = 31 * result + (int)(time ^ (time >>> 32));
-            return result;
+            return Objects.hash(workspaceName, uuid);
+        }
+    
+        @Override
+        public String toString() {
+            final StringBuilder sb = new StringBuilder("changes[");
+            sb.append("workspaceName='").append(workspaceName).append('\'');
+            sb.append(", time=").append(time);
+            sb.append(", uuid='").append(uuid).append('\'');
+            sb.append(']');
+            return sb.toString();
         }
     }
 
     protected static class TestListener implements ChangeSetListener {
-        private final List<TestChangeSet> receivedChangeSet;
+        private final ConcurrentLinkedDeque<TestChangeSet> receivedChangeSet;
         private final long timeoutMillis;
-        private int expectedNumberOfEvents;
-        private CountDownLatch latch;
+        private final int expectedNumberOfEvents;
+        private final CountDownLatch latch;
 
         protected TestListener() {
             this(0);
@@ -366,27 +374,21 @@ public abstract class AbstractChangeBusTest {
         protected TestListener( int expectedNumberOfEvents,
                                 long timeoutMillis ) {
             this.latch = new CountDownLatch(expectedNumberOfEvents);
-            this.receivedChangeSet = new ArrayList<>();
+            this.receivedChangeSet = new ConcurrentLinkedDeque<>();
             this.timeoutMillis = timeoutMillis;
             this.expectedNumberOfEvents = expectedNumberOfEvents;
         }
 
-        public synchronized void expectChangeSet( int expectedNumberOfEvents ) {
-            this.latch = new CountDownLatch(expectedNumberOfEvents);
-            this.expectedNumberOfEvents = expectedNumberOfEvents;
-            receivedChangeSet.clear();
-        }
-
         @Override
-        public synchronized void notify( ChangeSet changeSet ) {
+        public void notify( ChangeSet changeSet ) {
             if (!(changeSet instanceof TestChangeSet)) {
                 throw new IllegalArgumentException("Invalid type of change set received");
             }
             receivedChangeSet.add((TestChangeSet)changeSet);
             latch.countDown();
         }
-
-        public void assertExpectedEventsCount() {
+    
+        protected void assertExpectedEventsCount() {
             try {
                 assertTrue("Not enough events received", latch.await(timeoutMillis, TimeUnit.MILLISECONDS));
                 assertEquals("Incorrect number of events received", expectedNumberOfEvents, receivedChangeSet.size());
@@ -395,9 +397,36 @@ public abstract class AbstractChangeBusTest {
                 fail("Interrupted while waiting to verify event count");
             }
         }
+    
+        protected void assertExpectedEvents(ChangeSet...changes) {
+            if (expectedNumberOfEvents != changes.length) {
+                fail("The expected number of events must match what you expect. Fix the test");
+            }
+            if (changes.length == 0) {
+                try {
+                    Thread.sleep(timeoutMillis);
+                } catch (InterruptedException e) {
+                    Thread.interrupted();
+                }
+                assertTrue(assertNoEvents());
+                return;
+            }
+            assertExpectedEventsCount();
+            List<TestChangeSet> actualChanges = getObservedChangeSet();
+            assertEquals("Incorrect number of changes received", changes.length, actualChanges.size());
+            receivedChangeSet.forEach(change -> assertTrue(actualChanges.contains(change)));
+        }
 
-        public synchronized List<TestChangeSet> getObservedChangeSet() {
-            return new ArrayList<>(receivedChangeSet);
+        protected List<TestChangeSet> getObservedChangeSet() {
+            return receivedChangeSet.stream().collect(Collectors.toList());
+        }
+       
+        protected boolean assertNoEvents() {
+            return receivedChangeSet.isEmpty();
+        }
+        
+        protected void clear() {
+            receivedChangeSet.clear();
         }
     }
 }

--- a/modeshape-jcr/src/test/java/org/modeshape/jcr/bus/ClusteredChangeBusTest.java
+++ b/modeshape-jcr/src/test/java/org/modeshape/jcr/bus/ClusteredChangeBusTest.java
@@ -16,8 +16,6 @@
 
 package org.modeshape.jcr.bus;
 
-import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
@@ -29,6 +27,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.modeshape.jcr.ClusteringHelper;
 import org.modeshape.jcr.cache.change.ChangeSet;
+import org.modeshape.jcr.cache.change.ChangeSetListener;
 import org.modeshape.jcr.clustering.ClusteringService;
 
 /**
@@ -71,240 +70,85 @@ public class ClusteredChangeBusTest extends AbstractChangeBusTest {
             executorService.shutdownNow();
         }
     }
-
+    
     @Test
-    public void shouldSendChangeSetThroughCluster() throws Exception {
+    public void oneBusShouldNotifyRegisteredListeners() throws Exception {
         // Create three observers ...
-        TestListener listener1 = new TestListener();
-        TestListener listener2 = new TestListener();
-        TestListener listener3 = new TestListener();
-
-        // Create three buses using a real JGroups cluster ...
-        ClusteredChangeBus bus1 = startNewBus(0);
-        bus1.register(listener1);
-        // ------------------------------------
+        TestListener listener1 = new TestListener(1);
+        
+        startBusWithRegisteredListener(listener1);
+       
         // Send a change from the first bus ...
-        // ------------------------------------
-
-        // Set the observers to expect one event ...
-        listener1.expectChangeSet(1);
-        listener2.expectChangeSet(0); // shutdown
-        listener3.expectChangeSet(0); // shutdown
-
-        // Send changeSet to one of the buses ...
         ChangeSet changeSet = new TestChangeSet("ws1");
-        bus1.notify(changeSet);
-
-        // Wait for the observers to be notified ...
-        listener1.assertExpectedEventsCount();
-        listener2.assertExpectedEventsCount();
-        listener3.assertExpectedEventsCount();
-
-        // Now verify that all of the observers received the notification ...
-        assertThat(listener1.getObservedChangeSet().size(), is(1));
-        assertThat(listener2.getObservedChangeSet().size(), is(0));
-        assertThat(listener3.getObservedChangeSet().size(), is(0));
-        assertThat(listener1.getObservedChangeSet().get(0), is(changeSet));
-
-        // ------------------------------------
-        // Create a second bus ...
-        // ------------------------------------
-        ClusteredChangeBus bus2 = startNewBus(1);
-        bus2.register(listener2);
-
-        // ------------------------------------
-        // Send a change from the first bus ...
-        // ------------------------------------
-
-        // Set the observers to expect one event ...
-        listener1.expectChangeSet(1);
-        listener2.expectChangeSet(1);
-        listener3.expectChangeSet(0); // shutdown
-
-        // Send changeSet to one of the buses ...
-        changeSet = new TestChangeSet("ws1");
-        bus1.notify(changeSet);
-
-        // Wait for the observers to be notified ...
-        listener1.assertExpectedEventsCount();
-        listener2.assertExpectedEventsCount();
-        listener3.assertExpectedEventsCount();
-
-        // Now verify that all of the observers received the notification ...
-        assertThat(listener1.getObservedChangeSet().size(), is(1));
-        assertThat(listener2.getObservedChangeSet().size(), is(1));
-        assertThat(listener3.getObservedChangeSet().size(), is(0));
-        assertThat(listener1.getObservedChangeSet().get(0), is(changeSet));
-        assertThat(listener2.getObservedChangeSet().get(0), is(changeSet));
-
-        // ------------------------------------
-        // Send a change from the second bus ...
-        // ------------------------------------
-
-        // Set the observers to expect one event ...
-        listener1.expectChangeSet(1);
-        listener2.expectChangeSet(1);
-        listener3.expectChangeSet(0); // shutdown
-
-        // Send changeSet to one of the buses ...
-        changeSet = new TestChangeSet("ws2");
-        bus2.notify(changeSet);
-
-        // Wait for the observers to be notified ...
-        listener1.assertExpectedEventsCount();
-        listener2.assertExpectedEventsCount();
-        listener3.assertExpectedEventsCount();
-
-        // Now verify that all of the observers received the notification ...
-        assertThat(listener1.getObservedChangeSet().size(), is(1));
-        assertThat(listener2.getObservedChangeSet().size(), is(1));
-        assertThat(listener3.getObservedChangeSet().size(), is(0));
-        assertThat(listener1.getObservedChangeSet().get(0), is(changeSet));
-        assertThat(listener2.getObservedChangeSet().get(0), is(changeSet));
-
-        // ------------------------------------
-        // Create a third bus ...
-        // ------------------------------------
-        ClusteredChangeBus bus3 = startNewBus(2);
-        bus3.register(listener3);
-        // ------------------------------------
-        // Send a change from the first bus ...
-        // ------------------------------------
-
-        // Set the observers to expect one event ...
-        listener1.expectChangeSet(1);
-        listener2.expectChangeSet(1);
-        listener3.expectChangeSet(1);
-
-        // Send changeSet to one of the buses ...
-        changeSet = new TestChangeSet("ws1");
-        bus1.notify(changeSet);
-
-        // Wait for the observers to be notified ...
-        listener1.assertExpectedEventsCount();
-        listener2.assertExpectedEventsCount();
-        listener3.assertExpectedEventsCount();
-
-        // Now verify that all of the observers received the notification ...
-        assertThat(listener1.getObservedChangeSet().size(), is(1));
-        assertThat(listener2.getObservedChangeSet().size(), is(1));
-        assertThat(listener3.getObservedChangeSet().size(), is(1));
-        assertThat(listener1.getObservedChangeSet().get(0), is(changeSet));
-        assertThat(listener2.getObservedChangeSet().get(0), is(changeSet));
-        assertThat(listener3.getObservedChangeSet().get(0), is(changeSet));
-
-        // -------------------------------------
-        // Send a change from the second bus ...
-        // -------------------------------------
-
-        // Set the observers to expect one event ...
-        listener1.expectChangeSet(1);
-        listener2.expectChangeSet(1);
-        listener3.expectChangeSet(1);
-
-        // Send changeSet to one of the buses ...
-        ChangeSet changeSet2 = new TestChangeSet("ws2");
-        bus2.notify(changeSet2);
-
-        // Wait for the observers to be notified ...
-        listener1.assertExpectedEventsCount();
-        listener2.assertExpectedEventsCount();
-        listener3.assertExpectedEventsCount();
-
-        // Now verify that all of the observers received the notification ...
-        assertThat(listener1.getObservedChangeSet().size(), is(1));
-        assertThat(listener2.getObservedChangeSet().size(), is(1));
-        assertThat(listener3.getObservedChangeSet().size(), is(1));
-        assertThat(listener1.getObservedChangeSet().get(0), is(changeSet2));
-        assertThat(listener2.getObservedChangeSet().get(0), is(changeSet2));
-        assertThat(listener3.getObservedChangeSet().get(0), is(changeSet2));
-
-        // ------------------------------------
-        // Send a change from the third bus ...
-        // ------------------------------------
-
-        // Set the observers to expect one event ...
-        listener1.expectChangeSet(1);
-        listener2.expectChangeSet(1);
-        listener3.expectChangeSet(1);
-
-        // Send changeSet to one of the buses ...
-        ChangeSet changeSet3 = new TestChangeSet("ws3");
-        bus3.notify(changeSet3);
-
-        // Wait for the observers to be notified ...
-        listener1.assertExpectedEventsCount();
-        listener2.assertExpectedEventsCount();
-        listener3.assertExpectedEventsCount();
-
-        // Now verify that all of the observers received the notification ...
-        assertThat(listener1.getObservedChangeSet().size(), is(1));
-        assertThat(listener2.getObservedChangeSet().size(), is(1));
-        assertThat(listener3.getObservedChangeSet().size(), is(1));
-        assertThat(listener1.getObservedChangeSet().get(0), is(changeSet3));
-        assertThat(listener2.getObservedChangeSet().get(0), is(changeSet3));
-        assertThat(listener3.getObservedChangeSet().get(0), is(changeSet3));
-
-        // ---------------------------------------
-        // Stop the buses! I want to get off! ...
-        // ---------------------------------------
-        bus3.shutdown();
-        // ------------------------------------
-        // Send a change from the second bus ...
-        // ------------------------------------
-
-        // Set the observers to expect one event ...
-        listener1.expectChangeSet(1);
-        listener2.expectChangeSet(1);
-        listener3.expectChangeSet(0); // shutdown
-
-        // Send changeSet to one of the buses ...
-        changeSet = new TestChangeSet("ws2");
-        bus2.notify(changeSet);
-
-        // Wait for the observers to be notified ...
-        listener1.assertExpectedEventsCount();
-        listener2.assertExpectedEventsCount();
-        listener3.assertExpectedEventsCount();
-
-        // Now verify that all of the observers received the notification ...
-        assertThat(listener1.getObservedChangeSet().size(), is(1));
-        assertThat(listener2.getObservedChangeSet().size(), is(1));
-        assertThat(listener3.getObservedChangeSet().size(), is(0));
-        assertThat(listener1.getObservedChangeSet().get(0), is(changeSet));
-        assertThat(listener2.getObservedChangeSet().get(0), is(changeSet));
-
-        bus2.shutdown();
-        // ------------------------------------
-        // Send a change from the first bus ...
-        // ------------------------------------
-
-        // Set the observers to expect one event ...
-        listener1.expectChangeSet(1);
-        listener2.expectChangeSet(0); // shutdown
-        listener3.expectChangeSet(0); // shutdown
-
-        // Send changeSet to one of the buses ...
-        changeSet = new TestChangeSet("ws1");
-        bus1.notify(changeSet);
-
-        // Wait for the observers to be notified ...
-        listener1.assertExpectedEventsCount();
-        listener2.assertExpectedEventsCount();
-        listener3.assertExpectedEventsCount();
-
-        // Now verify that all of the observers received the notification ...
-        assertThat(listener1.getObservedChangeSet().size(), is(1));
-        assertThat(listener2.getObservedChangeSet().size(), is(0));
-        assertThat(listener3.getObservedChangeSet().size(), is(0));
-        assertThat(listener1.getObservedChangeSet().get(0), is(changeSet));
+        ChangeBus bus1 = buses.get(1);
+        bus1.notify(changeSet);          
+      
+        listener1.assertExpectedEvents(changeSet);
     }
-
+    
+    @Test
+    public void twoBusesShouldNotifyEachOther() throws Exception {
+        // Create three observers ...
+        TestListener listener1 = new TestListener(2);
+        TestListener listener2 = new TestListener(2);
+   
+        startBusWithRegisteredListener(listener1, listener2);
+    
+        // Send changeSet to one of the buses ...
+        ChangeSet changeSet1 = new TestChangeSet("bus1");
+        buses.get(1).notify(changeSet1);
+    
+        ChangeSet changeSet2 = new TestChangeSet("bus2");
+        buses.get(2).notify(changeSet2);    
+        
+        // Wait for the observers to be notified ...
+        listener1.assertExpectedEvents(changeSet1, changeSet2);
+        listener2.assertExpectedEvents(changeSet1, changeSet2);
+    } 
+    
+    @Test
+    public void shouldNotSendChangesIfBusIsShutdown() throws Exception {
+        // Create three observers ...
+        TestListener listener1 = new TestListener(1);
+        TestListener listener2 = new TestListener(1);
+        TestListener listener3 = new TestListener(1);
+    
+        startBusWithRegisteredListener(listener1, listener2, listener3);    
+      
+        // Send changeSet to one of the buses ...
+        ChangeSet changeSet = new TestChangeSet("bus3");
+        buses.get(3).notify(changeSet);
+        
+        listener1.assertExpectedEvents(changeSet);
+        listener2.assertExpectedEvents(changeSet);
+        listener3.assertExpectedEvents(changeSet);
+    
+        // shut down buses
+        buses.get(3).shutdown();
+        buses.get(2).shutdown();
+        
+        listener3.clear();
+        listener2.clear();
+        
+        changeSet = new TestChangeSet("bus1");
+        buses.get(1).notify(changeSet);
+    
+        listener2.assertNoEvents();
+        listener3.assertNoEvents();
+    }
+    
     private ClusteredChangeBus startNewBus(int clusteringServiceIdx) throws Exception {
         ChangeBus internalBus = new RepositoryChangeBus("repo", executorService);
         ClusteredChangeBus bus = new ClusteredChangeBus(internalBus, clusteringServices.get(clusteringServiceIdx));
         bus.start();
         buses.add(bus);
         return bus;
+    }
+    
+    private void startBusWithRegisteredListener(ChangeSetListener... listeners) throws Exception {
+        for (int i = 0; i < listeners.length; i++) {
+            ClusteredChangeBus bus = startNewBus(i);
+            bus.register(listeners[i]);
+        }
     }
 }

--- a/modeshape-schematic/src/main/java/org/modeshape/schematic/document/Document.java
+++ b/modeshape-schematic/src/main/java/org/modeshape/schematic/document/Document.java
@@ -16,6 +16,7 @@
 package org.modeshape.schematic.document;
 
 import java.io.Serializable;
+import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
@@ -247,6 +248,13 @@ public interface Document extends Serializable {
      * @return The {@link Binary} field value, if found, or null if there is no such pair or if the value is not a {@link Binary}
      */
     Binary getBinary( String name );
+    /**
+     * Get the {@link Date} value in this document for the given field name.
+     * 
+     * @param name The name of the pair
+     * @return The {@link Date} field value, if found, or null if there is no such pair or if the value is not a {@link Date}
+     */
+    Date getDate( String name );
 
     /**
      * Get the {@link Symbol} value in this document for the given field name.

--- a/modeshape-schematic/src/main/java/org/modeshape/schematic/internal/document/ArrayEditor.java
+++ b/modeshape-schematic/src/main/java/org/modeshape/schematic/internal/document/ArrayEditor.java
@@ -251,7 +251,12 @@ public class ArrayEditor implements EditableArray {
     public Binary getBinary( String name ) {
         return array.getBinary(name);
     }
-
+    
+    @Override
+    public Date getDate(String name) {
+        return array.getDate(name);
+    }
+    
     @Override
     public Symbol getSymbol( String name ) {
         return array.getSymbol(name);

--- a/modeshape-schematic/src/main/java/org/modeshape/schematic/internal/document/BasicArray.java
+++ b/modeshape-schematic/src/main/java/org/modeshape/schematic/internal/document/BasicArray.java
@@ -19,6 +19,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedList;
@@ -449,7 +450,13 @@ public class BasicArray implements MutableArray {
         Object value = get(name);
         return (value instanceof Binary) ? (Binary)value : null;
     }
-
+    
+    @Override
+    public Date getDate(String name) {
+        Object value = get(name);
+        return (value instanceof Date) ? (Date) value : null;
+    }
+    
     @Override
     public Symbol getSymbol( String name ) {
         Object value = get(name);

--- a/modeshape-schematic/src/main/java/org/modeshape/schematic/internal/document/BasicDocument.java
+++ b/modeshape-schematic/src/main/java/org/modeshape/schematic/internal/document/BasicDocument.java
@@ -16,6 +16,7 @@
 package org.modeshape.schematic.internal.document;
 
 import java.util.Collections;
+import java.util.Date;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -221,7 +222,13 @@ public class BasicDocument extends LinkedHashMap<String, Object> implements Muta
         Object value = get(name);
         return (value instanceof Number) ? (Number)value : defaultValue;
     }
-
+    
+    @Override
+    public Date getDate(String name) {
+        Object value = get(name);
+        return (value instanceof Date) ? (Date)value : null;
+    }
+    
     @Override
     public String getString( String name ) {
         return getString(name, null);

--- a/modeshape-schematic/src/main/java/org/modeshape/schematic/internal/document/DocumentEditor.java
+++ b/modeshape-schematic/src/main/java/org/modeshape/schematic/internal/document/DocumentEditor.java
@@ -211,7 +211,12 @@ public class DocumentEditor implements EditableDocument {
                              Number defaultValue ) {
         return document.getNumber(name, defaultValue);
     }
-
+    
+    @Override
+    public Date getDate(String name) {
+        return document.getDate(name);
+    }
+    
     @Override
     public String getString( String name ) {
         return document.getString(name);


### PR DESCRIPTION
This commit also changes the default locking method in a cluster to be DB locking, which is far more reliable than JGroups. That latter has been deprecated (code wise) and will be removed in the next major version.