### PR TITLE
Shallow cloning on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: java
 
 # Our Git tests require information from early branches/versions so we need to make sure Travis gets everything when cloning
 git:
-  depth: 9999
+  depth: 3
    
 # Travis by defaults runs the following `install` command:
 #


### PR DESCRIPTION
According to [https://docs.travis-ci.com/user/customizing-the-build#git-clone-depth](url), Travis CI provide a way to shallow clone a repository. This has the obvious benefit of speed, since you only need to download a small number of commits.