### PR TITLE
Fix parallel uploading in Amazon S3

### DIFF
--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/value/binary/S3BinaryStore.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/value/binary/S3BinaryStore.java
@@ -221,7 +221,8 @@ public class S3BinaryStore extends AbstractBinaryStore {
     @Override
     public BinaryValue storeValue(InputStream stream, boolean markAsUnused) throws BinaryStoreException {
         // Cache file on the file system in order to have SHA-1 hash calculated
-        BinaryValue cachedFile = fileSystemCache.storeValue(stream, markAsUnused);
+        // File is marked as used (unused=false)
+        BinaryValue cachedFile = fileSystemCache.storeValue(stream, false);
         try {
             // Retrieve SHA-1 hash
             BinaryKey key = new BinaryKey(cachedFile.getKey().toString());


### PR DESCRIPTION
Binary value must be marked as "used" (unused=false) when storing in fileSystemCache (no matter what is value of "markAsUnused"). In following case it can be crucial:

If couple of threads are trying to add different files in same S3BinaryStore at same time, they will store files in the same fileSystemCache, and when some thread finish, it will delete all files marked as unused from cache (that will be all files stored in cache from another threads), and exception: 

org.modeshape.jcr.value.binary.BinaryStoreException: Unable to find binary value with key "78ed7457b289ba42ff67256f33a88b5bf0ca3012" within binary store at "/tmp/modeshape-binary-store"
at org.modeshape.jcr.value.binary.S3BinaryStore.storeValue(S3BinaryStore.java:251)
at org.modeshape.jcr.value.binary.BinaryStoreValueFactory.create(BinaryStoreValueFactory.java:244)
... 164 more

will be thrown in all other threads (with different SHA-1).