### PR TITLE
[MODE-2697] Remove escaping of single quote characters in JSON documents

### DIFF
--- a/modeshape-schematic/src/main/java/org/modeshape/schematic/internal/document/CompactJsonWriter.java
+++ b/modeshape-schematic/src/main/java/org/modeshape/schematic/internal/document/CompactJsonWriter.java
@@ -170,8 +170,7 @@ public class CompactJsonWriter implements JsonWriter {
         for (char c = iter.first(); c != CharacterIterator.DONE; c = iter.next()) {
             switch (c) {
                 case '"':
-                case '\'':
-                    // Escape the single- or double-quote characters ..
+                    // Escape double-quote characters ..
                     writer.append('\\').append(c);
                     break;
                 case '/':


### PR DESCRIPTION
JSON grammar doesn't allow escaping of single quote characters:

![image](https://cloud.githubusercontent.com/assets/1470270/25574948/2bbbdab0-2e53-11e7-857e-d5370a819bd2.png)
