### PR TITLE
MODE-2684 Removes the compile time dependency of modeshape-core towards Apache Tika

### DIFF
--- a/deploy/jbossas/kit/jboss-wf/org/modeshape/main/module.xml
+++ b/deploy/jbossas/kit/jboss-wf/org/modeshape/main/module.xml
@@ -37,7 +37,7 @@
         <!-- for the DB binary store -->
         <module name="org.jgroups" slot="${jgroups.module.slot}"/>
 
-        <module name="org.apache.tika" slot="${version.org.apache.tika}" services="import"/>
+        <module name="org.apache.tika" slot="${version.org.apache.tika}" services="import" optional="true"/>
 
         <!-- For naming ... -->
         <module name="javax.api" export="true"/>

--- a/extractors/modeshape-extractor-tika/src/test/java/org/modeshape/extractor/tika/TikaTextExtractorTest.java
+++ b/extractors/modeshape-extractor-tika/src/test/java/org/modeshape/extractor/tika/TikaTextExtractorTest.java
@@ -41,7 +41,7 @@ import org.modeshape.common.util.FileUtil;
 import org.modeshape.common.util.IoUtil;
 import org.modeshape.jcr.InMemoryTestBinary;
 import org.modeshape.jcr.LocalEnvironment;
-import org.modeshape.jcr.mimetype.ContentDetector;
+import org.modeshape.jcr.mimetype.tika.TikaContentDetector;
 import org.modeshape.jcr.mimetype.MimeTypeDetector;
 import org.modeshape.jcr.text.TextExtractorContext;
 import org.modeshape.jcr.text.TextExtractorOutput;
