### PR TITLE
MODE-2720 Lucene index provider does not correctly handle LIKE constraints containing a backslash

### DIFF
--- a/index-providers/modeshape-lucene-index-provider/src/test/java/org/modeshape/jcr/index/lucene/SingleColumnIndexSearchTest.java
+++ b/index-providers/modeshape-lucene-index-provider/src/test/java/org/modeshape/jcr/index/lucene/SingleColumnIndexSearchTest.java
@@ -726,4 +726,30 @@ public class SingleColumnIndexSearchTest extends AbstractLuceneIndexSearchTest {
         validateCardinality(constraint, 1);
         validateFilterResults(constraint, 1, false, nodeKeys.get(0));
     }
+
+    @Test
+    @FixFor( "MODE-2720" )
+    public void shouldSearchForLikeConstraintContainingBackslash() throws Exception {
+        List<String> nodeKeys = indexNodes(STRING_PROP, "A\\B");
+
+        Constraint constraint = propertyValue(STRING_PROP, LIKE, "A\\\\B");
+        validateCardinality(constraint, 1);
+        validateFilterResults(constraint, 1, false, nodeKeys.get(0));
+
+        constraint = propertyValue(STRING_PROP, LIKE, "A\\\\B%");
+        validateCardinality(constraint, 1);
+        validateFilterResults(constraint, 1, false, nodeKeys.get(0));
+
+        constraint = propertyValue(STRING_PROP, LIKE, "A\\\\%");
+        validateCardinality(constraint, 1);
+        validateFilterResults(constraint, 1, false, nodeKeys.get(0));
+
+        constraint = propertyValue(STRING_PROP, LIKE, "%\\\\B");
+        validateCardinality(constraint, 1);
+        validateFilterResults(constraint, 1, false, nodeKeys.get(0));
+
+        constraint = propertyValue(STRING_PROP, LIKE, "%\\\\%");
+        validateCardinality(constraint, 1);
+        validateFilterResults(constraint, 1, false, nodeKeys.get(0));
+    }
 }

--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/query/engine/QueryUtil.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/query/engine/QueryUtil.java
@@ -49,8 +49,30 @@ public class QueryUtil {
         }
         return false;
     }
-    
-    
+
+    /**
+     * Removes {@code \}-triggered escape sequences from {@code jcrExpression}.
+     * @param jcrExpression {@link String}, never {@code null}
+     * @return {@link String}
+     * @since 5.5
+     */
+    public static String unescape( String jcrExpression ) {
+        Objects.requireNonNull(jcrExpression);
+        if (jcrExpression.indexOf('\\') < 0) {
+            return jcrExpression;
+        }
+        final StringBuilder buf = new StringBuilder(jcrExpression.length());
+
+        for (CharacterIterator iter = new StringCharacterIterator(jcrExpression); iter.current() != CharacterIterator.DONE; iter.next()) {
+            if (iter.current() == '\\' && iter.next() == '\\') {
+                buf.append('\\');
+                continue;
+            }
+            buf.append(iter.current());
+        }
+        return buf.toString();
+    }
+
     /**
      * Convert the JCR like expression to a regular expression. The JCR like expression uses '%' to match 0 or more characters,
      * '_' to match any single character, '\x' to match the 'x' character, and all other characters to match themselves. Note that


### PR DESCRIPTION
Fix, replace #1667 