### PR TITLE
MODE-2673: add missing argument to [threadAssociatedWithAnotherTransaction] i18n key.

### DIFF
--- a/persistence/modeshape-persistence-relational/src/main/java/org/modeshape/persistence/relational/RelationalDb.java
+++ b/persistence/modeshape-persistence-relational/src/main/java/org/modeshape/persistence/relational/RelationalDb.java
@@ -307,7 +307,8 @@ public class RelationalDb implements SchematicDb {
         logDebug("New transaction '{0}' started by ModeShape...", id);
         String activeTx = TransactionsHolder.activeTransaction(); 
         if (activeTx != null && !activeTx.equals(id)) {
-            LOGGER.warn(RelationalProviderI18n.threadAssociatedWithAnotherTransaction, activeTx, id);
+            LOGGER.warn(RelationalProviderI18n.threadAssociatedWithAnotherTransaction,
+                    Thread.currentThread().getName(), activeTx, id);
         }
         // mark the current thread as linked to a tx...
         TransactionsHolder.setActiveTxId(id);


### PR DESCRIPTION
Adding a name of the current thread may be a bit redundant, since logger can be typically configured to provide the name of the thread in which a given event was triggered, however, it certainly does not hurt to be a bit more verbose in this particular case.