### PR TITLE
Properly passed arguments from DocumentNotFoundException to DocumentS…

### DIFF
--- a/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/DocumentNotFoundException.java
+++ b/modeshape-jcr/src/main/java/org/modeshape/jcr/cache/DocumentNotFoundException.java
@@ -35,7 +35,7 @@ public class DocumentNotFoundException extends DocumentStoreException {
      */
     public DocumentNotFoundException( String key,
                                       String message ) {
-        super(message);
+        super(key, message);
     }
 
     /**


### PR DESCRIPTION
The particular parent constructor called before was as follows:
`public DocumentStoreException( String key )`

Since `message `was passed within `DocumentNotFoundException`, a textual message was being passed as the key to `DocumentStoreException`