### PR TITLE
MODE-2678 Changes the DatabaseBinaryStore to use  transactions instead of auto-committed connections

### DIFF
--- a/modeshape-jcr/src/test/java/org/modeshape/jcr/value/binary/DatabaseBinaryStoreTest.java
+++ b/modeshape-jcr/src/test/java/org/modeshape/jcr/value/binary/DatabaseBinaryStoreTest.java
@@ -15,13 +15,23 @@
  */
 package org.modeshape.jcr.value.binary;
 
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.io.InputStream;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.modeshape.common.FixFor;
+import org.modeshape.common.util.IoUtil;
 import org.modeshape.common.util.StringUtil;
 import org.modeshape.jcr.store.DataSourceConfig;
 import org.modeshape.jcr.value.BinaryValue;
@@ -71,5 +81,30 @@ public class DatabaseBinaryStoreTest extends AbstractBinaryStoreTest {
         String largeString = StringUtil.createString('x', Database.DEFAULT_MAX_EXTRACTED_TEXT_LENGTH + 1);
         store.storeExtractedText(res, largeString);
         assertEquals(largeString.substring(0, Database.DEFAULT_MAX_EXTRACTED_TEXT_LENGTH), store.getExtractedText(res));
+    }
+    
+    @Test
+    @FixFor( "MODE-2678" )
+    public void shouldHandleMultipleThreadsStoringTheSameBinary() throws Exception {
+        int count = 3;
+        ExecutorService executorService = Executors.newFixedThreadPool(count);
+        try {
+            BinaryStore binaryStore = getBinaryStore();
+            List<CompletableFuture<Void>> tasks = IntStream.range(0, count)
+                     .mapToObj(i -> CompletableFuture.runAsync(() -> {
+                         try {
+                             binaryStore.storeValue(
+                                     new ByteArrayInputStream(STORED_MEDIUM_BINARY), false);
+                         } catch (BinaryStoreException e) {
+                             throw new RuntimeException(e);
+                         }
+                     }, executorService))
+                    .collect(Collectors.toList());
+            tasks.forEach(CompletableFuture::join);                     
+            InputStream is = binaryStore.getInputStream(STORED_MEDIUM_KEY);
+            assertArrayEquals(STORED_MEDIUM_BINARY, IoUtil.readBytes(is));
+        } finally {
+            executorService.shutdown();        
+        }
     }
 }


### PR DESCRIPTION
It also fixes the case of multiple cluster nodes inserting the same binary simultaneously in the database.