### PR TITLE
Update JcrRepository.java

### DIFF
--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrRepository.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/JcrRepository.java
@@ -1192,6 +1192,7 @@ public class JcrRepository implements org.modeshape.jcr.api.Repository {
                                                      new FullTextSearchParser(), new JcrSqlQueryParser(), new JcrQomQueryParser());
                 RepositoryConfiguration.Reindexing reindexingCfg = config.getReindexing();
                 this.repositoryQueryManager = new RepositoryQueryManager(this, indexingExecutor, config, reindexingCfg);
+                this.repositoryQueryManager.initialize();
                 if (reindexingCfg.isAsync()) {
                     this.changeBus.register(this.repositoryQueryManager);
                 } else {


### PR DESCRIPTION
The problem is that indexes for queries are not used after a new running state of the repository is created after an update to the engine.
Initialize the RepositoryQueryManager when a new running state is created, so that the RepositoryIndexManager is also initialized and the indexes in the repository configuration are being used.