@@ -51,7 +51,7 @@ import org.modeshape.jcr.text.TextExtractorOutput;
  */
 public class TikaTextExtractorTest {
 
-    private static final MimeTypeDetector DETECTOR = new ContentDetector(new LocalEnvironment());
+    private static final MimeTypeDetector DETECTOR = new TikaContentDetector(new LocalEnvironment());
     private static final int DEFAULT_TIKA_WRITE_LIMIT = 100000;
     private static final String CHARS = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ";
     private static final Random RANDOM = new Random();

--- a/modeshape-jcr/pom.xml
+++ b/modeshape-jcr/pom.xml
@@ -65,6 +65,7 @@
         <dependency>
             <groupId>org.apache.tika</groupId>
             <artifactId>tika-core</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.tika</groupId>

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/RepositoryConfiguration.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/RepositoryConfiguration.java
@@ -54,10 +54,8 @@ import org.modeshape.jcr.api.index.IndexDefinition;
 import org.modeshape.jcr.api.index.IndexDefinition.IndexKind;
 import org.modeshape.jcr.api.txn.TransactionManagerLookup;
 import org.modeshape.jcr.index.local.LocalIndexProvider;
-import org.modeshape.jcr.mimetype.ContentDetector;
 import org.modeshape.jcr.mimetype.MimeTypeDetector;
-import org.modeshape.jcr.mimetype.NameOnlyDetector;
-import org.modeshape.jcr.mimetype.NullMimeTypeDetector;
+import org.modeshape.jcr.mimetype.MimeTypeDetectors;
 import org.modeshape.jcr.security.AnonymousProvider;
 import org.modeshape.jcr.security.JaasProvider;
 import org.modeshape.jcr.txn.DefaultTransactionManagerLookup;
@@ -1236,23 +1234,11 @@ public class RepositoryConfiguration {
         public String getType() {
             return binaryStorage.getString(FieldName.TYPE, FieldValue.BINARY_STORAGE_TYPE_TRANSIENT);
         }
-        
+    
         protected MimeTypeDetector getMimeTypeDetector(Environment environment) {
-            String mimeTypeDetection = binaryStorage.getString(FieldName.MIMETYPE_DETECTION, FieldValue.MIMETYPE_DETECTION_CONTENT);
-            switch (mimeTypeDetection.toLowerCase()) {
-                case FieldValue.MIMETYPE_DETECTION_CONTENT: {
-                    return new ContentDetector(environment);
-                }
-                case FieldValue.MIMETYPE_DETECTION_NAME: {
-                    return new NameOnlyDetector(environment);
-                }
-                case FieldValue.MIMETYPE_DETECTION_NONE: {
-                    return NullMimeTypeDetector.INSTANCE;
-                }
-                default: {
-                    throw new IllegalArgumentException("Unknown mime-type detector setting: " + mimeTypeDetection);
-                }
-            }
+            String mimeTypeDetection = binaryStorage.getString(FieldName.MIMETYPE_DETECTION,
+                                                               FieldValue.MIMETYPE_DETECTION_CONTENT);
+            return MimeTypeDetectors.createDetectorFor(mimeTypeDetection, environment);
         }
 
         /*

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/mimetype/DefaultMimeTypeDetector.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/mimetype/DefaultMimeTypeDetector.java
@@ -1,0 +1,75 @@
+/*
+ * ModeShape (http://www.modeshape.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.modeshape.jcr.mimetype;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.HashMap;
+import java.util.Map;
+import javax.jcr.Binary;
+import javax.jcr.RepositoryException;
+import org.modeshape.common.util.StringUtil;
+import org.modeshape.schematic.annotation.ThreadSafe;
+
+/**
+ * A {@link MimeTypeDetector} implementation which uses a properties file to load existing mime types and decides based on the 
+ * name of a binary what the mime type is.
+ * 
+ * @author Horia Chiorean (hchiorea@redhat.com)
+ */
+@ThreadSafe
+public final class DefaultMimeTypeDetector implements MimeTypeDetector {
+    
+    private final Map<String, String> mimeTypes;
+    
+    public DefaultMimeTypeDetector() {
+        mimeTypes = loadMimeTypes();
+    }
+    
+    private Map<String, String> loadMimeTypes() {
+        try (BufferedReader reader = 
+                     new BufferedReader(new InputStreamReader(DefaultMimeTypeDetector.class.getResourceAsStream("mimetypes.properties")))) {
+            Map<String, String> result = new HashMap<>();
+            reader.lines().forEach(line -> {
+                String[] parts = line.split("\\s");
+                if (parts.length >= 2) {
+                    String mimeType = parts[0];
+                    for (int i = 1; i < parts.length; i++) {
+                        String extension = parts[i].trim();
+                        if (!StringUtil.isBlank(extension)) {
+                            result.put(extension, mimeType);
+                        }
+                    }
+                }
+            });
+            return result;
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+    
+    @Override
+    public String mimeTypeOf(String name, Binary binaryValue) throws RepositoryException, IOException {
+        if (name == null) {
+            return null;
+        }
+        int lastDotIdx = name.lastIndexOf('.');
+        String extension = lastDotIdx > 0 && lastDotIdx + 1 < name.length() ? name.substring(lastDotIdx + 1) : name;
+        return mimeTypes.get(extension);
+    }
+}

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/mimetype/MimeTypeDetectors.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/mimetype/MimeTypeDetectors.java
@@ -1,0 +1,81 @@
+/*
+ * ModeShape (http://www.modeshape.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.modeshape.jcr.mimetype;
+
+import org.modeshape.common.logging.Logger;
+import org.modeshape.jcr.Environment;
+import org.modeshape.jcr.RepositoryConfiguration;
+import org.modeshape.jcr.mimetype.tika.TikaContentDetector;
+import org.modeshape.jcr.mimetype.tika.TikaNameOnlyDetector;
+
+/**
+ * Class which decides which {@link MimeTypeDetector} implementation to use at runtime
+ * 
+ * @author Horia Chiorean (hchiorea@redhat.com)
+ */
+public final class MimeTypeDetectors {
+    
+    private static final Logger LOGGER = Logger.getLogger(MimeTypeDetector.class);
+    private static final boolean TIKA_AVAILABLE; 
+    
+    static {
+        boolean tikaAvailable = true;
+        ClassLoader classLoader = MimeTypeDetector.class.getClassLoader();
+        try {
+            Class.forName("org.apache.tika.detect.DefaultDetector", true, classLoader);
+            Class.forName("org.apache.tika.metadata.Metadata", true, classLoader);
+        } catch (Throwable t) {
+            tikaAvailable = false;
+        }
+        TIKA_AVAILABLE = tikaAvailable;
+        if (LOGGER.isDebugEnabled()) {
+            if (TIKA_AVAILABLE) {
+                LOGGER.debug("Tika is available in the CP; will be used for mimetype detection");
+            } else {
+                LOGGER.debug("Tika is not available in the CP; ModeShape will use a DefaultMimetypeDetector");
+            }
+        }
+    }
+    
+    private MimeTypeDetectors() {
+    }
+    
+    /**
+     * Returns a new mime type detector implementation based on 
+     * the repository {@link org.modeshape.jcr.RepositoryConfiguration.FieldName#MIMETYPE_DETECTION} configuration 
+     *  
+     * @param mimeTypeDetectionConfig a {@code String}, may not be null
+     * @param environment an {@link Environment} instance specific to a repository 
+     * @return a {@link MimeTypeDetector} instance
+     */
+    public static MimeTypeDetector createDetectorFor(String mimeTypeDetectionConfig, Environment environment) {
+        switch (mimeTypeDetectionConfig.toLowerCase()) {
+            case RepositoryConfiguration.FieldValue.MIMETYPE_DETECTION_CONTENT: {
+                return TIKA_AVAILABLE ? new TikaContentDetector(environment) : new DefaultMimeTypeDetector();
+            }
+            case RepositoryConfiguration.FieldValue.MIMETYPE_DETECTION_NAME: {
+                return TIKA_AVAILABLE ? new TikaNameOnlyDetector(environment) : new DefaultMimeTypeDetector();
+            }
+            case RepositoryConfiguration.FieldValue.MIMETYPE_DETECTION_NONE: {
+                return NullMimeTypeDetector.INSTANCE;
+            }
+            default: {
+                throw new IllegalArgumentException("Unknown mime-type detector setting: " + mimeTypeDetectionConfig);
+            }
+        }   
+    }
+}

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/mimetype/tika/TikaContentDetector.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/mimetype/tika/TikaContentDetector.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.modeshape.jcr.mimetype;
+package org.modeshape.jcr.mimetype.tika;
 
 import java.io.InputStream;
 import org.apache.tika.detect.DefaultDetector;
@@ -27,17 +27,18 @@ import org.modeshape.common.annotation.Immutable;
 import org.modeshape.common.annotation.ThreadSafe;
 import org.modeshape.jcr.Environment;
 import org.modeshape.jcr.JcrI18n;
+import org.modeshape.jcr.mimetype.MimeTypeDetector;
 
 /**
  * {@link MimeTypeDetector} implementation which uses Apache Tika to determine the mimetype of a given binary, based on the 
  * content (binary) header. This involves reading at least the first X bytes from each binary and is more expensive than 
- * {@link NameOnlyDetector}
+ * {@link TikaNameOnlyDetector}
  *
  * @author Horia Chiorean (hchiorea@redhat.com)
  **/
 @Immutable
 @ThreadSafe
-public final class ContentDetector extends TikaMimeTypeDetector {
+public final class TikaContentDetector extends TikaMimeTypeDetector {
     
     private DefaultDetector detector;
     
@@ -46,7 +47,7 @@ public final class ContentDetector extends TikaMimeTypeDetector {
      * 
      * @param environment the {@link Environment} to use for class loading; may not be {@code null}
      */
-    public ContentDetector( Environment environment ) {
+    public TikaContentDetector(Environment environment) {
         super(environment);
     }
     

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/mimetype/tika/TikaMimeTypeDetector.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/mimetype/tika/TikaMimeTypeDetector.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.modeshape.jcr.mimetype;
+package org.modeshape.jcr.mimetype.tika;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -26,6 +26,7 @@ import org.modeshape.common.logging.Logger;
 import org.modeshape.common.util.SelfClosingInputStream;
 import org.modeshape.common.util.StringUtil;
 import org.modeshape.jcr.Environment;
+import org.modeshape.jcr.mimetype.MimeTypeDetector;
 
 /**
  * A base class for the {@link MimeTypeDetector}s that use the Tika library.

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/mimetype/tika/TikaNameOnlyDetector.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/mimetype/tika/TikaNameOnlyDetector.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.modeshape.jcr.mimetype;
+package org.modeshape.jcr.mimetype.tika;
 
 import java.io.InputStream;
 import org.apache.tika.detect.Detector;
@@ -25,6 +25,7 @@ import org.modeshape.common.annotation.Immutable;
 import org.modeshape.common.annotation.ThreadSafe;
 import org.modeshape.jcr.Environment;
 import org.modeshape.jcr.JcrI18n;
+import org.modeshape.jcr.mimetype.MimeTypeDetector;
 
 /**
  * {@link MimeTypeDetector} implementation which uses Apache Tika to determine the mimetype of a given binary, based only
@@ -34,7 +35,7 @@ import org.modeshape.jcr.JcrI18n;
  */
 @Immutable
 @ThreadSafe
-public final class NameOnlyDetector extends TikaMimeTypeDetector {
+public final class TikaNameOnlyDetector extends TikaMimeTypeDetector {
     
     private Detector detector;
 
@@ -43,7 +44,7 @@ public final class NameOnlyDetector extends TikaMimeTypeDetector {
      *
      * @param environment the {@link Environment} to use for class loading; may not be {@code null}
      */
-    public NameOnlyDetector( Environment environment ) {
+    public TikaNameOnlyDetector(Environment environment) {
         super(environment);
     }
     

--- a/modeshape-jcr/src/main/resources/org/modeshape/jcr/mimetype/mimetypes.properties
+++ b/modeshape-jcr/src/main/resources/org/modeshape/jcr/mimetype/mimetypes.properties
@@ -1,0 +1,766 @@
+application/andrew-inset   ez
+application/applixware    aw
+application/atom+xml    atom
+application/atomcat+xml    atomcat
+application/atomsvc+xml    atomsvc
+application/ccxml+xml    ccxml
+application/cdmi-capability   cdmia
+application/cdmi-container   cdmic
+application/cdmi-domain    cdmid
+application/cdmi-object    cdmio
+application/cdmi-queue    cdmiq
+application/cu-seeme    cu
+application/davmount+xml   davmount
+application/docbook+xml    dbk
+application/dssc+der    dssc
+application/dssc+xml    xdssc
+application/ecmascript    ecma
+application/emma+xml    emma
+application/epub+zip    epub
+application/exi     exi
+application/font-tdpfr    pfr
+application/font-woff    woff
+application/gml+xml    gml
+application/gpx+xml    gpx
+application/gxf     gxf
+application/hyperstudio    stk
+application/inkml+xml    ink inkml
+application/ipfix    ipfix
+applicati/java-archive   jar
+application/java-serialized-object  ser
+application/java-vm    class
+application/javascript    js
+application/json    json
+application/jsonml+json    jsonml
+application/lost+xml    lostxml
+application/mac-binhex40   hqx
+application/mac-compactpro   cpt
+application/mads+xml    mads
+application/marc    mrc
+application/marcxml+xml    mrcx
+application/mathematica    ma nb mb
+application/mathml+xml    mathml
+application/mbox    mbox
+application/mediaservercontrol+xml  mscml
+application/metalink+xml   metalink
+application/metalink4+xml   meta4
+application/mets+xml    mets
+application/mods+xml    mods
+application/mp21    m21 mp21
+application/mp4     mp4s
+application/msword    doc dot
+application/mxf     mxf
+application/octet-stream bin dms lrf mar so dist distz pkg bpk dump elc deploy
+application/oda     oda
+application/oebps-package+xml   opf
+application/ogg     ogx
+application/omdoc+xml    omdoc
+application/onenote    onetoc onetoc2 onetmp onepkg
+application/oxps    oxps
+application/patch-ops-error+xml   xer
+application/pdf     pdf
+application/pgp-encrypted   pgp
+application/pgp-signature   asc sig
+application/pics-rules    prf
+application/pkcs10    p10
+application/pkcs7-mime    p7m p7c
+application/pkcs7-signature   p7s
+application/pkcs8    p8
+application/pkix-attr-cert   ac
+application/pkix-cert    cer
+application/pkix-crl    crl
+application/pkix-pkipath   pkipath
+application/pkixcmp    pki
+application/pls+xml    pls
+application/postscript    ai eps ps
+application/prs.cww    cww
+application/pskc+xml    pskcxml
+application/rdf+xml    rdf
+application/reginfo+xml    rif
+application/relax-ng-compact-syntax  rnc
+application/resource-lists+xml   rl
+application/resource-lists-diff+xml  rld
+application/rls-services+xml   rs
+application/rpki-ghostbusters   gbr
+application/rpki-manifest   mft
+application/rpki-roa    roa
+application/rsd+xml    rsd
+application/rss+xml    rss
+application/rtf     rtf
+application/sbml+xml    sbml
+application/scvp-cv-request   scq
+application/scvp-cv-response   scs
+application/scvp-vp-request   spq
+application/scvp-vp-response   spp
+application/sdp     sdp
+application/set-payment-initiation  setpay
+application/set-registration-initiation  setreg
+application/shf+xml    shf
+application/smil+xml    smi smil
+application/sparql-query   rq
+application/sparql-results+xml   srx
+application/srgs    gram
+application/srgs+xml    grxml
+application/sru+xml    sru
+application/ssdl+xml    ssdl
+application/ssml+xml    ssml
+application/tei+xml    tei teicorpus
+application/thraud+xml    tfi
+application/timestamped-data   tsd
+application/vnd.3gpp.pic-bw-large  plb
+application/vnd.3gpp.pic-bw-small  psb
+application/vnd.3gpp.pic-bw-var   pvb
+application/vnd.3gpp2.tcap   tcap
+application/vnd.3m.post-it-notes  pwn
+application/vnd.accpac.simply.aso  aso
+application/vnd.accpac.simply.imp  imp
+application/vnd.acucobol   acu
+application/vnd.acucorp    atc acutc
+application/vnd.adobe.air-application-installer-package+zip air
+application/vnd.adobe.formscentral.fcdt  fcdt
+application/vnd.adobe.fxp   fxp fxpl
+application/vnd.adobe.xdp+xml   xdp
+application/vnd.adobe.xfdf   xfdf
+application/vnd.ahead.space   ahead
+application/vnd.airzip.filesecure.azf  azf
+application/vnd.airzip.filesecure.azs  azs
+application/vnd.amazon.ebook   azw
+application/vnd.americandynamics.acc  acc
+application/vnd.amiga.ami   ami
+application/vnd.android.package-archive  apk
+application/vnd.anser-web-certificate-issue-initiation cii
+application/vnd.anser-web-funds-transfer-initiation fti
+application/vnd.antix.game-component  atx
+application/vnd.apple.installer+xml  mpkg
+application/vnd.apple.mpegurl   m3u8
+application/vnd.aristanetworks.swi  swi
+application/vnd.astraea-software.iota  iota
+application/vnd.audiograph   aep
+application/vnd.blueice.multipass  mpm
+application/vnd.bmi    bmi
+application/vnd.businessobjects   rep
+application/vnd.chemdraw+xml   cdxml
+application/vnd.chipnuts.karaoke-mmd  mmd
+application/vnd.cinderella   cdy
+application/vnd.claymore   cla
+application/vnd.cloanto.rp9   rp9
+application/vnd.clonk.c4group   c4g c4d c4f c4p c4u
+application/vnd.cluetrust.cartomobile-config  c11amc
+application/vnd.cluetrust.cartomobile-config-pkg c11amz
+application/vnd.commonspace   csp
+application/vnd.contact.cmsg   cdbcmsg
+application/vnd.cosmocaller   cmc
+application/vnd.crick.clicker   clkx
+application/vnd.crick.clicker.keyboard  clkk
+application/vnd.crick.clicker.palette  clkp
+application/vnd.crick.clicker.template  clkt
+application/vnd.crick.clicker.wordbank  clkw
+application/vnd.criticaltools.wbs+xml  wbs
+application/vnd.ctc-posml   pml
+application/vnd.cups-ppd   ppd
+application/vnd.curl.car   car
+application/vnd.curl.pcurl   pcurl
+application/vnd.dart    dart
+application/vnd.data-vision.rdz   rdz
+application/vnd.dece.data   uvf uvvf uvd uvvd
+application/vnd.dece.ttml+xml   uvt uvvt
+application/vnd.dece.unspecified  uvx uvvx
+application/vnd.dece.zip   uvz uvvz
+application/vnd.denovo.fcselayout-link  fe_launch
+application/vnd.dna    dna
+application/vnd.dolby.mlp   mlp
+application/vnd.dpgraph    dpg
+application/vnd.dreamfactory   dfac
+application/vnd.ds-keypoint   kpxx
+application/vnd.dvb.ait    ait
+application/vnd.dvb.service   svc
+application/vnd.dynageo    geo
+application/vnd.ecowin.chart   mag
+application/vnd.enliven    nml
+application/vnd.epson.esf   esf
+application/vnd.epson.msf   msf
+application/vnd.epson.quickanime  qam
+application/vnd.epson.salt   slt
+application/vnd.epson.ssf   ssf
+application/vnd.eszigno3+xml   es3 et3
+application/vnd.ezpix-album   ez2
+application/vnd.ezpix-package   ez3
+application/vnd.fdf    fdf
+application/vnd.fdsn.mseed   mseed
+application/vnd.fdsn.seed   seed dataless
+application/vnd.flographit   gph
+application/vnd.fluxtime.clip   ftc
+application/vnd.framemaker   fm frame maker book
+application/vnd.frogans.fnc   fnc
+application/vnd.frogans.ltf   ltf
+application/vnd.fsc.weblaunch   fsc
+application/vnd.fujitsu.oasys   oas
+application/vnd.fujitsu.oasys2   oa2
+application/vnd.fujitsu.oasys3   oa3
+application/vnd.fujitsu.oasysgp   fg5
+application/vnd.fujitsu.oasysprs  bh2
+application/vnd.fujixerox.ddd   ddd
+application/vnd.fujixerox.docuworks  xdw
+application/vnd.fujixerox.docuworks.binder xbd
+application/vnd.fuzzysheet   fzs
+application/vnd.genomatix.tuxedo  txd
+application/vnd.geogebra.file   ggb
+application/vnd.geogebra.tool   ggt
+application/vnd.geometry-explorer  gex gre
+application/vnd.geonext    gxt
+application/vnd.geoplan    g2w
+application/vnd.geospace   g3w
+application/vnd.gmx    gmx
+application/vnd.google-earth.kml+xml  kml
+application/vnd.google-earth.kmz  kmz
+application/vnd.grafeq    gqf gqs
+application/vnd.groove-account   gac
+application/vnd.groove-help   ghf
+application/vnd.groove-identity-message  gim
+application/vnd.groove-injector   grv
+application/vnd.groove-tool-message  gtm
+application/vnd.groove-tool-template  tpl
+application/vnd.groove-vcard   vcg
+application/vnd.hal+xml    hal
+application/vnd.handheld-entertainment+xml zmm
+application/vnd.hbci    hbci
+application/vnd.hhe.lesson-player  les
+application/vnd.hp-hpgl    hpgl
+application/vnd.hp-hpid    hpid
+application/vnd.hp-hps    hps
+application/vnd.hp-jlyt    jlt
+application/vnd.hp-pcl    pcl
+application/vnd.hp-pclxl   pclxl
+application/vnd.hydrostatix.sof-data  sfd-hdstx
+application/vnd.ibm.minipay   mpy
+application/vnd.ibm.modcap   afp listafp list3820
+application/vnd.ibm.rights-management  irm
+application/vnd.ibm.secure-container  sc
+application/vnd.iccprofile   icc icm
+application/vnd.igloader   igl
+application/vnd.immervision-ivp   ivp
+application/vnd.immervision-ivu   ivu
+application/vnd.insors.igm   igm
+application/vnd.intercon.formnet  xpw xpx
+application/vnd.intergeo   i2g
+application/vnd.intu.qbo   qbo
+application/vnd.intu.qfx   qfx
+application/vnd.ipunplugged.rcprofile  rcprofile
+application/vnd.irepository.package+xml  irp
+application/vnd.is-xpr    xpr
+application/vnd.isac.fcs   fcs
+application/vnd.jam    jam
+application/vnd.jcp.javame.midlet-rms  rms
+application/vnd.jisp    jisp
+application/vnd.joost.joda-archive  joda
+application/vnd.kahootz    ktz ktr
+application/vnd.kde.karbon   karbon
+application/vnd.kde.kchart   chrt
+application/vnd.kde.kformula   kfo
+application/vnd.kde.kivio   flw
+application/vnd.kde.kontour   kon
+application/vnd.kde.kpresenter   kpr kpt
+application/vnd.kde.kspread   ksp
+application/vnd.kde.kword   kwd kwt
+application/vnd.kenameaapp   htke
+application/vnd.kidspiration   kia
+application/vnd.kinar    kne knp
+application/vnd.koan    skp skd skt skm
+application/vnd.kodak-descriptor  sse
+application/vnd.las.las+xml   lasxml
+application/vnd.llamagraphics.life-balance.desktop lbd
+application/vnd.llamagraphics.life-balance.exchange+xml lbe
+application/vnd.lotus-1-2-3   123
+application/vnd.lotus-approach   apr
+application/vnd.lotus-freelance   pre
+application/vnd.lotus-notes   nsf
+application/vnd.lotus-organizer   org
+application/vnd.lotus-screencam   scm
+application/vnd.lotus-wordpro   lwp
+application/vnd.macports.portpkg  portpkg
+application/vnd.mcd    mcd
+application/vnd.medcalcdata   mc1
+application/vnd.mediastation.cdkey  cdkey
+application/vnd.mfer    mwf
+application/vnd.mfmp    mfm
+application/vnd.micrografx.flo   flo
+application/vnd.micrografx.igx   igx
+application/vnd.mif    mif
+application/vnd.mobius.daf   daf
+application/vnd.mobius.dis   dis
+application/vnd.mobius.mbk   mbk
+application/vnd.mobius.mqy   mqy
+application/vnd.mobius.msl   msl
+application/vnd.mobius.plc   plc
+application/vnd.mobius.txf   txf
+application/vnd.mophun.application  mpn
+application/vnd.mophun.certificate  mpc
+application/vnd.mozilla.xul+xml   xul
+application/vnd.ms-artgalry   cil
+application/vnd.ms-cab-compressed  cab
+application/vnd.ms-excel   xls xlm xla xlc xlt xlw
+application/vnd.ms-excel.addin.macroenabled.12  xlam
+application/vnd.ms-excel.sheet.binary.macroenabled.12 xlsb
+application/vnd.ms-excel.sheet.macroenabled.12  xlsm
+application/vnd.ms-excel.template.macroenabled.12 xltm
+application/vnd.ms-fontobject   eot
+application/vnd.ms-htmlhelp   chm
+application/vnd.ms-ims    ims
+application/vnd.ms-lrm    lrm
+application/vnd.ms-officetheme   thmx
+application/vnd.ms-pki.seccat   cat
+application/vnd.ms-pki.stl   stl
+application/vnd.ms-powerpoint   ppt pps pot
+application/vnd.ms-powerpoint.addin.macroenabled.12  ppam
+application/vnd.ms-powerpoint.presentation.macroenabled.12 pptm
+application/vnd.ms-powerpoint.slide.macroenabled.12  sldm
+application/vnd.ms-powerpoint.slideshow.macroenabled.12  ppsm
+application/vnd.ms-powerpoint.template.macroenabled.12  potm
+application/vnd.ms-project   mpp mpt
+application/vnd.ms-word.document.macroenabled.12 docm
+application/vnd.ms-word.template.macroenabled.12 dotm
+application/vnd.ms-works   wps wks wcm wdb
+application/vnd.ms-wpl    wpl
+application/vnd.ms-xpsdocument   xps
+application/vnd.mseq    mseq
+application/vnd.musician   mus
+application/vnd.muvee.style   msty
+application/vnd.mynfc    taglet
+application/vnd.neurolanguage.nlu  nlu
+application/vnd.nitf    ntf nitf
+application/vnd.noblenet-directory  nnd
+application/vnd.noblenet-sealer   nns
+application/vnd.noblenet-web   nnw
+application/vnd.nokia.n-gage.data  ngdat
+application/vnd.nokia.n-gage.symbian.install n-gage
+application/vnd.nokia.radio-preset  rpst
+application/vnd.nokia.radio-presets  rpss
+application/vnd.novadigm.edm   edm
+application/vnd.novadigm.edx   edx
+application/vnd.novadigm.ext   ext
+application/vnd.oasis.opendocument.chart  odc
+application/vnd.oasis.opendocument.chart-template otc
+application/vnd.oasis.opendocument.database  odb
+application/vnd.oasis.opendocument.formula  odf
+application/vnd.oasis.opendocument.formula-template odft
+application/vnd.oasis.opendocument.graphics  odg
+application/vnd.oasis.opendocument.graphics-template otg
+application/vnd.oasis.opendocument.image  odi
+application/vnd.oasis.opendocument.image-template oti
+application/vnd.oasis.opendocument.presentation  odp
+application/vnd.oasis.opendocument.presentation-template otp
+application/vnd.oasis.opendocument.spreadsheet  ods
+application/vnd.oasis.opendocument.spreadsheet-template ots
+application/vnd.oasis.opendocument.text   odt
+application/vnd.oasis.opendocument.text-master  odm
+application/vnd.oasis.opendocument.text-template ott
+application/vnd.oasis.opendocument.text-web  oth
+application/vnd.olpc-sugar   xo
+application/vnd.oma.dd2+xml   dd2
+application/vnd.openofficeorg.extension  oxt
+application/vnd.openxmlformats-officedocument.presentationml.presentation pptx
+application/vnd.openxmlformats-officedocument.presentationml.slide sldx
+application/vnd.openxmlformats-officedocument.presentationml.slideshow ppsx
+application/vnd.openxmlformats-officedocument.presentationml.template potx
+application/vnd.openxmlformats-officedocument.spreadsheetml.sheet xlsx
+application/vnd.openxmlformats-officedocument.spreadsheetml.template xltx
+application/vnd.openxmlformats-officedocument.wordprocessingml.document docx
+application/vnd.openxmlformats-officedocument.wordprocessingml.template dotx
+application/vnd.osgeo.mapguide.package  mgp
+application/vnd.osgi.dp    dp
+application/vnd.osgi.subsystem   esa
+application/vnd.palm    pdb pqa oprc
+application/vnd.pawaafile   paw
+application/vnd.pg.format   str
+application/vnd.pg.osasli   ei6
+application/vnd.picsel    efif
+application/vnd.pmi.widget   wg
+application/vnd.pocketlearn   plf
+application/vnd.powerbuilder6   pbd
+application/vnd.previewsystems.box  box
+application/vnd.proteus.magazine  mgz
+application/vnd.publishare-delta-tree  qps
+application/vnd.pvi.ptid1   ptid
+application/vnd.quark.quarkxpress  qxd qxt qwd qwt qxl qxb
+application/vnd.realvnc.bed   bed
+application/vnd.recordare.musicxml  mxl
+application/vnd.recordare.musicxml+xml  musicxml
+application/vnd.rig.cryptonote   cryptonote
+application/vnd.rim.cod    cod
+application/vnd.rn-realmedia   rm
+application/vnd.rn-realmedia-vbr  rmvb
+application/vnd.route66.link66+xml  link66
+application/vnd.sailingtracker.track  st
+application/vnd.seemail    see
+application/vnd.sema    sema
+application/vnd.semd    semd
+application/vnd.semf    semf
+application/vnd.shana.informed.formdata  ifm
+application/vnd.shana.informed.formtemplate itp
+application/vnd.shana.informed.interchange iif
+application/vnd.shana.informed.package  ipk
+application/vnd.simtech-mindmapper  twd twds
+application/vnd.smaf    mmf
+application/vnd.smart.teacher   teacher
+application/vnd.solent.sdkm+xml   sdkm sdkd
+application/vnd.spotfire.dxp   dxp
+application/vnd.spotfire.sfs   sfs
+application/vnd.stardivision.calc  sdc
+application/vnd.stardivision.draw  sda
+application/vnd.stardivision.impress  sdd
+application/vnd.stardivision.math  smf
+application/vnd.stardivision.writer  sdw vor
+application/vnd.stardivision.writer-global sgl
+application/vnd.stepmania.package  smzip
+application/vnd.stepmania.stepchart  sm
+application/vnd.sun.xml.calc   sxc
+application/vnd.sun.xml.calc.template  stc
+application/vnd.sun.xml.draw   sxd
+application/vnd.sun.xml.draw.template  std
+application/vnd.sun.xml.impress   sxi
+application/vnd.sun.xml.impress.template sti
+application/vnd.sun.xml.math   sxm
+application/vnd.sun.xml.writer   sxw
+application/vnd.sun.xml.writer.global  sxg
+application/vnd.sun.xml.writer.template  stw
+application/vnd.sus-calendar   sus susp
+application/vnd.svd    svd
+application/vnd.symbian.install   sis sisx
+application/vnd.syncml+xml   xsm
+application/vnd.syncml.dm+wbxml   bdm
+application/vnd.syncml.dm+xml   xdm
+application/vnd.tao.intent-module-archive tao
+application/vnd.tcpdump.pcap   pcap cap dmp
+application/vnd.tmobile-livetv   tmo
+application/vnd.trid.tpt   tpt
+application/vnd.triscape.mxs   mxs
+application/vnd.trueapp    tra
+application/vnd.ufdl    ufd ufdl
+application/vnd.uiq.theme   utz
+application/vnd.umajin    umj
+application/vnd.unity    unityweb
+application/vnd.uoml+xml   uoml
+application/vnd.vcx    vcx
+application/vnd.visio    vsd vst vss vsw
+application/vnd.visionary   vis
+application/vnd.vsf    vsf
+application/vnd.wap.wbxml   wbxml
+application/vnd.wap.wmlc   wmlc
+application/vnd.wap.wmlscriptc   wmlsc
+application/vnd.webturbo   wtb
+application/vnd.wolfram.player   nbp
+application/vnd.wordperfect   wpd
+application/vnd.wqd    wqd
+application/vnd.wt.stf    stf
+application/vnd.xara    xar
+application/vnd.xfdl    xfdl
+application/vnd.yamaha.hv-dic   hvd
+application/vnd.yamaha.hv-script  hvs
+application/vnd.yamaha.hv-voice   hvp
+application/vnd.yamaha.openscoreformat   osf
+application/vnd.yamaha.openscoreformat.osfpvg+xml osfpvg
+application/vnd.yamaha.smaf-audio  saf
+application/vnd.yamaha.smaf-phrase  spf
+application/vnd.yellowriver-custom-menu  cmp
+application/vnd.zul    zir zirz
+application/vnd.zzazz.deck+xml   zaz
+application/voicexml+xml   vxml
+application/widget    wgt
+application/winhlp    hlp
+application/wsdl+xml    wsdl
+application/wspolicy+xml   wspolicy
+application/x-7z-compressed   7z
+application/x-abiword    abw
+application/x-ace-compressed   ace
+application/x-apple-diskimage   dmg
+application/x-authorware-bin   aab x32 u32 vox
+application/x-authorware-map   aam
+application/x-authorware-seg   aas
+application/x-bcpio    bcpio
+application/x-bittorrent   torrent
+application/x-blorb    blb blorb
+application/x-bzip    bz
+application/x-bzip2    bz2 boz
+application/x-cbr    cbr cba cbt cbz cb7
+application/x-cdlink    vcd
+application/x-cfs-compressed   cfs
+application/x-chat    chat
+application/x-chess-pgn    pgn
+application/x-conference   nsc
+application/x-cpio    cpio
+application/x-csh    csh
+application/x-debian-package   deb udeb
+application/x-dgc-compressed   dgc
+application/x-director   dir dcr dxr cst cct cxt w3d fgd swa
+application/x-doom    wad
+application/x-dtbncx+xml   ncx
+application/x-dtbook+xml   dtb
+application/x-dtbresource+xml   res
+application/x-dvi    dvi
+application/x-envoy    evy
+application/x-eva    eva
+application/x-font-bdf    bdf
+application/x-font-ghostscript   gsf
+application/x-font-linux-psf   psf
+application/x-font-otf    otf
+application/x-font-pcf    pcf
+application/x-font-snf    snf
+application/x-font-ttf    ttf ttc
+application/x-font-type1   pfa pfb pfm afm
+application/x-freearc    arc
+application/x-futuresplash   spl
+application/x-gca-compressed   gca
+application/x-glulx    ulx
+application/x-gnumeric    gnumeric
+application/x-gramps-xml   gramps
+application/x-gtar    gtar
+application/x-hdf    hdf
+application/x-install-instructions  install
+application/x-iso9660-image   iso
+application/x-java-jnlp-file   jnlp
+application/x-latex    latex
+application/x-lzh-compressed   lzh lha
+application/x-mie    mie
+application/x-mobipocket-ebook   prc mobi
+application/x-ms-application   application
+application/x-ms-shortcut   lnk
+application/x-ms-wmd    wmd
+application/x-ms-wmz    wmz
+application/x-ms-xbap    xbap
+application/x-msaccess    mdb
+application/x-msbinder    obd
+application/x-mscardfile   crd
+application/x-msclip    clp
+application/x-msdownload   exe dll com bat msi
+application/x-msmediaview   mvb m13 m14
+application/x-msmetafile   wmf wmz emf emz
+application/x-msmoney    mny
+application/x-mspublisher   pub
+application/x-msschedule   scd
+application/x-msterminal   trm
+application/x-mswrite    wri
+application/x-netcdf    nc cdf
+application/x-nzb    nzb
+application/x-pkcs12    p12 pfx
+application/x-pkcs7-certificates  p7b spc
+application/x-pkcs7-certreqresp   p7r
+application/x-rar-compressed   rar
+application/x-research-info-systems  ris
+application/x-sh    sh
+application/x-shar    shar
+application/x-shockwave-flash   swf
+application/x-silverlight-app   xap
+application/x-sql    sql
+application/x-stuffit    sit
+application/x-stuffitx    sitx
+application/x-subrip    srt
+application/x-sv4cpio    sv4cpio
+application/x-sv4crc    sv4crc
+application/x-t3vm-image   t3
+application/x-tads    gam
+application/x-tar    tar
+application/x-tcl    tcl
+application/x-tex    tex
+application/x-tex-tfm    tfm
+application/x-texinfo    texinfo texi
+application/x-tgif    obj
+application/x-ustar    ustar
+application/x-wais-source   src
+application/x-x509-ca-cert   der crt
+application/x-xfig    fig
+application/x-xliff+xml    xlf
+application/x-xpinstall    xpi
+application/x-xz    xz
+application/x-zmachine    z1 z2 z3 z4 z5 z6 z7 z8
+application/xaml+xml    xaml
+application/xcap-diff+xml   xdf
+application/xenc+xml    xenc
+application/xhtml+xml    xhtml xht
+application/xml     xml xsl xsd
+application/xml-dtd    dtd
+application/xop+xml    xop
+application/xproc+xml    xpl
+application/xslt+xml    xslt
+application/xspf+xml    xspf
+application/xv+xml    mxml xhvml xvml xvm
+application/yang    yang
+application/yin+xml    yin
+application/zip     zip
+audio/adpcm     adp
+audio/basic     au snd
+audio/midi     mid midi kar rmi
+audio/mp4     m4a mp4a
+audio/mpeg     mpga mp2 mp2a mp3 m2a m3a
+audio/ogg     oga ogg spx
+audio/s3m     s3m
+audio/silk     sil
+audio/vnd.dece.audio    uva uvva
+audio/vnd.digital-winds    eol
+audio/vnd.dra     dra
+audio/vnd.dts     dts
+audio/vnd.dts.hd    dtshd
+audio/vnd.lucent.voice    lvp
+audio/vnd.ms-playready.media.pya  pya
+audio/vnd.nuera.ecelp4800   ecelp4800
+audio/vnd.nuera.ecelp7470   ecelp7470
+audio/vnd.nuera.ecelp9600   ecelp9600
+audio/vnd.rip     rip
+audio/webm     weba
+audio/x-aac     aac
+audio/x-aiff     aif aiff aifc
+audio/x-caf     caf
+audio/x-flac     flac
+audio/x-matroska    mka
+audio/x-mpegurl     m3u
+audio/x-ms-wax     wax
+audio/x-ms-wma     wma
+audio/x-pn-realaudio    ram ra
+audio/x-pn-realaudio-plugin   rmp
+audio/x-wav     wav
+audio/xm     xm
+chemical/x-cdx     cdx
+chemical/x-cif     cif
+chemical/x-cmdf     cmdf
+chemical/x-cml     cml
+chemical/x-csml     csml
+chemical/x-xyz     xyz
+image/bmp     bmp
+image/cgm     cgm
+image/g3fax     g3
+image/gif     gif
+image/ief     ief
+image/jpeg     jpeg jpg jpe
+image/ktx     ktx
+image/png     png
+image/prs.btif     btif
+image/sgi     sgi
+image/svg+xml     svg svgz
+image/tiff     tiff tif
+image/vnd.adobe.photoshop   psd
+image/vnd.dece.graphic    uvi uvvi uvg uvvg
+image/vnd.djvu     djvu djv
+image/vnd.dvb.subtitle    sub
+image/vnd.dwg     dwg
+image/vnd.dxf     dxf
+image/vnd.fastbidsheet    fbs
+image/vnd.fpx     fpx
+image/vnd.fst     fst
+image/vnd.fujixerox.edmics-mmr   mmr
+image/vnd.fujixerox.edmics-rlc   rlc
+image/vnd.ms-modi    mdi
+image/vnd.ms-photo    wdp
+image/vnd.net-fpx    npx
+image/vnd.wap.wbmp    wbmp
+image/vnd.xiff     xif
+image/webp     webp
+image/x-3ds     3ds
+image/x-cmu-raster    ras
+image/x-cmx     cmx
+image/x-freehand    fh fhc fh4 fh5 fh7
+image/x-icon     ico
+image/x-mrsid-image    sid
+image/x-pcx     pcx
+image/x-pict     pic pct pict
+image/x-portable-anymap    pnm
+image/x-portable-bitmap    pbm
+image/x-portable-graymap   pgm
+image/x-portable-pixmap    ppm
+image/x-rgb     rgb
+image/x-tga     tga
+image/x-xbitmap     xbm
+image/x-xpixmap     xpm
+image/x-xwindowdump    xwd
+message/rfc822     eml mime
+model/iges     igs iges
+model/mesh     msh mesh silo
+model/vnd.collada+xml    dae
+model/vnd.dwf     dwf
+model/vnd.gdl     gdl
+model/vnd.gtw     gtw
+model/vnd.mts     mts
+model/vnd.vtu     vtu
+model/vrml     wrl vrml
+model/x3d+binary    x3db x3dbz
+model/x3d+vrml     x3dv x3dvz
+model/x3d+xml     x3d x3dz
+text/cache-manifest    appcache
+text/calendar     ics ifb
+text/css     css
+text/csv     csv
+text/html     html htm
+text/n3      n3
+text/plain     txt text conf def list log in
+text/prs.lines.tag    dsc
+text/richtext     rtx
+text/sgml     sgml sgm
+text/tab-separated-values   tsv
+text/troff     t tr roff man me ms
+text/turtle     ttl
+text/uri-list     uri uris urls
+text/vcard     vcard
+text/vnd.curl     curl
+text/vnd.curl.dcurl    dcurl
+text/vnd.curl.mcurl    mcurl
+text/vnd.curl.scurl    scurl
+text/vnd.dvb.subtitle    sub
+text/vnd.fly     fly
+text/vnd.fmi.flexstor    flx
+text/vnd.graphviz    gv
+text/vnd.in3d.3dml    3dml
+text/vnd.in3d.spot    spot
+text/vnd.sun.j2me.app-descriptor  jad
+text/vnd.wap.wml    wml
+text/vnd.wap.wmlscript    wmls
+text/x-asm     s asm
+text/x-c     c cc cxx cpp h hh dic
+text/x-fortran     f for f77 f90
+text/x-java-source    java
+text/x-nfo     nfo
+text/x-opml     opml
+text/x-pascal     p pas
+text/x-setext     etx
+text/x-sfv     sfv
+text/x-uuencode     uu
+text/x-vcalendar    vcs
+text/x-vcard     vcf
+video/3gpp     3gp
+video/3gpp2     3g2
+video/h261     h261
+video/h263     h263
+video/h264     h264
+video/jpeg     jpgv
+video/jpm     jpm jpgm
+video/mj2     mj2 mjp2
+video/mp4     mp4 mp4v mpg4
+video/mpeg     mpeg mpg mpe m1v m2v
+video/ogg     ogv
+video/quicktime     qt mov
+video/vnd.dece.hd    uvh uvvh
+video/vnd.dece.mobile    uvm uvvm
+video/vnd.dece.pd    uvp uvvp
+video/vnd.dece.sd    uvs uvvs
+video/vnd.dece.video    uvv uvvv
+video/vnd.dvb.file    dvb
+video/vnd.fvt     fvt
+video/vnd.mpegurl    mxu m4u
+video/vnd.ms-playready.media.pyv  pyv
+video/vnd.uvvu.mp4    uvu uvvu
+video/vnd.vivo     viv
+video/webm     webm
+video/x-f4v     f4v
+video/x-fli     fli
+video/x-flv     flv
+video/x-m4v     m4v
+video/x-matroska    mkv mk3d mks
+video/x-mng     mng
+video/x-ms-asf     asf asx
+video/x-ms-vob     vob
+video/x-ms-wm     wm
+video/x-ms-wmv     wmv
+video/x-ms-wmx     wmx
+video/x-ms-wvx     wvx
+video/x-msvideo     avi
+video/x-sgi-movie    movie
+video/x-smv     smv
+x-conference/x-cooltalk    ice
+text/jcr-cnd cnd

--- a/modeshape-jcr/src/test/java/org/modeshape/jcr/mimetype/DefaultMimeTypeDetectorTest.java
+++ b/modeshape-jcr/src/test/java/org/modeshape/jcr/mimetype/DefaultMimeTypeDetectorTest.java
@@ -1,0 +1,138 @@
+/*
+ * ModeShape (http://www.modeshape.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.modeshape.jcr.mimetype;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.IOException;
+import javax.jcr.RepositoryException;
+import org.apache.tika.mime.MediaType;
+import org.junit.Test;
+
+/**
+ * Unit test for {@link DefaultMimeTypeDetector}
+ * 
+ * @author Horia Chiorean (hchiorea@redhat.com)
+ */
+public class DefaultMimeTypeDetectorTest {
+    
+    private MimeTypeDetector detector = new DefaultMimeTypeDetector();
+    
+    @Test
+    public void shouldProvideMimeTypeForAu() throws Exception {
+        testMimeType("test.au", "audio/basic");
+    }
+    
+    @Test
+    public void shouldProvideMimeTypeForBin() throws Exception {
+        testMimeType("test.bin", MediaType.OCTET_STREAM.toString());
+    }
+    
+    @Test
+    public void shouldProvideMimeTypeForEmf() throws Exception {
+        testMimeType("test.emf", "application/x-msmetafile");
+    }
+    
+    @Test
+    public void shouldProvideMimeTypeForFli() throws Exception {
+        testMimeType("test.fli", "video/x-fli");
+    }
+    
+    @Test
+    public void shouldProvideMimeTypeForPcx() throws Exception {
+        testMimeType("test.pcx", "image/x-pcx");
+    }
+    
+    @Test
+    public void shouldProvideMimeTypeForPict() throws Exception {
+        testMimeType("test.pict", "image/x-pict");
+    }
+    
+    @Test
+    public void shouldProvideMimeTypeForPsd() throws Exception {
+        testMimeType("test.psd", "image/vnd.adobe.photoshop");
+    }
+    
+    @Test
+    public void shouldProvideMimeTypeForTar() throws Exception {
+        testMimeType("test.tar", "application/x-tar");
+    }
+    
+    @Test
+    public void shouldProvideMimeTypeForPdf() throws Exception {
+        testMimeType("modeshape_pdfcontext.pdf", "application/pdf");
+    }
+    
+    @Test
+    public void shouldProvideMimeTypeForOpenOfficePresentation() throws Exception {
+        testMimeType("component-architecture.odp", "application/vnd.oasis.opendocument.presentation");
+    }
+    
+    @Test
+    public void shouldProvideMimeTypeForXml() throws Exception {
+        testMimeType("master.xml", MediaType.APPLICATION_XML.toString());
+    }
+    
+    @Test
+    public void shouldProvideMimeTypeForXsd() throws Exception {
+        testMimeType("xsd_file.xsd", MediaType.APPLICATION_XML.toString());
+    }
+    
+    @Test
+    public void shouldProvideMimeTypeForWsdl() throws Exception {
+        testMimeType("uddi_api_v3_portType.wsdl", "application/wsdl+xml");
+    }
+    
+    @Test
+    public void shouldProvideMimeTypeForBitmap() throws Exception {
+        testMimeType("test.bmp", "image/bmp");
+    }
+    
+    @Test
+    public void shouldProvideMimeTypeForPng() throws Exception {
+        testMimeType("test.png", "image/png");
+    }
+    
+    @Test
+    public void shouldProvideMimeTypeForJpg() throws Exception {
+        testMimeType("test.jpg", "image/jpeg");
+    }
+    
+    @Test
+    public void shouldProvideMimeTypeForOgg() throws Exception {
+        testMimeType("test.ogg", "audio/ogg");
+    }
+    
+    @Test
+    public void shouldProvideMimeTypeForWave() throws Exception {
+        testMimeType("test.wav", "audio/x-wav");
+    }
+    
+    @Test
+    public void shouldProvideMimeTypeForJavaClass() throws Exception {
+        testMimeType("test_1.2.class", "application/java-vm");
+    }
+    
+    @Test
+    public void shouldProvideMimeTypeForCND() throws Exception {
+        testMimeType("aircraft.cnd", "text/jcr-cnd");
+    }
+    
+    private void testMimeType(String filename, String expectedMimeType) throws IOException, RepositoryException {
+        assertEquals(expectedMimeType, detector.mimeTypeOf(filename, null));
+    }
+}

--- a/modeshape-jcr/src/test/java/org/modeshape/jcr/mimetype/MimeTypeDetectorsTest.java
+++ b/modeshape-jcr/src/test/java/org/modeshape/jcr/mimetype/MimeTypeDetectorsTest.java
@@ -1,0 +1,59 @@
+/*
+ * ModeShape (http://www.modeshape.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.modeshape.jcr.mimetype;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import org.junit.Test;
+import org.modeshape.jcr.Environment;
+import org.modeshape.jcr.LocalEnvironment;
+import org.modeshape.jcr.RepositoryConfiguration;
+
+/**
+ * Unit test for {@link MimeTypeDetectors}
+ *
+ * @author Horia Chiorean (hchiorea@redhat.com)
+ */
+public class MimeTypeDetectorsTest {
+    
+    private final Environment environment = new LocalEnvironment();
+    
+    @Test
+    public void shouldReturnValidContentDetector() {
+        assertNotNull(MimeTypeDetectors.createDetectorFor(RepositoryConfiguration.FieldValue.MIMETYPE_DETECTION_CONTENT,
+                                                          environment));
+    }
+    
+    @Test
+    public void shouldReturnValidNameDetector() {
+        assertNotNull(MimeTypeDetectors.createDetectorFor(RepositoryConfiguration.FieldValue.MIMETYPE_DETECTION_NAME,
+                                                          environment));
+    }
+    
+    @Test
+    public void shouldReturnValidEmptyDetector() {
+        MimeTypeDetector detector = MimeTypeDetectors.createDetectorFor(
+                RepositoryConfiguration.FieldValue.MIMETYPE_DETECTION_NONE, environment);
+        assertEquals(NullMimeTypeDetector.INSTANCE, detector);
+    }
+    
+    @Test( expected = IllegalArgumentException.class )
+    public void shouldFailForInvalidConfigurationValue() {
+        MimeTypeDetectors.createDetectorFor("test", environment);
+    }
+}

--- a/modeshape-jcr/src/test/java/org/modeshape/jcr/mimetype/tika/ContentDetectorTest.java
+++ b/modeshape-jcr/src/test/java/org/modeshape/jcr/mimetype/tika/ContentDetectorTest.java
@@ -14,27 +14,29 @@
  * limitations under the License.
  */
 
-package org.modeshape.jcr.mimetype;
+package org.modeshape.jcr.mimetype.tika;
 
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsNull.notNullValue;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
+
 import java.io.IOException;
 import java.io.InputStream;
 import org.apache.tika.mime.MediaType;
 import org.junit.Test;
 import org.modeshape.jcr.InMemoryTestBinary;
 import org.modeshape.jcr.LocalEnvironment;
+import org.modeshape.jcr.mimetype.MimeTypeDetector;
 
 /**
- * Unit test for {@link ContentDetector}
+ * Unit test for {@link TikaContentDetector}
  * 
  * @author Horia Chiorean
  */
 public class ContentDetectorTest {
 
-    private static final MimeTypeDetector DETECTOR = new ContentDetector(new LocalEnvironment());
+    private static final MimeTypeDetector DETECTOR = new TikaContentDetector(new LocalEnvironment());
 
     private static final String TXT_FILE = "mimetype/modeshape.txt";
     private static final String PDF_FILE = "mimetype/modeshape_gs.pdf";

--- a/modeshape-jcr/src/test/java/org/modeshape/jcr/mimetype/tika/NameOnlyDetectorTest.java
+++ b/modeshape-jcr/src/test/java/org/modeshape/jcr/mimetype/tika/NameOnlyDetectorTest.java
@@ -13,10 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.modeshape.jcr.mimetype;
+package org.modeshape.jcr.mimetype.tika;
 
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
+
 import java.io.InputStream;
 import java.util.HashSet;
 import java.util.Set;
@@ -25,15 +26,16 @@ import org.junit.Test;
 import org.modeshape.common.util.StringUtil;
 import org.modeshape.jcr.InMemoryTestBinary;
 import org.modeshape.jcr.LocalEnvironment;
+import org.modeshape.jcr.mimetype.MimeTypeDetector;
 
 /**
- * Unit test for {@link NameOnlyDetector}.
+ * Unit test for {@link TikaNameOnlyDetector}.
  *
  * @author Horia Chiorean
  */
 public class NameOnlyDetectorTest {
     
-    private static final MimeTypeDetector DETECTOR = new NameOnlyDetector(new LocalEnvironment());
+    private static final MimeTypeDetector DETECTOR = new TikaNameOnlyDetector(new LocalEnvironment());
 
     protected void testMimeType( String name,
                                  String... mimeTypes ) throws Exception {

--- a/modeshape-jcr/src/test/java/org/modeshape/jcr/value/binary/AbstractBinaryStoreTest.java
+++ b/modeshape-jcr/src/test/java/org/modeshape/jcr/value/binary/AbstractBinaryStoreTest.java
@@ -21,6 +21,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -43,11 +44,10 @@ import org.junit.rules.TestRule;
 import org.modeshape.common.FixFor;
 import org.modeshape.common.junit.SkipTestRule;
 import org.modeshape.common.util.IoUtil;
-import org.modeshape.jcr.LocalEnvironment;
 import org.modeshape.jcr.TextExtractors;
 import org.modeshape.jcr.api.text.TextExtractor;
+import org.modeshape.jcr.mimetype.DefaultMimeTypeDetector;
 import org.modeshape.jcr.mimetype.MimeTypeDetector;
-import org.modeshape.jcr.mimetype.NameOnlyDetector;
 import org.modeshape.jcr.value.BinaryKey;
 import org.modeshape.jcr.value.BinaryValue;
 
@@ -74,7 +74,7 @@ public abstract class AbstractBinaryStoreTest {
     public static final BinaryKey EMPTY_BINARY_KEY;
     public static final String TEXT_DATA;
 
-    protected static final MimeTypeDetector DEFAULT_DETECTOR = new NameOnlyDetector(new LocalEnvironment());
+    protected static final MimeTypeDetector DEFAULT_DETECTOR = new DefaultMimeTypeDetector();
     
     private static final Random RANDOM = new Random();
 

--- a/sequencers/modeshape-sequencer-audio/src/main/java/org/modeshape/sequencer/audio/AudioMetadata.java
+++ b/sequencers/modeshape-sequencer-audio/src/main/java/org/modeshape/sequencer/audio/AudioMetadata.java
@@ -139,7 +139,7 @@ public class AudioMetadata {
         if (mimeType.startsWith("audio/mpeg")) {
             format = FORMAT_MP3;
             audioFile = new MP3FileReader().read(fileCopy);
-        } else if (mimeType.startsWith("audio/vorbis") || mimeType.startsWith("audio/x-vorbis")) {
+        } else if (mimeType.startsWith("audio/vorbis") || mimeType.startsWith("audio/x-vorbis") || mimeType.startsWith("audio/ogg")) {
             format = FORMAT_VORBIS;
             audioFile = new OggFileReader().read(fileCopy);
         } else if (mimeType.startsWith("audio/flac") || mimeType.startsWith("audio/x-flac")) {

--- a/sequencers/modeshape-sequencer-audio/src/test/java/org/modeshape/sequencer/audio/AudioMetadataSequencerTest.java
+++ b/sequencers/modeshape-sequencer-audio/src/test/java/org/modeshape/sequencer/audio/AudioMetadataSequencerTest.java
@@ -97,11 +97,11 @@ public class AudioMetadataSequencerTest extends AbstractSequencerTest {
 
         // THEN
         Node sequencedNodeDifferentLocation = getOutputNode(rootNode, "sequenced/audio/" + filename);
-        assertMetaDataProperties(sequencedNodeDifferentLocation, "ogg", "audio/vorbis", 112L, 44100L, "2", 2.0,
+        assertMetaDataProperties(sequencedNodeDifferentLocation, "ogg", "audio/ogg", 112L, 44100L, "2", 2.0,
                 "Album", "Artist", "Comment", "Title", "2015", "1", "Speech", "image/jpeg");
 
         Node sequencedNodeSameLocation = getOutputNode(audioNode, METADATA_NODE);
-        assertMetaDataProperties(sequencedNodeSameLocation, "ogg", "audio/vorbis", 112L, 44100L, "2", 2.0,
+        assertMetaDataProperties(sequencedNodeSameLocation, "ogg", "audio/ogg", 112L, 44100L, "2", 2.0,
                 "Album", "Artist", "Comment", "Title", "2015", "1", "Speech", "image/jpeg");
     }
 

--- a/web/modeshape-web-cmis-war/src/test/java/org/modeshape/cmis/ModeShapeCmisClientTest.java
+++ b/web/modeshape-web-cmis-war/src/test/java/org/modeshape/cmis/ModeShapeCmisClientTest.java
@@ -15,6 +15,8 @@
  */
 package org.modeshape.cmis;
 
+import static org.junit.Assert.assertEquals;
+
 import java.io.ByteArrayInputStream;
 import java.util.HashMap;
 import java.util.List;
@@ -30,10 +32,9 @@ import org.apache.chemistry.opencmis.commons.SessionParameter;
 import org.apache.chemistry.opencmis.commons.data.ContentStream;
 import org.apache.chemistry.opencmis.commons.enums.BindingType;
 import org.apache.chemistry.opencmis.commons.enums.VersioningState;
-import org.apache.tika.io.IOUtils;
 import org.junit.Before;
 import org.junit.Test;
-import static org.junit.Assert.assertEquals;
+import org.modeshape.common.util.IoUtil;
 
 /**
  * Unit test for CMIS bridge
@@ -155,7 +156,7 @@ public class ModeShapeCmisClientTest {
         for (Document doc : versions) {
             String verId = doc.getId();
             Document versDoc = (Document)session.getObject(verId);
-            String s = IOUtils.toString(versDoc.getContentStream().getStream());
+            String s = IoUtil.read(versDoc.getContentStream().getStream());
             
             assertEquals(contents[i], s);
             i++;

--- a/web/modeshape-web-jcr-rest-war/src/test/java/org/modeshape/web/jcr/rest/ModeShapeRestServiceTest.java
+++ b/web/modeshape-web-jcr-rest-war/src/test/java/org/modeshape/web/jcr/rest/ModeShapeRestServiceTest.java
@@ -337,7 +337,7 @@ public class ModeShapeRestServiceTest extends AbstractRestTest {
     public void shouldRetrieveBinaryPropertyValue() throws Exception {
         doPost("put/node_with_binary_property.json", itemsUrl(TEST_NODE)).isCreated();
         Response response = doGet(binaryUrl(TEST_NODE, "testProperty")).isOk()
-                                                                       .hasMimeType(MediaType.TEXT_PLAIN)
+                                                                       .hasMimeType(MediaType.APPLICATION_JSON)
                                                                        .hasContentDisposition(RestBinaryHandler.DEFAULT_CONTENT_DISPOSITION_PREFIX
                                                                                               + TEST_NODE);
         assertEquals("testValue", response.contentAsString());


### PR DESCRIPTION
The mime type extraction functionality will still function as-is if Tika is present, but now there is also an independent extension-based default which will be used if Tika is not present in the CP at runtime