### PR TITLE
MODE-2672 Fixes the handling of node removals spanning multiple session saves via the same user transaction

### DIFF
--- a/modeshape-jcr/src/main/java/org/modeshape/connector/filesystem/LegacySidecarExtraPropertyStore.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/connector/filesystem/LegacySidecarExtraPropertyStore.java
@@ -355,7 +355,7 @@ class LegacySidecarExtraPropertyStore implements ExtraPropertiesStore {
             }
         }
         if (values.isEmpty()) return null;
-        return propertyFactory.create(name, type, values);
+        return propertyFactory.create(name, type, values.size() > 1 ? values : values.get(0));
     }
 
     @Override

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/AbstractJcrNode.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/AbstractJcrNode.java
@@ -28,6 +28,7 @@ import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -3527,7 +3528,24 @@ abstract class AbstractJcrNode extends AbstractJcrItem implements Node {
             return e.getMessage();
         }
     }
-
+    
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof AbstractJcrNode)) {
+            return false;
+        }
+        AbstractJcrNode that = (AbstractJcrNode) o;
+        return Objects.equals(key, that.key);
+    }
+    
+    @Override
+    public int hashCode() {
+        return Objects.hash(key);
+    }
+    
     /**
      * Determines whether this node, or any nodes below it, contain changes that depend on nodes that are outside of this node's
      * hierarchy.

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrSession.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrSession.java
@@ -1178,9 +1178,7 @@ public class JcrSession implements org.modeshape.jcr.api.Session {
         try {
             cache().save(systemContent.cache(),
                          new JcrPreSave(systemContent, baseVersionKeys, originalVersionKeys, aclChangesCount()));
-            this.baseVersionKeys.set(null);
-            this.originalVersionKeys.set(null);
-            this.aclChangesCount.set(0);
+            clearState();
         } catch (WrappedException e) {
             Throwable cause = e.getCause();
             throw (cause instanceof RepositoryException) ? (RepositoryException)cause : new RepositoryException(e.getCause());
@@ -1205,7 +1203,16 @@ public class JcrSession implements org.modeshape.jcr.api.Session {
             // The repository has been shutdown ...
         }
     }
-
+    
+    private void clearState() {
+        this.cache.clear();
+        this.baseVersionKeys.set(null);
+        this.originalVersionKeys.set(null);
+        this.aclChangesCount.set(0);
+        this.jcrNodes.clear();
+        this.shareableNodeCache().clear();
+    }
+    
     /**
      * Save a subset of the changes made within this session.
      *
@@ -1281,8 +1288,7 @@ public class JcrSession implements org.modeshape.jcr.api.Session {
     public void refresh( boolean keepChanges ) throws RepositoryException {
         checkLive();
         if (!keepChanges) {
-            cache.clear();
-            aclChangesCount.set(0);
+           clearState();
         }
         // Otherwise there is nothing to do, as all persistent changes are always immediately visible to all sessions
         // using that same workspace

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrSharedNodeCache.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrSharedNodeCache.java
@@ -50,7 +50,7 @@ import org.modeshape.jcr.value.Path;
  */
 final class JcrSharedNodeCache {
 
-    private final ConcurrentMap<NodeKey, SharedSet> sharedSets = new ConcurrentHashMap<NodeKey, SharedSet>();
+    private final ConcurrentMap<NodeKey, SharedSet> sharedSets = new ConcurrentHashMap<>();
 
     protected final JcrSession session;
 
@@ -70,13 +70,11 @@ final class JcrSharedNodeCache {
      */
     public SharedSet getSharedSet( AbstractJcrNode shareableNode ) {
         NodeKey shareableNodeKey = shareableNode.key();
-        SharedSet sharedSet = sharedSets.get(shareableNodeKey);
-        if (sharedSet == null) {
-            SharedSet newSharedSet = new SharedSet(shareableNode);
-            sharedSet = sharedSets.putIfAbsent(shareableNodeKey, newSharedSet);
-            if (sharedSet == null) sharedSet = newSharedSet;
-        }
-        return sharedSet;
+        return sharedSets.computeIfAbsent(shareableNodeKey, key -> new SharedSet(shareableNode));
+    }
+    
+    protected void clear() {
+        sharedSets.clear();
     }
 
     /**

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrVersionHistoryNode.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrVersionHistoryNode.java
@@ -187,7 +187,7 @@ final class JcrVersionHistoryNode extends JcrSystemNode implements VersionHistor
         throws ReferentialIntegrityException, AccessDeniedException, UnsupportedRepositoryOperationException, VersionException,
         RepositoryException {
 
-        assert versionToBeRemoved.getParent() == this;
+        assert versionToBeRemoved.getParent().equals(this);
 
         if (versionToBeRemoved.getName().equalsIgnoreCase(JcrLexicon.ROOT_VERSION.getString())) {
             //the root version should not be removed

--- a/modeshape-jcr/src/test/java/org/modeshape/jcr/SequencingTest.java
+++ b/modeshape-jcr/src/test/java/org/modeshape/jcr/SequencingTest.java
@@ -17,11 +17,11 @@ package org.modeshape.jcr;
 
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsNull.notNullValue;
-import static org.hamcrest.core.IsSame.sameInstance;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
+
 import java.io.InputStream;
 import javax.jcr.Node;
 import org.junit.Test;
@@ -127,7 +127,7 @@ public class SequencingTest extends AbstractSequencerTest {
         // Now verify that the test sequencer created a node ...
         Node derivedNode = getOutputNode("/foo/" + TestSequencersHolder.DERIVED_NODE_NAME);
         assertNotNull(derivedNode);
-        assertThat(derivedNode.getParent(), is(sameInstance(foo)));
+        assertThat(derivedNode.getParent(), is(foo));
     }
 
     @Test

--- a/modeshape-jcr/src/test/java/org/modeshape/jcr/ShareableNodesTest.java
+++ b/modeshape-jcr/src/test/java/org/modeshape/jcr/ShareableNodesTest.java
@@ -335,6 +335,7 @@ public class ShareableNodesTest extends SingleUseAbstractTest {
         assertSharedSetIs(sharedNode, originalPath, sharedPath);
 
         // Remove the node from Joe ..
+        minibus = session.getNode("/NewSecondArea/Joe/Type 2");
         minibus.remove();
         session.save();
     }

--- a/persistence/modeshape-persistence-relational/src/main/java/org/modeshape/persistence/relational/DefaultStatements.java
+++ b/persistence/modeshape-persistence-relational/src/main/java/org/modeshape/persistence/relational/DefaultStatements.java
@@ -24,6 +24,7 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
@@ -124,7 +125,7 @@ public class DefaultStatements implements Statements {
     }
     
     @Override
-    public <R> List<R> load( Connection connection, List<String> ids, Function<Document, R> parser ) throws SQLException {
+    public <R> List<R> load(Connection connection, Collection<String> ids, Function<Document, R> parser) throws SQLException {
         if (logger.isDebugEnabled()) {
             logger.debug("Loading ids {0} from {1}", ids.toString(), tableName());
         }

--- a/persistence/modeshape-persistence-relational/src/main/java/org/modeshape/persistence/relational/Statements.java
+++ b/persistence/modeshape-persistence-relational/src/main/java/org/modeshape/persistence/relational/Statements.java
@@ -17,6 +17,7 @@ package org.modeshape.persistence.relational;
 
 import java.sql.Connection;
 import java.sql.SQLException;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
@@ -96,13 +97,13 @@ public interface Statements {
      * </p>
      *
      * @param connection a {@link Connection} instance; may not be null
-     * @param ids a {@link List} of ids; may not be null
+     * @param ids a {@link Collection} of ids; may not be null
      * @param parser a {@link Function} which is used to transform or process each of documents corresponding to the given IDS; 
      * may not be null
      * @return a {@link List} of {@code Object} instances for each of the ids which were found in the DB; never {@code null}
      * @throws SQLException if the operation fails.
      */
-    <R> List<R> load( Connection connection, List<String> ids, Function<Document, R> parser) throws SQLException;
+    <R> List<R> load(Connection connection, Collection<String> ids, Function<Document, R> parser) throws SQLException;
 
     /**
      * Starts a batch update operation with the given connection.


### PR DESCRIPTION
The problem was that the `RelationalDb` was incorrectly sending back a "dummy" document which had no ID causing subsequent failures.

This commit contains an additional (unrelated) change which clears the internal `JcrSession` state after a successful `save` or `refresh`. This should ensure better memory handling as it does not keep "hydrated" JCR node references in the internal cache