### PR TITLE
Add a version to the top level pom.xml.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,6 +10,7 @@
 
 	<groupId>org.modeshape</groupId>
 	<artifactId>modeshape</artifactId>
+        <version>5.5-SNAPSHOT</version>
 
 	<packaging>pom</packaging>
 	<name>ModeShape</name>


### PR DESCRIPTION
I'm trying to mvn:versions:set on the project, but it doesn't look like I can if there is no version in the top level pom.xml.

[ERROR] Failed to execute goal org.codehaus.mojo:versions-maven-plugin:2.7:set (default-cli) on project modeshape: Project version is inherited from parent. -> [Help 1]

Adding a version cures that.